### PR TITLE
feat: port rule no-self-compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-symbol`
 - `no-new-wrappers`
 - `no-proto`
+- `no-self-compare`
 - `no-sparse-arrays`
 - `no-unsafe-negation`
 - `no-void`

--- a/src/core.zig
+++ b/src/core.zig
@@ -33,6 +33,7 @@ pub const Options = struct {
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,
     no_proto: bool = true,
+    no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
     no_unsafe_negation: bool = true,
     no_void: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,6 +54,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new_wrappers = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
+            options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
@@ -219,6 +221,7 @@ fn printHelp() void {
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-proto=off            Disable no-proto
+        \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-void=off             Disable no-void

--- a/src/root.zig
+++ b/src/root.zig
@@ -878,6 +878,59 @@ test "can disable no-sparse-arrays" {
     try std.testing.expect(!hasRule(result, rules.no_sparse_arrays.id));
 }
 
+test "reports no-self-compare for equivalent comparison operands" {
+    const source =
+        \\value === value;
+        \\object.property != object.property;
+        \\(count) < count;
+        \\items[index] >= items[index];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), countRule(result, rules.no_self_compare.id));
+}
+
+test "does not report no-self-compare for different operands or non-comparison operators" {
+    const source =
+        \\value === other;
+        \\object.left === object.right;
+        \\value + value;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_self_compare.id));
+}
+
+test "can disable no-self-compare" {
+    const source =
+        \\value === value;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_self_compare = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_self_compare.id));
+}
+
 test "reports no-void for void unary expressions" {
     const source =
         \\void 0;

--- a/src/rules/no_self_compare.zig
+++ b/src/rules/no_self_compare.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-self-compare";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isComparisonOperator(expression.operator)) return;
+    if (!sameSource(tree, expression.left, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not compare a value to itself.",
+        tree.span(index),
+    );
+}
+
+fn isComparisonOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn sameSource(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    if (left == .null or right == .null) return false;
+
+    const left_span = tree.span(unwrapTransparent(tree, left));
+    const right_span = tree.span(unwrapTransparent(tree, right));
+
+    const left_start: usize = @intCast(left_span.start);
+    const left_end: usize = @intCast(left_span.end);
+    const right_start: usize = @intCast(right_span.start);
+    const right_end: usize = @intCast(right_span.end);
+
+    if (left_start >= left_end or right_start >= right_end) return false;
+    if (left_end > tree.source.len or right_end > tree.source.len) return false;
+
+    return std.mem.eql(u8, tree.source[left_start..left_end], tree.source[right_start..right_end]);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -23,6 +23,7 @@ pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_proto = @import("no_proto.zig");
+pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
@@ -194,6 +195,9 @@ const BasicVisitor = struct {
         }
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_self_compare) {
+            try no_self_compare.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_unsafe_negation) {
             try no_unsafe_negation.check(self.allocator, self.diagnostics, ctx.tree, expression, index);


### PR DESCRIPTION
## Summary
- port the no-self-compare lint rule
- add the rule option, CLI toggle, and README entry
- cover equal source operands, parenthesized operands, allowed different operands, non-comparison operators, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/ea8a9dbaa8effb20d0ada529b3ed2d21/test --cache-dir=./.zig-cache --seed=0x672de1eb
- zig build run -j1 -- --eqeqeq=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-self-compare.js
- zig build run -j1 -- --no-self-compare=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-self-compare-disabled.js

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 55 tests.