### PR TITLE
feat: port rule no-labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-labels`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -39,6 +39,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_labels: bool = true,
     no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
+            options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -257,6 +259,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-labels=off           Disable no-labels
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_labels.zig
+++ b/src/rules/no_labels.zig
@@ -1,0 +1,23 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-labels";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Labels are not allowed.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_labels = @import("no_labels.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -250,6 +251,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_catch) {
             try no_useless_catch.check(self.allocator, self.diagnostics, ctx.tree, clause, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_labeled_statement(
+        self: *BasicVisitor,
+        _: ast.LabeledStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_labels) {
+            try no_labels.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -91,6 +91,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_labels.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_labels.zig
+++ b/tests/rules/no_labels.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-labels for labeled statements" {
+    const source =
+        \\start:
+        \\for (const item of items) {
+        \\  if (item) break start;
+        \\}
+        \\done:
+        \\use(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_labels.id));
+}
+
+test "does not report no-labels for unlabeled loops" {
+    const source =
+        \\for (const item of items) {
+        \\  if (item) break;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_labels.id));
+}
+
+test "can disable no-labels" {
+    const source =
+        \\start:
+        \\for (const item of items) {
+        \\  if (item) break start;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_labels = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_labels.id));
+}


### PR DESCRIPTION
## Summary
- add no-labels for labeled statements
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_labels.zig

## Tests
- ./.zig-cache/o/4e4dd4c3fb70fa39bad66e692ecd1334/root --seed=0x202fa6f1
- zig build -Doptimize=ReleaseFast -j1