### PR TITLE
feat: port rule no-await-in-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-async-promise-executor`
 - `no-alert`
 - `no-array-constructor`
+- `no-await-in-loop`
 - `no-caller`
 - `no-case-declarations`
 - `no-class-assign`

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,7 @@ pub const Options = struct {
     default_case_last: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
+    no_await_in_loop: bool = true,
     no_alert: bool = true,
     no_caller: bool = true,
     no_case_declarations: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_async_promise_executor = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
             options.no_array_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--no-await-in-loop=off")) {
+            options.no_await_in_loop = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
         } else if (std.mem.eql(u8, arg, "--no-caller=off")) {
@@ -325,6 +327,7 @@ fn printHelp() void {
         \\  --default-case-last=off   Disable default-case-last
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor
+        \\  --no-await-in-loop=off    Disable no-await-in-loop
         \\  --no-alert=off            Disable no-alert
         \\  --no-caller=off           Disable no-caller
         \\  --no-case-declarations=off Disable no-case-declarations

--- a/src/rules/no_await_in_loop.zig
+++ b/src/rules/no_await_in_loop.zig
@@ -1,0 +1,47 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-await-in-loop";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (!isInsideLoop(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected await inside a loop.",
+        tree.span(index),
+    );
+}
+
+fn isInsideLoop(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .arrow_function_expression,
+            .function,
+            => return false,
+            .for_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .while_statement,
+            .do_while_statement,
+            => return true,
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -12,6 +12,7 @@ pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
+pub const no_await_in_loop = @import("no_await_in_loop.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_case_declarations = @import("no_case_declarations.zig");
 pub const no_class_assign = @import("no_class_assign.zig");
@@ -676,6 +677,18 @@ const BasicVisitor = struct {
             if (ctx.path.parent()) |parent| {
                 try no_new.check(self.allocator, self.diagnostics, ctx.tree, index, parent);
             }
+        }
+        return .proceed;
+    }
+
+    pub fn enter_await_expression(
+        self: *BasicVisitor,
+        _: ast.AwaitExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_await_in_loop) {
+            try no_await_in_loop.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -19,6 +19,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_await_in_loop.zig");
+}
+
+comptime {
     _ = @import("rules/no_array_constructor.zig");
 }
 

--- a/tests/rules/no_await_in_loop.zig
+++ b/tests/rules/no_await_in_loop.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-await-in-loop for await expressions inside loop bodies" {
+    const source =
+        \\async function run(items) {
+        \\  for (const item of items) {
+        \\    await work(item);
+        \\  }
+        \\  while (ready) {
+        \\    await next();
+        \\  }
+        \\  do {
+        \\    await finish();
+        \\  } while (again);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_await_in_loop.id));
+}
+
+test "does not report no-await-in-loop outside loops or across nested functions" {
+    const source =
+        \\async function run(items) {
+        \\  await setup();
+        \\  for (const item of items) {
+        \\    async function nested() {
+        \\      await work(item);
+        \\    }
+        \\    const callback = async () => {
+        \\      await other(item);
+        \\    };
+        \\  }
+        \\  for await (const item of items) {
+        \\    use(item);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_await_in_loop.id));
+}
+
+test "can disable no-await-in-loop" {
+    const source =
+        \\async function run(items) {
+        \\  for (const item of items) {
+        \\    await work(item);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_await_in_loop = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_await_in_loop.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-await-in-loop` rule from ESLint
- wire the CLI option and await expression check
- add focused tests under `tests/rules/no_await_in_loop.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-await-in-loop

## Tests
- direct generated Zig test binary: All 246 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`