### PR TITLE
feat: port rule no-else-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-block-statements`
 - `no-empty-character-class`
 - `no-empty-pattern`
+- `no-else-return`
 - `no-extra-boolean-cast`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -34,6 +34,7 @@ pub const Options = struct {
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_pattern: bool = true,
+    no_else_return: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,6 +56,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_character_class = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-pattern=off")) {
             options.no_empty_pattern = false;
+        } else if (std.mem.eql(u8, arg, "--no-else-return=off")) {
+            options.no_else_return = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -250,6 +252,7 @@ fn printHelp() void {
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-pattern=off  Disable no-empty-pattern
+        \\  --no-else-return=off    Disable no-else-return
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/rules/no_else_return.zig
+++ b/src/rules/no_else_return.zig
@@ -1,0 +1,50 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-else-return";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+) Allocator.Error!void {
+    if (statement.alternate == .null) return;
+    if (!alwaysExits(tree, statement.consequent)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary else after return.",
+        tree.span(statement.alternate),
+    );
+}
+
+fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .return_statement,
+        .throw_statement,
+        .break_statement,
+        .continue_statement,
+        => true,
+        .block_statement => |block| blockAlwaysExits(tree, block),
+        .if_statement => |statement| statement.alternate != .null and
+            alwaysExits(tree, statement.consequent) and
+            alwaysExits(tree, statement.alternate),
+        else => false,
+    };
+}
+
+fn blockAlwaysExits(tree: *const ast.Tree, block: ast.BlockStatement) bool {
+    if (block.body.len == 0) return false;
+
+    const statements = tree.extra(block.body);
+    return alwaysExits(tree, statements[statements.len - 1]);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -24,6 +24,7 @@ pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
 pub const no_empty_pattern = @import("no_empty_pattern.zig");
+pub const no_else_return = @import("no_else_return.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
@@ -129,6 +130,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_constant_condition) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        if (self.options.no_else_return) {
+            try no_else_return.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -71,6 +71,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_else_return.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_boolean_cast.zig");
 }
 

--- a/tests/rules/no_else_return.zig
+++ b/tests/rules/no_else_return.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-else-return after returning consequent" {
+    const source =
+        \\function first(value) {
+        \\  if (value) {
+        \\    return 1;
+        \\  } else {
+        \\    return 2;
+        \\  }
+        \\}
+        \\function second(value) {
+        \\  if (value) throw error;
+        \\  else return 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_else_return.id));
+}
+
+test "does not report no-else-return when consequent can continue" {
+    const source =
+        \\function first(value) {
+        \\  if (value) {
+        \\    use(value);
+        \\  } else {
+        \\    return 2;
+        \\  }
+        \\}
+        \\function second(value) {
+        \\  if (value) return 1;
+        \\  return 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_else_return.id));
+}
+
+test "can disable no-else-return" {
+    const source =
+        \\function first(value) {
+        \\  if (value) return 1;
+        \\  else return 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_else_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_else_return.id));
+}


### PR DESCRIPTION
## Summary
- add no-else-return for unnecessary else branches after exiting consequents
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_else_return.zig

## Tests
- ./.zig-cache/o/76dff74b007a76ace30c5d0493ba7319/root --seed=0xb30da77f
- zig build -Doptimize=ReleaseFast -j1