### PR TITLE
feat: port rule no-prototype-builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-plusplus`
 - `no-promise-executor-return`
 - `no-proto`
+- `no-prototype-builtins`
 - `no-regex-spaces`
 - `no-return-assign`
 - `no-script-url`

--- a/src/core.zig
+++ b/src/core.zig
@@ -73,6 +73,7 @@ pub const Options = struct {
     no_plusplus: bool = true,
     no_promise_executor_return: bool = true,
     no_proto: bool = true,
+    no_prototype_builtins: bool = true,
     no_regex_spaces: bool = true,
     no_return_assign: bool = true,
     no_script_url: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,6 +134,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_promise_executor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-prototype-builtins=off")) {
+            options.no_prototype_builtins = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
@@ -371,6 +373,7 @@ fn printHelp() void {
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto
+        \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-assign=off    Disable no-return-assign
         \\  --no-script-url=off       Disable no-script-url

--- a/src/rules/no_prototype_builtins.zig
+++ b/src/rules/no_prototype_builtins.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-prototype-builtins";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = builtinName(tree, call.callee) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Do not access Object.prototype method `{s}` from target object.",
+        .{name},
+    );
+}
+
+fn builtinName(tree: *const ast.Tree, callee: ast.NodeIndex) ?[]const u8 {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const name = propertyName(tree, member) orelse return null;
+    if (!isPrototypeBuiltin(name)) return null;
+    if (isSafePrototypeCall(tree, member.object)) return null;
+    return name;
+}
+
+fn isSafePrototypeCall(tree: *const ast.Tree, object: ast.NodeIndex) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, object))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "prototype")) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, "Object");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) {
+        return switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        };
+    }
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isPrototypeBuiltin(name: []const u8) bool {
+    return std.mem.eql(u8, name, "hasOwnProperty") or
+        std.mem.eql(u8, name, "isPrototypeOf") or
+        std.mem.eql(u8, name, "propertyIsEnumerable");
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -63,6 +63,7 @@ pub const no_octal_escape = @import("no_octal_escape.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
 pub const no_proto = @import("no_proto.zig");
+pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
 pub const no_script_url = @import("no_script_url.zig");
@@ -650,6 +651,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_console) {
             try no_console.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.no_prototype_builtins) {
+            try no_prototype_builtins.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -227,6 +227,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_prototype_builtins.zig");
+}
+
+comptime {
     _ = @import("rules/no_regex_spaces.zig");
 }
 

--- a/tests/rules/no_prototype_builtins.zig
+++ b/tests/rules/no_prototype_builtins.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-prototype-builtins for direct object prototype method calls" {
+    const source =
+        \\foo.hasOwnProperty("bar");
+        \\foo.isPrototypeOf(bar);
+        \\foo.propertyIsEnumerable("bar");
+        \\foo["hasOwnProperty"]("bar");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_prototype_builtins.id));
+}
+
+test "does not report no-prototype-builtins for safe prototype calls or other members" {
+    const source =
+        \\Object.prototype.hasOwnProperty.call(foo, "bar");
+        \\Object.prototype.propertyIsEnumerable.call(foo, "bar");
+        \\foo.hasOwn("bar");
+        \\foo[method]("bar");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_prototype_builtins.id));
+}
+
+test "can disable no-prototype-builtins" {
+    const source =
+        \\foo.hasOwnProperty("bar");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_prototype_builtins = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_prototype_builtins.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-prototype-builtins` rule from ESLint
- wire the CLI option and call expression check
- add focused tests under `tests/rules/no_prototype_builtins.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-prototype-builtins

## Tests
- direct generated Zig test binary: All 236 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`