### PR TITLE
feat: port rule no-extra-semi

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-pattern`
 - `no-empty-static-block`
 - `no-else-return`
+- `no-extra-semi`
 - `no-extra-boolean-cast`
 - `no-for-in`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -38,6 +38,7 @@ pub const Options = struct {
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
+    no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,6 +64,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_static_block = false;
         } else if (std.mem.eql(u8, arg, "--no-else-return=off")) {
             options.no_else_return = false;
+        } else if (std.mem.eql(u8, arg, "--no-extra-semi=off")) {
+            options.no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
@@ -298,6 +300,7 @@ fn printHelp() void {
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return
+        \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/rules/no_extra_semi.zig
+++ b/src/rules/no_extra_semi.zig
@@ -1,0 +1,43 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-extra-semi";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (isStatementBody(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary semicolon.",
+        tree.span(index),
+    );
+}
+
+fn isStatementBody(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+
+    return switch (tree.data(parent)) {
+        .if_statement => |statement| statement.consequent == index or statement.alternate == index,
+        .for_statement => |statement| statement.body == index,
+        .for_in_statement => |statement| statement.body == index,
+        .for_of_statement => |statement| statement.body == index,
+        .while_statement => |statement| statement.body == index,
+        .do_while_statement => |statement| statement.body == index,
+        .with_statement => |statement| statement.body == index,
+        .labeled_statement => |statement| statement.body == index,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
+pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
@@ -235,6 +236,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_debugger) {
             try no_debugger.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_empty_statement(
+        self: *BasicVisitor,
+        _: ast.EmptyStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_extra_semi) {
+            try no_extra_semi.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -91,6 +91,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_extra_semi.zig");
+}
+
+comptime {
     _ = @import("rules/no_for_in.zig");
 }
 

--- a/tests/rules/no_extra_semi.zig
+++ b/tests/rules/no_extra_semi.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-extra-semi for unnecessary empty statements" {
+    const source =
+        \\const value = 1;;
+        \\function run() {}
+        \\;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_semi.id));
+}
+
+test "does not report no-extra-semi for empty statement bodies" {
+    const source =
+        \\while (ready);
+        \\for (; ready; );
+        \\if (ready); else ;
+        \\label: ;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_labels = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_semi.id));
+}
+
+test "can disable no-extra-semi" {
+    const source =
+        \\const value = 1;;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_extra_semi = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_semi.id));
+}


### PR DESCRIPTION
## Summary
- add the no-extra-semi rule for unnecessary empty statements
- keep empty statement bodies allowed for loops and labeled/control statements
- add a CLI toggle and focused tests in tests/rules/no_extra_semi.zig

## Test
- .zig-cache/o/323a773459932fe2b693e66b25807beb/root --seed=0x88ddfab6
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-extra-semi