### PR TITLE
feat: port rule no-return-await

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-proto`
 - `no-prototype-builtins`
 - `no-regex-spaces`
+- `no-return-await`
 - `no-return-assign`
 - `no-script-url`
 - `no-self-assign`

--- a/src/core.zig
+++ b/src/core.zig
@@ -76,6 +76,7 @@ pub const Options = struct {
     no_proto: bool = true,
     no_prototype_builtins: bool = true,
     no_regex_spaces: bool = true,
+    no_return_await: bool = true,
     no_return_assign: bool = true,
     no_script_url: bool = true,
     no_self_assign: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -140,6 +140,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_prototype_builtins = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
+        } else if (std.mem.eql(u8, arg, "--no-return-await=off")) {
+            options.no_return_await = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
             options.no_return_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-script-url=off")) {
@@ -378,6 +380,7 @@ fn printHelp() void {
         \\  --no-proto=off            Disable no-proto
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-regex-spaces=off     Disable no-regex-spaces
+        \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign
         \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign

--- a/src/rules/no_return_await.zig
+++ b/src/rules/no_return_await.zig
@@ -1,0 +1,69 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-return-await";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ReturnStatement,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (!isAwaitExpression(tree, statement.argument)) return;
+    if (!isInsideAsyncFunction(tree, ctx)) return;
+    if (isInsideTryBlock(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Redundant use of await on a return value.",
+        tree.span(index),
+    );
+}
+
+fn isAwaitExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .await_expression => true,
+        else => false,
+    };
+}
+
+fn isInsideAsyncFunction(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .arrow_function_expression => |function| return function.async,
+            .function => |function| return function.async,
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+fn isInsideTryBlock(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .arrow_function_expression,
+            .function,
+            => return false,
+            .try_statement => |statement| {
+                const child = ctx.path.ancestor(depth - 1) orelse return false;
+                return statement.block == child;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -66,6 +66,7 @@ pub const no_promise_executor_return = @import("no_promise_executor_return.zig")
 pub const no_proto = @import("no_proto.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
+pub const no_return_await = @import("no_return_await.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
 pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
@@ -404,6 +405,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_setter_return) {
             try no_setter_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
+        }
+        if (self.options.no_return_await) {
+            try no_return_await.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         if (self.options.no_return_assign) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -239,6 +239,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_return_await.zig");
+}
+
+comptime {
     _ = @import("rules/no_return_assign.zig");
 }
 

--- a/tests/rules/no_return_await.zig
+++ b/tests/rules/no_return_await.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-return-await for async return await outside try blocks" {
+    const source =
+        \\async function first() {
+        \\  return await value;
+        \\}
+        \\const second = async () => {
+        \\  return await value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_await.id));
+}
+
+test "does not report no-return-await outside async functions or inside try blocks" {
+    const source =
+        \\function normal() {
+        \\  return value;
+        \\}
+        \\async function guarded() {
+        \\  try {
+        \\    return await value;
+        \\  } catch (error) {
+        \\    return value;
+        \\  }
+        \\}
+        \\async function nested() {
+        \\  function inner() {
+        \\    return value;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_return_await.id));
+}
+
+test "can disable no-return-await" {
+    const source =
+        \\async function first() {
+        \\  return await value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_return_await = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_return_await.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-return-await` rule from ESLint
- wire the CLI option and return statement check
- add focused tests under `tests/rules/no_return_await.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-return-await

## Tests
- direct generated Zig test binary: All 243 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`