### PR TITLE
feat: port rule no-multi-str

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-nan`
 - `no-labels`
 - `no-lone-blocks`
+- `no-multi-str`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -41,6 +41,7 @@ pub const Options = struct {
     no_global_is_nan: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,
+    no_multi_str: bool = true,
     no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,6 +70,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
             options.no_lone_blocks = false;
+        } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
+            options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -263,6 +265,7 @@ fn printHelp() void {
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
+        \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_multi_str.zig
+++ b/src/rules/no_multi_str.zig
@@ -1,0 +1,53 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-multi-str";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasLineContinuation(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Multiline strings are not allowed.",
+        tree.span(index),
+    );
+}
+
+fn hasLineContinuation(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    var offset: usize = 0;
+    while (offset < source.len) : (offset += 1) {
+        if (source[offset] != '\\' or offset + 1 >= source.len) continue;
+
+        switch (source[offset + 1]) {
+            '\n', '\r' => return true,
+            0xE2 => {
+                if (offset + 3 >= source.len) continue;
+                if (source[offset + 2] == 0x80 and
+                    (source[offset + 3] == 0xA8 or source[offset + 3] == 0xA9))
+                {
+                    return true;
+                }
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -31,6 +31,7 @@ pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
+pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -341,6 +342,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_var) {
             try no_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_string_literal(
+        self: *BasicVisitor,
+        _: ast.StringLiteral,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_multi_str) {
+            try no_multi_str.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_multi_str.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_multi_str.zig
+++ b/tests/rules/no_multi_str.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-multi-str for string line continuations" {
+    const source =
+        "const first = 'line \\\n" ++
+        "continued';\n" ++
+        "const second = \"line \\\r\n" ++
+        "continued\";\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_multi_str.id));
+}
+
+test "does not report no-multi-str for escaped newline sequences or template literals" {
+    const source =
+        \\const escaped = "line\ncontinued";
+        \\const template = `line
+        \\continued`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_str.id));
+}
+
+test "can disable no-multi-str" {
+    const source =
+        "const value = 'line \\\n" ++
+        "continued';\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multi_str = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_str.id));
+}


### PR DESCRIPTION
## Summary
- add no-multi-str for string literal line continuations
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_multi_str.zig

## Tests
- ./.zig-cache/o/2c35fe7f63aed52eb2b9110833a41a8a/root --seed=0x10c7c443
- zig build -Doptimize=ReleaseFast -j1