### PR TITLE
feat: port rule no-new-func

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-new-func`
 - `no-new-object`
 - `no-new-symbol`
 - `no-new-wrappers`

--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,6 +40,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
+            options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
             options.no_new_object = false;
         } else if (std.mem.eql(u8, arg, "--no-new-symbol=off")) {
@@ -204,6 +206,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -394,6 +394,62 @@ test "can disable no-global-is-finite" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!hasRule(result, rules.no_global_is_finite.id));
+}
+
+test "reports no-new-func for Function constructor usage" {
+    const source =
+        \\const a = new Function("return 1");
+        \\const b = Function("return 1");
+        \\const c = Function.call(null, "return 1");
+        \\const d = Function.apply(null, ["return 1"]);
+        \\const e = Function.bind(null, "return 1");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), countRule(result, rules.no_new_func.id));
+}
+
+test "does not report no-new-func for shadowed Function" {
+    const source =
+        \\function local(Function) {
+        \\  const a = new Function("return 1");
+        \\  const b = Function("return 1");
+        \\  const c = Function.call(null, "return 1");
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_func.id));
+}
+
+test "can disable no-new-func" {
+    const source =
+        \\const a = new Function("return 1");
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new_func = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_new_func.id));
 }
 
 test "reports no-new-object for constructed global Object" {

--- a/src/rules/no_new_func.zig
+++ b/src/rules/no_new_func.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-new-func";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalFunctionReference(ctx.tree, self.symbol_table, expression.callee)) {
+            try addDiagnostic(self, ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isForbiddenFunctionCall(ctx.tree, self.symbol_table, call.callee)) {
+            try addDiagnostic(self, ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Do not use the Function constructor.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isForbiddenFunctionCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+    if (isGlobalFunctionReference(tree, symbol_table, unwrapped)) return true;
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!isForbiddenProperty(property_name)) return false;
+
+    return isGlobalFunctionReference(tree, symbol_table, member.object);
+}
+
+fn isGlobalFunctionReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Function") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isForbiddenProperty(name: []const u8) bool {
+    return std.mem.eql(u8, name, "call") or
+        std.mem.eql(u8, name, "apply") or
+        std.mem.eql(u8, name, "bind");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -16,6 +16,7 @@ pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
@@ -59,6 +60,10 @@ pub fn runSemantic(
 
     if (options.no_global_is_nan) {
         try no_global_is_nan.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_new_func) {
+        try no_new_func.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_object) {


### PR DESCRIPTION
## Summary
- port the no-new-func lint rule
- add the semantic rule option, CLI toggle, and README entry
- cover Function constructor usage, Function.call/apply/bind, shadowed Function, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/ed481d0a0c25a3a500a40f415c799645/test --cache-dir=./.zig-cache --seed=0x55d8cf44
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-func.js
- zig build run -j1 -- --no-new-func=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-new-func-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 43 tests.