### PR TITLE
feat: port rule no-comma-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 
 - `no-alert`
 - `no-console`
+- `no-comma-operator`
 - `no-debugger`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     no_alert: bool = true,
     no_console: bool = true,
+    no_comma_operator: bool = true,
     no_debugger: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_alert = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
+        } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
+            options.no_comma_operator = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -178,6 +180,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --no-alert=off            Disable no-alert
+        \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-for-in=off           Disable no-for-in

--- a/src/root.zig
+++ b/src/root.zig
@@ -336,6 +336,55 @@ test "can disable no-global-is-finite" {
     try std.testing.expect(!hasRule(result, rules.no_global_is_finite.id));
 }
 
+test "reports no-comma-operator outside for init and update" {
+    const source =
+        \\const value = (doSomething(), 0);
+        \\for (; doSomething(), test; ) {}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(hasRule(result, rules.no_comma_operator.id));
+}
+
+test "allows comma operator in for init and update" {
+    const source =
+        \\for (i = 0, j = 0; test; i++, j++) {}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_comma_operator.id));
+}
+
+test "can disable no-comma-operator" {
+    const source =
+        \\const value = (doSomething(), 0);
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_comma_operator.id));
+}
+
 test "reports semantic rules" {
     const source =
         \\const unused = missing;

--- a/src/rules/no_comma_operator.zig
+++ b/src/rules/no_comma_operator.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-comma-operator";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    _: ast.SequenceExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (isNestedSequence(tree, ctx)) return;
+    if (isAllowedForPart(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "The comma operator is disallowed.",
+        tree.span(index),
+    );
+}
+
+fn isNestedSequence(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    return switch (tree.data(parent)) {
+        .sequence_expression => true,
+        else => false,
+    };
+}
+
+fn isAllowedForPart(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    const for_statement = switch (tree.data(parent)) {
+        .for_statement => |for_statement| for_statement,
+        else => return false,
+    };
+
+    return for_statement.init == index or for_statement.update == index;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
+pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
 pub const no_for_in = @import("no_for_in.zig");
@@ -122,6 +123,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_sequence_expression(
+        self: *BasicVisitor,
+        expression: ast.SequenceExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_comma_operator) {
+            try no_comma_operator.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-comma-operator lint rule
- add the rule option, CLI toggle, and README entry
- allow comma operators in for init/update while reporting other sequence expressions

## Test
- zig build test -Doptimize=ReleaseFast --summary all -j1
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-comma-operator.js
- zig build run -j1 -- --no-comma-operator=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-comma-operator.js
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-comma-operator-valid.js