### PR TITLE
feat: port rule no-async-promise-executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 
 - `default-case`
 - `default-case-last`
+- `no-async-promise-executor`
 - `no-alert`
 - `no-array-constructor`
 - `no-caller`

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
+    no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
     no_alert: bool = true,
     no_caller: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
             options.default_case_last = false;
+        } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
+            options.no_async_promise_executor = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
             options.no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
@@ -281,6 +283,7 @@ fn printHelp() void {
         \\Options:
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
+        \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller

--- a/src/rules/no_async_promise_executor.zig
+++ b/src/rules/no_async_promise_executor.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-async-promise-executor";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isGlobalPromiseReference(ctx.tree, self.symbol_table, expression.callee)) return .proceed;
+        if (!hasAsyncExecutor(ctx.tree, expression.arguments)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Promise executor functions should not be async.",
+            ctx.tree.span(index),
+        );
+
+        return .proceed;
+    }
+};
+
+fn hasAsyncExecutor(tree: *const ast.Tree, arguments: ast.IndexRange) bool {
+    if (arguments.len == 0) return false;
+    const executor = unwrapTransparent(tree, tree.extra(arguments)[0]);
+
+    return switch (tree.data(executor)) {
+        .arrow_function_expression => |arrow| arrow.async,
+        .function => |function| function.async,
+        else => false,
+    };
+}
+
+fn isGlobalPromiseReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Promise") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
+pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
@@ -91,6 +92,10 @@ pub fn runSemantic(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.no_async_promise_executor) {
+        try no_async_promise_executor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.no_array_constructor) {
         try no_array_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -15,6 +15,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_async_promise_executor.zig");
+}
+
+comptime {
     _ = @import("rules/no_array_constructor.zig");
 }
 

--- a/tests/rules/no_async_promise_executor.zig
+++ b/tests/rules/no_async_promise_executor.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-async-promise-executor for async promise executors" {
+    const source =
+        \\new Promise(async (resolve) => resolve());
+        \\new Promise(async function (resolve) {
+        \\  resolve();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_async_promise_executor.id));
+}
+
+test "does not report no-async-promise-executor for non-async executors or shadowed Promise" {
+    const source =
+        \\new Promise((resolve) => resolve());
+        \\function local(Promise) {
+        \\  new Promise(async (resolve) => resolve());
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_async_promise_executor.id));
+}
+
+test "can disable no-async-promise-executor" {
+    const source =
+        \\new Promise(async (resolve) => resolve());
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_async_promise_executor = false,
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_async_promise_executor.id));
+}


### PR DESCRIPTION
## Summary
- add the no-async-promise-executor rule for async Promise executors
- use semantic reference resolution to avoid shadowed Promise false positives
- add a CLI toggle and focused tests in tests/rules/no_async_promise_executor.zig

## Test
- .zig-cache/o/7c011b952ecb31997c4100e4031548e6/root --seed=0x95272f9a
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-async-promise-executor