### PR TITLE
feat: port rule no-octal-escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-symbol`
 - `no-new-wrappers`
 - `no-octal`
+- `no-octal-escape`
 - `no-proto`
 - `no-regex-spaces`
 - `no-self-compare`

--- a/src/core.zig
+++ b/src/core.zig
@@ -47,6 +47,7 @@ pub const Options = struct {
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,
     no_octal: bool = true,
+    no_octal_escape: bool = true,
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -82,6 +82,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new_wrappers = false;
         } else if (std.mem.eql(u8, arg, "--no-octal=off")) {
             options.no_octal = false;
+        } else if (std.mem.eql(u8, arg, "--no-octal-escape=off")) {
+            options.no_octal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -275,6 +277,7 @@ fn printHelp() void {
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-octal=off            Disable no-octal
+        \\  --no-octal-escape=off     Disable no-octal-escape
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare

--- a/src/rules/no_octal_escape.zig
+++ b/src/rules/no_octal_escape.zig
@@ -1,0 +1,58 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-octal-escape";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasOctalEscape(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Octal escape sequences should not be used.",
+        tree.span(index),
+    );
+}
+
+fn hasOctalEscape(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    var offset: usize = 0;
+    while (offset < source.len) {
+        if (source[offset] != '\\' or offset + 1 >= source.len) {
+            offset += 1;
+            continue;
+        }
+
+        const escaped = source[offset + 1];
+        if (isOctalDigit(escaped) and (escaped != '0' or isNextOctalDigit(source, offset + 2))) {
+            return true;
+        }
+
+        offset += 2;
+    }
+
+    return false;
+}
+
+fn isNextOctalDigit(source: []const u8, offset: usize) bool {
+    return offset < source.len and isOctalDigit(source[offset]);
+}
+
+fn isOctalDigit(byte: u8) bool {
+    return byte >= '0' and byte <= '7';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -37,6 +37,7 @@ pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
+pub const no_octal_escape = @import("no_octal_escape.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
@@ -368,6 +369,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_multi_str) {
             try no_multi_str.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.no_octal_escape) {
+            try no_octal_escape.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -123,6 +123,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_octal_escape.zig");
+}
+
+comptime {
     _ = @import("rules/no_proto.zig");
 }
 

--- a/tests/rules/no_octal_escape.zig
+++ b/tests/rules/no_octal_escape.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-octal-escape for octal string escape sequences" {
+    const source =
+        \\const first = "\251";
+        \\const second = "\07";
+        \\const third = "\00";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_octal_escape.id));
+}
+
+test "does not report no-octal-escape for null or escaped backslash sequences" {
+    const source =
+        \\const nul = "\0";
+        \\const escapedBackslash = "\\1";
+        \\const hex = "\xA9";
+        \\const unicode = "\u00A9";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_octal_escape.id));
+}
+
+test "can disable no-octal-escape" {
+    const source =
+        \\const value = "\251";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_octal_escape = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_octal_escape.id));
+}


### PR DESCRIPTION
## Summary
- add no-octal-escape for octal string escape sequences
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_octal_escape.zig

## Tests
- ./.zig-cache/o/2c1ddecdbf6eb213a065edf0f03adc65/root --seed=0xf53125cd
- zig build -Doptimize=ReleaseFast -j1