### PR TITLE
feat: port rule no-obj-calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`
+- `no-obj-calls`
 - `no-new-func`
 - `no-new-object`
 - `no-new-symbol`

--- a/src/core.zig
+++ b/src/core.zig
@@ -59,6 +59,7 @@ pub const Options = struct {
     no_new: bool = true,
     no_nested_ternary: bool = true,
     no_new_func: bool = true,
+    no_obj_calls: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,
     no_new_wrappers: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -106,6 +106,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_nested_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
+        } else if (std.mem.eql(u8, arg, "--no-obj-calls=off")) {
+            options.no_obj_calls = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
             options.no_new_object = false;
         } else if (std.mem.eql(u8, arg, "--no-new-symbol=off")) {
@@ -341,6 +343,7 @@ fn printHelp() void {
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-new-func=off         Disable no-new-func
+        \\  --no-obj-calls=off        Disable no-obj-calls
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol
         \\  --no-new-wrappers=off     Disable no-new-wrappers

--- a/src/rules/no_obj_calls.zig
+++ b/src/rules/no_obj_calls.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-obj-calls";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (globalObjectName(ctx.tree, self.symbol_table, call.callee)) |name| {
+            try self.addDiagnostic(ctx.tree, index, name);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (globalObjectName(ctx.tree, self.symbol_table, expression.callee)) |name| {
+            try self.addDiagnostic(ctx.tree, index, name);
+        }
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) Allocator.Error!void {
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "'{s}' is not a function.",
+            .{name},
+        );
+    }
+};
+
+fn globalObjectName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, callee);
+    const name = identifierReferenceName(tree, unwrapped) orelse return null;
+    if (!isForbiddenObject(name)) return null;
+    if (!isUnresolvedReference(symbol_table, unwrapped)) return null;
+    return name;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isForbiddenObject(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Math") or
+        std.mem.eql(u8, name, "JSON") or
+        std.mem.eql(u8, name, "Reflect") or
+        std.mem.eql(u8, name, "Atomics") or
+        std.mem.eql(u8, name, "Intl") or
+        std.mem.eql(u8, name, "Temporal");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -49,6 +49,7 @@ pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
 pub const no_new_func = @import("no_new_func.zig");
+pub const no_obj_calls = @import("no_obj_calls.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
@@ -155,6 +156,10 @@ pub fn runSemantic(
 
     if (options.no_new_func) {
         try no_new_func.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_obj_calls) {
+        try no_obj_calls.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_object) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -167,6 +167,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_obj_calls.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_func.zig");
 }
 

--- a/tests/rules/no_obj_calls.zig
+++ b/tests/rules/no_obj_calls.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-obj-calls for global object calls" {
+    const source =
+        \\Math();
+        \\JSON();
+        \\Reflect();
+        \\Atomics();
+        \\Intl();
+        \\Temporal();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
+test "reports no-obj-calls for global object constructors" {
+    const source =
+        \\new Math();
+        \\new JSON();
+        \\new Reflect();
+        \\new Atomics();
+        \\new Intl();
+        \\new Temporal();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
+test "does not report no-obj-calls for member calls or shadowed names" {
+    const source =
+        \\Math.max(1, 2);
+        \\JSON.parse("{}");
+        \\function run(Math, JSON) {
+        \\  Math();
+        \\  new JSON();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_obj_calls.id));
+}
+
+test "can disable no-obj-calls" {
+    const source =
+        \\Math();
+        \\new JSON();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_obj_calls = false,
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_obj_calls.id));
+}


### PR DESCRIPTION
## Summary
- add no-obj-calls rule support
- detect calls and constructors for non-callable global objects
- wire the rule into options and semantic traversal
- add focused tests for reporting, shadowed names, member calls, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-obj-calls

## Tests
- direct generated Zig test binary: All 209 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check