### PR TITLE
feat: port rule default-case-last

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
 - `default-case`
+- `default-case-last`
 - `no-alert`
 - `no-array-constructor`
 - `no-caller`

--- a/src/core.zig
+++ b/src/core.zig
@@ -18,6 +18,7 @@ pub const Severity = enum {
 
 pub const Options = struct {
     default_case: bool = true,
+    default_case_last: bool = true,
     no_array_constructor: bool = true,
     no_alert: bool = true,
     no_caller: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,8 @@ pub fn main(init: std.process.Init) !void {
             return;
         } else if (std.mem.eql(u8, arg, "--default-case=off")) {
             options.default_case = false;
+        } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
+            options.default_case_last = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
             options.no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
@@ -260,6 +262,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --default-case=off        Disable default-case
+        \\  --default-case-last=off   Disable default-case-last
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller

--- a/src/rules/default_case_last.zig
+++ b/src/rules/default_case_last.zig
@@ -1,0 +1,37 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "default-case-last";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+) Allocator.Error!void {
+    var default_case: ast.NodeIndex = .null;
+
+    for (tree.extra(statement.cases)) |case_index| {
+        const switch_case = switch (tree.data(case_index)) {
+            .switch_case => |switch_case| switch_case,
+            else => continue,
+        };
+
+        if (switch_case.@"test" == .null) {
+            default_case = case_index;
+        } else if (default_case != .null) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Default case should be the last case.",
+                tree.span(default_case),
+            );
+            return;
+        }
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -7,6 +7,7 @@ const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const default_case = @import("default_case.zig");
+pub const default_case_last = @import("default_case_last.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
@@ -235,6 +236,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.default_case) {
             try default_case.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        if (self.options.default_case_last) {
+            try default_case_last.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         if (self.options.no_duplicate_case) {
             try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -3,6 +3,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/default_case_last.zig");
+}
+
+comptime {
     _ = @import("rules/eqeqeq.zig");
 }
 

--- a/tests/rules/default_case_last.zig
+++ b/tests/rules/default_case_last.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports default-case-last when default is before another case" {
+    const source =
+        \\switch (value) {
+        \\  default:
+        \\    runDefault();
+        \\    break;
+        \\  case 1:
+        \\    runOne();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .default_case = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.default_case_last.id));
+}
+
+test "does not report default-case-last when default is last or absent" {
+    const source =
+        \\switch (first) {
+        \\  case 1:
+        \\    runOne();
+        \\    break;
+        \\  default:
+        \\    runDefault();
+        \\}
+        \\switch (second) {
+        \\  case 1:
+        \\    runOne();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .default_case = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_case_last.id));
+}
+
+test "can disable default-case-last" {
+    const source =
+        \\switch (value) {
+        \\  default:
+        \\    runDefault();
+        \\  case 1:
+        \\    runOne();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .default_case = false,
+        .default_case_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_case_last.id));
+}


### PR DESCRIPTION
## Summary
- add default-case-last for default cases that appear before another case
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/default_case_last.zig

## Tests
- ./.zig-cache/o/4957693e61ec07a5483f6caacd5de87c/root --seed=0x14fd5f36
- zig build -Doptimize=ReleaseFast -j1