### PR TITLE
feat: port rule no-duplicate-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-debugger`
 - `no-dupe-keys`
 - `no-delete-var`
+- `no-duplicate-case`
 - `no-empty-block-statements`
 - `no-empty-character-class`
 - `no-extra-boolean-cast`

--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,7 @@ pub const Options = struct {
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,
+    no_duplicate_case: bool = true,
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,6 +40,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_comma_operator = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
+        } else if (std.mem.eql(u8, arg, "--no-duplicate-case=off")) {
+            options.no_duplicate_case = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-keys=off")) {
             options.no_dupe_keys = false;
         } else if (std.mem.eql(u8, arg, "--no-delete-var=off")) {
@@ -228,6 +230,7 @@ fn printHelp() void {
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
+        \\  --no-duplicate-case=off   Disable no-duplicate-case
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements

--- a/src/root.zig
+++ b/src/root.zig
@@ -390,6 +390,79 @@ test "can disable no-caller" {
     try std.testing.expect(!hasRule(result, rules.no_caller.id));
 }
 
+test "reports no-duplicate-case for repeated switch case labels" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    break;
+        \\  case 2:
+        \\    break;
+        \\  case 1:
+        \\    break;
+        \\  case name:
+        \\    break;
+        \\  case name:
+        \\    break;
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), countRule(result, rules.no_duplicate_case.id));
+}
+
+test "does not report no-duplicate-case for distinct labels or default clauses" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    break;
+        \\  case "1":
+        \\    break;
+        \\  default:
+        \\    break;
+        \\}
+        \\switch (other) {
+        \\  case 1:
+        \\    break;
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_duplicate_case.id));
+}
+
+test "can disable no-duplicate-case" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    break;
+        \\  case 1:
+        \\    break;
+        \\}
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_duplicate_case = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_duplicate_case.id));
+}
+
 test "reports no-dupe-keys for duplicate object literal keys" {
     const source =
         \\const object = {

--- a/src/rules/no_duplicate_case.zig
+++ b/src/rules/no_duplicate_case.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-duplicate-case";
+
+const SeenCase = struct {
+    tag: std.meta.Tag(ast.NodeData),
+    source: []const u8,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+) Allocator.Error!void {
+    var seen: std.ArrayList(SeenCase) = .empty;
+    defer seen.deinit(allocator);
+
+    for (tree.extra(statement.cases)) |case_index| {
+        const switch_case = switch (tree.data(case_index)) {
+            .switch_case => |switch_case| switch_case,
+            else => continue,
+        };
+
+        if (switch_case.@"test" == .null) continue;
+
+        const tag = std.meta.activeTag(tree.data(switch_case.@"test"));
+        const source = nodeSource(tree, switch_case.@"test") orelse continue;
+
+        if (isDuplicate(seen.items, tag, source)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Duplicate case label.",
+                tree.span(case_index),
+            );
+        } else {
+            try seen.append(allocator, .{
+                .tag = tag,
+                .source = source,
+            });
+        }
+    }
+}
+
+fn isDuplicate(
+    seen: []const SeenCase,
+    tag: std.meta.Tag(ast.NodeData),
+    source: []const u8,
+) bool {
+    for (seen) |entry| {
+        if (entry.tag == tag and sourceEqual(entry.source, source)) return true;
+    }
+    return false;
+}
+
+fn nodeSource(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+
+    if (start >= end or end > tree.source.len) return null;
+    return std.mem.trim(u8, tree.source[start..end], " \t\r\n");
+}
+
+fn sourceEqual(left: []const u8, right: []const u8) bool {
+    return std.mem.eql(u8, left, right);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -16,6 +16,7 @@ pub const no_constant_condition = @import("no_constant_condition.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
+pub const no_duplicate_case = @import("no_duplicate_case.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
@@ -191,6 +192,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_debugger) {
             try no_debugger.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_switch_statement(
+        self: *BasicVisitor,
+        statement: ast.SwitchStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_duplicate_case) {
+            try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- add no-duplicate-case rule for repeated switch case labels
- expose the rule through options, CLI toggles, and rule registration
- add focused tests for reporting, allowed cases, and disabling the rule

## Tests
- zig build test -Doptimize=ReleaseFast -j1 (local runner terminated with signal KILL after compiling)
- ./.zig-cache/o/2de1a036f7a5591143f0e018c035e449/test --cache-dir=./.zig-cache --seed=0x1109797
- zig build -Doptimize=ReleaseFast -j1