### PR TITLE
feat: port rule no-ternary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-regex-spaces`
 - `no-self-compare`
 - `no-sparse-arrays`
+- `no-ternary`
 - `no-throw-literal`
 - `no-unsafe-finally`
 - `no-unsafe-negation`

--- a/src/core.zig
+++ b/src/core.zig
@@ -53,6 +53,7 @@ pub const Options = struct {
     no_regex_spaces: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
+    no_ternary: bool = true,
     no_throw_literal: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -94,6 +94,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
+        } else if (std.mem.eql(u8, arg, "--no-ternary=off")) {
+            options.no_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
@@ -285,6 +287,7 @@ fn printHelp() void {
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
+        \\  --no-ternary=off          Disable no-ternary
         \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation

--- a/src/rules/no_ternary.zig
+++ b/src/rules/no_ternary.zig
@@ -1,0 +1,23 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-ternary";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Ternary operators are not allowed.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -43,6 +43,7 @@ pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
+pub const no_ternary = @import("no_ternary.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
@@ -192,11 +193,14 @@ const BasicVisitor = struct {
     pub fn enter_conditional_expression(
         self: *BasicVisitor,
         expression: ast.ConditionalExpression,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_constant_condition) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, expression.@"test");
+        }
+        if (self.options.no_ternary) {
+            try no_ternary.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -147,6 +147,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_ternary.zig");
+}
+
+comptime {
     _ = @import("rules/no_throw_literal.zig");
 }
 

--- a/tests/rules/no_ternary.zig
+++ b/tests/rules/no_ternary.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-ternary for conditional expressions" {
+    const source =
+        \\const value = ready ? a : b;
+        \\const nested = first ? second ? a : b : c;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_ternary.id));
+}
+
+test "does not report no-ternary for if statements" {
+    const source =
+        \\if (ready) {
+        \\  use(a);
+        \\} else {
+        \\  use(b);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_ternary.id));
+}
+
+test "can disable no-ternary" {
+    const source =
+        \\const value = ready ? a : b;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_ternary.id));
+}


### PR DESCRIPTION
## Summary
- add no-ternary for conditional expressions
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_ternary.zig

## Tests
- ./.zig-cache/o/e8af08a6a26f9507bfb40304d5fa566e/root --seed=0x14a224e7
- zig build -Doptimize=ReleaseFast -j1