### PR TITLE
feat: port rule no-implied-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-for-in`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-implied-eval`
 - `no-labels`
 - `no-lone-blocks`
 - `no-lonely-if`

--- a/src/core.zig
+++ b/src/core.zig
@@ -46,6 +46,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_implied_eval: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,
     no_lonely_if: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,6 +80,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-implied-eval=off")) {
+            options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
             options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
@@ -316,6 +318,7 @@ fn printHelp() void {
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if

--- a/src/rules/no_implied_eval.zig
+++ b/src/rules/no_implied_eval.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-implied-eval";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (hasStringFirstArgument(ctx.tree, call.arguments) and isImpliedEvalCallee(ctx.tree, self.symbol_table, call.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Implied eval can be harmful. Pass a function instead of a string.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn hasStringFirstArgument(tree: *const ast.Tree, arguments: ast.IndexRange) bool {
+    if (arguments.len == 0) return false;
+
+    const first = unwrapTransparent(tree, tree.extra(arguments)[0]);
+    return switch (tree.data(first)) {
+        .string_literal => true,
+        .template_literal => |template| template.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn isImpliedEvalCallee(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return isImpliedEvalName(name) and isUnresolvedReference(symbol_table, unwrapped);
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!isImpliedEvalName(property_name)) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return isGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isImpliedEvalName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "setTimeout") or
+        std.mem.eql(u8, name, "setInterval") or
+        std.mem.eql(u8, name, "execScript");
+}
+
+fn isGlobalObjectName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "window") or
+        std.mem.eql(u8, name, "globalThis") or
+        std.mem.eql(u8, name, "global");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -36,6 +36,7 @@ pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
@@ -121,6 +122,10 @@ pub fn runSemantic(
 
     if (options.no_global_is_nan) {
         try no_global_is_nan.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_implied_eval) {
+        try no_implied_eval.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_func) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -119,6 +119,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_implied_eval.zig");
+}
+
+comptime {
     _ = @import("rules/no_labels.zig");
 }
 

--- a/tests/rules/no_implied_eval.zig
+++ b/tests/rules/no_implied_eval.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-implied-eval for string timer and execScript calls" {
+    const source =
+        \\setTimeout("alert(1)", 100);
+        \\setInterval(`tick()`, 100);
+        \\execScript("alert(1)");
+        \\window.setTimeout("alert(1)");
+        \\globalThis["setInterval"]("tick()", 100);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_alert = false,
+        .no_eval = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_implied_eval.id));
+}
+
+test "does not report no-implied-eval for function arguments or shadowed calls" {
+    const source =
+        \\setTimeout(() => alert(1), 100);
+        \\setInterval(handler, 100);
+        \\const setTimeout = customTimer;
+        \\setTimeout("not global");
+        \\const window = sandbox;
+        \\window.setTimeout("not global");
+        \\object.setInterval("not global");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_alert = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implied_eval.id));
+}
+
+test "can disable no-implied-eval" {
+    const source =
+        \\setTimeout("alert(1)", 100);
+        \\window.setInterval("tick()", 100);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_implied_eval = false,
+        .no_alert = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implied_eval.id));
+}


### PR DESCRIPTION
## Summary
- add no-implied-eval rule support
- detect string timer and execScript calls through direct and global object callees
- wire the rule into options and semantic traversal
- add focused tests for reporting, allowed calls, shadowed calls, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-implied-eval

## Tests
- direct generated Zig test binary: All 189 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check