### PR TITLE
feat: port rule no-useless-catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-sparse-arrays`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
+- `no-useless-catch`
 - `no-void`
 - `no-with`
 - `no-var`

--- a/src/core.zig
+++ b/src/core.zig
@@ -48,6 +48,7 @@ pub const Options = struct {
     no_sparse_arrays: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
+    no_useless_catch: bool = true,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,6 +84,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
+            options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -262,6 +264,7 @@ fn printHelp() void {
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
+        \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/rules/no_useless_catch.zig
+++ b/src/rules/no_useless_catch.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-catch";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    clause: ast.CatchClause,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (clause.param == .null) return;
+
+    const parameter_name = bindingName(tree, clause.param) orelse return;
+    const body = switch (tree.data(clause.body)) {
+        .block_statement => |body| body,
+        else => return,
+    };
+    if (body.body.len != 1) return;
+
+    const statement_index = tree.extra(body.body)[0];
+    const thrown = switch (tree.data(statement_index)) {
+        .throw_statement => |statement| statement.argument,
+        else => return,
+    };
+
+    if (!isIdentifierReference(tree, thrown, parameter_name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary catch clause.",
+        tree.span(index),
+    );
+}
+
+fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .chain_expression => |chain| isIdentifierReference(tree, chain.expression, name),
+        .parenthesized_expression => |parenthesized| isIdentifierReference(tree, parenthesized.expression, name),
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -39,6 +39,7 @@ pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
+pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
@@ -233,6 +234,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_unsafe_finally) {
             try no_unsafe_finally.check(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_catch_clause(
+        self: *BasicVisitor,
+        clause: ast.CatchClause,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_useless_catch) {
+            try no_useless_catch.check(self.allocator, self.diagnostics, ctx.tree, clause, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -127,6 +127,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_catch.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_vars.zig");
 }
 

--- a/tests/rules/no_useless_catch.zig
+++ b/tests/rules/no_useless_catch.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-catch for catch clauses that only rethrow" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  throw error;
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch (reason) {
+        \\  throw (reason);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_catch.id));
+}
+
+test "does not report no-useless-catch for useful catch clauses" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  report(error);
+        \\  throw error;
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  throw wrap(error);
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch {
+        \\  throw error;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_catch.id));
+}
+
+test "can disable no-useless-catch" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  throw error;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_catch = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_catch.id));
+}


### PR DESCRIPTION
## Summary
- add no-useless-catch for catch clauses that only rethrow the caught error
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_useless_catch.zig

## Tests
- ./.zig-cache/o/814c89da467694f620ff43cb851ba209/root --seed=0x884e7c12
- zig build -Doptimize=ReleaseFast -j1