### PR TITLE
feat: port rule no-setter-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-script-url`
 - `no-self-assign`
 - `no-self-compare`
+- `no-setter-return`
 - `no-sequences`
 - `no-sparse-arrays`
 - `no-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -76,6 +76,7 @@ pub const Options = struct {
     no_script_url: bool = true,
     no_self_assign: bool = true,
     no_self_compare: bool = true,
+    no_setter_return: bool = true,
     no_sequences: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -140,6 +140,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-self-compare=off")) {
             options.no_self_compare = false;
+        } else if (std.mem.eql(u8, arg, "--no-setter-return=off")) {
+            options.no_setter_return = false;
         } else if (std.mem.eql(u8, arg, "--no-sequences=off")) {
             options.no_sequences = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
@@ -366,6 +368,7 @@ fn printHelp() void {
         \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare
+        \\  --no-setter-return=off    Disable no-setter-return
         \\  --no-sequences=off        Disable no-sequences
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary

--- a/src/rules/no_setter_return.zig
+++ b/src/rules/no_setter_return.zig
@@ -1,0 +1,170 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-setter-return";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ReturnStatement,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (statement.argument == .null) return;
+    if (!isInsideSetterBody(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected return of a value in setter.",
+        tree.span(index),
+    );
+}
+
+fn isInsideSetterBody(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .arrow_function_expression => return false,
+            .function => {
+                const parent = ctx.path.ancestor(depth + 1) orelse return false;
+                return switch (tree.data(parent)) {
+                    .method_definition => |method| method.kind == .set and method.value == ancestor,
+                    .object_property => |property| isSetterProperty(tree, ctx, property, ancestor, depth + 1),
+                    else => false,
+                };
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+fn isSetterProperty(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    property: ast.ObjectProperty,
+    function_index: ast.NodeIndex,
+    property_depth: usize,
+) bool {
+    if (property.value != function_index) return false;
+    if (property.kind == .set) return true;
+
+    if (!isPropertyNamed(tree, property, "set")) return false;
+    const object_index = ctx.path.ancestor(property_depth + 1) orelse return false;
+    return isPropertyDescriptorContext(tree, ctx, object_index, property_depth + 1);
+}
+
+fn isPropertyDescriptorContext(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+    object_depth: usize,
+) bool {
+    if (isDefinePropertyDescriptor(tree, ctx, object_index, object_depth)) return true;
+    if (isNestedDescriptorObject(tree, ctx, object_index, object_depth)) return true;
+    return false;
+}
+
+fn isDefinePropertyDescriptor(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+    object_depth: usize,
+) bool {
+    const parent = ctx.path.ancestor(object_depth + 1) orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 3 or arguments[2] != object_index) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "defineProperty");
+}
+
+fn isNestedDescriptorObject(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+    object_depth: usize,
+) bool {
+    const property_index = ctx.path.ancestor(object_depth + 1) orelse return false;
+    const property = switch (tree.data(property_index)) {
+        .object_property => |property| property,
+        else => return false,
+    };
+    if (property.value != object_index) return false;
+
+    const descriptors_object = ctx.path.ancestor(object_depth + 2) orelse return false;
+    const call_index = ctx.path.ancestor(object_depth + 3) orelse return false;
+    const call = switch (tree.data(call_index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2 or arguments[1] != descriptors_object) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "create") or
+        isStaticMemberCall(tree, call.callee, "Object", "defineProperties");
+}
+
+fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name: []const u8, property_name: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, object_name) and
+        isIdentifierNameNamed(tree, member.property, property_name);
+}
+
+fn isPropertyNamed(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
+    if (property.computed) return false;
+
+    return switch (tree.data(property.key)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .string_literal => |literal| std.mem.eql(u8, tree.string(literal.value), name),
+        else => false,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -66,6 +66,7 @@ pub const no_return_assign = @import("no_return_assign.zig");
 pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
+pub const no_setter_return = @import("no_setter_return.zig");
 pub const no_sequences = @import("no_sequences.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
@@ -395,6 +396,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_constructor_return) {
             try no_constructor_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
+        }
+        if (self.options.no_setter_return) {
+            try no_setter_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         if (self.options.no_return_assign) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -239,6 +239,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_setter_return.zig");
+}
+
+comptime {
     _ = @import("rules/no_sequences.zig");
 }
 

--- a/tests/rules/no_setter_return.zig
+++ b/tests/rules/no_setter_return.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-setter-return for returning values from class and object setters" {
+    const source =
+        \\class Example {
+        \\  set value(next) {
+        \\    return next;
+        \\  }
+        \\}
+        \\const object = {
+        \\  set value(next) {
+        \\    return next;
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_setter_return.id));
+}
+
+test "reports no-setter-return for common property descriptor setters" {
+    const source =
+        \\Object.defineProperty(object, "value", {
+        \\  set(next) {
+        \\    return next;
+        \\  },
+        \\});
+        \\Object.defineProperties(object, {
+        \\  value: {
+        \\    set(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
+        \\Object.create(proto, {
+        \\  value: {
+        \\    set: function(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_setter_return.id));
+}
+
+test "does not report no-setter-return for bare returns methods or nested functions" {
+    const source =
+        \\class Example {
+        \\  set value(next) {
+        \\    return;
+        \\    function nested() {
+        \\      return next;
+        \\    }
+        \\    const arrow = () => {
+        \\      return next;
+        \\    };
+        \\  }
+        \\  method() {
+        \\    return next;
+        \\  }
+        \\}
+        \\const object = {
+        \\  set: function(next) {
+        \\    return next;
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_setter_return.id));
+}
+
+test "can disable no-setter-return" {
+    const source =
+        \\class Example {
+        \\  set value(next) {
+        \\    return next;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_setter_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_setter_return.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-setter-return` rule from ESLint
- wire the CLI option and rule registry
- add focused tests under `tests/rules/no_setter_return.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-setter-return

## Tests
- direct generated Zig test binary: All 223 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`