### PR TITLE
feat: port rule no-throw-literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-regex-spaces`
 - `no-self-compare`
 - `no-sparse-arrays`
+- `no-throw-literal`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-useless-catch`

--- a/src/core.zig
+++ b/src/core.zig
@@ -50,6 +50,7 @@ pub const Options = struct {
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
+    no_throw_literal: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_useless_catch: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,6 +88,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
+        } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
+            options.no_throw_literal = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
@@ -274,6 +276,7 @@ fn printHelp() void {
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
+        \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-catch=off    Disable no-useless-catch

--- a/src/rules/no_throw_literal.zig
+++ b/src/rules/no_throw_literal.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-throw-literal";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ThrowStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isInvalidThrowArgument(tree, unwrapTransparent(tree, statement.argument))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected an error object to be thrown.",
+        tree.span(index),
+    );
+}
+
+fn isInvalidThrowArgument(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .template_literal,
+        => true,
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .binary_expression => |expression| expression.operator == .add,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -40,6 +40,7 @@ pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
+pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_undef = @import("no_undef.zig");
@@ -253,6 +254,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_catch) {
             try no_useless_catch.check(self.allocator, self.diagnostics, ctx.tree, clause, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_throw_statement(
+        self: *BasicVisitor,
+        statement: ast.ThrowStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_throw_literal) {
+            try no_throw_literal.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -135,6 +135,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_throw_literal.zig");
+}
+
+comptime {
     _ = @import("rules/no_unsafe_finally.zig");
 }
 

--- a/tests/rules/no_throw_literal.zig
+++ b/tests/rules/no_throw_literal.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-throw-literal for literal throw arguments" {
+    const source =
+        \\throw "error";
+        \\throw 1;
+        \\throw true;
+        \\throw null;
+        \\throw undefined;
+        \\throw `error`;
+        \\throw "prefix " + error;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_throw_literal.id));
+}
+
+test "does not report no-throw-literal for error objects or references" {
+    const source =
+        \\throw new Error("boom");
+        \\throw error;
+        \\throw getError();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_throw_literal.id));
+}
+
+test "can disable no-throw-literal" {
+    const source =
+        \\throw "error";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_throw_literal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_throw_literal.id));
+}


### PR DESCRIPTION
## Summary
- add no-throw-literal for literal throw arguments
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_throw_literal.zig

## Tests
- ./.zig-cache/o/582d81bde36b18d6c2f8f89693b467b6/root --seed=0x64cd02c4
- zig build -Doptimize=ReleaseFast -j1