### PR TITLE
feat: port rule no-template-curly-in-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-sequences`
 - `no-sparse-arrays`
 - `no-ternary`
+- `no-template-curly-in-string`
 - `no-throw-literal`
 - `no-unneeded-ternary`
 - `no-unsafe-finally`

--- a/src/core.zig
+++ b/src/core.zig
@@ -86,6 +86,7 @@ pub const Options = struct {
     no_sequences: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,
+    no_template_curly_in_string: bool = true,
     no_throw_literal: bool = true,
     no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -160,6 +160,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_sparse_arrays = false;
         } else if (std.mem.eql(u8, arg, "--no-ternary=off")) {
             options.no_ternary = false;
+        } else if (std.mem.eql(u8, arg, "--no-template-curly-in-string=off")) {
+            options.no_template_curly_in_string = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
@@ -392,6 +394,7 @@ fn printHelp() void {
         \\  --no-sequences=off        Disable no-sequences
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary
+        \\  --no-template-curly-in-string=off Disable no-template-curly-in-string
         \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally

--- a/src/rules/no_template_curly_in_string.zig
+++ b/src/rules/no_template_curly_in_string.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-template-curly-in-string";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.StringLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasTemplateExpressionText(tree.string(literal.value))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected template expression in regular string.",
+        tree.span(index),
+    );
+}
+
+fn hasTemplateExpressionText(value: []const u8) bool {
+    var start: usize = 0;
+    while (std.mem.indexOfPos(u8, value, start, "${")) |open| {
+        if (std.mem.indexOfScalarPos(u8, value, open + 2, '}') != null) return true;
+        start = open + 2;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -76,6 +76,7 @@ pub const no_setter_return = @import("no_setter_return.zig");
 pub const no_sequences = @import("no_sequences.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
+pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
@@ -525,6 +526,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_octal_escape) {
             try no_octal_escape.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.no_template_curly_in_string) {
+            try no_template_curly_in_string.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -279,6 +279,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_template_curly_in_string.zig");
+}
+
+comptime {
     _ = @import("rules/no_throw_literal.zig");
 }
 

--- a/tests/rules/no_template_curly_in_string.zig
+++ b/tests/rules/no_template_curly_in_string.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-template-curly-in-string for template-looking text in strings" {
+    const source =
+        \\const first = "Hello ${name}";
+        \\const second = 'Total: ${amount}';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_template_curly_in_string.id));
+}
+
+test "does not report no-template-curly-in-string for templates or incomplete text" {
+    const source =
+        \\const template = `Hello ${name}`;
+        \\const dollar = "Price is $5";
+        \\const open = "Hello ${name";
+        \\const braces = "Hello {name}";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_template_curly_in_string.id));
+}
+
+test "can disable no-template-curly-in-string" {
+    const source =
+        \\const first = "Hello ${name}";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_template_curly_in_string = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_template_curly_in_string.id));
+}


### PR DESCRIPTION
## Summary
- add the `no-template-curly-in-string` rule from ESLint
- wire the CLI option and string literal check
- add focused tests under `tests/rules/no_template_curly_in_string.zig`

## Reference
- https://eslint.org/docs/latest/rules/no-template-curly-in-string

## Tests
- direct generated Zig test binary: All 249 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`