### PR TITLE
feat: port rule no-iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-nan`
 - `no-implied-eval`
 - `no-import-assign`
+- `no-iterator`
 - `no-labels`
 - `no-lone-blocks`
 - `no-lonely-if`

--- a/src/core.zig
+++ b/src/core.zig
@@ -58,6 +58,7 @@ pub const Options = struct {
     no_global_is_nan: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
+    no_iterator: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,
     no_lonely_if: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,6 +104,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
             options.no_import_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-iterator=off")) {
+            options.no_iterator = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
             options.no_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-lone-blocks=off")) {
@@ -368,6 +370,7 @@ fn printHelp() void {
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
+        \\  --no-iterator=off          Disable no-iterator
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if

--- a/src/rules/no_iterator.zig
+++ b/src/rules/no_iterator.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-iterator";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = propertyName(tree, member) orelse return;
+    if (!std.mem.eql(u8, name, "__iterator__")) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Avoid use of the non-standard __iterator__ property.",
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -48,6 +48,7 @@ pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
+pub const no_iterator = @import("no_iterator.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
@@ -712,6 +713,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_proto) {
             try no_proto.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.no_iterator) {
+            try no_iterator.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -167,6 +167,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_iterator.zig");
+}
+
+comptime {
     _ = @import("rules/no_labels.zig");
 }
 

--- a/tests/rules/no_iterator.zig
+++ b/tests/rules/no_iterator.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-iterator for iterator member access" {
+    const source =
+        \\foo.__iterator__ = bar;
+        \\foo["__iterator__"] = bar;
+        \\const iterator = foo.__iterator__;
+        \\const iterator2 = foo["__iterator__"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_iterator.id));
+}
+
+test "does not report no-iterator for object literal properties or other members" {
+    const source =
+        \\const value = {
+        \\  __iterator__: bar,
+        \\  other: foo.__iter__,
+        \\};
+        \\foo[iterator] = bar;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_iterator.id));
+}
+
+test "can disable no-iterator" {
+    const source =
+        \\const iterator = foo.__iterator__;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_iterator = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_iterator.id));
+}


### PR DESCRIPTION
## Summary
- add the no-iterator rule for __iterator__ member access
- wire the rule into options, CLI flags, and member-expression dispatch
- add focused rule tests under tests/rules/no_iterator.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-iterator

## Tests
- .zig-cache/o/78ac3c186ae88932d5163d418d84f06f/root --seed=0xda2b3dd4
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true