### PR TITLE
feat: port rule no-constant-condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-array-constructor`
 - `no-caller`
 - `no-compare-neg-zero`
+- `no-constant-condition`
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,7 @@ pub const Options = struct {
     no_alert: bool = true,
     no_caller: bool = true,
     no_compare_neg_zero: bool = true,
+    no_constant_condition: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_caller = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
             options.no_compare_neg_zero = false;
+        } else if (std.mem.eql(u8, arg, "--no-constant-condition=off")) {
+            options.no_constant_condition = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
@@ -217,6 +219,7 @@ fn printHelp() void {
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
+        \\  --no-constant-condition=off Disable no-constant-condition
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger

--- a/src/root.zig
+++ b/src/root.zig
@@ -230,6 +230,59 @@ test "can disable no-with" {
     try std.testing.expect(!hasRule(result, rules.no_with.id));
 }
 
+test "reports no-constant-condition for constant boolean contexts" {
+    const source =
+        \\if ((true)) { use(); }
+        \\while ("ready") { break; }
+        \\do { break; } while (`ready`);
+        \\for (; /ready/; ) { break; }
+        \\const value = null ? 1 : 2;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), countRule(result, rules.no_constant_condition.id));
+}
+
+test "does not report no-constant-condition for dynamic conditions" {
+    const source =
+        \\if (ready) { use(); }
+        \\while (`${ready}`) { break; }
+        \\for (; ready; ) { break; }
+        \\const value = ready ? 1 : 2;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_constant_condition.id));
+}
+
+test "can disable no-constant-condition" {
+    const source =
+        \\if (false) { use(); }
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_constant_condition.id));
+}
+
 test "reports no-caller for arguments caller and callee access" {
     const source =
         \\function f() {

--- a/src/rules/no_constant_condition.zig
+++ b/src/rules/no_constant_condition.zig
@@ -1,0 +1,62 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-constant-condition";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+) Allocator.Error!void {
+    const unwrapped = unwrapTransparent(tree, expression);
+    if (!isConstantExpression(tree, unwrapped)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected constant condition.",
+        tree.span(unwrapped),
+    );
+}
+
+fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .boolean_literal,
+        .null_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .string_literal,
+        .regexp_literal,
+        .array_expression,
+        .object_expression,
+        .arrow_function_expression,
+        => true,
+        .template_literal => |literal| literal.expressions.len == 0,
+        .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
+        .class => |class| class.type == .class_expression,
+        .unary_expression => |unary| unary.operator == .logical_not and isConstantExpression(tree, unwrapTransparent(tree, unary.argument)),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -11,6 +11,7 @@ pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
+pub const no_constant_condition = @import("no_constant_condition.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
@@ -107,6 +108,66 @@ const BasicVisitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     options: core.Options,
+
+    pub fn enter_if_statement(
+        self: *BasicVisitor,
+        statement: ast.IfStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_constant_condition) {
+            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        return .proceed;
+    }
+
+    pub fn enter_while_statement(
+        self: *BasicVisitor,
+        statement: ast.WhileStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_constant_condition) {
+            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        return .proceed;
+    }
+
+    pub fn enter_do_while_statement(
+        self: *BasicVisitor,
+        statement: ast.DoWhileStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_constant_condition) {
+            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        return .proceed;
+    }
+
+    pub fn enter_for_statement(
+        self: *BasicVisitor,
+        statement: ast.ForStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_constant_condition and statement.@"test" != .null) {
+            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        return .proceed;
+    }
+
+    pub fn enter_conditional_expression(
+        self: *BasicVisitor,
+        expression: ast.ConditionalExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_constant_condition) {
+            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, expression.@"test");
+        }
+        return .proceed;
+    }
 
     pub fn enter_debugger_statement(
         self: *BasicVisitor,


### PR DESCRIPTION
## Summary
- add no-constant-condition diagnostics for static expressions in boolean contexts
- cover if, while, do while, for test, and conditional expression test positions
- add CLI option, README entry, and focused tests

## Test
- zig fmt src/core.zig src/main.zig src/root.zig src/rules/root.zig src/rules/no_constant_condition.zig
- git diff --check
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1 (test runner was killed in --listen mode after compiling)
- ./.zig-cache/o/318e5e2d88c5fec74240a745f815ff2e/test
- CLI smoke for no-constant-condition and --no-constant-condition=off