### PR TITLE
feat: port rule no-nested-ternary

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-lone-blocks`
 - `no-multi-str`
 - `no-new`
+- `no-nested-ternary`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -43,6 +43,7 @@ pub const Options = struct {
     no_lone_blocks: bool = true,
     no_multi_str: bool = true,
     no_new: bool = true,
+    no_nested_ternary: bool = true,
     no_new_func: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -74,6 +74,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
             options.no_new = false;
+        } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
+            options.no_nested_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -279,6 +281,7 @@ fn printHelp() void {
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new=off              Disable no-new
+        \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_nested_ternary.zig
+++ b/src/rules/no_nested_ternary.zig
@@ -1,0 +1,57 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-nested-ternary";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasNestedTernary(tree, expression)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Nested ternary expressions are not allowed.",
+        tree.span(index),
+    );
+}
+
+fn hasNestedTernary(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {
+    return subtreeHasConditionalExpression(tree, expression.@"test") or
+        subtreeHasConditionalExpression(tree, expression.consequent) or
+        subtreeHasConditionalExpression(tree, expression.alternate);
+}
+
+fn subtreeHasConditionalExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    switch (tree.data(index)) {
+        .conditional_expression => return true,
+        inline else => |node| {
+            const Node = @TypeOf(node);
+            if (@typeInfo(Node) != .@"struct") return false;
+
+            inline for (@typeInfo(Node).@"struct".fields) |field| {
+                if (field.type == ast.NodeIndex) {
+                    if (subtreeHasConditionalExpression(tree, @field(node, field.name))) return true;
+                } else if (field.type == ast.IndexRange) {
+                    const range = @field(node, field.name);
+                    for (tree.extra(range)) |child| {
+                        if (subtreeHasConditionalExpression(tree, child)) return true;
+                    }
+                }
+            }
+        },
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -33,6 +33,7 @@ pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
+pub const no_nested_ternary = @import("no_nested_ternary.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -199,6 +200,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_constant_condition) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, expression.@"test");
+        }
+        if (self.options.no_nested_ternary) {
+            try no_nested_ternary.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_ternary) {
             try no_ternary.check(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -107,6 +107,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_nested_ternary.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_nested_ternary.zig
+++ b/tests/rules/no_nested_ternary.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-nested-ternary for conditional expressions inside branches" {
+    const source =
+        \\const first = foo ? bar ? a : b : c;
+        \\const second = foo ? a : bar ? b : c;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_nested_ternary.id));
+}
+
+test "does not report no-nested-ternary for simple conditional expressions" {
+    const source =
+        \\const value = ready ? a : b;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_nested_ternary.id));
+}
+
+test "can disable no-nested-ternary" {
+    const source =
+        \\const value = foo ? bar ? a : b : c;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_nested_ternary = false,
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_nested_ternary.id));
+}


### PR DESCRIPTION
## Summary
- add no-nested-ternary for conditional expressions containing another conditional expression
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_nested_ternary.zig

## Tests
- ./.zig-cache/o/192c830f8ea40a11d3a89eaf5192ce1a/root --seed=0xecbe7a46
- zig build -Doptimize=ReleaseFast -j1