### PR TITLE
feat: port rule no-empty-function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-duplicate-case`
 - `no-empty-block-statements`
 - `no-empty-character-class`
+- `no-empty-function`
 - `no-empty-pattern`
 - `no-empty-static-block`
 - `no-else-return`

--- a/src/core.zig
+++ b/src/core.zig
@@ -36,6 +36,7 @@ pub const Options = struct {
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
+    no_empty_function: bool = true,
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -60,6 +60,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
             options.no_empty_character_class = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-function=off")) {
+            options.no_empty_function = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-pattern=off")) {
             options.no_empty_pattern = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-static-block=off")) {
@@ -302,6 +304,7 @@ fn printHelp() void {
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
+        \\  --no-empty-function=off Disable no-empty-function
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return

--- a/src/rules/no_empty_function.zig
+++ b/src/rules/no_empty_function.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-empty-function";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (body.body.len != 0) return;
+    if (hasCommentInsideBraces(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected empty function.",
+        tree.span(index),
+    );
+}
+
+fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (tree.source.len == 0 or start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    const open = std.mem.indexOfScalar(u8, source, '{') orelse return false;
+    const close = std.mem.lastIndexOfScalar(u8, source, '}') orelse return false;
+    if (open >= close) return false;
+
+    return containsOnlyWhitespaceAndHasComment(source[open + 1 .. close]);
+}
+
+fn containsOnlyWhitespaceAndHasComment(source: []const u8) bool {
+    var has_comment = false;
+    var index: usize = 0;
+
+    while (index < source.len) {
+        switch (source[index]) {
+            ' ', '\t', '\n', '\r', 0x0B, 0x0C => index += 1,
+            '/' => {
+                if (index + 1 >= source.len) return false;
+
+                switch (source[index + 1]) {
+                    '/' => {
+                        has_comment = true;
+                        index += 2;
+                        while (index < source.len and source[index] != '\n' and source[index] != '\r') {
+                            index += 1;
+                        }
+                    },
+                    '*' => {
+                        has_comment = true;
+                        index += 2;
+                        var closed = false;
+                        while (index + 1 < source.len) : (index += 1) {
+                            if (source[index] == '*' and source[index + 1] == '/') {
+                                index += 2;
+                                closed = true;
+                                break;
+                            }
+                        }
+                        if (!closed) return false;
+                    },
+                    else => return false,
+                }
+            },
+            else => return false,
+        }
+    }
+
+    return has_comment;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
+pub const no_empty_function = @import("no_empty_function.zig");
 pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
@@ -389,6 +390,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
+        if (self.options.no_empty_function) {
+            try no_empty_function.check(self.allocator, self.diagnostics, ctx.tree, body, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -79,6 +79,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_empty_function.zig");
+}
+
+comptime {
     _ = @import("rules/no_empty_pattern.zig");
 }
 

--- a/tests/rules/no_empty_function.zig
+++ b/tests/rules/no_empty_function.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-empty-function for empty function bodies" {
+    const source =
+        \\function empty() {}
+        \\const arrow = () => {};
+        \\class Example {
+        \\  method() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_empty_function.id));
+}
+
+test "does not report no-empty-function for non-empty or commented bodies" {
+    const source =
+        \\function nonempty() {
+        \\  return 1;
+        \\}
+        \\const documented = () => {
+        \\  // intentionally empty
+        \\};
+        \\class Example {
+        \\  method() { /* noop */ }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_function.id));
+}
+
+test "can disable no-empty-function" {
+    const source =
+        \\function empty() {}
+        \\const arrow = () => {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_function.id));
+}


### PR DESCRIPTION
## Summary
- add no-empty-function rule support
- wire the rule into options, CLI flag, and function body traversal
- add focused tests for empty, commented, non-empty, and disabled cases

## Reference
- https://eslint.org/docs/latest/rules/no-empty-function

## Tests
- direct generated Zig test binary: All 183 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check