### PR TITLE
feat: port rule no-unneeded-ternary

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-sparse-arrays`
 - `no-ternary`
 - `no-throw-literal`
+- `no-unneeded-ternary`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-useless-concat`

--- a/src/core.zig
+++ b/src/core.zig
@@ -60,6 +60,7 @@ pub const Options = struct {
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,
     no_throw_literal: bool = true,
+    no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_useless_concat: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,6 +108,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
+        } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
+            options.no_unneeded_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
@@ -306,6 +308,7 @@ fn printHelp() void {
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-throw-literal=off    Disable no-throw-literal
+        \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-concat=off   Disable no-useless-concat

--- a/src/rules/no_unneeded_ternary.zig
+++ b/src/rules/no_unneeded_ternary.zig
@@ -1,0 +1,51 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-unneeded-ternary";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const consequent = booleanLiteralValue(tree, expression.consequent) orelse return;
+    const alternate = booleanLiteralValue(tree, expression.alternate) orelse return;
+    if (consequent == alternate) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary use of boolean literals in conditional expression.",
+        tree.span(index),
+    );
+}
+
+fn booleanLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?bool {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .boolean_literal => |literal| literal.value,
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -50,6 +50,7 @@ pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
+pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
@@ -210,6 +211,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_nested_ternary) {
             try no_nested_ternary.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_unneeded_ternary) {
+            try no_unneeded_ternary.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_ternary) {
             try no_ternary.check(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -175,6 +175,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unneeded_ternary.zig");
+}
+
+comptime {
     _ = @import("rules/no_unsafe_finally.zig");
 }
 

--- a/tests/rules/no_unneeded_ternary.zig
+++ b/tests/rules/no_unneeded_ternary.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unneeded-ternary for boolean literal branches" {
+    const source =
+        \\const first = enabled ? true : false;
+        \\const second = enabled ? false : true;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "does not report no-unneeded-ternary for non-boolean branches or default assignments" {
+    const source =
+        \\const first = enabled ? value : fallback;
+        \\const second = enabled ? enabled : fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "can disable no-unneeded-ternary" {
+    const source =
+        \\const value = enabled ? true : false;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unneeded_ternary = false,
+        .no_ternary = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unneeded_ternary.id));
+}


### PR DESCRIPTION
## Summary
- add the no-unneeded-ternary rule for boolean literal ternary branches
- add a CLI toggle and list the rule in the README
- add focused tests in tests/rules/no_unneeded_ternary.zig

## Test
- .zig-cache/o/46c3611125a3c5bf1668c34b16fa86cd/root --seed=0xd3977fb7
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-unneeded-ternary