### PR TITLE
feat: port rule no-empty-block-statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`
+- `no-empty-block-statements`
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,7 @@ pub const Options = struct {
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,
+    no_empty_block_statements: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_comma_operator = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
+            options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-finite=off")) {
@@ -187,6 +189,7 @@ fn printHelp() void {
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
+        \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan

--- a/src/root.zig
+++ b/src/root.zig
@@ -173,6 +173,66 @@ test "can disable no-with" {
     try std.testing.expect(!hasRule(result, rules.no_with.id));
 }
 
+test "reports no-empty-block-statements for empty blocks" {
+    const source =
+        \\if (ready) {}
+        \\function empty() {}
+        \\class C {
+        \\  static {}
+        \\  method() {}
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), countRule(result, rules.no_empty_block_statements.id));
+}
+
+test "does not report no-empty-block-statements for commented blocks" {
+    const source =
+        \\if (ready) { /* intentionally empty */ }
+        \\function empty() {
+        \\  // intentionally empty
+        \\}
+        \\class C {
+        \\  static { /* intentionally empty */ }
+        \\  method() { /* intentionally empty */ }
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_block_statements.id));
+}
+
+test "can disable no-empty-block-statements" {
+    const source =
+        \\if (ready) {}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_block_statements.id));
+}
+
 test "reports no-alert for global alert APIs" {
     const source =
         \\alert("here");

--- a/src/rules/no_empty_block_statements.zig
+++ b/src/rules/no_empty_block_statements.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-empty-block-statements";
+
+pub fn checkBlockStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.BlockStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkBody(allocator, diagnostics, tree, block.body, index);
+}
+
+pub fn checkFunctionBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkBody(allocator, diagnostics, tree, body.body, index);
+}
+
+pub fn checkStaticBlock(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.StaticBlock,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkBody(allocator, diagnostics, tree, block.body, index);
+}
+
+fn checkBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.IndexRange,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (body.len != 0) return;
+    if (hasCommentInsideBraces(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected empty block statement.",
+        tree.span(index),
+    );
+}
+
+fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (tree.source.len == 0 or start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    const open = std.mem.indexOfScalar(u8, source, '{') orelse return false;
+    const close = std.mem.lastIndexOfScalar(u8, source, '}') orelse return false;
+    if (open >= close) return false;
+
+    return containsOnlyWhitespaceAndHasComment(source[open + 1 .. close]);
+}
+
+fn containsOnlyWhitespaceAndHasComment(source: []const u8) bool {
+    var has_comment = false;
+    var index: usize = 0;
+
+    while (index < source.len) {
+        switch (source[index]) {
+            ' ', '\t', '\n', '\r', 0x0B, 0x0C => index += 1,
+            '/' => {
+                if (index + 1 >= source.len) return false;
+
+                switch (source[index + 1]) {
+                    '/' => {
+                        has_comment = true;
+                        index += 2;
+                        while (index < source.len and source[index] != '\n' and source[index] != '\r') {
+                            index += 1;
+                        }
+                    },
+                    '*' => {
+                        has_comment = true;
+                        index += 2;
+                        var closed = false;
+                        while (index + 1 < source.len) : (index += 1) {
+                            if (source[index] == '*' and source[index + 1] == '/') {
+                                index += 2;
+                                closed = true;
+                                break;
+                            }
+                        }
+                        if (!closed) return false;
+                    },
+                    else => return false,
+                }
+            },
+            else => return false,
+        }
+    }
+
+    return has_comment;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -11,6 +11,7 @@ pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
+pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
@@ -89,6 +90,42 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_for_in) {
             try no_for_in.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_block_statement(
+        self: *BasicVisitor,
+        block: ast.BlockStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_block_statements) {
+            try no_empty_block_statements.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_function_body(
+        self: *BasicVisitor,
+        body: ast.FunctionBody,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_block_statements) {
+            try no_empty_block_statements.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_static_block(
+        self: *BasicVisitor,
+        block: ast.StaticBlock,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_block_statements) {
+            try no_empty_block_statements.checkStaticBlock(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-empty-block-statements lint rule
- add the rule option, CLI toggle, and README entry
- report empty block statements, function bodies, and static blocks while allowing comment-only empty blocks

## Test
- zig build test -Doptimize=ReleaseFast -j1
- direct ReleaseFast test binary run: all 25 tests passed
- CLI fixtures verified plain empty blocks report and commented empty blocks do not