### PR TITLE
feat: port rule no-loss-of-precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-labels`
 - `no-lone-blocks`
 - `no-lonely-if`
+- `no-loss-of-precision`
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -60,6 +60,7 @@ pub const Options = struct {
     no_labels: bool = true,
     no_lone_blocks: bool = true,
     no_lonely_if: bool = true,
+    no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,6 +108,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_lone_blocks = false;
         } else if (std.mem.eql(u8, arg, "--no-lonely-if=off")) {
             options.no_lonely_if = false;
+        } else if (std.mem.eql(u8, arg, "--no-loss-of-precision=off")) {
+            options.no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
@@ -360,6 +362,7 @@ fn printHelp() void {
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
+        \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary

--- a/src/rules/no_loss_of_precision.zig
+++ b/src/rules/no_loss_of_precision.zig
@@ -1,0 +1,157 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-loss-of-precision";
+
+const max_safe_integer = "9007199254740991";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.NumericLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const raw = tree.string(literal.raw);
+    if (!losesPrecision(raw, literal.kind)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Number literal loses precision.",
+        tree.span(index),
+    );
+}
+
+fn losesPrecision(raw: []const u8, kind: ast.NumericLiteral.Kind) bool {
+    var buffer: [256]u8 = undefined;
+    const clean = stripSeparators(raw, &buffer) orelse return false;
+    if (clean.len == 0) return false;
+
+    return switch (kind) {
+        .decimal => decimalLosesPrecision(clean),
+        .hex => prefixedIntegerLosesPrecision(clean, 16),
+        .octal => octalLosesPrecision(clean),
+        .binary => prefixedIntegerLosesPrecision(clean, 2),
+    };
+}
+
+fn stripSeparators(raw: []const u8, buffer: []u8) ?[]const u8 {
+    if (raw.len > buffer.len) return null;
+
+    var len: usize = 0;
+    for (raw) |char| {
+        if (char == '_') continue;
+        buffer[len] = std.ascii.toLower(char);
+        len += 1;
+    }
+    return buffer[0..len];
+}
+
+fn decimalLosesPrecision(clean: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, clean, 'e') != null) return false;
+
+    if (std.mem.indexOfScalar(u8, clean, '.')) |dot| {
+        var significant: usize = 0;
+        var seen_non_zero = false;
+        for (clean[0..dot]) |char| {
+            if (!std.ascii.isDigit(char)) return false;
+            if (char != '0') seen_non_zero = true;
+            if (seen_non_zero) significant += 1;
+        }
+        for (clean[dot + 1 ..]) |char| {
+            if (!std.ascii.isDigit(char)) return false;
+            if (char != '0') seen_non_zero = true;
+            if (seen_non_zero) significant += 1;
+        }
+        return significant > 17;
+    }
+
+    const digits = trimLeadingZeros(trimTrailingZeros(clean));
+    if (digits.len == 0) return false;
+    if (digits.len < max_safe_integer.len) return false;
+    if (digits.len > max_safe_integer.len) return true;
+    return std.mem.order(u8, digits, max_safe_integer) == .gt;
+}
+
+fn octalLosesPrecision(clean: []const u8) bool {
+    const digits = if (clean.len >= 2 and clean[0] == '0' and clean[1] == 'o')
+        clean[2..]
+    else if (clean.len >= 1 and clean[0] == '0')
+        clean[1..]
+    else
+        clean;
+
+    return integerDigitsLosePrecision(digits, 8);
+}
+
+fn prefixedIntegerLosesPrecision(clean: []const u8, base: u8) bool {
+    if (clean.len < 3) return false;
+    return integerDigitsLosePrecision(clean[2..], base);
+}
+
+fn integerDigitsLosePrecision(raw_digits: []const u8, base: u8) bool {
+    const digits = trimLeadingZeros(raw_digits);
+    if (digits.len == 0) return false;
+
+    const bit_len = integerBitLength(digits, base) orelse return false;
+    const trailing_zero_bits = integerTrailingZeroBits(digits, base) orelse return false;
+    if (bit_len <= trailing_zero_bits) return false;
+
+    return bit_len - trailing_zero_bits > 53;
+}
+
+fn integerBitLength(digits: []const u8, base: u8) ?usize {
+    const first = std.fmt.charToDigit(digits[0], base) catch return null;
+    if (first == 0) return null;
+
+    const leading_bits: usize = @as(usize, @bitSizeOf(u8)) - @clz(first);
+    return switch (base) {
+        2 => leading_bits + digits.len - 1,
+        8 => leading_bits + (digits.len - 1) * 3,
+        16 => leading_bits + (digits.len - 1) * 4,
+        else => null,
+    };
+}
+
+fn integerTrailingZeroBits(digits: []const u8, base: u8) ?usize {
+    var count: usize = 0;
+    var index = digits.len;
+
+    while (index > 0) {
+        index -= 1;
+        const digit = std.fmt.charToDigit(digits[index], base) catch return null;
+        if (digit == 0) {
+            count += switch (base) {
+                2 => 1,
+                8 => 3,
+                16 => 4,
+                else => return null,
+            };
+            continue;
+        }
+
+        count += @ctz(digit);
+        return count;
+    }
+
+    return count;
+}
+
+fn trimLeadingZeros(value: []const u8) []const u8 {
+    var start: usize = 0;
+    while (start < value.len and value[start] == '0') : (start += 1) {}
+    return value[start..];
+}
+
+fn trimTrailingZeros(value: []const u8) []const u8 {
+    var end = value.len;
+    while (end > 0 and value[end - 1] == '0') : (end -= 1) {}
+    return value[0..end];
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -50,6 +50,7 @@ pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
+pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
@@ -546,6 +547,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_floating_decimal) {
             try no_floating_decimal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_loss_of_precision) {
+            try no_loss_of_precision.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -175,6 +175,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_loss_of_precision.zig");
+}
+
+comptime {
     _ = @import("rules/no_multi_str.zig");
 }
 

--- a/tests/rules/no_loss_of_precision.zig
+++ b/tests/rules/no_loss_of_precision.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-loss-of-precision for decimal literals with lost digits" {
+    const source =
+        \\const tooLarge = 9007199254740993;
+        \\const manyDigits = 5123000000000000000000000000001;
+        \\const decimal = 1230000000000000000000000.0;
+        \\const fractional = .1230000000000000000000000;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_floating_decimal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_loss_of_precision.id));
+}
+
+test "reports no-loss-of-precision for non-decimal literals with lost bits" {
+    const source =
+        \\const hex = 0X20000000000001;
+        \\const separated = 0X2_000000000_0001;
+        \\const binary = 0b100000000000000000000000000000000000000000000000000001;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_loss_of_precision.id));
+}
+
+test "does not report no-loss-of-precision for safe or documented literals" {
+    const source =
+        \\const small = 12345;
+        \\const decimal = 123.456;
+        \\const exponent = 123e34;
+        \\const trailingZeros = 12300000000000000000000000;
+        \\const hex = 0x1FFFFFFFFFFFFF;
+        \\const powerOfTwo = 0x20000000000000;
+        \\const max = 9007199254740991;
+        \\const separated = 9007_1992547409_91;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_loss_of_precision.id));
+}
+
+test "can disable no-loss-of-precision" {
+    const source =
+        \\const tooLarge = 9007199254740993;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_loss_of_precision = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_loss_of_precision.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-loss-of-precision` rule from ESLint
- wire the CLI option and numeric literal check
- add focused tests under `tests/rules/no_loss_of_precision.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-loss-of-precision

## Tests
- direct generated Zig test binary: All 240 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`