### PR TITLE
feat: port rule no-constructor-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-const-assign`
 - `no-control-regex`
 - `no-console`
+- `no-constructor-return`
 - `no-comma-operator`
 - `no-debugger`
 - `no-dupe-args`

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,6 +32,7 @@ pub const Options = struct {
     no_control_regex: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,
+    no_constructor_return: bool = true,
     no_debugger: bool = true,
     no_duplicate_case: bool = true,
     no_dupe_args: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,6 +52,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
             options.no_comma_operator = false;
+        } else if (std.mem.eql(u8, arg, "--no-constructor-return=off")) {
+            options.no_constructor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
             options.no_debugger = false;
         } else if (std.mem.eql(u8, arg, "--no-duplicate-case=off")) {
@@ -318,6 +320,7 @@ fn printHelp() void {
         \\  --no-control-regex=off   Disable no-control-regex
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
+        \\  --no-constructor-return=off Disable no-constructor-return
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-duplicate-case=off   Disable no-duplicate-case
         \\  --no-dupe-args=off        Disable no-dupe-args

--- a/src/rules/no_constructor_return.zig
+++ b/src/rules/no_constructor_return.zig
@@ -1,0 +1,48 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-constructor-return";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ReturnStatement,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (statement.argument == .null) return;
+    if (!isInsideConstructorBody(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected return of a value in constructor.",
+        tree.span(index),
+    );
+}
+
+fn isInsideConstructorBody(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .arrow_function_expression => return false,
+            .function => {
+                const parent = ctx.path.ancestor(depth + 1) orelse return false;
+                return switch (tree.data(parent)) {
+                    .method_definition => |method| method.kind == .constructor and method.value == ancestor,
+                    else => false,
+                };
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -22,6 +22,7 @@ pub const no_const_assign = @import("no_const_assign.zig");
 pub const no_control_regex = @import("no_control_regex.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
+pub const no_constructor_return = @import("no_constructor_return.zig");
 pub const no_debugger = @import("no_debugger.zig");
 pub const no_duplicate_case = @import("no_duplicate_case.zig");
 pub const no_dupe_args = @import("no_dupe_args.zig");
@@ -385,9 +386,12 @@ const BasicVisitor = struct {
     pub fn enter_return_statement(
         self: *BasicVisitor,
         statement: ast.ReturnStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_constructor_return) {
+            try no_constructor_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
+        }
         if (self.options.no_return_assign) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -47,6 +47,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_constructor_return.zig");
+}
+
+comptime {
     _ = @import("rules/no_const_assign.zig");
 }
 

--- a/tests/rules/no_constructor_return.zig
+++ b/tests/rules/no_constructor_return.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-constructor-return for returning values from constructors" {
+    const source =
+        \\class First {
+        \\  constructor() {
+        \\    return {};
+        \\  }
+        \\}
+        \\class Second {
+        \\  constructor() {
+        \\    return value;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_constructor_return.id));
+}
+
+test "does not report no-constructor-return for bare returns methods or nested functions" {
+    const source =
+        \\class Example {
+        \\  constructor() {
+        \\    return;
+        \\    function nested() {
+        \\      return value;
+        \\    }
+        \\    const arrow = () => {
+        \\      return value;
+        \\    };
+        \\  }
+        \\  method() {
+        \\    return value;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constructor_return.id));
+}
+
+test "can disable no-constructor-return" {
+    const source =
+        \\class First {
+        \\  constructor() {
+        \\    return {};
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_constructor_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constructor_return.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-constructor-return` rule from ESLint
- wire the CLI option and rule registry
- add focused tests under `tests/rules/no_constructor_return.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-constructor-return

## Tests
- direct generated Zig test binary: All 215 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`