### PR TITLE
feat: port rule no-new-wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-new-wrappers`
 - `no-proto`
 - `no-void`
 - `no-with`

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_new_wrappers: bool = true,
     no_proto: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-new-wrappers=off")) {
+            options.no_new_wrappers = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -190,6 +192,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-proto=off            Disable no-proto
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -334,6 +334,61 @@ test "can disable no-global-is-finite" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!hasRule(result, rules.no_global_is_finite.id));
+}
+
+test "reports no-new-wrappers for global wrapper constructors" {
+    const source =
+        \\const string = new String("text");
+        \\const number = new Number(1);
+        \\const boolean = new Boolean(false);
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), countRule(result, rules.no_new_wrappers.id));
+}
+
+test "does not report no-new-wrappers for calls or shadowed constructors" {
+    const source =
+        \\const string = String(value);
+        \\const number = Number(value);
+        \\const boolean = Boolean(value);
+        \\function local(String) {
+        \\  const value = new String("text");
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_wrappers.id));
+}
+
+test "can disable no-new-wrappers" {
+    const source =
+        \\const string = new String("text");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new_wrappers = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_wrappers.id));
 }
 
 test "reports no-comma-operator outside for init and update" {

--- a/src/rules/no_new_wrappers.zig
+++ b/src/rules/no_new_wrappers.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-new-wrappers";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (globalWrapperName(ctx.tree, self.symbol_table, expression.callee)) |name| {
+            try core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                ctx.tree.span(index),
+                "Do not use {s} as a constructor.",
+                .{name},
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn globalWrapperName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return null;
+    if (!isWrapperName(name) or !isUnresolvedReference(symbol_table, unwrapped)) return null;
+
+    return name;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isWrapperName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "String") or
+        std.mem.eql(u8, name, "Number") or
+        std.mem.eql(u8, name, "Boolean");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
@@ -53,6 +54,10 @@ pub fn runSemantic(
 
     if (options.no_global_is_nan) {
         try no_global_is_nan.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_new_wrappers) {
+        try no_new_wrappers.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {


### PR DESCRIPTION
## Summary
- port the no-new-wrappers lint rule
- add the semantic rule option, CLI toggle, and README entry
- cover global wrapper constructors, regular wrapper calls, shadowed constructors, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/b3d554cd596c241c285b4bbed6650535/test --cache-dir=./.zig-cache --seed=0x14cb6807
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-wrappers.js
- zig build run -j1 -- --no-new-wrappers=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-wrappers-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 25 tests.