### PR TITLE
feat: port rule no-void

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-proto`
+- `no-void`
 - `no-with`
 - `no-var`
 - `eqeqeq`

--- a/src/core.zig
+++ b/src/core.zig
@@ -25,6 +25,7 @@ pub const Options = struct {
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_proto: bool = true,
+    no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,
     eqeqeq: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -38,6 +38,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_nan = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-void=off")) {
+            options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
@@ -189,6 +191,7 @@ fn printHelp() void {
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-proto=off            Disable no-proto
+        \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --eqeqeq=off              Disable eqeqeq

--- a/src/root.zig
+++ b/src/root.zig
@@ -439,6 +439,60 @@ test "can disable no-proto" {
     try std.testing.expect(!hasRule(result, rules.no_proto.id));
 }
 
+test "reports no-void for void unary expressions" {
+    const source =
+        \\void 0;
+        \\function f() {
+        \\  return void 0;
+        \\}
+        \\const value = void(0);
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), countRule(result, rules.no_void.id));
+}
+
+test "does not report no-void for delete or property names" {
+    const source =
+        \\delete object.value;
+        \\object.void();
+        \\object.void = value;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_void.id));
+}
+
+test "can disable no-void" {
+    const source =
+        \\void 0;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_void = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_void.id));
+}
+
 test "reports semantic rules" {
     const source =
         \\const unused = missing;

--- a/src/rules/no_void.zig
+++ b/src/rules/no_void.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-void";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .void) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "The use of void is not allowed.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -18,6 +18,7 @@ pub const no_proto = @import("no_proto.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
+pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 
 pub fn runBasic(
@@ -124,6 +125,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_unary_expression(
+        self: *BasicVisitor,
+        expression: ast.UnaryExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_void) {
+            try no_void.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-void lint rule
- add the rule option, CLI toggle, and README entry
- cover void unary expressions, valid delete/member cases, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/5a56948358449ed91010dcb8e465da9f/test
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-void.js
- zig build run -j1 -- --no-void=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-void.js

Note: zig build test currently compiles successfully but the Zig build runner terminates in --listen mode; the generated test binary passes all 22 tests.