### PR TITLE
feat: port rule no-lone-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-labels`
+- `no-lone-blocks`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -40,6 +40,7 @@ pub const Options = struct {
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_labels: bool = true,
+    no_lone_blocks: bool = true,
     no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -68,6 +68,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_nan = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
             options.no_labels = false;
+        } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
+            options.no_lone_blocks = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -260,6 +262,7 @@ fn printHelp() void {
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-labels=off           Disable no-labels
+        \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_lone_blocks.zig
+++ b/src/rules/no_lone_blocks.zig
@@ -1,0 +1,59 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-lone-blocks";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.BlockStatement,
+    index: ast.NodeIndex,
+    parent: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isStatementListParent(tree.data(parent))) return;
+    if (hasBlockScopedBinding(tree, block)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Block is unnecessary.",
+        tree.span(index),
+    );
+}
+
+fn isStatementListParent(data: ast.NodeData) bool {
+    return switch (data) {
+        .program,
+        .block_statement,
+        .switch_case,
+        => true,
+        else => false,
+    };
+}
+
+fn hasBlockScopedBinding(tree: *const ast.Tree, block: ast.BlockStatement) bool {
+    const statements = tree.extra(block.body);
+    for (statements) |statement| {
+        switch (tree.data(statement)) {
+            .variable_declaration => |declaration| switch (declaration.kind) {
+                .@"var" => {},
+                .let, .@"const", .using, .await_using => return true,
+            },
+            .class => |class| {
+                if (class.type == .class_declaration) return true;
+            },
+            .function => |function| {
+                if (function.type == .function_declaration) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_labels = @import("no_labels.zig");
+pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -285,6 +286,11 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_lone_blocks) {
+            if (ctx.path.parent()) |parent| {
+                try no_lone_blocks.check(self.allocator, self.diagnostics, ctx.tree, block, index, parent);
+            }
+        }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -95,6 +95,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_lone_blocks.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_lone_blocks.zig
+++ b/tests/rules/no_lone_blocks.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-lone-blocks for unnecessary block statements" {
+    const source =
+        \\{
+        \\  run();
+        \\}
+        \\if (ready) {
+        \\  {
+        \\    run();
+        \\  }
+        \\}
+        \\switch (value) {
+        \\  case 1:
+        \\    {
+        \\      run();
+        \\    }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_lone_blocks.id));
+}
+
+test "does not report no-lone-blocks for scoped declarations" {
+    const source =
+        \\{
+        \\  let value = getValue();
+        \\  use(value);
+        \\}
+        \\{
+        \\  const value = getValue();
+        \\  use(value);
+        \\}
+        \\{
+        \\  class Scoped {}
+        \\  use(Scoped);
+        \\}
+        \\{
+        \\  function scoped() {}
+        \\  use(scoped);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lone_blocks.id));
+}
+
+test "does not report no-lone-blocks for structured statement bodies" {
+    const source =
+        \\if (ready) { run(); } else { stop(); }
+        \\while (ready) { run(); }
+        \\for (let i = 0; i < 1; i++) { run(); }
+        \\try { run(); } catch (error) { handle(error); } finally { cleanup(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lone_blocks.id));
+}
+
+test "can disable no-lone-blocks" {
+    const source =
+        \\{
+        \\  run();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_lone_blocks = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lone_blocks.id));
+}


### PR DESCRIPTION
## Summary
- add no-lone-blocks for unnecessary standalone block statements
- allow block-scoped declaration blocks and structured statement bodies
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_lone_blocks.zig

## Tests
- ./.zig-cache/o/b3b84176dda7e3fffd8f85df7f7d9da5/root --seed=0x24bf2b4
- zig build -Doptimize=ReleaseFast -j1