### PR TITLE
feat: port rule no-ex-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-static-block`
 - `no-else-return`
 - `no-eval`
+- `no-ex-assign`
 - `no-extra-semi`
 - `no-extra-boolean-cast`
 - `no-for-in`

--- a/src/core.zig
+++ b/src/core.zig
@@ -41,6 +41,7 @@ pub const Options = struct {
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
     no_eval: bool = true,
+    no_ex_assign: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_for_in: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,6 +70,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_else_return = false;
         } else if (std.mem.eql(u8, arg, "--no-eval=off")) {
             options.no_eval = false;
+        } else if (std.mem.eql(u8, arg, "--no-ex-assign=off")) {
+            options.no_ex_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-semi=off")) {
             options.no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
@@ -315,6 +317,7 @@ fn printHelp() void {
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return
         \\  --no-eval=off           Disable no-eval
+        \\  --no-ex-assign=off      Disable no-ex-assign
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-for-in=off           Disable no-for-in

--- a/src/rules/no_ex_assign.zig
+++ b/src/rules/no_ex_assign.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-ex-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left, index);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument, index);
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+        diagnostic_node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const identifier = unwrapTransparent(tree, target);
+        if (!isIdentifierReference(tree, identifier)) return;
+
+        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        if (symbol_id == .none) return;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.catch_var) return;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Do not reassign catch parameters.",
+            tree.span(diagnostic_node),
+        );
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn symbolForReferenceNode(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) traverser.semantic.SymbolId {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id);
+        }
+    }
+
+    return .none;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -31,6 +31,7 @@ pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
 pub const no_eval = @import("no_eval.zig");
+pub const no_ex_assign = @import("no_ex_assign.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_for_in = @import("no_for_in.zig");
@@ -111,6 +112,10 @@ pub fn runSemantic(
 
     if (options.no_eval) {
         try no_eval.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_ex_assign) {
+        try no_ex_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_alert) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_ex_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_boolean_cast.zig");
 }
 

--- a/tests/rules/no_ex_assign.zig
+++ b/tests/rules/no_ex_assign.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-ex-assign for reassigned catch parameters" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  error = replacement;
+        \\  error++;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_ex_assign.id));
+}
+
+test "does not report no-ex-assign for shadowed variables or member writes" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  {
+        \\    let error = replacement;
+        \\    error = other;
+        \\  }
+        \\  error.message = "handled";
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_ex_assign.id));
+}
+
+test "can disable no-ex-assign" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  error = replacement;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_ex_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_ex_assign.id));
+}


### PR DESCRIPTION
## Summary
- add no-ex-assign rule support
- detect assignments and updates that resolve to catch parameters
- wire the rule into options and semantic traversal
- add focused tests for reassignment, shadowed variables, member writes, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-ex-assign

## Tests
- direct generated Zig test binary: All 195 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check