### PR TITLE
feat: port rule no-for-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 
 - `no-console`
 - `no-debugger`
+- `no-for-in`
 - `no-with`
 - `no-var`
 - `eqeqeq`

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     no_console: bool = true,
     no_debugger: bool = true,
+    no_for_in: bool = true,
     no_with: bool = true,
     no_var: bool = true,
     eqeqeq: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
+        } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
+            options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
@@ -171,6 +173,7 @@ fn printHelp() void {
         \\Options:
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
+        \\  --no-for-in=off           Disable no-for-in
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --eqeqeq=off              Disable eqeqeq

--- a/src/root.zig
+++ b/src/root.zig
@@ -106,6 +106,9 @@ test "reports structural rules" {
         \\  console.log(value);
         \\  debugger;
         \\}
+        \\for (const key in value) {
+        \\  console.log(key);
+        \\}
         \\with (point) {
         \\  x = 1;
         \\}
@@ -122,7 +125,26 @@ test "reports structural rules" {
     try std.testing.expect(hasRule(result, rules.eqeqeq.id));
     try std.testing.expect(hasRule(result, rules.no_console.id));
     try std.testing.expect(hasRule(result, rules.no_debugger.id));
+    try std.testing.expect(hasRule(result, rules.no_for_in.id));
     try std.testing.expect(hasRule(result, rules.no_with.id));
+}
+
+test "can disable no-for-in" {
+    const source =
+        \\for (const key in object) {
+        \\  console.log(key);
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_for_in = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_for_in.id));
 }
 
 test "can disable no-with" {

--- a/src/rules/no_for_in.zig
+++ b/src/rules/no_for_in.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-for-in";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected for-in loop.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -9,6 +9,7 @@ const Allocator = std.mem.Allocator;
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
+pub const no_for_in = @import("no_for_in.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
@@ -58,6 +59,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_debugger) {
             try no_debugger.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_for_in_statement(
+        self: *BasicVisitor,
+        _: ast.ForInStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_for_in) {
+            try no_for_in.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-for-in lint rule
- add the rule option, CLI toggle, and README entry
- cover enabled and disabled behavior in unit tests

## Test
- zig build test -Doptimize=ReleaseFast --summary all -j1
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-for-in.js
- zig build run -j1 -- --no-for-in=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-for-in.js