### PR TITLE
feat: port rule no-proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-proto`
 - `no-with`
 - `no-var`
 - `eqeqeq`

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_proto: bool = true,
     no_with: bool = true,
     no_var: bool = true,
     eqeqeq: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
+            options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
@@ -186,6 +188,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-proto=off            Disable no-proto
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --eqeqeq=off              Disable eqeqeq

--- a/src/root.zig
+++ b/src/root.zig
@@ -385,6 +385,60 @@ test "can disable no-comma-operator" {
     try std.testing.expect(!hasRule(result, rules.no_comma_operator.id));
 }
 
+test "reports no-proto for proto member access" {
+    const source =
+        \\obj.__proto__ = a;
+        \\obj["__proto__"] = b;
+        \\const c = obj.__proto__;
+        \\const d = obj["__proto__"];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(hasRule(result, rules.no_proto.id));
+}
+
+test "does not report no-proto for object literal proto property" {
+    const source =
+        \\const value = {
+        \\  __proto__: null,
+        \\  a: 1,
+        \\};
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_proto.id));
+}
+
+test "can disable no-proto" {
+    const source =
+        \\const c = obj.__proto__;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_proto = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_proto.id));
+}
+
 test "reports semantic rules" {
     const source =
         \\const unused = missing;

--- a/src/rules/no_proto.zig
+++ b/src/rules/no_proto.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-proto";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = propertyName(tree, member) orelse return;
+    if (!std.mem.eql(u8, name, "__proto__")) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Avoid use of the deprecated __proto__ accessor.",
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_proto = @import("no_proto.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
@@ -147,6 +148,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_console) {
             try no_console.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_member_expression(
+        self: *BasicVisitor,
+        member: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_proto) {
+            try no_proto.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-proto lint rule
- add the rule option, CLI toggle, and README entry
- report static and computed __proto__ member access while allowing object literal prototype properties

## Test
- zig build test -Doptimize=ReleaseFast --summary all -j1
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-proto.js
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-proto-valid.js
- zig build run -j1 -- --no-proto=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-proto.js