### PR TITLE
feat: port rule no-compare-neg-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
 - `no-alert`
+- `no-compare-neg-zero`
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`

--- a/src/core.zig
+++ b/src/core.zig
@@ -18,6 +18,7 @@ pub const Severity = enum {
 
 pub const Options = struct {
     no_alert: bool = true,
+    no_compare_neg_zero: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,8 @@ pub fn main(init: std.process.Init) !void {
             return;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
+        } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
+            options.no_compare_neg_zero = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
@@ -184,6 +186,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --no-alert=off            Disable no-alert
+        \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger

--- a/src/root.zig
+++ b/src/root.zig
@@ -493,6 +493,61 @@ test "can disable no-void" {
     try std.testing.expect(!hasRule(result, rules.no_void.id));
 }
 
+test "reports no-compare-neg-zero for comparisons against negative zero" {
+    const source =
+        \\x === -0;
+        \\-0 == x;
+        \\x < -0;
+        \\-0 >= x;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), countRule(result, rules.no_compare_neg_zero.id));
+}
+
+test "does not report no-compare-neg-zero for non-comparisons" {
+    const source =
+        \\x === 0;
+        \\x === -1;
+        \\x === +0;
+        \\Object.is(x, -0);
+        \\x || -0;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_compare_neg_zero.id));
+}
+
+test "can disable no-compare-neg-zero" {
+    const source =
+        \\x === -0;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_compare_neg_zero = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_compare_neg_zero.id));
+}
+
 test "reports semantic rules" {
     const source =
         \\const unused = missing;

--- a/src/rules/no_compare_neg_zero.zig
+++ b/src/rules/no_compare_neg_zero.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-compare-neg-zero";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isComparisonOperator(expression.operator)) return;
+    if (!isNegativeZero(tree, expression.left) and !isNegativeZero(tree, expression.right)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Do not use the {s} operator to compare against -0.",
+        .{expression.operator.toString()},
+    );
+}
+
+fn isComparisonOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isNegativeZero(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    const unary = switch (tree.data(index)) {
+        .unary_expression => |unary| unary,
+        else => return false,
+    };
+    if (unary.operator != .negate) return false;
+
+    return switch (tree.data(unary.argument)) {
+        .numeric_literal => |literal| std.mem.eql(u8, tree.string(literal.raw), "0"),
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
+pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
@@ -123,6 +124,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_compare_neg_zero) {
+            try no_compare_neg_zero.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }


### PR DESCRIPTION
## Summary
- port the no-compare-neg-zero lint rule
- add the rule option, CLI toggle, and README entry
- cover comparisons against -0, non-comparison valid cases, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/20ce14a84eb9d91f75c2360ec890cca3/test
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-compare-neg-zero.js
- zig build run -j1 -- --no-compare-neg-zero=off --eqeqeq=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-compare-neg-zero.js

Note: zig build test compiles successfully, but the Zig build runner terminates in --listen mode; the generated test binary passes all 25 tests.