### PR TITLE
feat: port rule no-delete-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`
+- `no-delete-var`
 - `no-empty-block-statements`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,
+    no_delete_var: bool = true,
     no_empty_block_statements: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_comma_operator = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
+        } else if (std.mem.eql(u8, arg, "--no-delete-var=off")) {
+            options.no_delete_var = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -210,6 +212,7 @@ fn printHelp() void {
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
+        \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/root.zig
+++ b/src/root.zig
@@ -285,6 +285,56 @@ test "can disable no-caller" {
     try std.testing.expect(!hasRule(result, rules.no_caller.id));
 }
 
+test "reports no-delete-var for deleting identifiers" {
+    const source =
+        \\delete value;
+        \\delete undefined;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), countRule(result, rules.no_delete_var.id));
+}
+
+test "does not report no-delete-var for property deletion" {
+    const source =
+        \\delete object.value;
+        \\delete object["value"];
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_delete_var.id));
+}
+
+test "can disable no-delete-var" {
+    const source =
+        \\delete value;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_delete_var = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_delete_var.id));
+}
+
 test "reports no-empty-block-statements for empty blocks" {
     const source =
         \\if (ready) {}

--- a/src/rules/no_delete_var.zig
+++ b/src/rules/no_delete_var.zig
@@ -1,0 +1,36 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-delete-var";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .delete) return;
+    if (!isIdentifierReference(tree, expression.argument)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not delete variables.",
+        tree.span(index),
+    );
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
+pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
@@ -207,6 +208,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_delete_var) {
+            try no_delete_var.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_void) {
             try no_void.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }


### PR DESCRIPTION
## Summary
- port the no-delete-var lint rule
- add the rule option, CLI toggle, and README entry
- cover delete identifier, allowed property deletion, and disabled behavior in unit tests

## Test
- ./.zig-cache/o/646ed86027ca305163395ceee64c7897/test --cache-dir=./.zig-cache --seed=0x79b54a6e
- zig build run -j1 -- --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-delete-var.cjs
- zig build run -j1 -- --no-delete-var=off --no-console=off --no-unused-vars=off --no-undef=off --semantic-errors=off /tmp/no-delete-var-disabled.cjs

Note: zig build test compiled successfully, but the Zig build runner terminated in --listen mode; the generated test binary passed all 55 tests.