### PR TITLE
feat: port rule no-useless-concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-throw-literal`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
+- `no-useless-concat`
 - `no-useless-catch`
 - `no-void`
 - `no-with`

--- a/src/core.zig
+++ b/src/core.zig
@@ -62,6 +62,7 @@ pub const Options = struct {
     no_throw_literal: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
+    no_useless_concat: bool = true,
     no_useless_catch: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,6 +112,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
+            options.no_useless_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
             options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -306,6 +308,7 @@ fn printHelp() void {
         \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
+        \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/rules/no_useless_concat.zig
+++ b/src/rules/no_useless_concat.zig
@@ -1,0 +1,70 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-useless-concat";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .add) return;
+    if (!isStringLikeLiteral(tree, expression.left)) return;
+    if (!isStringLikeLiteral(tree, expression.right)) return;
+    if (!sameLine(tree, expression.left, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected string literal concatenation.",
+        tree.span(index),
+    );
+}
+
+fn isStringLikeLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => true,
+        .template_literal => |template| template.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn sameLine(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_span = tree.span(unwrapTransparent(tree, left));
+    const right_span = tree.span(unwrapTransparent(tree, right));
+    const left_end: usize = @intCast(left_span.end);
+    const right_start: usize = @intCast(right_span.start);
+    if (left_end > right_start or right_start > tree.source.len) return false;
+
+    return !containsLineTerminator(tree.source[left_end..right_start]);
+}
+
+fn containsLineTerminator(source: []const u8) bool {
+    for (source) |byte| {
+        if (byte == '\n' or byte == '\r') return true;
+    }
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -52,6 +52,7 @@ pub const no_ternary = @import("no_ternary.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
+pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
@@ -430,6 +431,9 @@ const BasicVisitor = struct {
         }
         if (self.options.use_isnan) {
             try use_isnan.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_useless_concat) {
+            try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -183,6 +183,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_concat.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_catch.zig");
 }
 

--- a/tests/rules/no_useless_concat.zig
+++ b/tests/rules/no_useless_concat.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-concat for same line string literal concatenation" {
+    const source =
+        \\const first = "foo" + "bar";
+        \\const second = `foo` + "bar";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_concat.id));
+}
+
+test "does not report no-useless-concat for dynamic or multiline concatenation" {
+    const source =
+        \\const dynamic = "foo" + value;
+        \\const templated = `foo ${value}` + "bar";
+        \\const multiline = "foo" +
+        \\  "bar";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_concat.id));
+}
+
+test "can disable no-useless-concat" {
+    const source =
+        \\const value = "foo" + "bar";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_concat = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_concat.id));
+}


### PR DESCRIPTION
## Summary
- add no-useless-concat for same line string literal concatenation
- expose the rule through options, CLI toggles, and rule registration
- add focused tests in tests/rules/no_useless_concat.zig

## Tests
- ./.zig-cache/o/4e5b6e92997e2ff0372a8b2e8150aa53/root --seed=0xbaadc536
- zig build -Doptimize=ReleaseFast -j1