### PR TITLE
feat: port rule no-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-labels`
 - `no-lone-blocks`
 - `no-multi-str`
+- `no-new`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -42,6 +42,7 @@ pub const Options = struct {
     no_labels: bool = true,
     no_lone_blocks: bool = true,
     no_multi_str: bool = true,
+    no_new: bool = true,
     no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,6 +72,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_lone_blocks = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
+        } else if (std.mem.eql(u8, arg, "--no-new=off")) {
+            options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -276,6 +278,7 @@ fn printHelp() void {
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-multi-str=off        Disable no-multi-str
+        \\  --no-new=off              Disable no-new
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_new.zig
+++ b/src/rules/no_new.zig
@@ -1,0 +1,26 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-new";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    parent: ast.NodeIndex,
+) Allocator.Error!void {
+    if (tree.data(parent) != .expression_statement) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not use 'new' for side effects.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -32,6 +32,7 @@ pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
+pub const no_new = @import("no_new.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -464,6 +465,20 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_console) {
             try no_console.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *BasicVisitor,
+        _: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_new) {
+            if (ctx.path.parent()) |parent| {
+                try no_new.check(self.allocator, self.diagnostics, ctx.tree, index, parent);
+            }
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -103,6 +103,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_new.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_new.zig
+++ b/tests/rules/no_new.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-new for constructor calls used as statements" {
+    const source =
+        \\new Widget();
+        \\new namespace.Widget(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_new.id));
+}
+
+test "does not report no-new when constructed values are used" {
+    const source =
+        \\const widget = new Widget();
+        \\returnValue(new Widget());
+        \\function makeWidget() {
+        \\  return new Widget();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new.id));
+}
+
+test "can disable no-new" {
+    const source =
+        \\new Widget();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new.id));
+}


### PR DESCRIPTION
## Summary
- add no-new for constructor calls used only as expression statements
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_new.zig

## Tests
- ./.zig-cache/o/f0b335a367b03bfd72c9fbf07a10b148/root --seed=0x6627819a
- zig build -Doptimize=ReleaseFast -j1