### PR TITLE
feat: port rule no-plusplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-wrappers`
 - `no-octal`
 - `no-octal-escape`
+- `no-plusplus`
 - `no-proto`
 - `no-regex-spaces`
 - `no-self-compare`

--- a/src/core.zig
+++ b/src/core.zig
@@ -48,6 +48,7 @@ pub const Options = struct {
     no_new_wrappers: bool = true,
     no_octal: bool = true,
     no_octal_escape: bool = true,
+    no_plusplus: bool = true,
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,6 +84,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_octal = false;
         } else if (std.mem.eql(u8, arg, "--no-octal-escape=off")) {
             options.no_octal_escape = false;
+        } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
+            options.no_plusplus = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -278,6 +280,7 @@ fn printHelp() void {
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-octal=off            Disable no-octal
         \\  --no-octal-escape=off     Disable no-octal-escape
+        \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare

--- a/src/rules/no_plusplus.zig
+++ b/src/rules/no_plusplus.zig
@@ -1,0 +1,23 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-plusplus";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unary operator '++' or '--' used.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -38,6 +38,7 @@ pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
 pub const no_octal_escape = @import("no_octal_escape.zig");
+pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
@@ -423,6 +424,18 @@ const BasicVisitor = struct {
         }
         if (self.options.no_void) {
             try no_void.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *BasicVisitor,
+        _: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_plusplus) {
+            try no_plusplus.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -127,6 +127,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_plusplus.zig");
+}
+
+comptime {
     _ = @import("rules/no_proto.zig");
 }
 

--- a/tests/rules/no_plusplus.zig
+++ b/tests/rules/no_plusplus.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-plusplus for increment and decrement operators" {
+    const source =
+        \\let index = 0;
+        \\index++;
+        \\++index;
+        \\index--;
+        \\--index;
+        \\for (let i = 0; i < 3; i++) {
+        \\  run(i);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_plusplus.id));
+}
+
+test "does not report no-plusplus for compound assignments" {
+    const source =
+        \\let index = 0;
+        \\index += 1;
+        \\index -= 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_plusplus.id));
+}
+
+test "can disable no-plusplus" {
+    const source =
+        \\let index = 0;
+        \\index++;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_plusplus.id));
+}


### PR DESCRIPTION
## Summary
- add no-plusplus for increment and decrement operators
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_plusplus.zig

## Tests
- ./.zig-cache/o/6be550f74d9ee1b965439139dea590de/root --seed=0x36d7500c
- zig build -Doptimize=ReleaseFast -j1