### PR TITLE
feat: port rule no-unsafe-finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-regex-spaces`
 - `no-self-compare`
 - `no-sparse-arrays`
+- `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-void`
 - `no-with`

--- a/src/core.zig
+++ b/src/core.zig
@@ -46,6 +46,7 @@ pub const Options = struct {
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
+    no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,6 +80,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
+        } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
+            options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -258,6 +260,7 @@ fn printHelp() void {
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
+        \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/rules/no_unsafe_finally.zig
+++ b/src/rules/no_unsafe_finally.zig
@@ -1,0 +1,89 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-unsafe-finally";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.TryStatement,
+) Allocator.Error!void {
+    if (statement.finalizer == .null) return;
+
+    try scanNode(allocator, diagnostics, tree, statement.finalizer);
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .return_statement,
+        .throw_statement,
+        .break_statement,
+        .continue_statement,
+        => try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Control flow statements in finally blocks are unsafe.",
+            tree.span(index),
+        ),
+        .block_statement => |block| try scanRange(allocator, diagnostics, tree, block.body),
+        .static_block => |block| try scanRange(allocator, diagnostics, tree, block.body),
+        .if_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.consequent);
+            try scanNode(allocator, diagnostics, tree, statement.alternate);
+        },
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const switch_case = switch (tree.data(case_index)) {
+                    .switch_case => |switch_case| switch_case,
+                    else => continue,
+                };
+                try scanRange(allocator, diagnostics, tree, switch_case.consequent);
+            }
+        },
+        .for_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .for_in_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .for_of_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .do_while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .with_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .labeled_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .try_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.block);
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return,
+                };
+                try scanNode(allocator, diagnostics, tree, handler.body);
+            }
+        },
+        .function,
+        .class,
+        => return,
+        else => return,
+    }
+}
+
+fn scanRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+) Allocator.Error!void {
+    for (tree.extra(range)) |child| {
+        try scanNode(allocator, diagnostics, tree, child);
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -36,6 +36,7 @@ pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
+pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
@@ -220,6 +221,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_case_declarations) {
             try no_case_declarations.check(self.allocator, self.diagnostics, ctx.tree, switch_case);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_try_statement(
+        self: *BasicVisitor,
+        statement: ast.TryStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_unsafe_finally) {
+            try no_unsafe_finally.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -119,6 +119,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unsafe_finally.zig");
+}
+
+comptime {
     _ = @import("rules/no_unsafe_negation.zig");
 }
 

--- a/tests/rules/no_unsafe_finally.zig
+++ b/tests/rules/no_unsafe_finally.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unsafe-finally for control flow in finally blocks" {
+    const source =
+        \\function one() {
+        \\  try { use(); } finally { return 1; }
+        \\}
+        \\function two() {
+        \\  try { use(); } finally { if (ready) { throw error; } }
+        \\}
+        \\function three() {
+        \\  while (ready) {
+        \\    try { use(); } finally { break; }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_unsafe_finally.id));
+}
+
+test "does not report no-unsafe-finally for nested function control flow" {
+    const source =
+        \\function outer() {
+        \\  try { use(); } finally {
+        \\    function inner() {
+        \\      return 1;
+        \\    }
+        \\    class Local {
+        \\      method() {
+        \\        return 2;
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_finally.id));
+}
+
+test "reports no-unsafe-finally once for nested finally blocks" {
+    const source =
+        \\function outer() {
+        \\  try { use(); } finally {
+        \\    try { use(); } finally { return 1; }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unsafe_finally.id));
+}
+
+test "can disable no-unsafe-finally" {
+    const source =
+        \\function f() {
+        \\  try { use(); } finally { return 1; }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unsafe_finally = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_finally.id));
+}


### PR DESCRIPTION
## Summary
- add no-unsafe-finally for control flow statements inside finally blocks
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_unsafe_finally.zig

## Tests
- ./.zig-cache/o/e759ccdde9e7ba50bff512ebcc588c57/test --cache-dir=./.zig-cache --seed=0xf2c933d4
- zig build -Doptimize=ReleaseFast -j1