### PR TITLE
feat: port rule no-extra-boolean-cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-dupe-keys`
 - `no-delete-var`
 - `no-empty-block-statements`
+- `no-extra-boolean-cast`
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`

--- a/src/core.zig
+++ b/src/core.zig
@@ -27,6 +27,7 @@ pub const Options = struct {
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,
+    no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_delete_var = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
+        } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
+            options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-finite=off")) {
@@ -221,6 +223,7 @@ fn printHelp() void {
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
+        \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -451,6 +451,61 @@ test "can disable no-empty-block-statements" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!hasRule(result, rules.no_empty_block_statements.id));
+}
+
+test "reports no-extra-boolean-cast in boolean contexts" {
+    const source =
+        \\if (Boolean(value)) { use(value); }
+        \\while (!!value) { break; }
+        \\do { value++; } while (Boolean(value));
+        \\for (; !!value; value++) { break; }
+        \\const selected = Boolean(value) ? 1 : 2;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), countRule(result, rules.no_extra_boolean_cast.id));
+}
+
+test "does not report no-extra-boolean-cast outside boolean contexts or for shadowed Boolean" {
+    const source =
+        \\const a = Boolean(value);
+        \\const b = !!value;
+        \\function local(Boolean) {
+        \\  if (Boolean(value)) { use(value); }
+        \\}
+        \\if (!value) { use(value); }
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_extra_boolean_cast.id));
+}
+
+test "can disable no-extra-boolean-cast" {
+    const source =
+        \\if (Boolean(value)) { use(value); }
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_extra_boolean_cast = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_extra_boolean_cast.id));
 }
 
 test "reports no-alert for global alert APIs" {

--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -1,0 +1,168 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-extra-boolean-cast";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_if_statement(
+        self: *Visitor,
+        statement: ast.IfStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkBooleanContext(ctx.tree, statement.@"test");
+        return .proceed;
+    }
+
+    pub fn enter_while_statement(
+        self: *Visitor,
+        statement: ast.WhileStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkBooleanContext(ctx.tree, statement.@"test");
+        return .proceed;
+    }
+
+    pub fn enter_do_while_statement(
+        self: *Visitor,
+        statement: ast.DoWhileStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkBooleanContext(ctx.tree, statement.@"test");
+        return .proceed;
+    }
+
+    pub fn enter_for_statement(
+        self: *Visitor,
+        statement: ast.ForStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (statement.@"test" != .null) {
+            try self.checkBooleanContext(ctx.tree, statement.@"test");
+        }
+        return .proceed;
+    }
+
+    pub fn enter_conditional_expression(
+        self: *Visitor,
+        expression: ast.ConditionalExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkBooleanContext(ctx.tree, expression.@"test");
+        return .proceed;
+    }
+
+    fn checkBooleanContext(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        expression: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const unwrapped = unwrapTransparent(tree, expression);
+
+        if (isBooleanCall(tree, self.symbol_table, unwrapped) or isDoubleNegation(tree, unwrapped)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Redundant boolean cast in a boolean context.",
+                tree.span(unwrapped),
+            );
+        }
+    }
+};
+
+fn isBooleanCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const call = switch (tree.data(index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const callee = unwrapTransparent(tree, call.callee);
+    const name = identifierReferenceName(tree, callee) orelse return false;
+    return std.mem.eql(u8, name, "Boolean") and isUnresolvedReference(symbol_table, callee);
+}
+
+fn isDoubleNegation(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const outer = switch (tree.data(index)) {
+        .unary_expression => |unary| unary,
+        else => return false,
+    };
+    if (outer.operator != .logical_not) return false;
+
+    const inner_index = unwrapTransparent(tree, outer.argument);
+    const inner = switch (tree.data(inner_index)) {
+        .unary_expression => |unary| unary,
+        else => return false,
+    };
+    return inner.operator == .logical_not;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -17,6 +17,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
+pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
@@ -59,6 +60,10 @@ pub fn runSemantic(
 ) Allocator.Error!void {
     if (options.no_array_constructor) {
         try no_array_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_extra_boolean_cast) {
+        try no_extra_boolean_cast.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_alert) {


### PR DESCRIPTION
## Summary
- add no-extra-boolean-cast diagnostics for Boolean(...) and !!... in boolean contexts
- avoid reporting shadowed Boolean calls and non-boolean-context casts
- add CLI option, README entry, and focused tests

## Test
- zig fmt src/core.zig src/main.zig src/root.zig src/rules/root.zig src/rules/no_extra_boolean_cast.zig
- git diff --check
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1 (test runner was killed in --listen mode after compiling)
- ./.zig-cache/o/f1f2ef17bb9513a0b8d31982d19ac908/test
- CLI smoke for no-extra-boolean-cast and --no-extra-boolean-cast=off