### PR TITLE
feat: port rule no-alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) for parsing, AST traver
 
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
+- `no-alert`
 - `no-console`
 - `no-debugger`
 - `no-for-in`

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    no_alert: bool = true,
     no_console: bool = true,
     no_debugger: bool = true,
     no_for_in: bool = true,
@@ -112,10 +113,12 @@ pub fn freeDiagnostics(allocator: Allocator, diagnostics: *DiagnosticList) void 
 
 pub fn isKnownGlobal(name: []const u8) bool {
     const globals = [_][]const u8{
+        "alert",
         "Array",
         "BigInt",
         "Boolean",
         "Buffer",
+        "confirm",
         "Date",
         "Error",
         "Headers",
@@ -150,6 +153,7 @@ pub fn isKnownGlobal(name: []const u8) bool {
         "globalThis",
         "module",
         "process",
+        "prompt",
         "queueMicrotask",
         "require",
         "setInterval",

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,8 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
+        } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
+            options.no_alert = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
@@ -171,6 +173,7 @@ fn printHelp() void {
         \\  utoo-lint [options] [file-or-directory ...]
         \\
         \\Options:
+        \\  --no-alert=off            Disable no-alert
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-for-in=off           Disable no-for-in

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -99,6 +99,14 @@ fn hasRule(result: Result, rule_id: []const u8) bool {
     return false;
 }
 
+fn countRule(result: Result, rule_id: []const u8) usize {
+    var count: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) count += 1;
+    }
+    return count;
+}
+
 test "reports structural rules" {
     const source =
         \\var value = 1;
@@ -163,6 +171,61 @@ test "can disable no-with" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!hasRule(result, rules.no_with.id));
+}
+
+test "reports no-alert for global alert APIs" {
+    const source =
+        \\alert("here");
+        \\confirm("continue?");
+        \\prompt("name");
+        \\window.alert("hello");
+        \\globalThis.prompt("name");
+        \\window["confirm"]("continue?");
+        \\(alert)("wrapped");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), countRule(result, rules.no_alert.id));
+}
+
+test "does not report no-alert for shadowed alert" {
+    const source =
+        \\const alert = customAlert;
+        \\alert("custom");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_alert.id));
+}
+
+test "can disable no-alert" {
+    const source =
+        \\alert("here");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_alert = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_alert.id));
 }
 
 test "reports semantic rules" {

--- a/src/rules/no_alert.zig
+++ b/src/rules/no_alert.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-alert";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (forbiddenCallee(ctx.tree, self.symbol_table, call.callee)) |name| {
+            try core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                ctx.tree.span(index),
+                "Unexpected {s}.",
+                .{name},
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn forbiddenCallee(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        if (isForbiddenFunction(name) and isUnresolvedReference(symbol_table, unwrapped)) {
+            return name;
+        }
+        return null;
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return null;
+    if (!isGlobalObject(object_name) or !isUnresolvedReference(symbol_table, object)) {
+        return null;
+    }
+
+    const property_name = propertyName(tree, member) orelse return null;
+    if (isForbiddenFunction(property_name)) return property_name;
+
+    return null;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn isForbiddenFunction(name: []const u8) bool {
+    return std.mem.eql(u8, name, "alert") or
+        std.mem.eql(u8, name, "confirm") or
+        std.mem.eql(u8, name, "prompt");
+}
+
+fn isGlobalObject(name: []const u8) bool {
+    return std.mem.eql(u8, name, "window") or
+        std.mem.eql(u8, name, "globalThis");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -6,6 +6,7 @@ const ast = parser.ast;
 const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
+pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
@@ -37,6 +38,10 @@ pub fn runSemantic(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.no_alert) {
+        try no_alert.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.no_unused_vars) {
         try no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }


### PR DESCRIPTION
## Summary
- port the no-alert lint rule
- add the rule option, CLI toggle, and README entry
- cover global calls, shadowed bindings, and disabled behavior in unit tests

## Test
- zig build test -Doptimize=ReleaseFast --summary all -j1
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-alert-all.js
- zig build run -j1 -- --no-alert=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-alert-all.js