### PR TITLE
feat: port rule no-floating-decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-ex-assign`
 - `no-extra-semi`
 - `no-extra-boolean-cast`
+- `no-floating-decimal`
 - `no-for-in`
 - `no-func-assign`
 - `no-global-is-finite`

--- a/src/core.zig
+++ b/src/core.zig
@@ -49,6 +49,7 @@ pub const Options = struct {
     no_ex_assign: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
+    no_floating_decimal: bool = true,
     no_for_in: bool = true,
     no_func_assign: bool = true,
     no_global_is_finite: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -86,6 +86,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
             options.no_extra_boolean_cast = false;
+        } else if (std.mem.eql(u8, arg, "--no-floating-decimal=off")) {
+            options.no_floating_decimal = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-func-assign=off")) {
@@ -341,6 +343,7 @@ fn printHelp() void {
         \\  --no-ex-assign=off      Disable no-ex-assign
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
+        \\  --no-floating-decimal=off Disable no-floating-decimal
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-func-assign=off      Disable no-func-assign
         \\  --no-global-is-finite=off Disable no-global-is-finite

--- a/src/rules/no_floating_decimal.zig
+++ b/src/rules/no_floating_decimal.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-floating-decimal";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.NumericLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const raw = tree.string(literal.raw);
+    if (!hasFloatingDecimal(raw)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "A leading or trailing decimal point should include a digit.",
+        tree.span(index),
+    );
+}
+
+fn hasFloatingDecimal(raw: []const u8) bool {
+    if (raw.len == 0) return false;
+
+    if (raw[0] == '.') return raw.len > 1 and std.ascii.isDigit(raw[1]);
+    if (raw[raw.len - 1] == '.') return raw.len > 1 and std.ascii.isDigit(raw[raw.len - 2]);
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -39,6 +39,7 @@ pub const no_eval = @import("no_eval.zig");
 pub const no_ex_assign = @import("no_ex_assign.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
+pub const no_floating_decimal = @import("no_floating_decimal.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_func_assign = @import("no_func_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
@@ -539,6 +540,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_octal) {
             try no_octal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_floating_decimal) {
+            try no_floating_decimal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -131,6 +131,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_floating_decimal.zig");
+}
+
+comptime {
     _ = @import("rules/no_for_in.zig");
 }
 

--- a/tests/rules/no_floating_decimal.zig
+++ b/tests/rules/no_floating_decimal.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-floating-decimal for leading or trailing decimal points" {
+    const source =
+        \\const leading = .5;
+        \\const trailing = 2.;
+        \\const negative = -.7;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_floating_decimal.id));
+}
+
+test "does not report no-floating-decimal for complete decimal literals" {
+    const source =
+        \\const whole = 2;
+        \\const decimal = 2.0;
+        \\const zero = 0.5;
+        \\const exponent = 1e3;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_floating_decimal.id));
+}
+
+test "can disable no-floating-decimal" {
+    const source =
+        \\const leading = .5;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_floating_decimal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_floating_decimal.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-floating-decimal` rule from ESLint
- wire the CLI option and numeric literal visitor
- add focused tests under `tests/rules/no_floating_decimal.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-floating-decimal

## Tests
- direct generated Zig test binary: All 226 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`