### PR TITLE
feat: port rule no-new-symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-new-symbol`
 - `no-proto`
 - `no-void`
 - `no-with`

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_new_symbol: bool = true,
     no_proto: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-new-symbol=off")) {
+            options.no_new_symbol = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -190,6 +192,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-proto=off            Disable no-proto
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_symbol or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -334,6 +334,58 @@ test "can disable no-global-is-finite" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!hasRule(result, rules.no_global_is_finite.id));
+}
+
+test "reports no-new-symbol for constructed global Symbol" {
+    const source =
+        \\const foo = new Symbol("foo");
+        \\const bar = new (Symbol)("bar");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), countRule(result, rules.no_new_symbol.id));
+}
+
+test "does not report no-new-symbol for calls or shadowed Symbol" {
+    const source =
+        \\const foo = Symbol("foo");
+        \\function local(Symbol) {
+        \\  const bar = new Symbol("bar");
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_symbol.id));
+}
+
+test "can disable no-new-symbol" {
+    const source =
+        \\const foo = new Symbol("foo");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new_symbol = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_symbol.id));
 }
 
 test "reports no-comma-operator outside for init and update" {

--- a/src/rules/no_new_symbol.zig
+++ b/src/rules/no_new_symbol.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-new-symbol";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalSymbolReference(ctx.tree, self.symbol_table, expression.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .@"error",
+                id,
+                "`Symbol` cannot be called as a constructor.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isGlobalSymbolReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Symbol") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
@@ -53,6 +54,10 @@ pub fn runSemantic(
 
     if (options.no_global_is_nan) {
         try no_global_is_nan.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_new_symbol) {
+        try no_new_symbol.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {


### PR DESCRIPTION
## Summary
- port the no-new-symbol lint rule
- add the semantic rule option, CLI toggle, and README entry
- cover constructed global Symbol, regular Symbol calls, shadowed Symbol, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/4f25754e2249f44e9d81b4452cadf0d4/test --cache-dir=./.zig-cache --seed=0xdc15d5d0
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-symbol.js
- zig build run -j1 -- --no-new-symbol=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-symbol-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 25 tests.