### PR TITLE
feat: port rule no-empty-character-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-dupe-keys`
 - `no-delete-var`
 - `no-empty-block-statements`
+- `no-empty-character-class`
 - `no-extra-boolean-cast`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -27,6 +27,7 @@ pub const Options = struct {
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,
+    no_empty_character_class: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_delete_var = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
+            options.no_empty_character_class = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -223,6 +225,7 @@ fn printHelp() void {
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
+        \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/root.zig
+++ b/src/root.zig
@@ -989,6 +989,57 @@ test "can disable no-proto" {
     try std.testing.expect(!hasRule(result, rules.no_proto.id));
 }
 
+test "reports no-empty-character-class for empty regex character classes" {
+    const source =
+        \\const first = /^abc[]/;
+        \\const second = /foo[]bar/;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), countRule(result, rules.no_empty_character_class.id));
+}
+
+test "does not report no-empty-character-class for escaped or negated classes" {
+    const source =
+        \\const escaped = /\[\]/;
+        \\const negated = /[^]/;
+        \\const non_empty = /[a-z]/;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_character_class.id));
+}
+
+test "can disable no-empty-character-class" {
+    const source =
+        \\const first = /^abc[]/;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_character_class = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_character_class.id));
+}
+
 test "reports no-regex-spaces for consecutive regex pattern spaces" {
     const source =
         \\const first = /foo  bar/;

--- a/src/rules/no_empty_character_class.zig
+++ b/src/rules/no_empty_character_class.zig
@@ -1,0 +1,50 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-empty-character-class";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasEmptyCharacterClass(tree.string(literal.pattern))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Empty character classes are not allowed.",
+        tree.span(index),
+    );
+}
+
+fn hasEmptyCharacterClass(pattern: []const u8) bool {
+    var escaped = false;
+    var index: usize = 0;
+
+    while (index < pattern.len) : (index += 1) {
+        const char = pattern[index];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+
+        if (char == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (char == '[' and index + 1 < pattern.len and pattern[index + 1] == ']') {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -17,6 +17,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
+pub const no_empty_character_class = @import("no_empty_character_class.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
@@ -297,6 +298,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_character_class) {
+            try no_empty_character_class.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
         if (self.options.no_regex_spaces) {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }


### PR DESCRIPTION
## Summary
- add no-empty-character-class diagnostics for empty regex character classes
- allow escaped brackets, non-empty classes, and negated [^] classes
- add CLI option, README entry, and focused tests

## Test
- zig fmt src/core.zig src/main.zig src/root.zig src/rules/root.zig src/rules/no_empty_character_class.zig
- git diff --check
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1 (test runner was killed in --listen mode after compiling)
- ./.zig-cache/o/4f0dc82cf670eed023b81266c7521b60/test
- CLI smoke for no-empty-character-class and --no-empty-character-class=off