### PR TITLE
feat: port rule no-new-native-nonconstructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`
+- `no-new-native-nonconstructor`
 - `no-obj-calls`
 - `no-new-func`
 - `no-new-object`

--- a/src/core.zig
+++ b/src/core.zig
@@ -66,6 +66,7 @@ pub const Options = struct {
     no_multi_str: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
+    no_new_native_nonconstructor: bool = true,
     no_new_func: bool = true,
     no_obj_calls: bool = true,
     no_new_object: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -120,6 +120,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
             options.no_nested_ternary = false;
+        } else if (std.mem.eql(u8, arg, "--no-new-native-nonconstructor=off")) {
+            options.no_new_native_nonconstructor = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
         } else if (std.mem.eql(u8, arg, "--no-obj-calls=off")) {
@@ -378,6 +380,7 @@ fn printHelp() void {
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
+        \\  --no-new-native-nonconstructor=off Disable no-new-native-nonconstructor
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-obj-calls=off        Disable no-obj-calls
         \\  --no-new-object=off       Disable no-new-object

--- a/src/rules/no_new_native_nonconstructor.zig
+++ b/src/rules/no_new_native_nonconstructor.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-new-native-nonconstructor";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (nativeNonconstructorName(ctx.tree, self.symbol_table, expression.callee)) |name| {
+            try core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .@"error",
+                id,
+                ctx.tree.span(index),
+                "`{s}` cannot be called as a constructor.",
+                .{name},
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn nativeNonconstructorName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return null;
+    if (!isNativeNonconstructorName(name) or !isUnresolvedReference(symbol_table, unwrapped)) return null;
+
+    return name;
+}
+
+fn isNativeNonconstructorName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Symbol") or
+        std.mem.eql(u8, name, "BigInt");
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -56,6 +56,7 @@ pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
+pub const no_new_native_nonconstructor = @import("no_new_native_nonconstructor.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_obj_calls = @import("no_obj_calls.zig");
 pub const no_new_object = @import("no_new_object.zig");
@@ -170,6 +171,10 @@ pub fn runSemantic(
 
     if (options.no_new_func) {
         try no_new_func.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_new_native_nonconstructor) {
+        try no_new_native_nonconstructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_obj_calls) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -199,6 +199,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_new_native_nonconstructor.zig");
+}
+
+comptime {
     _ = @import("rules/no_obj_calls.zig");
 }
 

--- a/tests/rules/no_new_native_nonconstructor.zig
+++ b/tests/rules/no_new_native_nonconstructor.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-new-native-nonconstructor for global Symbol and BigInt constructors" {
+    const source =
+        \\const symbol = new Symbol("value");
+        \\const wrapped = new (Symbol)("value");
+        \\const bigint = new BigInt(1);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_new_native_nonconstructor.id));
+}
+
+test "does not report no-new-native-nonconstructor for calls or shadowed names" {
+    const source =
+        \\const symbol = Symbol("value");
+        \\const bigint = BigInt(1);
+        \\function local(Symbol, BigInt) {
+        \\  const localSymbol = new Symbol("value");
+        \\  const localBigInt = new BigInt(1);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new_native_nonconstructor.id));
+}
+
+test "can disable no-new-native-nonconstructor" {
+    const source =
+        \\const symbol = new Symbol("value");
+        \\const bigint = new BigInt(1);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new_native_nonconstructor = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new_native_nonconstructor.id));
+}


### PR DESCRIPTION
## Summary
- add the no-new-native-nonconstructor rule for global Symbol and BigInt constructor usage
- wire the rule into options, CLI flags, and semantic rule dispatch
- add focused rule tests under tests/rules/no_new_native_nonconstructor.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-new-native-nonconstructor

## Tests
- .zig-cache/o/6f07c13e5df24b86a80b2392400348ef/root --seed=0x6f9140aa
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true