### PR TITLE
feat: port rule no-unsafe-negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-proto`
+- `no-unsafe-negation`
 - `no-void`
 - `no-with`
 - `no-var`

--- a/src/core.zig
+++ b/src/core.zig
@@ -25,6 +25,7 @@ pub const Options = struct {
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_proto: bool = true,
+    no_unsafe_negation: bool = true,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -38,6 +38,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_nan = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
+            options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -191,6 +193,7 @@ fn printHelp() void {
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-proto=off            Disable no-proto
+        \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/root.zig
+++ b/src/root.zig
@@ -493,6 +493,58 @@ test "can disable no-void" {
     try std.testing.expect(!hasRule(result, rules.no_void.id));
 }
 
+test "reports no-unsafe-negation before in and instanceof" {
+    const source =
+        \\!value in object;
+        \\!value instanceof Constructor;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), countRule(result, rules.no_unsafe_negation.id));
+}
+
+test "does not report no-unsafe-negation for other unary expressions" {
+    const source =
+        \\-value in object;
+        \\~value in object;
+        \\typeof value in object;
+        \\void value in object;
+        \\value instanceof Constructor;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_void = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_unsafe_negation.id));
+}
+
+test "can disable no-unsafe-negation" {
+    const source =
+        \\!value in object;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unsafe_negation = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_unsafe_negation.id));
+}
+
 test "reports semantic rules" {
     const source =
         \\const unused = missing;

--- a/src/rules/no_unsafe_negation.zig
+++ b/src/rules/no_unsafe_negation.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unsafe-negation";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .in and expression.operator != .instanceof) return;
+    if (!isLogicalNot(tree, expression.left)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "The negation operator is used unsafely on the left side of this binary expression.",
+        tree.span(index),
+    );
+}
+
+fn isLogicalNot(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .unary_expression => |unary| unary.operator == .logical_not,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -15,6 +15,7 @@ pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_proto = @import("no_proto.zig");
+pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
@@ -125,6 +126,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_unsafe_negation) {
+            try no_unsafe_negation.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-unsafe-negation lint rule
- add the rule option, CLI toggle, and README entry
- cover unsafe negation before in/instanceof, valid unary cases, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/c25e5609408883768148d35460fc90d2/test --cache-dir=./.zig-cache --seed=0x521b2df9
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-unsafe-negation.js
- zig build run -j1 -- --no-unsafe-negation=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-unsafe-negation-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 25 tests.