### PR TITLE
feat: port rule no-return-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-plusplus`
 - `no-proto`
 - `no-regex-spaces`
+- `no-return-assign`
 - `no-self-compare`
 - `no-sparse-arrays`
 - `no-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -56,6 +56,7 @@ pub const Options = struct {
     no_plusplus: bool = true,
     no_proto: bool = true,
     no_regex_spaces: bool = true,
+    no_return_assign: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -100,6 +100,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
+        } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
+            options.no_return_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
@@ -304,6 +306,7 @@ fn printHelp() void {
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
+        \\  --no-return-assign=off    Disable no-return-assign
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary

--- a/src/rules/no_return_assign.zig
+++ b/src/rules/no_return_assign.zig
@@ -1,0 +1,75 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-return-assign";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+) Allocator.Error!void {
+    const assignment = findUnparenthesizedAssignment(tree, expression) orelse return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Return statement should not contain assignment.",
+        tree.span(assignment),
+    );
+}
+
+fn findUnparenthesizedAssignment(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+
+    switch (tree.data(index)) {
+        .parenthesized_expression => return null,
+        .assignment_expression => return index,
+        .chain_expression => |chain| return findUnparenthesizedAssignment(tree, chain.expression),
+        .binary_expression => |expression| {
+            if (findUnparenthesizedAssignment(tree, expression.left)) |assignment| return assignment;
+            return findUnparenthesizedAssignment(tree, expression.right);
+        },
+        .logical_expression => |expression| {
+            if (findUnparenthesizedAssignment(tree, expression.left)) |assignment| return assignment;
+            return findUnparenthesizedAssignment(tree, expression.right);
+        },
+        .unary_expression => |expression| return findUnparenthesizedAssignment(tree, expression.argument),
+        .conditional_expression => |expression| {
+            if (findUnparenthesizedAssignment(tree, expression.@"test")) |assignment| return assignment;
+            if (findUnparenthesizedAssignment(tree, expression.consequent)) |assignment| return assignment;
+            return findUnparenthesizedAssignment(tree, expression.alternate);
+        },
+        .sequence_expression => |expression| {
+            for (tree.extra(expression.expressions)) |item| {
+                if (findUnparenthesizedAssignment(tree, item)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .call_expression => |call| {
+            if (findUnparenthesizedAssignment(tree, call.callee)) |assignment| return assignment;
+            for (tree.extra(call.arguments)) |argument| {
+                if (findUnparenthesizedAssignment(tree, argument)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .new_expression => |new| {
+            if (findUnparenthesizedAssignment(tree, new.callee)) |assignment| return assignment;
+            for (tree.extra(new.arguments)) |argument| {
+                if (findUnparenthesizedAssignment(tree, argument)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .member_expression => |member| {
+            if (findUnparenthesizedAssignment(tree, member.object)) |assignment| return assignment;
+            if (member.computed) return findUnparenthesizedAssignment(tree, member.property);
+            return null;
+        },
+        else => return null,
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -46,6 +46,7 @@ pub const no_octal_escape = @import("no_octal_escape.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
+pub const no_return_assign = @import("no_return_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
@@ -299,6 +300,18 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
+    pub fn enter_return_statement(
+        self: *BasicVisitor,
+        statement: ast.ReturnStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_return_assign) {
+            try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);
+        }
+        return .proceed;
+    }
+
     pub fn enter_labeled_statement(
         self: *BasicVisitor,
         _: ast.LabeledStatement,
@@ -411,6 +424,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_octal) {
             try no_octal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *BasicVisitor,
+        expression: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_return_assign and expression.expression) {
+            try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, expression.body);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -159,6 +159,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_return_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_self_compare.zig");
 }
 

--- a/tests/rules/no_return_assign.zig
+++ b/tests/rules/no_return_assign.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-return-assign for returned assignments" {
+    const source =
+        \\function update(value, next) {
+        \\  return value = next;
+        \\}
+        \\const assign = (value, next) => value += next;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_assign.id));
+}
+
+test "does not report no-return-assign for comparisons or parenthesized assignments" {
+    const source =
+        \\function compare(value, next) {
+        \\  return value === next;
+        \\}
+        \\function update(value, next) {
+        \\  return (value = next);
+        \\}
+        \\const assign = (value, next) => (value += next);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_return_assign.id));
+}
+
+test "can disable no-return-assign" {
+    const source =
+        \\function update(value, next) {
+        \\  return value = next;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_return_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_return_assign.id));
+}


### PR DESCRIPTION
## Summary
- add the no-return-assign rule for return statements and concise arrow bodies
- add a CLI toggle and list the rule in the README
- add focused tests in tests/rules/no_return_assign.zig

## Test
- .zig-cache/o/f67b263fdebc3625910bdceb56c1ca0e/root --seed=0x3c34cc4
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-return-assign