### PR TITLE
feat: port rule no-const-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-cond-assign`
 - `no-compare-neg-zero`
 - `no-constant-condition`
+- `no-const-assign`
 - `no-control-regex`
 - `no-console`
 - `no-comma-operator`

--- a/src/core.zig
+++ b/src/core.zig
@@ -28,6 +28,7 @@ pub const Options = struct {
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,
+    no_const_assign: bool = true,
     no_control_regex: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,6 +44,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_compare_neg_zero = false;
         } else if (std.mem.eql(u8, arg, "--no-constant-condition=off")) {
             options.no_constant_condition = false;
+        } else if (std.mem.eql(u8, arg, "--no-const-assign=off")) {
+            options.no_const_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-control-regex=off")) {
             options.no_control_regex = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
@@ -308,6 +310,7 @@ fn printHelp() void {
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition
+        \\  --no-const-assign=off    Disable no-const-assign
         \\  --no-control-regex=off   Disable no-control-regex
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console

--- a/src/rules/no_const_assign.zig
+++ b/src/rules/no_const_assign.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-const-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left, index);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument, index);
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+        diagnostic_node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const identifier = unwrapTransparent(tree, target);
+        if (!isIdentifierReference(tree, identifier)) return;
+
+        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        if (symbol_id == .none) return;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.const_var) return;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Constant bindings should not be reassigned.",
+            tree.span(diagnostic_node),
+        );
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn symbolForReferenceNode(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) traverser.semantic.SymbolId {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id);
+        }
+    }
+
+    return .none;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -18,6 +18,7 @@ pub const no_class_assign = @import("no_class_assign.zig");
 pub const no_cond_assign = @import("no_cond_assign.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_constant_condition = @import("no_constant_condition.zig");
+pub const no_const_assign = @import("no_const_assign.zig");
 pub const no_control_regex = @import("no_control_regex.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
@@ -126,6 +127,10 @@ pub fn runSemantic(
 
     if (options.no_class_assign) {
         try no_class_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_const_assign) {
+        try no_const_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_func_assign) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -47,6 +47,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_const_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_constant_condition.zig");
 }
 

--- a/tests/rules/no_const_assign.zig
+++ b/tests/rules/no_const_assign.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-const-assign for reassigned const bindings" {
+    const source =
+        \\const first = 1;
+        \\first = 2;
+        \\const second = 1;
+        \\second += 2;
+        \\const third = 1;
+        \\third++;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_const_assign.id));
+}
+
+test "does not report no-const-assign for let bindings or member writes" {
+    const source =
+        \\let value = 1;
+        \\value = 2;
+        \\const object = {};
+        \\object.value = 1;
+        \\function update(value) {
+        \\  value = 3;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_const_assign.id));
+}
+
+test "can disable no-const-assign" {
+    const source =
+        \\const first = 1;
+        \\first = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_const_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_const_assign.id));
+}


### PR DESCRIPTION
## Summary
- add no-const-assign rule support
- detect assignments and updates that resolve to const-like bindings
- wire the rule into options and semantic traversal
- add focused tests for reporting, allowed writes, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-const-assign

## Tests
- direct generated Zig test binary: All 205 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check