### PR TITLE
feat: port rule no-caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
 - `no-alert`
+- `no-caller`
 - `no-compare-neg-zero`
 - `no-console`
 - `no-comma-operator`

--- a/src/core.zig
+++ b/src/core.zig
@@ -18,6 +18,7 @@ pub const Severity = enum {
 
 pub const Options = struct {
     no_alert: bool = true,
+    no_caller: bool = true,
     no_compare_neg_zero: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,8 @@ pub fn main(init: std.process.Init) !void {
             return;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
+        } else if (std.mem.eql(u8, arg, "--no-caller=off")) {
+            options.no_caller = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
             options.no_compare_neg_zero = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
@@ -196,6 +198,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --no-alert=off            Disable no-alert
+        \\  --no-caller=off           Disable no-caller
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console

--- a/src/root.zig
+++ b/src/root.zig
@@ -173,6 +173,61 @@ test "can disable no-with" {
     try std.testing.expect(!hasRule(result, rules.no_with.id));
 }
 
+test "reports no-caller for arguments caller and callee access" {
+    const source =
+        \\function f() {
+        \\  arguments.callee;
+        \\  arguments.caller;
+        \\  arguments["callee"];
+        \\  arguments["caller"];
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), countRule(result, rules.no_caller.id));
+}
+
+test "does not report no-caller for other objects or properties" {
+    const source =
+        \\object.callee;
+        \\arguments.length;
+        \\arguments[name];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_caller.id));
+}
+
+test "can disable no-caller" {
+    const source =
+        \\arguments.callee;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_caller = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_caller.id));
+}
+
 test "reports no-empty-block-statements for empty blocks" {
     const source =
         \\if (ready) {}

--- a/src/rules/no_caller.zig
+++ b/src/rules/no_caller.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-caller";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isArgumentsObject(tree, member.object)) return;
+
+    const name = propertyName(tree, member) orelse return;
+    if (!isForbiddenProperty(name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Avoid using arguments.caller or arguments.callee.",
+        tree.span(index),
+    );
+}
+
+fn isArgumentsObject(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "arguments"),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isForbiddenProperty(name: []const u8) bool {
+    return std.mem.eql(u8, name, "caller") or
+        std.mem.eql(u8, name, "callee");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
+pub const no_caller = @import("no_caller.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
@@ -231,6 +232,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_caller) {
+            try no_caller.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
         if (self.options.no_proto) {
             try no_proto.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }


### PR DESCRIPTION
## Summary
- port the no-caller lint rule
- add the rule option, CLI toggle, and README entry
- cover arguments.caller/callee, computed string access, allowed member access, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/927bdec8ca676ef3897f2e2fa014f50c/test --cache-dir=./.zig-cache --seed=0xa6970f6a
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-caller.js
- zig build run -j1 -- --no-caller=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-caller-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 43 tests.