### PR TITLE
feat: port rule no-script-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-proto`
 - `no-regex-spaces`
 - `no-return-assign`
+- `no-script-url`
 - `no-self-assign`
 - `no-self-compare`
 - `no-sparse-arrays`

--- a/src/core.zig
+++ b/src/core.zig
@@ -57,6 +57,7 @@ pub const Options = struct {
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_return_assign: bool = true,
+    no_script_url: bool = true,
     no_self_assign: bool = true,
     no_self_compare: bool = true,
     no_sparse_arrays: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
             options.no_return_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-script-url=off")) {
+            options.no_script_url = false;
         } else if (std.mem.eql(u8, arg, "--no-self-assign=off")) {
             options.no_self_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
@@ -309,6 +311,7 @@ fn printHelp() void {
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-assign=off    Disable no-return-assign
+        \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays

--- a/src/rules/no_script_url.zig
+++ b/src/rules/no_script_url.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-script-url";
+
+pub fn checkStringLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.StringLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isScriptUrl(tree.string(literal.value))) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkTemplateLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.TemplateLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (literal.expressions.len != 0) return;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return;
+
+    const quasi = tree.data(quasis[0]).template_element;
+    if (quasi.is_cooked_undefined) return;
+    if (!isScriptUrl(tree.string(quasi.cooked))) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Script URL is a form of eval.",
+        tree.span(index),
+    );
+}
+
+fn isScriptUrl(value: []const u8) bool {
+    return startsWithIgnoreAsciiCase(value, "javascript:");
+}
+
+fn startsWithIgnoreAsciiCase(value: []const u8, prefix: []const u8) bool {
+    if (value.len < prefix.len) return false;
+
+    for (prefix, 0..) |expected, index| {
+        if (std.ascii.toLower(value[index]) != expected) return false;
+    }
+    return true;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -47,6 +47,7 @@ pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
+pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
@@ -404,15 +405,30 @@ const BasicVisitor = struct {
 
     pub fn enter_string_literal(
         self: *BasicVisitor,
-        _: ast.StringLiteral,
+        literal: ast.StringLiteral,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_script_url) {
+            try no_script_url.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
         if (self.options.no_multi_str) {
             try no_multi_str.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         if (self.options.no_octal_escape) {
             try no_octal_escape.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_template_literal(
+        self: *BasicVisitor,
+        literal: ast.TemplateLiteral,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_script_url) {
+            try no_script_url.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -163,6 +163,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_script_url.zig");
+}
+
+comptime {
     _ = @import("rules/no_self_assign.zig");
 }
 

--- a/tests/rules/no_script_url.zig
+++ b/tests/rules/no_script_url.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-script-url for javascript urls" {
+    const source =
+        \\const first = "javascript:alert(1)";
+        \\const second = `JaVaScRiPt:alert(2)`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_script_url.id));
+}
+
+test "does not report no-script-url for non-script urls or interpolated templates" {
+    const source =
+        \\const first = "https://example.com";
+        \\const second = `java${scheme}:alert(1)`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_script_url.id));
+}
+
+test "can disable no-script-url" {
+    const source =
+        \\const url = "javascript:alert(1)";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_script_url = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_script_url.id));
+}


### PR DESCRIPTION
## Summary
- add the no-script-url rule for string literals and static template literals
- add a CLI toggle and list the rule in the README
- add focused tests in tests/rules/no_script_url.zig

## Test
- .zig-cache/o/9670a96daee17f7b7c2b33cd17e1cf6e/root --seed=0xbb901710
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-script-url