### PR TITLE
feat: port rule no-div-regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-dupe-else-if`
 - `no-dupe-keys`
 - `no-delete-var`
+- `no-div-regex`
 - `no-duplicate-case`
 - `no-empty-block-statements`
 - `no-empty-character-class`

--- a/src/core.zig
+++ b/src/core.zig
@@ -39,6 +39,7 @@ pub const Options = struct {
     no_dupe_args: bool = true,
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
+    no_div_regex: bool = true,
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_function: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_dupe_keys = false;
         } else if (std.mem.eql(u8, arg, "--no-delete-var=off")) {
             options.no_delete_var = false;
+        } else if (std.mem.eql(u8, arg, "--no-div-regex=off")) {
+            options.no_div_regex = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
@@ -333,6 +335,7 @@ fn printHelp() void {
         \\  --no-dupe-args=off        Disable no-dupe-args
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
+        \\  --no-div-regex=off        Disable no-div-regex
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-function=off Disable no-empty-function

--- a/src/rules/no_div_regex.zig
+++ b/src/rules/no_div_regex.zig
@@ -1,0 +1,27 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-div-regex";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const pattern = tree.string(literal.pattern);
+    if (pattern.len == 0 or pattern[0] != '=') return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "A regular expression literal can be confused with '/='.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const no_duplicate_case = @import("no_duplicate_case.zig");
 pub const no_dupe_args = @import("no_dupe_args.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
+pub const no_div_regex = @import("no_div_regex.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
 pub const no_empty_function = @import("no_empty_function.zig");
@@ -767,6 +768,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_empty_character_class) {
             try no_empty_character_class.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_div_regex) {
+            try no_div_regex.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.no_regex_spaces) {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -75,6 +75,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_div_regex.zig");
+}
+
+comptime {
     _ = @import("rules/no_duplicate_case.zig");
 }
 

--- a/tests/rules/no_div_regex.zig
+++ b/tests/rules/no_div_regex.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-div-regex for regex literals that start with equals" {
+    const source =
+        \\function value() {
+        \\  return /=foo/;
+        \\}
+        \\const pattern = /=bar/u;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_div_regex.id));
+}
+
+test "does not report no-div-regex for ordinary regex literals" {
+    const source =
+        \\const first = /foo=/;
+        \\const second = /foo/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_div_regex.id));
+}
+
+test "can disable no-div-regex" {
+    const source =
+        \\const pattern = /=foo/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_div_regex = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_div_regex.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-div-regex` rule from ESLint
- wire the CLI option and regexp literal visitor
- add focused tests under `tests/rules/no_div_regex.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-div-regex

## Tests
- direct generated Zig test binary: All 229 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`