### PR TITLE
feat: port rule no-control-regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-cond-assign`
 - `no-compare-neg-zero`
 - `no-constant-condition`
+- `no-control-regex`
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`

--- a/src/core.zig
+++ b/src/core.zig
@@ -23,6 +23,7 @@ pub const Options = struct {
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,
+    no_control_regex: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,
     no_debugger: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_compare_neg_zero = false;
         } else if (std.mem.eql(u8, arg, "--no-constant-condition=off")) {
             options.no_constant_condition = false;
+        } else if (std.mem.eql(u8, arg, "--no-control-regex=off")) {
+            options.no_control_regex = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
@@ -227,6 +229,7 @@ fn printHelp() void {
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition
+        \\  --no-control-regex=off   Disable no-control-regex
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger

--- a/src/root.zig
+++ b/src/root.zig
@@ -335,6 +335,56 @@ test "can disable no-constant-condition" {
     try std.testing.expect(!hasRule(result, rules.no_constant_condition.id));
 }
 
+test "reports no-control-regex for control characters in regex literals" {
+    const source =
+        \\const first = /\x1f/;
+        \\const second = /\u001f/;
+        \\const third = /\u{1f}/u;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), countRule(result, rules.no_control_regex.id));
+}
+
+test "does not report no-control-regex for printable regex escapes" {
+    const source =
+        \\const first = /\x20/;
+        \\const second = /\u0020/;
+        \\const third = /\cA/;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_control_regex.id));
+}
+
+test "can disable no-control-regex" {
+    const source =
+        \\const pattern = /\x1f/;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_control_regex = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_control_regex.id));
+}
+
 test "reports no-caller for arguments caller and callee access" {
     const source =
         \\function f() {

--- a/src/rules/no_control_regex.zig
+++ b/src/rules/no_control_regex.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-control-regex";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    var control_chars: std.ArrayList(u8) = .empty;
+    defer control_chars.deinit(allocator);
+
+    try collectControlChars(allocator, tree.string(literal.pattern), &control_chars);
+    if (control_chars.items.len == 0) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Unexpected control character(s) in regular expression: {s}.",
+        .{control_chars.items},
+    );
+}
+
+fn collectControlChars(
+    allocator: Allocator,
+    pattern: []const u8,
+    out: *std.ArrayList(u8),
+) Allocator.Error!void {
+    var index: usize = 0;
+    while (index < pattern.len) {
+        const char = pattern[index];
+
+        if (char < 0x20) {
+            try appendControlChar(allocator, out, char);
+            index += 1;
+            continue;
+        }
+
+        if (char == '\\' and index + 1 < pattern.len) {
+            switch (pattern[index + 1]) {
+                'x' => {
+                    if (index + 3 < pattern.len) {
+                        if (parseFixedHex(pattern[index + 2 .. index + 4])) |value| {
+                            if (value <= 0x1f) try appendControlChar(allocator, out, value);
+                        }
+                        index += 4;
+                        continue;
+                    }
+                },
+                'u' => {
+                    if (parseUnicodeEscape(pattern, &index)) |value| {
+                        if (value <= 0x1f) try appendControlChar(allocator, out, value);
+                        continue;
+                    }
+                },
+                else => {},
+            }
+        }
+
+        index += 1;
+    }
+}
+
+fn parseUnicodeEscape(pattern: []const u8, index: *usize) ?u8 {
+    const start = index.*;
+    if (start + 1 >= pattern.len or pattern[start] != '\\' or pattern[start + 1] != 'u') return null;
+
+    if (start + 2 < pattern.len and pattern[start + 2] == '{') {
+        var cursor = start + 3;
+        var value: u21 = 0;
+        var saw_digit = false;
+
+        while (cursor < pattern.len and pattern[cursor] != '}') : (cursor += 1) {
+            const digit = hexValue(pattern[cursor]) orelse return null;
+            saw_digit = true;
+            value = value * 16 + digit;
+            if (value > 0x10ffff) return null;
+        }
+
+        if (!saw_digit or cursor >= pattern.len or pattern[cursor] != '}') return null;
+
+        index.* = cursor + 1;
+        if (value <= 0xff) return @intCast(value);
+        return null;
+    }
+
+    if (start + 5 >= pattern.len) return null;
+    const value = parseFixedHex(pattern[start + 2 .. start + 6]) orelse return null;
+    index.* = start + 6;
+    return value;
+}
+
+fn parseFixedHex(bytes: []const u8) ?u8 {
+    var value: u16 = 0;
+    for (bytes) |byte| {
+        const digit = hexValue(byte) orelse return null;
+        value = value * 16 + digit;
+    }
+
+    if (value > 0xff) return null;
+    return @intCast(value);
+}
+
+fn hexValue(byte: u8) ?u8 {
+    return switch (byte) {
+        '0'...'9' => byte - '0',
+        'a'...'f' => byte - 'a' + 10,
+        'A'...'F' => byte - 'A' + 10,
+        else => null,
+    };
+}
+
+fn appendControlChar(
+    allocator: Allocator,
+    out: *std.ArrayList(u8),
+    value: u8,
+) Allocator.Error!void {
+    if (out.items.len > 0) try out.appendSlice(allocator, ", ");
+    const escaped = try std.fmt.allocPrint(allocator, "\\x{x:0>2}", .{value});
+    defer allocator.free(escaped);
+    try out.appendSlice(allocator, escaped);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -13,6 +13,7 @@ pub const no_caller = @import("no_caller.zig");
 pub const no_cond_assign = @import("no_cond_assign.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_constant_condition = @import("no_constant_condition.zig");
+pub const no_control_regex = @import("no_control_regex.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
@@ -385,6 +386,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_control_regex) {
+            try no_control_regex.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
         if (self.options.no_empty_character_class) {
             try no_empty_character_class.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }


### PR DESCRIPTION
## Summary
- add no-control-regex for control characters in regex literals
- expose the rule through options, CLI toggles, and rule registration
- add tests for reporting, allowed printable escapes, and disabling the rule

## Notes
- this ports regex literal coverage first, matching the current regex rule integration points

## Tests
- zig build test -Doptimize=ReleaseFast -j1 (local runner terminated with signal KILL after compiling)
- ./.zig-cache/o/41cf220095a36daa0ec1ec39482fdbd4/test --cache-dir=./.zig-cache --seed=0xa927a231
- zig build -Doptimize=ReleaseFast -j1