### PR TITLE
feat: port rule default-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
+- `default-case`
 - `no-alert`
 - `no-array-constructor`
 - `no-caller`

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    default_case: bool = true,
     no_array_constructor: bool = true,
     no_alert: bool = true,
     no_caller: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,8 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
+        } else if (std.mem.eql(u8, arg, "--default-case=off")) {
+            options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
             options.no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
@@ -257,6 +259,7 @@ fn printHelp() void {
         \\  utoo-lint [options] [file-or-directory ...]
         \\
         \\Options:
+        \\  --default-case=off        Disable default-case
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller

--- a/src/rules/default_case.zig
+++ b/src/rules/default_case.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "default-case";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (hasDefaultCase(tree, statement)) return;
+    if (hasNoDefaultComment(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected a default case.",
+        tree.span(index),
+    );
+}
+
+fn hasDefaultCase(tree: *const ast.Tree, statement: ast.SwitchStatement) bool {
+    for (tree.extra(statement.cases)) |case_index| {
+        const switch_case = switch (tree.data(case_index)) {
+            .switch_case => |switch_case| switch_case,
+            else => continue,
+        };
+        if (switch_case.@"test" == .null) return true;
+    }
+
+    return false;
+}
+
+fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return false;
+
+    return std.mem.indexOf(u8, tree.source[start..end], "no default") != null;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -6,6 +6,7 @@ const ast = parser.ast;
 const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
+pub const default_case = @import("default_case.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
@@ -229,9 +230,12 @@ const BasicVisitor = struct {
     pub fn enter_switch_statement(
         self: *BasicVisitor,
         statement: ast.SwitchStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.default_case) {
+            try default_case.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
         if (self.options.no_duplicate_case) {
             try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1,4 +1,8 @@
 comptime {
+    _ = @import("rules/default_case.zig");
+}
+
+comptime {
     _ = @import("rules/eqeqeq.zig");
 }
 

--- a/tests/rules/default_case.zig
+++ b/tests/rules/default_case.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports default-case for switch statements without default" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    runOne();
+        \\    break;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.default_case.id));
+}
+
+test "does not report default-case when default exists or comment opts out" {
+    const source =
+        \\switch (first) {
+        \\  case 1:
+        \\    runOne();
+        \\    break;
+        \\  default:
+        \\    runDefault();
+        \\}
+        \\switch (second) {
+        \\  // no default
+        \\  case 1:
+        \\    runOne();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_case.id));
+}
+
+test "can disable default-case" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    runOne();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .default_case = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_case.id));
+}


### PR DESCRIPTION
## Summary
- add default-case for switch statements without a default branch
- allow no default comments in switch statements
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/default_case.zig

## Tests
- ./.zig-cache/o/89edfa04d3e090679f76da62a75c4b7f/root --seed=0xa9f6dad1
- zig build -Doptimize=ReleaseFast -j1