### PR TITLE
feat: port rule no-octal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-object`
 - `no-new-symbol`
 - `no-new-wrappers`
+- `no-octal`
 - `no-proto`
 - `no-regex-spaces`
 - `no-self-compare`

--- a/src/core.zig
+++ b/src/core.zig
@@ -46,6 +46,7 @@ pub const Options = struct {
     no_new_object: bool = true,
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,
+    no_octal: bool = true,
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,6 +80,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new_symbol = false;
         } else if (std.mem.eql(u8, arg, "--no-new-wrappers=off")) {
             options.no_new_wrappers = false;
+        } else if (std.mem.eql(u8, arg, "--no-octal=off")) {
+            options.no_octal = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -272,6 +274,7 @@ fn printHelp() void {
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers
+        \\  --no-octal=off            Disable no-octal
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare

--- a/src/rules/no_octal.zig
+++ b/src/rules/no_octal.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-octal";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.NumericLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isLegacyOctal(tree, literal)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Octal literals should not be used.",
+        tree.span(index),
+    );
+}
+
+fn isLegacyOctal(tree: *const ast.Tree, literal: ast.NumericLiteral) bool {
+    if (literal.kind != .octal) return false;
+
+    const raw = tree.string(literal.raw);
+    if (raw.len < 2) return false;
+
+    return !std.mem.startsWith(u8, raw, "0o") and
+        !std.mem.startsWith(u8, raw, "0O");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -36,6 +36,7 @@ pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
+pub const no_octal = @import("no_octal.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
@@ -367,6 +368,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_multi_str) {
             try no_multi_str.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_numeric_literal(
+        self: *BasicVisitor,
+        literal: ast.NumericLiteral,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_octal) {
+            try no_octal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -119,6 +119,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_octal.zig");
+}
+
+comptime {
     _ = @import("rules/no_proto.zig");
 }
 

--- a/tests/rules/no_octal.zig
+++ b/tests/rules/no_octal.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-octal for legacy octal numeric literals" {
+    const source =
+        \\const value = 071;
+        \\const other = 0123;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_octal.id));
+}
+
+test "does not report no-octal for modern octal or decimal literals" {
+    const source =
+        \\const modern = 0o71;
+        \\const upper = 0O71;
+        \\const decimal = 71;
+        \\const zero = 0;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_octal.id));
+}
+
+test "can disable no-octal" {
+    const source =
+        \\const value = 071;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_octal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_octal.id));
+}


### PR DESCRIPTION
## Summary
- add no-octal for legacy octal numeric literals
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_octal.zig

## Tests
- ./.zig-cache/o/e0a9bba2b30f4ef18e135761b79e2330/root --seed=0x66d929f5
- zig build -Doptimize=ReleaseFast -j1