### PR TITLE
feat: port rule no-new-require

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-native-nonconstructor`
 - `no-obj-calls`
 - `no-new-func`
+- `no-new-require`
 - `no-new-object`
 - `no-new-symbol`
 - `no-new-wrappers`

--- a/src/core.zig
+++ b/src/core.zig
@@ -68,6 +68,7 @@ pub const Options = struct {
     no_nested_ternary: bool = true,
     no_new_native_nonconstructor: bool = true,
     no_new_func: bool = true,
+    no_new_require: bool = true,
     no_obj_calls: bool = true,
     no_new_object: bool = true,
     no_new_symbol: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,6 +124,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new_native_nonconstructor = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
             options.no_new_func = false;
+        } else if (std.mem.eql(u8, arg, "--no-new-require=off")) {
+            options.no_new_require = false;
         } else if (std.mem.eql(u8, arg, "--no-obj-calls=off")) {
             options.no_obj_calls = false;
         } else if (std.mem.eql(u8, arg, "--no-new-object=off")) {
@@ -382,6 +384,7 @@ fn printHelp() void {
         \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-new-native-nonconstructor=off Disable no-new-native-nonconstructor
         \\  --no-new-func=off         Disable no-new-func
+        \\  --no-new-require=off      Disable no-new-require
         \\  --no-obj-calls=off        Disable no-obj-calls
         \\  --no-new-object=off       Disable no-new-object
         \\  --no-new-symbol=off       Disable no-new-symbol

--- a/src/rules/no_new_require.zig
+++ b/src/rules/no_new_require.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-new-require";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NewExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isRequireConstructorCallee(tree, expression.callee)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not use new with require().",
+        tree.span(index),
+    );
+}
+
+fn isRequireConstructorCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| return std.mem.eql(u8, tree.string(identifier.name), "require"),
+        .call_expression => |call| {
+            const callee = unwrapTransparent(tree, call.callee);
+            return switch (tree.data(callee)) {
+                .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "require"),
+                else => false,
+            };
+        },
+        else => return false,
+    }
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -58,6 +58,7 @@ pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
 pub const no_new_native_nonconstructor = @import("no_new_native_nonconstructor.zig");
 pub const no_new_func = @import("no_new_func.zig");
+pub const no_new_require = @import("no_new_require.zig");
 pub const no_obj_calls = @import("no_obj_calls.zig");
 pub const no_new_object = @import("no_new_object.zig");
 pub const no_new_symbol = @import("no_new_symbol.zig");
@@ -683,7 +684,7 @@ const BasicVisitor = struct {
 
     pub fn enter_new_expression(
         self: *BasicVisitor,
-        _: ast.NewExpression,
+        expression: ast.NewExpression,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
@@ -691,6 +692,9 @@ const BasicVisitor = struct {
             if (ctx.path.parent()) |parent| {
                 try no_new.check(self.allocator, self.diagnostics, ctx.tree, index, parent);
             }
+        }
+        if (self.options.no_new_require) {
+            try no_new_require.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -211,6 +211,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_new_require.zig");
+}
+
+comptime {
     _ = @import("rules/no_new_object.zig");
 }
 

--- a/tests/rules/no_new_require.zig
+++ b/tests/rules/no_new_require.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-new-require for constructing require calls" {
+    const source =
+        \\const foo = new require("foo");
+        \\const bar = new (require)("bar");
+        \\const baz = new (require("baz"));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_new_require.id));
+}
+
+test "does not report no-new-require for ordinary require or constructed values" {
+    const source =
+        \\const Foo = require("foo");
+        \\const foo = new Foo();
+        \\const resolved = require.resolve("foo");
+        \\const custom = new require.resolve("foo");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new_require.id));
+}
+
+test "can disable no-new-require" {
+    const source =
+        \\const foo = new require("foo");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new_require = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_new_require.id));
+}


### PR DESCRIPTION
## Summary
- add the no-new-require rule for constructing require calls
- wire the rule into options, CLI flags, and new-expression dispatch
- add focused rule tests under tests/rules/no_new_require.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-new-require

## Tests
- .zig-cache/o/89fc510e07018b21d0798e2d95cd2bcc/root --seed=0x1b9dcf6e
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true