### PR TITLE
feat: port rule no-promise-executor-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-octal`
 - `no-octal-escape`
 - `no-plusplus`
+- `no-promise-executor-return`
 - `no-proto`
 - `no-regex-spaces`
 - `no-return-assign`

--- a/src/core.zig
+++ b/src/core.zig
@@ -57,6 +57,7 @@ pub const Options = struct {
     no_octal: bool = true,
     no_octal_escape: bool = true,
     no_plusplus: bool = true,
+    no_promise_executor_return: bool = true,
     no_proto: bool = true,
     no_regex_spaces: bool = true,
     no_return_assign: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_octal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
             options.no_plusplus = false;
+        } else if (std.mem.eql(u8, arg, "--no-promise-executor-return=off")) {
+            options.no_promise_executor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -321,6 +323,7 @@ fn printHelp() void {
         \\  --no-octal=off            Disable no-octal
         \\  --no-octal-escape=off     Disable no-octal-escape
         \\  --no-plusplus=off         Disable no-plusplus
+        \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-assign=off    Disable no-return-assign

--- a/src/rules/no_promise_executor_return.zig
+++ b/src/rules/no_promise_executor_return.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-promise-executor-return";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isGlobalPromiseReference(ctx.tree, self.symbol_table, expression.callee)) return .proceed;
+        const executor = promiseExecutor(ctx.tree, expression.arguments) orelse return .proceed;
+
+        try checkExecutor(self.allocator, self.diagnostics, ctx.tree, executor);
+        return .proceed;
+    }
+};
+
+fn promiseExecutor(tree: *const ast.Tree, arguments: ast.IndexRange) ?ast.NodeIndex {
+    if (arguments.len == 0) return null;
+
+    const executor = unwrapTransparent(tree, tree.extra(arguments)[0]);
+    return switch (tree.data(executor)) {
+        .arrow_function_expression,
+        .function,
+        => executor,
+        else => null,
+    };
+}
+
+fn checkExecutor(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    executor: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (tree.data(executor)) {
+        .arrow_function_expression => |arrow| {
+            if (arrow.expression) {
+                try addDiagnostic(allocator, diagnostics, tree, arrow.body);
+            } else {
+                try scanFunctionBody(allocator, diagnostics, tree, arrow.body);
+            }
+        },
+        .function => |function| try scanFunctionBody(allocator, diagnostics, tree, function.body),
+        else => {},
+    }
+}
+
+fn scanFunctionBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body_index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (body_index == .null) return;
+
+    const body = switch (tree.data(body_index)) {
+        .function_body => |body| body,
+        else => return,
+    };
+
+    try scanRange(allocator, diagnostics, tree, body.body);
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .return_statement => |statement| {
+            if (statement.argument != .null) {
+                try addDiagnostic(allocator, diagnostics, tree, index);
+            }
+        },
+        .block_statement => |block| try scanRange(allocator, diagnostics, tree, block.body),
+        .static_block => |block| try scanRange(allocator, diagnostics, tree, block.body),
+        .if_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.consequent);
+            try scanNode(allocator, diagnostics, tree, statement.alternate);
+        },
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const switch_case = switch (tree.data(case_index)) {
+                    .switch_case => |switch_case| switch_case,
+                    else => continue,
+                };
+                try scanRange(allocator, diagnostics, tree, switch_case.consequent);
+            }
+        },
+        .for_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .for_in_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .for_of_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .do_while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .with_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .labeled_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .try_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.block);
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return,
+                };
+                try scanNode(allocator, diagnostics, tree, handler.body);
+            }
+            try scanNode(allocator, diagnostics, tree, statement.finalizer);
+        },
+        .function,
+        .arrow_function_expression,
+        .class,
+        => return,
+        else => return,
+    }
+}
+
+fn scanRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+) Allocator.Error!void {
+    for (tree.extra(range)) |child| {
+        try scanNode(allocator, diagnostics, tree, child);
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Promise executor should not return a value.",
+        tree.span(index),
+    );
+}
+
+fn isGlobalPromiseReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Promise") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -47,6 +47,7 @@ pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
 pub const no_octal_escape = @import("no_octal_escape.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
+pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
@@ -130,6 +131,10 @@ pub fn runSemantic(
 
     if (options.no_new_wrappers) {
         try no_new_wrappers.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_promise_executor_return) {
+        try no_promise_executor_return.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -163,6 +163,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_promise_executor_return.zig");
+}
+
+comptime {
     _ = @import("rules/no_proto.zig");
 }
 

--- a/tests/rules/no_promise_executor_return.zig
+++ b/tests/rules/no_promise_executor_return.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-promise-executor-return for returned values" {
+    const source =
+        \\new Promise((resolve) => resolve());
+        \\new Promise(function (resolve) {
+        \\  if (ready) {
+        \\    return resolve();
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_promise_executor_return.id));
+}
+
+test "does not report no-promise-executor-return for bare returns nested functions or shadowed Promise" {
+    const source =
+        \\new Promise(function (resolve) {
+        \\  if (ready) return;
+        \\  function nested() {
+        \\    return resolve();
+        \\  }
+        \\});
+        \\function local(Promise) {
+        \\  new Promise((resolve) => resolve());
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_promise_executor_return.id));
+}
+
+test "can disable no-promise-executor-return" {
+    const source =
+        \\new Promise((resolve) => resolve());
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_promise_executor_return = false,
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_promise_executor_return.id));
+}


### PR DESCRIPTION
## Summary
- add the no-promise-executor-return rule for Promise executors returning values
- use semantic reference resolution to avoid shadowed Promise false positives
- add focused tests in tests/rules/no_promise_executor_return.zig

## Test
- .zig-cache/o/0a30ae043a25ea62f79657f3a6c748cb/root --seed=0xe5d6ed83
- zig build -Doptimize=ReleaseFast -j1

Reference: https://eslint.org/docs/latest/rules/no-promise-executor-return