### PR TITLE
feat: port rule no-array-constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
 - `no-alert`
+- `no-array-constructor`
 - `no-compare-neg-zero`
 - `no-console`
 - `no-comma-operator`

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    no_array_constructor: bool = true,
     no_alert: bool = true,
     no_compare_neg_zero: bool = true,
     no_console: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,8 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
+        } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
+            options.no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
@@ -195,6 +197,7 @@ fn printHelp() void {
         \\  utoo-lint [options] [file-or-directory ...]
         \\
         \\Options:
+        \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-alert=off            Disable no-alert
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-comma-operator=off   Disable no-comma-operator

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -135,6 +135,63 @@ test "reports structural rules" {
     try std.testing.expect(hasRule(result, rules.no_debugger.id));
     try std.testing.expect(hasRule(result, rules.no_for_in.id));
     try std.testing.expect(hasRule(result, rules.no_with.id));
+}
+
+test "reports no-array-constructor for disallowed Array constructor usage" {
+    const source =
+        \\const a = Array();
+        \\const b = new Array();
+        \\const c = Array(1, 2);
+        \\const d = new Array("a", "b");
+        \\const e = Array(...items);
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), countRule(result, rules.no_array_constructor.id));
+}
+
+test "does not report no-array-constructor for single non-spread argument or shadowed Array" {
+    const source =
+        \\const a = Array(length);
+        \\const b = new Array(10);
+        \\function local(Array) {
+        \\  const c = Array();
+        \\  const d = new Array(1, 2);
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_array_constructor.id));
+}
+
+test "can disable no-array-constructor" {
+    const source =
+        \\const a = Array();
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_array_constructor = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_array_constructor.id));
 }
 
 test "can disable no-for-in" {

--- a/src/rules/no_array_constructor.zig
+++ b/src/rules/no_array_constructor.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-array-constructor";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isDisallowedArrayConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments)) {
+            try addDiagnostic(self, ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isDisallowedArrayConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments)) {
+            try addDiagnostic(self, ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Use an array literal instead of the Array constructor.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isDisallowedArrayConstructor(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+    arguments: ast.IndexRange,
+) bool {
+    if (!isGlobalArrayReference(tree, symbol_table, callee)) return false;
+    if (arguments.len != 1) return true;
+
+    const argument = tree.extra(arguments)[0];
+    return switch (tree.data(argument)) {
+        .spread_element => true,
+        else => false,
+    };
+}
+
+fn isGlobalArrayReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Array") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
+pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
@@ -49,6 +50,10 @@ pub fn runSemantic(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.no_array_constructor) {
+        try no_array_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.no_alert) {
         try no_alert.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }


### PR DESCRIPTION
## Summary
- port the no-array-constructor lint rule
- add the semantic rule option, CLI toggle, and README entry
- cover disallowed Array constructor calls, the single non-spread argument allowance, shadowed Array, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/d857bc93e33b05b984c4710d6ac384b1/test --cache-dir=./.zig-cache --seed=0xe30679a2
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-array-constructor.js
- zig build run -j1 -- --no-array-constructor=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-array-constructor-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 43 tests.