### PR TITLE
feat: port rule no-empty-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-duplicate-case`
 - `no-empty-block-statements`
 - `no-empty-character-class`
+- `no-empty-pattern`
 - `no-extra-boolean-cast`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,6 +32,7 @@ pub const Options = struct {
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
+    no_empty_pattern: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,6 +52,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
             options.no_empty_character_class = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-pattern=off")) {
+            options.no_empty_pattern = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -238,6 +240,7 @@ fn printHelp() void {
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
+        \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/root.zig
+++ b/src/root.zig
@@ -681,6 +681,60 @@ test "can disable no-empty-block-statements" {
     try std.testing.expect(!hasRule(result, rules.no_empty_block_statements.id));
 }
 
+test "reports no-empty-pattern for empty destructuring patterns" {
+    const source =
+        \\const {} = object;
+        \\const [] = list;
+        \\function first({}) {}
+        \\function second([]) {}
+        \\const { value: {} } = object;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), countRule(result, rules.no_empty_pattern.id));
+}
+
+test "does not report no-empty-pattern for non-empty destructuring patterns" {
+    const source =
+        \\const { value } = object;
+        \\const [value] = list;
+        \\const [...items] = list;
+        \\const { ...rest } = object;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_pattern.id));
+}
+
+test "can disable no-empty-pattern" {
+    const source =
+        \\const {} = object;
+        \\const [] = list;
+    ;
+
+    var result = try lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_pattern = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!hasRule(result, rules.no_empty_pattern.id));
+}
+
 test "reports no-extra-boolean-cast in boolean contexts" {
     const source =
         \\if (Boolean(value)) { use(value); }

--- a/src/rules/no_empty_pattern.zig
+++ b/src/rules/no_empty_pattern.zig
@@ -1,0 +1,49 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-empty-pattern";
+
+pub fn checkObjectPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (pattern.properties.len > 0 or pattern.rest != .null) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, "object");
+}
+
+pub fn checkArrayPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ArrayPattern,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (pattern.elements.len > 0 or pattern.rest != .null) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, "array");
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    pattern_type: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Unexpected empty {s} pattern.",
+        .{pattern_type},
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -22,6 +22,7 @@ pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
+pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
@@ -376,6 +377,30 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_object_pattern(
+        self: *BasicVisitor,
+        pattern: ast.ObjectPattern,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_pattern) {
+            try no_empty_pattern.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_array_pattern(
+        self: *BasicVisitor,
+        pattern: ast.ArrayPattern,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_empty_pattern) {
+            try no_empty_pattern.checkArrayPattern(self.allocator, self.diagnostics, ctx.tree, pattern, index);
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary
- add no-empty-pattern for empty object and array destructuring patterns
- expose the rule through options, CLI toggles, and rule registration
- add tests for reporting, non-empty patterns, and disabling the rule

## Tests
- zig build test -Doptimize=ReleaseFast -j1 (local runner terminated with signal KILL after compiling)
- ./.zig-cache/o/b11a91594e3f48ec193b3dfa80c09683/test --cache-dir=./.zig-cache --seed=0xfd531d11
- zig build -Doptimize=ReleaseFast -j1