### PR TITLE
feat: port rule no-useless-call

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-useless-computed-key`
+- `no-useless-call`
 - `no-useless-concat`
 - `no-useless-catch`
 - `no-useless-rename`

--- a/src/core.zig
+++ b/src/core.zig
@@ -92,6 +92,7 @@ pub const Options = struct {
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_useless_computed_key: bool = true,
+    no_useless_call: bool = true,
     no_useless_concat: bool = true,
     no_useless_catch: bool = true,
     no_useless_rename: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -172,6 +172,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key=off")) {
             options.no_useless_computed_key = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-call=off")) {
+            options.no_useless_call = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
             options.no_useless_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
@@ -400,6 +402,7 @@ fn printHelp() void {
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
+        \\  --no-useless-call=off     Disable no-useless-call
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-rename=off   Disable no-useless-rename

--- a/src/rules/no_useless_call.zig
+++ b/src/rules/no_useless_call.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-call";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (call.optional) return;
+
+    const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return,
+    };
+    if (callee_member.optional) return;
+
+    const method = propertyName(tree, callee_member) orelse return;
+    if (!std.mem.eql(u8, method, "call") and !std.mem.eql(u8, method, "apply")) return;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return;
+
+    if (!hasUselessThisArg(tree, callee_member.object, arguments[0])) return;
+    if (std.mem.eql(u8, method, "apply") and !hasArrayLiteralArguments(tree, arguments)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary use of call or apply.",
+        tree.span(index),
+    );
+}
+
+fn hasUselessThisArg(tree: *const ast.Tree, target: ast.NodeIndex, this_arg: ast.NodeIndex) bool {
+    const unwrapped_target = unwrapTransparent(tree, target);
+
+    const target_member = switch (tree.data(unwrapped_target)) {
+        .member_expression => |member| member,
+        else => return isNullOrUndefined(tree, this_arg),
+    };
+
+    if (target_member.optional) return false;
+    if (!isSimpleReference(tree, target_member.object)) return false;
+
+    return sameSource(tree, target_member.object, this_arg);
+}
+
+fn hasArrayLiteralArguments(tree: *const ast.Tree, arguments: []const ast.NodeIndex) bool {
+    if (arguments.len < 2) return false;
+
+    const array = switch (tree.data(unwrapTransparent(tree, arguments[1]))) {
+        .array_expression => |array| array,
+        else => return false,
+    };
+
+    for (tree.extra(array.elements)) |element| {
+        if (element == .null) return false;
+    }
+
+    return true;
+}
+
+fn isNullOrUndefined(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        else => false,
+    };
+}
+
+fn isSimpleReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference,
+        .this_expression,
+        => true,
+        .member_expression => |member| !member.optional and isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
+        else => false,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn sameSource(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_source = sourceSlice(tree, unwrapTransparent(tree, left)) orelse return false;
+    const right_source = sourceSlice(tree, unwrapTransparent(tree, right)) orelse return false;
+
+    return std.mem.eql(u8, left_source, right_source);
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+
+    if (start >= end or end > tree.source.len) return null;
+    return tree.source[start..end];
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -82,6 +82,7 @@ pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_useless_computed_key = @import("no_useless_computed_key.zig");
+pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
@@ -667,6 +668,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_prototype_builtins) {
             try no_prototype_builtins.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.no_useless_call) {
+            try no_useless_call.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -303,6 +303,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_call.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_concat.zig");
 }
 

--- a/tests/rules/no_useless_call.zig
+++ b/tests/rules/no_useless_call.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-call for unnecessary call expressions" {
+    const source =
+        \\foo.call(undefined);
+        \\foo.call(null, a, b);
+        \\obj.foo.call(obj, a);
+        \\this.foo.call(this, a);
+        \\obj.foo.bar.call(obj.foo, a);
+        \\foo["call"](undefined, a);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_useless_call.id));
+}
+
+test "reports no-useless-call for unnecessary apply expressions with array arguments" {
+    const source =
+        \\foo.apply(undefined, []);
+        \\foo.apply(null, [a, b]);
+        \\obj.foo.apply(obj, [a]);
+        \\this.foo.apply(this, [a]);
+        \\obj.foo["apply"](obj, [a]);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_call.id));
+}
+
+test "does not report no-useless-call when this binding or arguments are meaningful" {
+    const source =
+        \\foo.call(obj, a);
+        \\obj.foo.call(other, a);
+        \\getObj().foo.call(getObj(), a);
+        \\foo.apply(undefined, args);
+        \\obj.foo.apply(obj, args);
+        \\foo.apply(undefined, [, a]);
+        \\foo.apply(obj, [a]);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_call.id));
+}
+
+test "can disable no-useless-call" {
+    const source =
+        \\foo.call(undefined, a);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_call = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_call.id));
+}


### PR DESCRIPTION
## Summary
- add the no-useless-call rule for unnecessary Function.prototype.call/apply usage
- wire the rule into options, CLI flags, and rule dispatch
- add focused rule tests under tests/rules/no_useless_call.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-useless-call

## Tests
- .zig-cache/o/7c65918e54ec8b121c059a9dff08c884/root --seed=0x55ac4a15
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true