### PR TITLE
feat: port rule no-useless-rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-unsafe-negation`
 - `no-useless-concat`
 - `no-useless-catch`
+- `no-useless-rename`
 - `no-void`
 - `no-with`
 - `no-var`

--- a/src/core.zig
+++ b/src/core.zig
@@ -69,6 +69,7 @@ pub const Options = struct {
     no_unsafe_negation: bool = true,
     no_useless_concat: bool = true,
     no_useless_catch: bool = true,
+    no_useless_rename: bool = true,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
             options.no_useless_catch = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
+            options.no_useless_rename = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -325,6 +327,7 @@ fn printHelp() void {
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-catch=off    Disable no-useless-catch
+        \\  --no-useless-rename=off   Disable no-useless-rename
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/rules/no_useless_rename.zig
+++ b/src/rules/no_useless_rename.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-rename";
+
+pub fn checkImportSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportSpecifier,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasAsBetween(tree, specifier.imported, specifier.local)) return;
+
+    const imported = propertyName(tree, specifier.imported) orelse return;
+    const local = bindingName(tree, specifier.local) orelse return;
+    if (!std.mem.eql(u8, imported, local)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkExportSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ExportSpecifier,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasAsBetween(tree, specifier.local, specifier.exported)) return;
+
+    const local = referenceOrPropertyName(tree, specifier.local) orelse return;
+    const exported = propertyName(tree, specifier.exported) orelse return;
+    if (!std.mem.eql(u8, local, exported)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkObjectPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+) Allocator.Error!void {
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        if (property.shorthand or property.computed) continue;
+
+        const key = propertyName(tree, property.key) orelse continue;
+        const value = bindingOrAssignmentName(tree, property.value) orelse continue;
+        if (!std.mem.eql(u8, key, value)) continue;
+
+        try addDiagnostic(allocator, diagnostics, tree, property_index);
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Useless rename to the same name.",
+        tree.span(index),
+    );
+}
+
+fn bindingOrAssignmentName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .assignment_pattern => |pattern| bindingName(tree, pattern.left),
+        else => bindingName(tree, index),
+    };
+}
+
+fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn referenceOrPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => propertyName(tree, index),
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn hasAsBetween(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    if (left == .null or right == .null) return false;
+
+    const left_span = tree.span(left);
+    const right_span = tree.span(right);
+    const left_end: usize = @intCast(left_span.end);
+    const right_start: usize = @intCast(right_span.start);
+    if (left_end > right_start or right_start > tree.source.len) return false;
+
+    var iter = std.mem.tokenizeAny(u8, tree.source[left_end..right_start], " \t\r\n");
+    while (iter.next()) |token| {
+        if (std.mem.eql(u8, token, "as")) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -60,6 +60,7 @@ pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
+pub const no_useless_rename = @import("no_useless_rename.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
@@ -612,6 +613,33 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_empty_pattern) {
             try no_empty_pattern.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, index);
+        }
+        if (self.options.no_useless_rename) {
+            try no_useless_rename.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_import_specifier(
+        self: *BasicVisitor,
+        specifier: ast.ImportSpecifier,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_useless_rename) {
+            try no_useless_rename.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_export_specifier(
+        self: *BasicVisitor,
+        specifier: ast.ExportSpecifier,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_useless_rename) {
+            try no_useless_rename.checkExportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -211,6 +211,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_rename.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_vars.zig");
 }
 

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-rename for same-name import export and destructuring aliases" {
+    const source =
+        \\import { foo as foo } from "mod";
+        \\export { foo as foo };
+        \\const { bar: bar, baz: baz = fallback } = source;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_rename.id));
+}
+
+test "does not report no-useless-rename for meaningful aliases or shorthand" {
+    const source =
+        \\import { foo as bar, baz } from "mod";
+        \\export { foo as bar };
+        \\const { foo: bar, baz } = source;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_rename.id));
+}
+
+test "can disable no-useless-rename" {
+    const source =
+        \\import { foo as foo } from "mod";
+        \\const { bar: bar } = source;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_rename = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_rename.id));
+}


### PR DESCRIPTION
## Summary
- add the no-useless-rename rule for import/export aliases and object destructuring
- distinguish explicit import/export aliases from shorthand specifiers
- add a CLI toggle and focused tests in tests/rules/no_useless_rename.zig

## Test
- .zig-cache/o/8d9e5e716053758253f3f9e8488d2796/root --seed=0xd37f8e55
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-useless-rename