### PR TITLE
feat: port rule no-sparse-arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-symbol`
 - `no-new-wrappers`
 - `no-proto`
+- `no-sparse-arrays`
 - `no-unsafe-negation`
 - `no-void`
 - `no-with`

--- a/src/core.zig
+++ b/src/core.zig
@@ -30,6 +30,7 @@ pub const Options = struct {
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,
     no_proto: bool = true,
+    no_sparse_arrays: bool = true,
     no_unsafe_negation: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,6 +48,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new_wrappers = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
+            options.no_sparse_arrays = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -208,6 +210,7 @@ fn printHelp() void {
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-proto=off            Disable no-proto
+        \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/root.zig
+++ b/src/root.zig
@@ -658,6 +658,58 @@ test "can disable no-proto" {
     try std.testing.expect(!hasRule(result, rules.no_proto.id));
 }
 
+test "reports no-sparse-arrays for array holes" {
+    const source =
+        \\const first = [1,, 2];
+        \\const second = [,];
+        \\const third = [,,];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), countRule(result, rules.no_sparse_arrays.id));
+}
+
+test "does not report no-sparse-arrays for explicit values" {
+    const source =
+        \\const first = [1, undefined, 2];
+        \\const second = [...items];
+        \\const third = [];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_sparse_arrays.id));
+}
+
+test "can disable no-sparse-arrays" {
+    const source =
+        \\const first = [1,, 2];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_sparse_arrays = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_sparse_arrays.id));
+}
+
 test "reports no-void for void unary expressions" {
     const source =
         \\void 0;

--- a/src/rules/no_sparse_arrays.zig
+++ b/src/rules/no_sparse_arrays.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-sparse-arrays";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrayExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasHole(tree, expression.elements)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected sparse array.",
+        tree.span(index),
+    );
+}
+
+fn hasHole(tree: *const ast.Tree, elements: ast.IndexRange) bool {
+    for (tree.extra(elements)) |element| {
+        if (element == .null) return true;
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -20,6 +20,7 @@ pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_proto = @import("no_proto.zig");
+pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
@@ -233,6 +234,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_proto) {
             try no_proto.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_array_expression(
+        self: *BasicVisitor,
+        expression: ast.ArrayExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_sparse_arrays) {
+            try no_sparse_arrays.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- port the no-sparse-arrays lint rule
- add the rule option, CLI toggle, and README entry
- cover array holes, explicit values, spreads, empty arrays, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/4cf93d12c4558c3a6da9bb8814ef2228/test --cache-dir=./.zig-cache --seed=0x5411ef5b
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-sparse-arrays.js
- zig build run -j1 -- --no-sparse-arrays=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-sparse-arrays-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 43 tests.