### PR TITLE
feat: port rule no-lonely-if

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-nan`
 - `no-labels`
 - `no-lone-blocks`
+- `no-lonely-if`
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -41,6 +41,7 @@ pub const Options = struct {
     no_global_is_nan: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,
+    no_lonely_if: bool = true,
     no_multi_str: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,6 +70,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
             options.no_lone_blocks = false;
+        } else if (std.mem.eql(u8, arg, "--no-lonely-if=off")) {
+            options.no_lonely_if = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
@@ -279,6 +281,7 @@ fn printHelp() void {
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
+        \\  --no-lonely-if=off        Disable no-lonely-if
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary

--- a/src/rules/no_lonely_if.zig
+++ b/src/rules/no_lonely_if.zig
@@ -1,0 +1,41 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-lonely-if";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+) Allocator.Error!void {
+    const lonely_if = lonelyIf(tree, statement) orelse return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected if as the only statement in an else block.",
+        tree.span(lonely_if),
+    );
+}
+
+fn lonelyIf(tree: *const ast.Tree, statement: ast.IfStatement) ?ast.NodeIndex {
+    if (statement.alternate == .null) return null;
+
+    const block = switch (tree.data(statement.alternate)) {
+        .block_statement => |block| block,
+        else => return null,
+    };
+    if (block.body.len != 1) return null;
+
+    const child = tree.extra(block.body)[0];
+    return switch (tree.data(child)) {
+        .if_statement => child,
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -31,6 +31,7 @@ pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
+pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
@@ -143,6 +144,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_else_return) {
             try no_else_return.check(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
+        if (self.options.no_lonely_if) {
+            try no_lonely_if.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_lonely_if.zig");
+}
+
+comptime {
     _ = @import("rules/no_multi_str.zig");
 }
 

--- a/tests/rules/no_lonely_if.zig
+++ b/tests/rules/no_lonely_if.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-lonely-if for if as only else block statement" {
+    const source =
+        \\if (first) {
+        \\  runFirst();
+        \\} else {
+        \\  if (second) {
+        \\    runSecond();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_else_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_lonely_if.id));
+}
+
+test "does not report no-lonely-if when else block has multiple statements" {
+    const source =
+        \\if (first) {
+        \\  runFirst();
+        \\} else {
+        \\  prepare();
+        \\  if (second) {
+        \\    runSecond();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lonely_if.id));
+}
+
+test "can disable no-lonely-if" {
+    const source =
+        \\if (first) {
+        \\  runFirst();
+        \\} else {
+        \\  if (second) {
+        \\    runSecond();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_lonely_if = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lonely_if.id));
+}


### PR DESCRIPTION
## Summary
- add no-lonely-if for if statements that are the only statement in an else block
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_lonely_if.zig

## Tests
- ./.zig-cache/o/7f0aabc135a7c5aa3fa11d8954e8904b/root --seed=0xf1774305
- zig build -Doptimize=ReleaseFast -j1