### PR TITLE
feat: port rule no-dupe-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-console`
 - `no-comma-operator`
 - `no-debugger`
+- `no-dupe-args`
 - `no-dupe-keys`
 - `no-delete-var`
 - `no-duplicate-case`

--- a/src/core.zig
+++ b/src/core.zig
@@ -34,6 +34,7 @@ pub const Options = struct {
     no_comma_operator: bool = true,
     no_debugger: bool = true,
     no_duplicate_case: bool = true,
+    no_dupe_args: bool = true,
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_empty_block_statements: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,6 +56,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_debugger = false;
         } else if (std.mem.eql(u8, arg, "--no-duplicate-case=off")) {
             options.no_duplicate_case = false;
+        } else if (std.mem.eql(u8, arg, "--no-dupe-args=off")) {
+            options.no_dupe_args = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-keys=off")) {
             options.no_dupe_keys = false;
         } else if (std.mem.eql(u8, arg, "--no-delete-var=off")) {
@@ -318,6 +320,7 @@ fn printHelp() void {
         \\  --no-console=off          Disable no-console
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-duplicate-case=off   Disable no-duplicate-case
+        \\  --no-dupe-args=off        Disable no-dupe-args
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-empty-block-statements=off Disable no-empty-block-statements

--- a/src/rules/no_dupe_args.zig
+++ b/src/rules/no_dupe_args.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-dupe-args";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    if (function.params == .null) return;
+
+    const params = switch (tree.data(function.params)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(allocator);
+
+    for (tree.extra(params.items)) |param_index| {
+        const parameter = switch (tree.data(param_index)) {
+            .formal_parameter => |parameter| parameter,
+            else => continue,
+        };
+
+        const name = parameterName(tree, parameter.pattern) orelse continue;
+        const result = try seen.getOrPut(allocator, name);
+        if (result.found_existing) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(parameter.pattern),
+                "Duplicate parameter '{s}'.",
+                .{name},
+            );
+        }
+    }
+}
+
+fn parameterName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .assignment_pattern => |pattern| parameterName(tree, pattern.left),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -24,6 +24,7 @@ pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
 pub const no_debugger = @import("no_debugger.zig");
 pub const no_duplicate_case = @import("no_duplicate_case.zig");
+pub const no_dupe_args = @import("no_dupe_args.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
@@ -191,6 +192,18 @@ const BasicVisitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     options: core.Options,
+
+    pub fn enter_function(
+        self: *BasicVisitor,
+        function: ast.Function,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_dupe_args) {
+            try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        return .proceed;
+    }
 
     pub fn enter_if_statement(
         self: *BasicVisitor,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -75,6 +75,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_dupe_args.zig");
+}
+
+comptime {
     _ = @import("rules/no_dupe_keys.zig");
 }
 

--- a/tests/rules/no_dupe_args.zig
+++ b/tests/rules/no_dupe_args.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-dupe-args for duplicate function parameters" {
+    const source =
+        \\function first(a, b, a) {}
+        \\const second = function (value, value) {};
+        \\function third(a, b = a, b) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_dupe_args.id));
+}
+
+test "does not report no-dupe-args for unique parameters or binding patterns" {
+    const source =
+        \\function first(a, b, c) {}
+        \\function second({ value }, value) {}
+        \\const arrow = (a, a) => a;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_args.id));
+}
+
+test "can disable no-dupe-args" {
+    const source =
+        \\function first(a, a) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_dupe_args = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_args.id));
+}


### PR DESCRIPTION
## Summary
- add no-dupe-args rule support
- detect duplicate parameter names in function declarations and function expressions
- wire the rule into options and basic traversal
- add focused tests for reporting, allowed patterns, and disabled mode

## Reference
- https://eslint.org/docs/latest/rules/no-dupe-args

## Tests
- direct generated Zig test binary: All 212 tests passed
- zig build -Doptimize=ReleaseFast -j1
- git diff --check