### PR TITLE
feat: port rule use-isnan

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `eqeqeq`
 - `no-unused-vars`
 - `no-undef`
+- `use-isnan`
 - `parse` diagnostics from Yuku, including semantic early errors by default
 
 ## Prerequisites

--- a/src/core.zig
+++ b/src/core.zig
@@ -50,6 +50,7 @@ pub const Options = struct {
     no_with: bool = true,
     no_var: bool = true,
     eqeqeq: bool = true,
+    use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_undef: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,6 +88,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_var = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
             options.eqeqeq = false;
+        } else if (std.mem.eql(u8, arg, "--use-isnan=off")) {
+            options.use_isnan = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-vars=off")) {
             options.no_unused_vars = false;
         } else if (std.mem.eql(u8, arg, "--no-undef=off")) {
@@ -258,6 +260,7 @@ fn printHelp() void {
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --eqeqeq=off              Disable eqeqeq
+        \\  --use-isnan=off           Disable use-isnan
         \\  --no-unused-vars=off      Disable no-unused-vars
         \\  --no-undef=off            Disable no-undef
         \\  --semantic-errors=off     Disable parser semantic errors

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -41,6 +41,7 @@ pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
+pub const use_isnan = @import("use_isnan.zig");
 
 pub fn runBasic(
     allocator: Allocator,
@@ -299,6 +300,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unsafe_negation) {
             try no_unsafe_negation.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.use_isnan) {
+            try use_isnan.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/src/rules/use_isnan.zig
+++ b/src/rules/use_isnan.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "use-isnan";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isEqualityOperator(expression.operator)) return;
+    if (!isNaNReference(tree, expression.left) and !isNaNReference(tree, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use Number.isNaN or isNaN to compare with NaN.",
+        tree.span(index),
+    );
+}
+
+fn isEqualityOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isNaNReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "NaN"),
+        .chain_expression => |chain| isNaNReference(tree, chain.expression),
+        .parenthesized_expression => |parenthesized| isNaNReference(tree, parenthesized.expression),
+        else => false,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -137,3 +137,7 @@ comptime {
 comptime {
     _ = @import("rules/no_with.zig");
 }
+
+comptime {
+    _ = @import("rules/use_isnan.zig");
+}

--- a/tests/rules/use_isnan.zig
+++ b/tests/rules/use_isnan.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports use-isnan for equality comparisons with NaN" {
+    const source =
+        \\if (value == NaN) { use(value); }
+        \\if (NaN !== value) { use(value); }
+        \\if ((value) != (NaN)) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.use_isnan.id));
+}
+
+test "does not report use-isnan for non-equality comparisons or Number.isNaN" {
+    const source =
+        \\if (value > NaN) { use(value); }
+        \\if (Number.isNaN(value)) { use(value); }
+        \\if (isNaN(value)) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.use_isnan.id));
+}
+
+test "can disable use-isnan" {
+    const source =
+        \\if (value === NaN) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .use_isnan = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.use_isnan.id));
+}


### PR DESCRIPTION
## Summary
- add use-isnan for equality comparisons with NaN
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/use_isnan.zig

## Tests
- zig build test -Doptimize=ReleaseFast -j1 (local runner terminated with signal KILL after compiling)
- ./.zig-cache/o/82dc2f63dc8494d0caeb2e3a881b557a/test --cache-dir=./.zig-cache --seed=0x436d13fd
- zig build -Doptimize=ReleaseFast -j1