### PR TITLE
feat: port rule no-empty-static-block

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-block-statements`
 - `no-empty-character-class`
 - `no-empty-pattern`
+- `no-empty-static-block`
 - `no-else-return`
 - `no-extra-boolean-cast`
 - `no-for-in`

--- a/src/core.zig
+++ b/src/core.zig
@@ -36,6 +36,7 @@ pub const Options = struct {
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_pattern: bool = true,
+    no_empty_static_block: bool = true,
     no_else_return: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -60,6 +60,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_character_class = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-pattern=off")) {
             options.no_empty_pattern = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-static-block=off")) {
+            options.no_empty_static_block = false;
         } else if (std.mem.eql(u8, arg, "--no-else-return=off")) {
             options.no_else_return = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
@@ -294,6 +296,7 @@ fn printHelp() void {
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-pattern=off  Disable no-empty-pattern
+        \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in

--- a/src/rules/no_empty_static_block.zig
+++ b/src/rules/no_empty_static_block.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-empty-static-block";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.StaticBlock,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (block.body.len != 0) return;
+    if (hasCommentInsideBraces(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected empty static block.",
+        tree.span(index),
+    );
+}
+
+fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (tree.source.len == 0 or start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    const open = std.mem.indexOfScalar(u8, source, '{') orelse return false;
+    const close = std.mem.lastIndexOfScalar(u8, source, '}') orelse return false;
+    if (open >= close) return false;
+
+    return containsOnlyWhitespaceAndHasComment(source[open + 1 .. close]);
+}
+
+fn containsOnlyWhitespaceAndHasComment(source: []const u8) bool {
+    var has_comment = false;
+    var index: usize = 0;
+
+    while (index < source.len) {
+        switch (source[index]) {
+            ' ', '\t', '\n', '\r', 0x0B, 0x0C => index += 1,
+            '/' => {
+                if (index + 1 >= source.len) return false;
+
+                switch (source[index + 1]) {
+                    '/' => {
+                        has_comment = true;
+                        index += 2;
+                        while (index < source.len and source[index] != '\n' and source[index] != '\r') {
+                            index += 1;
+                        }
+                    },
+                    '*' => {
+                        has_comment = true;
+                        index += 2;
+                        const end = std.mem.indexOf(u8, source[index..], "*/") orelse return false;
+                        index += end + 2;
+                    },
+                    else => return false,
+                }
+            },
+            else => return false,
+        }
+    }
+
+    return has_comment;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
 pub const no_empty_pattern = @import("no_empty_pattern.zig");
+pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_for_in = @import("no_for_in.zig");
@@ -377,6 +378,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkStaticBlock(self.allocator, self.diagnostics, ctx.tree, block, index);
+        }
+        if (self.options.no_empty_static_block) {
+            try no_empty_static_block.check(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -79,6 +79,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_empty_static_block.zig");
+}
+
+comptime {
     _ = @import("rules/no_else_return.zig");
 }
 

--- a/tests/rules/no_empty_static_block.zig
+++ b/tests/rules/no_empty_static_block.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-empty-static-block for empty static blocks" {
+    const source =
+        \\class First {
+        \\  static {}
+        \\}
+        \\class Second {
+        \\  static {
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_empty_static_block.id));
+}
+
+test "does not report no-empty-static-block for non-empty or commented static blocks" {
+    const source =
+        \\class First {
+        \\  static { setup(); }
+        \\}
+        \\class Second {
+        \\  static { /* intentionally empty */ }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_static_block.id));
+}
+
+test "can disable no-empty-static-block" {
+    const source =
+        \\class First {
+        \\  static {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_static_block = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_static_block.id));
+}


### PR DESCRIPTION
## Summary
- add the no-empty-static-block rule for empty class static blocks
- ignore static blocks that contain comments
- add a CLI toggle and focused tests in tests/rules/no_empty_static_block.zig

## Test
- .zig-cache/o/d56c366ac567efaf320b604eb07bd4a3/root --seed=0x6d2ad577
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-empty-static-block