### PR TITLE
feat: port rule no-with

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 
 - `no-console`
 - `no-debugger`
+- `no-with`
 - `no-var`
 - `eqeqeq`
 - `no-unused-vars`

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     no_console: bool = true,
     no_debugger: bool = true,
+    no_with: bool = true,
     no_var: bool = true,
     eqeqeq: bool = true,
     no_unused_vars: bool = true,
@@ -162,4 +163,3 @@ pub fn isKnownGlobal(name: []const u8) bool {
 
     return false;
 }
-

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
+        } else if (std.mem.eql(u8, arg, "--no-with=off")) {
+            options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -169,6 +171,7 @@ fn printHelp() void {
         \\Options:
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
+        \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --eqeqeq=off              Disable eqeqeq
         \\  --no-unused-vars=off      Disable no-unused-vars

--- a/src/root.zig
+++ b/src/root.zig
@@ -106,9 +106,12 @@ test "reports structural rules" {
         \\  console.log(value);
         \\  debugger;
         \\}
+        \\with (point) {
+        \\  x = 1;
+        \\}
     ;
 
-    var result = try lintSource(std.testing.allocator, source, "fixture.ts", .{
+    var result = try lintSource(std.testing.allocator, source, "fixture.cjs", .{
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -119,6 +122,25 @@ test "reports structural rules" {
     try std.testing.expect(hasRule(result, rules.eqeqeq.id));
     try std.testing.expect(hasRule(result, rules.no_console.id));
     try std.testing.expect(hasRule(result, rules.no_debugger.id));
+    try std.testing.expect(hasRule(result, rules.no_with.id));
+}
+
+test "can disable no-with" {
+    const source =
+        \\with (point) {
+        \\  x = 1;
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.cjs", .{
+        .no_with = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_with.id));
 }
 
 test "reports semantic rules" {

--- a/src/rules/no_with.zig
+++ b/src/rules/no_with.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-with";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Unexpected use of with statement.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -12,6 +12,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
+pub const no_with = @import("no_with.zig");
 
 pub fn runBasic(
     allocator: Allocator,
@@ -61,6 +62,18 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
+    pub fn enter_with_statement(
+        self: *BasicVisitor,
+        _: ast.WithStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_with) {
+            try no_with.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
     pub fn enter_variable_declaration(
         self: *BasicVisitor,
         declaration: ast.VariableDeclaration,
@@ -97,4 +110,3 @@ const BasicVisitor = struct {
         return .proceed;
     }
 };
-


### PR DESCRIPTION
## Summary
- port the no-with lint rule
- add the rule option, CLI toggle, and README entry
- cover enabled and disabled behavior in unit tests

## Test
- zig build test -Doptimize=ReleaseFast --summary all -j1
- zig build run -j1 -- --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-with.cjs
- zig build run -j1 -- --no-with=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-with.cjs