### PR TITLE
feat: port rule no-case-declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-alert`
 - `no-array-constructor`
 - `no-caller`
+- `no-case-declarations`
 - `no-cond-assign`
 - `no-compare-neg-zero`
 - `no-constant-condition`

--- a/src/core.zig
+++ b/src/core.zig
@@ -20,6 +20,7 @@ pub const Options = struct {
     no_array_constructor: bool = true,
     no_alert: bool = true,
     no_caller: bool = true,
+    no_case_declarations: bool = true,
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_alert = false;
         } else if (std.mem.eql(u8, arg, "--no-caller=off")) {
             options.no_caller = false;
+        } else if (std.mem.eql(u8, arg, "--no-case-declarations=off")) {
+            options.no_case_declarations = false;
         } else if (std.mem.eql(u8, arg, "--no-cond-assign=off")) {
             options.no_cond_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
@@ -230,6 +232,7 @@ fn printHelp() void {
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller
+        \\  --no-case-declarations=off Disable no-case-declarations
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition

--- a/src/rules/no_case_declarations.zig
+++ b/src/rules/no_case_declarations.zig
@@ -1,0 +1,36 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-case-declarations";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    switch_case: ast.SwitchCase,
+) Allocator.Error!void {
+    for (tree.extra(switch_case.consequent)) |statement_index| {
+        if (!isLexicalDeclaration(tree, statement_index)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Wrap lexical declarations in a block statement.",
+            tree.span(statement_index),
+        );
+    }
+}
+
+fn isLexicalDeclaration(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .variable_declaration => |declaration| declaration.kind != .@"var",
+        .function => |function| function.type == .function_declaration or function.type == .ts_declare_function,
+        .class => |class| class.type == .class_declaration,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -10,6 +10,7 @@ pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
+pub const no_case_declarations = @import("no_case_declarations.zig");
 pub const no_cond_assign = @import("no_cond_assign.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_constant_condition = @import("no_constant_condition.zig");
@@ -207,6 +208,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_duplicate_case) {
             try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_switch_case(
+        self: *BasicVisitor,
+        switch_case: ast.SwitchCase,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_case_declarations) {
+            try no_case_declarations.check(self.allocator, self.diagnostics, ctx.tree, switch_case);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -15,6 +15,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_case_declarations.zig");
+}
+
+comptime {
     _ = @import("rules/no_comma_operator.zig");
 }
 

--- a/tests/rules/no_case_declarations.zig
+++ b/tests/rules/no_case_declarations.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-case-declarations for lexical declarations in switch cases" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    let first = value;
+        \\    break;
+        \\  case 2:
+        \\    const second = value;
+        \\    break;
+        \\  default:
+        \\    class Local {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_case_declarations.id));
+}
+
+test "does not report no-case-declarations for var or blocked declarations" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    var first = value;
+        \\    break;
+        \\  case 2: {
+        \\    const second = value;
+        \\    break;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_case_declarations.id));
+}
+
+test "can disable no-case-declarations" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    const first = value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_case_declarations = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_case_declarations.id));
+}


### PR DESCRIPTION
## Summary
- add no-case-declarations for lexical declarations directly inside switch cases
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_case_declarations.zig

## Tests
- zig build test -Doptimize=ReleaseFast -j1 (local runner terminated with signal KILL after compiling)
- ./.zig-cache/o/7954137ca9a96abd17e74e169540c738/test --cache-dir=./.zig-cache --seed=0xecbb7d96
- zig build -Doptimize=ReleaseFast -j1