### PR TITLE
docs: add Yuku GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![utoo-lint logo](assets/utoo-lint-logo.svg)
 
 `utoo-lint` is an experimental JavaScript and TypeScript linter written in Zig.
-It uses [`yuku`](https://github.com/yuku-toolchain/yuku) for parsing, AST traversal, scope tracking, and symbol resolution.
+It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github.com/yuku-toolchain/yuku) for parsing, AST traversal, scope tracking, and symbol resolution.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- show the Yuku GitHub URL explicitly in README

## Test
- not run; documentation-only change