### PR TITLE
feat: port rule no-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-pattern`
 - `no-empty-static-block`
 - `no-else-return`
+- `no-eval`
 - `no-extra-semi`
 - `no-extra-boolean-cast`
 - `no-for-in`

--- a/src/core.zig
+++ b/src/core.zig
@@ -40,6 +40,7 @@ pub const Options = struct {
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
+    no_eval: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -68,6 +68,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_static_block = false;
         } else if (std.mem.eql(u8, arg, "--no-else-return=off")) {
             options.no_else_return = false;
+        } else if (std.mem.eql(u8, arg, "--no-eval=off")) {
+            options.no_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-semi=off")) {
             options.no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
@@ -308,6 +310,7 @@ fn printHelp() void {
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return
+        \\  --no-eval=off           Disable no-eval
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in

--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-eval";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isEvalCall(ctx.tree, self.symbol_table, call.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "eval can be harmful.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isEvalCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return std.mem.eql(u8, name, "eval");
+    }
+
+    switch (tree.data(unwrapped)) {
+        .sequence_expression => |sequence| {
+            const expressions = tree.extra(sequence.expressions);
+            if (expressions.len == 0) return false;
+            const last = unwrapTransparent(tree, expressions[expressions.len - 1]);
+            const name = identifierReferenceName(tree, last) orelse return false;
+            return std.mem.eql(u8, name, "eval");
+        },
+        .member_expression => |member| return isGlobalEvalMember(tree, symbol_table, member),
+        else => return false,
+    }
+}
+
+fn isGlobalEvalMember(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    member: ast.MemberExpression,
+) bool {
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property_name, "eval")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return isGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isGlobalObjectName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "window") or
+        std.mem.eql(u8, name, "globalThis") or
+        std.mem.eql(u8, name, "global");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const no_empty_function = @import("no_empty_function.zig");
 pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
+pub const no_eval = @import("no_eval.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_for_in = @import("no_for_in.zig");
@@ -104,6 +105,10 @@ pub fn runSemantic(
 
     if (options.no_extra_boolean_cast) {
         try no_extra_boolean_cast.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_eval) {
+        try no_eval.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_alert) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -95,6 +95,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_eval.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_boolean_cast.zig");
 }
 

--- a/tests/rules/no_eval.zig
+++ b/tests/rules/no_eval.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-eval for direct indirect and global eval calls" {
+    const source =
+        \\eval("code");
+        \\(eval)("code");
+        \\(0, eval)("code");
+        \\window.eval("code");
+        \\globalThis["eval"]("code");
+        \\global.eval("code");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_sequences = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_eval.id));
+}
+
+test "does not report no-eval for non-global eval members" {
+    const source =
+        \\const object = { eval() {} };
+        \\object.eval("code");
+        \\object["eval"]("code");
+        \\const window = sandbox;
+        \\window.eval("code");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_eval.id));
+}
+
+test "can disable no-eval" {
+    const source =
+        \\eval("code");
+        \\window.eval("code");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_eval = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_eval.id));
+}


### PR DESCRIPTION
## Summary
- add no-eval rule support
- detect direct, indirect, and global object eval calls
- wire the rule into options and semantic traversal
- add focused tests for reporting, allowed member calls, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-eval

## Tests
- direct generated Zig test binary: All 186 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check