### PR TITLE
feat: port rule no-import-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-implied-eval`
+- `no-import-assign`
 - `no-labels`
 - `no-lone-blocks`
 - `no-lonely-if`

--- a/src/core.zig
+++ b/src/core.zig
@@ -50,6 +50,7 @@ pub const Options = struct {
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_implied_eval: bool = true,
+    no_import_assign: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,
     no_lonely_if: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,6 +88,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_nan = false;
         } else if (std.mem.eql(u8, arg, "--no-implied-eval=off")) {
             options.no_implied_eval = false;
+        } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
+            options.no_import_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
             options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
@@ -328,6 +330,7 @@ fn printHelp() void {
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implied-eval=off      Disable no-implied-eval
+        \\  --no-import-assign=off     Disable no-import-assign
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if

--- a/src/rules/no_import_assign.zig
+++ b/src/rules/no_import_assign.zig
@@ -1,0 +1,230 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-import-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+    defer visitor.namespace_import_names.deinit(allocator);
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    namespace_import_names: std.StringHashMapUnmanaged(void) = .empty,
+
+    pub fn enter_import_namespace_specifier(
+        self: *Visitor,
+        specifier: ast.ImportNamespaceSpecifier,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const name = bindingIdentifierName(ctx.tree, specifier.local) orelse return .proceed;
+        try self.namespace_import_names.put(self.allocator, name, {});
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.isForbiddenTarget(ctx.tree, expression.left) or self.isForbiddenNamespaceMember(ctx.tree, expression.left)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.isForbiddenTarget(ctx.tree, expression.argument) or self.isForbiddenNamespaceMember(ctx.tree, expression.argument)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isObjectAssignCall(ctx.tree, self.symbol_table, call.callee) and call.arguments.len > 0) {
+            const first = ctx.tree.extra(call.arguments)[0];
+            if (self.namespaceSymbolFromExpression(ctx.tree, first) != .none) {
+                try self.addDiagnostic(ctx.tree, index);
+            }
+        }
+        return .proceed;
+    }
+
+    fn isForbiddenTarget(self: *Visitor, tree: *const ast.Tree, target: ast.NodeIndex) bool {
+        const symbol_id = self.symbolFromIdentifierExpression(tree, target);
+        if (symbol_id == .none) return false;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        return symbol.flags.import;
+    }
+
+    fn isForbiddenNamespaceMember(self: *Visitor, tree: *const ast.Tree, target: ast.NodeIndex) bool {
+        const member = switch (tree.data(unwrapTransparent(tree, target))) {
+            .member_expression => |member| member,
+            else => return false,
+        };
+
+        return self.namespaceSymbolFromExpression(tree, member.object) != .none;
+    }
+
+    fn namespaceSymbolFromExpression(self: *Visitor, tree: *const ast.Tree, expression: ast.NodeIndex) traverser.semantic.SymbolId {
+        const symbol_id = self.symbolFromIdentifierExpression(tree, expression);
+        if (symbol_id == .none) return .none;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.import) return .none;
+
+        const name = tree.string(symbol.name);
+        if (!self.namespace_import_names.contains(name)) return .none;
+
+        return symbol_id;
+    }
+
+    fn symbolFromIdentifierExpression(self: *Visitor, tree: *const ast.Tree, expression: ast.NodeIndex) traverser.semantic.SymbolId {
+        const identifier = unwrapTransparent(tree, expression);
+        if (!isIdentifierReference(tree, identifier)) return .none;
+        return symbolForReferenceNode(self.symbol_table, identifier);
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Imported bindings are read-only.",
+            tree.span(index),
+        );
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn symbolForReferenceNode(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) traverser.semantic.SymbolId {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id);
+        }
+    }
+
+    return .none;
+}
+
+fn isObjectAssignCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property_name, "assign")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Object") and isUnresolvedReference(symbol_table, object);
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -40,6 +40,7 @@ pub const no_func_assign = @import("no_func_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
+pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
@@ -141,6 +142,10 @@ pub fn runSemantic(
 
     if (options.no_implied_eval) {
         try no_implied_eval.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_import_assign) {
+        try no_import_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_func) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -135,6 +135,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_import_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_labels.zig");
 }
 

--- a/tests/rules/no_import_assign.zig
+++ b/tests/rules/no_import_assign.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-import-assign for reassigned imported bindings" {
+    const source =
+        \\import def, { named } from "mod";
+        \\import * as ns from "ns";
+        \\def = replacement;
+        \\named++;
+        \\ns = replacement;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_import_assign.id));
+}
+
+test "reports no-import-assign for namespace import mutation" {
+    const source =
+        \\import * as ns from "ns";
+        \\ns.value = replacement;
+        \\ns["value"]++;
+        \\Object.assign(ns, { value: replacement });
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_import_assign.id));
+}
+
+test "does not report no-import-assign for local shadowing or imported object property writes" {
+    const source =
+        \\import def, { named } from "mod";
+        \\import * as ns from "ns";
+        \\def.value = replacement;
+        \\named.value = replacement;
+        \\function update(ns) {
+        \\  ns.value = replacement;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_import_assign.id));
+}
+
+test "can disable no-import-assign" {
+    const source =
+        \\import def from "mod";
+        \\def = replacement;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_import_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_import_assign.id));
+}


### PR DESCRIPTION
## Summary
- add no-import-assign rule support
- detect assignments and updates to imported bindings
- detect namespace import member mutation and Object.assign namespace mutation
- wire the rule into options and semantic traversal
- add focused tests for reporting, allowed property writes, local shadowing, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-import-assign

## Tests
- direct generated Zig test binary: All 202 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check