### PR TITLE
feat: port rule no-func-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-extra-semi`
 - `no-extra-boolean-cast`
 - `no-for-in`
+- `no-func-assign`
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-implied-eval`

--- a/src/core.zig
+++ b/src/core.zig
@@ -44,6 +44,7 @@ pub const Options = struct {
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,
+    no_func_assign: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_implied_eval: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,6 +76,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
+        } else if (std.mem.eql(u8, arg, "--no-func-assign=off")) {
+            options.no_func_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-finite=off")) {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
@@ -316,6 +318,7 @@ fn printHelp() void {
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in
+        \\  --no-func-assign=off      Disable no-func-assign
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implied-eval=off      Disable no-implied-eval

--- a/src/rules/no_func_assign.zig
+++ b/src/rules/no_func_assign.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-func-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left, index);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument, index);
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+        diagnostic_node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const identifier = unwrapTransparent(tree, target);
+        if (!isIdentifierReference(tree, identifier)) return;
+
+        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        if (symbol_id == .none) return;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.function) return;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Function declarations should not be reassigned.",
+            tree.span(diagnostic_node),
+        );
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn symbolForReferenceNode(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) traverser.semantic.SymbolId {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id);
+        }
+    }
+
+    return .none;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const no_eval = @import("no_eval.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_for_in = @import("no_for_in.zig");
+pub const no_func_assign = @import("no_func_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
@@ -114,6 +115,10 @@ pub fn runSemantic(
 
     if (options.no_alert) {
         try no_alert.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_func_assign) {
+        try no_func_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_global_is_finite) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -111,6 +111,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_func_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_global_is_finite.zig");
 }
 

--- a/tests/rules/no_func_assign.zig
+++ b/tests/rules/no_func_assign.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-func-assign for reassigned function bindings" {
+    const source =
+        \\function first() {}
+        \\first = replacement;
+        \\function second() {}
+        \\second += replacement;
+        \\function third() {}
+        \\third++;
+        \\const fn = function named() {
+        \\  named = replacement;
+        \\  named++;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_func_assign.id));
+}
+
+test "does not report no-func-assign for shadowed variables or member assignments" {
+    const source =
+        \\function outer(value) {
+        \\  value = 1;
+        \\}
+        \\function wrapper() {
+        \\  let outer = 1;
+        \\  outer = 2;
+        \\}
+        \\const object = {};
+        \\object.outer = 3;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_func_assign.id));
+}
+
+test "can disable no-func-assign" {
+    const source =
+        \\function first() {}
+        \\first = replacement;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_func_assign = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_func_assign.id));
+}


### PR DESCRIPTION
## Summary
- add no-func-assign rule support
- detect assignments and updates that resolve to function bindings
- wire the rule into options and semantic traversal
- add focused tests for reassignment, shadowed names, member assignments, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-func-assign

## Tests
- direct generated Zig test binary: All 192 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check