### PR TITLE
feat: port rule no-sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-script-url`
 - `no-self-assign`
 - `no-self-compare`
+- `no-sequences`
 - `no-sparse-arrays`
 - `no-ternary`
 - `no-throw-literal`

--- a/src/core.zig
+++ b/src/core.zig
@@ -60,6 +60,7 @@ pub const Options = struct {
     no_script_url: bool = true,
     no_self_assign: bool = true,
     no_self_compare: bool = true,
+    no_sequences: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,
     no_throw_literal: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,6 +108,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
             options.no_self_compare = false;
+        } else if (std.mem.eql(u8, arg, "--no-sequences=off")) {
+            options.no_sequences = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
         } else if (std.mem.eql(u8, arg, "--no-ternary=off")) {
@@ -314,6 +316,7 @@ fn printHelp() void {
         \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare
+        \\  --no-sequences=off        Disable no-sequences
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-throw-literal=off    Disable no-throw-literal

--- a/src/rules/no_sequences.zig
+++ b/src/rules/no_sequences.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-sequences";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    _: ast.SequenceExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (isNestedSequence(tree, ctx)) return;
+    if (isAllowedForPart(tree, index, ctx)) return;
+    if (isAllowedParenthesizedSequence(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected use of comma operator.",
+        tree.span(index),
+    );
+}
+
+fn isNestedSequence(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    return switch (tree.data(parent)) {
+        .sequence_expression => true,
+        else => false,
+    };
+}
+
+fn isAllowedForPart(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    const for_statement = switch (tree.data(parent)) {
+        .for_statement => |for_statement| for_statement,
+        else => return false,
+    };
+
+    return for_statement.init == index or for_statement.update == index;
+}
+
+fn isAllowedParenthesizedSequence(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    const parenthesized = switch (tree.data(parent)) {
+        .parenthesized_expression => |parenthesized| parenthesized,
+        else => return false,
+    };
+    if (parenthesized.expression != index) return false;
+
+    const grandparent = ctx.path.ancestor(2) orelse return true;
+    return switch (tree.data(grandparent)) {
+        .arrow_function_expression => |arrow| arrow.body != parent,
+        else => true,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -50,6 +50,7 @@ pub const no_return_assign = @import("no_return_assign.zig");
 pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
+pub const no_sequences = @import("no_sequences.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
@@ -531,6 +532,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_comma_operator) {
             try no_comma_operator.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
+        }
+        if (self.options.no_sequences) {
+            try no_sequences.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -175,6 +175,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_sequences.zig");
+}
+
+comptime {
     _ = @import("rules/no_sparse_arrays.zig");
 }
 

--- a/tests/rules/no_sequences.zig
+++ b/tests/rules/no_sequences.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-sequences for unparenthesized sequence expressions" {
+    const source =
+        \\foo = doSomething(), bar = foo;
+        \\const arrow = () => (foo = doSomething(), foo);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_self_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_sequences.id));
+}
+
+test "does not report no-sequences for allowed sequence expressions" {
+    const source =
+        \\const value = (foo = doSomething(), foo);
+        \\const arrow = () => ((foo = doSomething(), foo));
+        \\for (i = 0, j = 0; test; i++, j++) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_self_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_sequences.id));
+}
+
+test "can disable no-sequences" {
+    const source =
+        \\foo = doSomething(), bar = foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_sequences = false,
+        .no_comma_operator = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_sequences.id));
+}


### PR DESCRIPTION
## Summary
- add the no-sequences rule for sequence expressions
- allow parenthesized sequences and for-loop init/update expressions
- add a CLI toggle and focused tests in tests/rules/no_sequences.zig

## Test
- .zig-cache/o/6db73db30e2813262cf2d8be37908aaa/root --seed=0x2a76bbb4
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-sequences