### PR TITLE
feat: port rule no-useless-computed-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-unneeded-ternary`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
+- `no-useless-computed-key`
 - `no-useless-concat`
 - `no-useless-catch`
 - `no-useless-rename`

--- a/src/core.zig
+++ b/src/core.zig
@@ -86,6 +86,7 @@ pub const Options = struct {
     no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
+    no_useless_computed_key: bool = true,
     no_useless_concat: bool = true,
     no_useless_catch: bool = true,
     no_useless_rename: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -160,6 +160,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-computed-key=off")) {
+            options.no_useless_computed_key = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
             options.no_useless_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
@@ -382,6 +384,7 @@ fn printHelp() void {
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
+        \\  --no-useless-computed-key=off Disable no-useless-computed-key
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-rename=off   Disable no-useless-rename

--- a/src/rules/no_useless_computed_key.zig
+++ b/src/rules/no_useless_computed_key.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-computed-key";
+
+pub fn checkObjectExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+) Allocator.Error!void {
+    for (tree.extra(expression.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        if (!property.computed) continue;
+        if (!isStaticKey(tree, property.key)) continue;
+        if (isObjectProtoProperty(tree, property)) continue;
+
+        try addDiagnostic(allocator, diagnostics, tree, property.key);
+    }
+}
+
+pub fn checkObjectPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+) Allocator.Error!void {
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        if (!property.computed) continue;
+        if (!isStaticKey(tree, property.key)) continue;
+
+        try addDiagnostic(allocator, diagnostics, tree, property.key);
+    }
+}
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!method.computed) return;
+    if (!isStaticKey(tree, method.key)) return;
+    if (isClassConstructorMethod(tree, method)) return;
+    if (isStaticPrototypeMember(tree, method.static, method.key)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!property.computed) return;
+    if (!isStaticKey(tree, property.key)) return;
+    if (isStaticPrototypeMember(tree, property.static, property.key)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessarily computed property key.",
+        tree.span(index),
+    );
+}
+
+fn isStaticKey(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .string_literal,
+        .numeric_literal,
+        => true,
+        else => false,
+    };
+}
+
+fn isObjectProtoProperty(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
+    if (!property.computed or property.kind != .init or property.method) return false;
+    return keyName(tree, property.key) != null and std.mem.eql(u8, keyName(tree, property.key).?, "__proto__");
+}
+
+fn isClassConstructorMethod(tree: *const ast.Tree, method: ast.MethodDefinition) bool {
+    if (method.static or method.kind != .method) return false;
+    return keyName(tree, method.key) != null and std.mem.eql(u8, keyName(tree, method.key).?, "constructor");
+}
+
+fn isStaticPrototypeMember(tree: *const ast.Tree, is_static: bool, key: ast.NodeIndex) bool {
+    if (!is_static) return false;
+    return keyName(tree, key) != null and std.mem.eql(u8, keyName(tree, key).?, "prototype");
+}
+
+fn keyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -76,6 +76,7 @@ pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
+pub const no_useless_computed_key = @import("no_useless_computed_key.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
@@ -703,6 +704,9 @@ const BasicVisitor = struct {
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
         }
+        if (self.options.no_useless_computed_key) {
+            try no_useless_computed_key.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         return .proceed;
     }
 
@@ -717,6 +721,33 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_rename) {
             try no_useless_rename.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+        }
+        if (self.options.no_useless_computed_key) {
+            try no_useless_computed_key.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_method_definition(
+        self: *BasicVisitor,
+        method: ast.MethodDefinition,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_useless_computed_key) {
+            try no_useless_computed_key.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_property_definition(
+        self: *BasicVisitor,
+        property: ast.PropertyDefinition,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_useless_computed_key) {
+            try no_useless_computed_key.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -279,6 +279,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_computed_key.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_concat.zig");
 }
 

--- a/tests/rules/no_useless_computed_key.zig
+++ b/tests/rules/no_useless_computed_key.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-computed-key for object and pattern literal keys" {
+    const source =
+        \\const object = {
+        \\  ["name"]: value,
+        \\  [0]: value,
+        \\  ["method"]() {},
+        \\};
+        \\const { ["name"]: name, [0]: zero } = object;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_computed_key.id));
+}
+
+test "reports no-useless-computed-key for class members with literal keys" {
+    const source =
+        \\class Example {
+        \\  ["method"]() {}
+        \\  get ["value"]() {
+        \\    return value;
+        \\  }
+        \\  ["field"] = value;
+        \\  static ["name"]() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_computed_key.id));
+}
+
+test "does not report no-useless-computed-key for dynamic keys or semantic exceptions" {
+    const source =
+        \\const object = {
+        \\  [name]: value,
+        \\  ["__proto__"]: value,
+        \\};
+        \\const { [name]: local } = object;
+        \\class Example {
+        \\  ["constructor"]() {}
+        \\  static ["prototype"]() {}
+        \\  [name]() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_computed_key.id));
+}
+
+test "can disable no-useless-computed-key" {
+    const source =
+        \\const object = {
+        \\  ["name"]: value,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_computed_key = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_computed_key.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-useless-computed-key` rule from ESLint
- wire the CLI option and object/class member checks
- add focused tests under `tests/rules/no_useless_computed_key.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-useless-computed-key

## Tests
- direct generated Zig test binary: All 233 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`