### PR TITLE
feat: port rule no-class-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-array-constructor`
 - `no-caller`
 - `no-case-declarations`
+- `no-class-assign`
 - `no-cond-assign`
 - `no-compare-neg-zero`
 - `no-constant-condition`

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     no_alert: bool = true,
     no_caller: bool = true,
     no_case_declarations: bool = true,
+    no_class_assign: bool = true,
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_caller = false;
         } else if (std.mem.eql(u8, arg, "--no-case-declarations=off")) {
             options.no_case_declarations = false;
+        } else if (std.mem.eql(u8, arg, "--no-class-assign=off")) {
+            options.no_class_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-cond-assign=off")) {
             options.no_cond_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
@@ -300,6 +302,7 @@ fn printHelp() void {
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller
         \\  --no-case-declarations=off Disable no-case-declarations
+        \\  --no-class-assign=off     Disable no-class-assign
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition

--- a/src/rules/no_class_assign.zig
+++ b/src/rules/no_class_assign.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-class-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left, index);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument, index);
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+        diagnostic_node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const identifier = unwrapTransparent(tree, target);
+        if (!isIdentifierReference(tree, identifier)) return;
+
+        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        if (symbol_id == .none) return;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.class) return;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Class declarations should not be reassigned.",
+            tree.span(diagnostic_node),
+        );
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn symbolForReferenceNode(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) traverser.semantic.SymbolId {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id);
+        }
+    }
+
+    return .none;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_case_declarations = @import("no_case_declarations.zig");
+pub const no_class_assign = @import("no_class_assign.zig");
 pub const no_cond_assign = @import("no_cond_assign.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_constant_condition = @import("no_constant_condition.zig");
@@ -120,6 +121,10 @@ pub fn runSemantic(
 
     if (options.no_alert) {
         try no_alert.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_class_assign) {
+        try no_class_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_func_assign) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -31,6 +31,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_class_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_comma_operator.zig");
 }
 

--- a/tests/rules/no_class_assign.zig
+++ b/tests/rules/no_class_assign.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-class-assign for reassigned class bindings" {
+    const source =
+        \\class First {}
+        \\First = replacement;
+        \\class Second {}
+        \\Second += replacement;
+        \\class Third {}
+        \\Third++;
+        \\const value = class Named {
+        \\  method() {
+        \\    Named = replacement;
+        \\  }
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_class_assign.id));
+}
+
+test "does not report no-class-assign for shadowed variables or member assignments" {
+    const source =
+        \\class First {}
+        \\function wrapper(First) {
+        \\  First = replacement;
+        \\}
+        \\{
+        \\  let First = 1;
+        \\  First = 2;
+        \\}
+        \\object.First = replacement;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_class_assign.id));
+}
+
+test "can disable no-class-assign" {
+    const source =
+        \\class First {}
+        \\First = replacement;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_class_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_class_assign.id));
+}


### PR DESCRIPTION
## Summary
- add no-class-assign rule support
- detect assignments and updates that resolve to class bindings
- wire the rule into options and semantic traversal
- add focused tests for reassignment, shadowed names, member assignments, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-class-assign

## Tests
- direct generated Zig test binary: All 198 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check