### PR TITLE
feat: port rule no-self-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-proto`
 - `no-regex-spaces`
 - `no-return-assign`
+- `no-self-assign`
 - `no-self-compare`
 - `no-sparse-arrays`
 - `no-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -57,6 +57,7 @@ pub const Options = struct {
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_return_assign: bool = true,
+    no_self_assign: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
             options.no_return_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-self-assign=off")) {
+            options.no_self_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
@@ -307,6 +309,7 @@ fn printHelp() void {
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-assign=off    Disable no-return-assign
+        \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary

--- a/src/rules/no_self_assign.zig
+++ b/src/rules/no_self_assign.zig
@@ -1,0 +1,117 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-self-assign";
+
+const Reference = union(enum) {
+    this,
+    identifier: []const u8,
+    member: struct {
+        object: *const Reference,
+        property: []const u8,
+    },
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isSelfAssignOperator(expression.operator)) return;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
+    const right = (try referenceFromExpression(arena_allocator, tree, expression.right)) orelse return;
+    if (!referencesEqual(left, right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Self-assignment has no effect.",
+        tree.span(index),
+    );
+}
+
+fn isSelfAssignOperator(operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .assign,
+        .logical_or_assign,
+        .logical_and_assign,
+        .nullish_assign,
+        => true,
+        else => false,
+    };
+}
+
+fn referenceFromExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!?*const Reference {
+    if (index == .null) return null;
+
+    switch (tree.data(index)) {
+        .identifier_reference => |identifier| return try newReference(allocator, .{ .identifier = tree.string(identifier.name) }),
+        .this_expression => return newReference(allocator, .this),
+        .chain_expression => |chain| return try referenceFromExpression(allocator, tree, chain.expression),
+        .parenthesized_expression => |parenthesized| return try referenceFromExpression(allocator, tree, parenthesized.expression),
+        .member_expression => |member| {
+            const object = (try referenceFromExpression(allocator, tree, member.object)) orelse return null;
+            const property = propertyName(tree, member) orelse return null;
+            return try newReference(allocator, .{ .member = .{
+                .object = object,
+                .property = property,
+            } });
+        },
+        else => return null,
+    }
+}
+
+fn newReference(allocator: Allocator, reference: Reference) Allocator.Error!*const Reference {
+    const owned = try allocator.create(Reference);
+    owned.* = reference;
+    return owned;
+}
+
+fn referencesEqual(left: *const Reference, right: *const Reference) bool {
+    switch (left.*) {
+        .this => return right.* == .this,
+        .identifier => |left_name| return switch (right.*) {
+            .identifier => |right_name| std.mem.eql(u8, left_name, right_name),
+            else => false,
+        },
+        .member => |left_member| return switch (right.*) {
+            .member => |right_member| std.mem.eql(u8, left_member.property, right_member.property) and
+                referencesEqual(left_member.object, right_member.object),
+            else => false,
+        },
+    }
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .identifier_reference => |identifier| tree.string(identifier.name),
+            .string_literal => |literal| tree.string(literal.value),
+            .numeric_literal => |literal| tree.string(literal.raw),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -47,6 +47,7 @@ pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
+pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
@@ -436,6 +437,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, expression.body);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *BasicVisitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_self_assign) {
+            try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -163,6 +163,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_self_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_self_compare.zig");
 }
 

--- a/tests/rules/no_self_assign.zig
+++ b/tests/rules/no_self_assign.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-self-assign for equivalent assignment references" {
+    const source =
+        \\foo = foo;
+        \\foo ||= foo;
+        \\object.value = object.value;
+        \\this.value = this["value"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_self_assign.id));
+}
+
+test "does not report no-self-assign for different references or effectful objects" {
+    const source =
+        \\foo = bar;
+        \\foo += foo;
+        \\object.value = object.other;
+        \\getObject().value = getObject().value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_self_assign.id));
+}
+
+test "can disable no-self-assign" {
+    const source =
+        \\foo = foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_self_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_self_assign.id));
+}


### PR DESCRIPTION
## Summary
- add the no-self-assign rule for equivalent assignment references
- add a CLI toggle and list the rule in the README
- add focused tests in tests/rules/no_self_assign.zig

## Test
- .zig-cache/o/1568b4e9fa7bb82dcb4c05d4e24d40c8/root --seed=0x55ada398
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-self-assign