### PR TITLE
feat: port rule no-path-concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-wrappers`
 - `no-octal`
 - `no-octal-escape`
+- `no-path-concat`
 - `no-plusplus`
 - `no-promise-executor-return`
 - `no-proto`

--- a/src/core.zig
+++ b/src/core.zig
@@ -75,6 +75,7 @@ pub const Options = struct {
     no_new_wrappers: bool = true,
     no_octal: bool = true,
     no_octal_escape: bool = true,
+    no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_promise_executor_return: bool = true,
     no_proto: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,6 +138,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_octal = false;
         } else if (std.mem.eql(u8, arg, "--no-octal-escape=off")) {
             options.no_octal_escape = false;
+        } else if (std.mem.eql(u8, arg, "--no-path-concat=off")) {
+            options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
             options.no_plusplus = false;
         } else if (std.mem.eql(u8, arg, "--no-promise-executor-return=off")) {
@@ -391,6 +393,7 @@ fn printHelp() void {
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-octal=off            Disable no-octal
         \\  --no-octal-escape=off     Disable no-octal-escape
+        \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto

--- a/src/rules/no_path_concat.zig
+++ b/src/rules/no_path_concat.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-path-concat";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .add) return;
+    if (!isPathConcat(tree, expression.left, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use path.join() or path.resolve() instead of path string concatenation.",
+        tree.span(index),
+    );
+}
+
+fn isPathConcat(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    return (isPathMetaIdentifier(tree, left) and isStringLikePathPart(tree, right)) or
+        (isPathMetaIdentifier(tree, right) and isStringLikePathPart(tree, left));
+}
+
+fn isPathMetaIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| {
+            const name = tree.string(identifier.name);
+            return std.mem.eql(u8, name, "__dirname") or std.mem.eql(u8, name, "__filename");
+        },
+        else => false,
+    };
+}
+
+fn isStringLikePathPart(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| containsPathSeparator(tree.string(literal.value)),
+        .template_literal => |template| template.expressions.len == 0 and containsPathSeparator(sourceSlice(tree, index) orelse ""),
+        else => false,
+    };
+}
+
+fn containsPathSeparator(value: []const u8) bool {
+    return std.mem.indexOfScalar(u8, value, '/') != null or
+        std.mem.indexOfScalar(u8, value, '\\') != null;
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(unwrapTransparent(tree, index));
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+
+    if (start >= end or end > tree.source.len) return null;
+    return tree.source[start..end];
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -65,6 +65,7 @@ pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
 pub const no_octal_escape = @import("no_octal_escape.zig");
+pub const no_path_concat = @import("no_path_concat.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
 pub const no_proto = @import("no_proto.zig");
@@ -618,6 +619,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_concat) {
             try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_path_concat) {
+            try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -235,6 +235,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_path_concat.zig");
+}
+
+comptime {
     _ = @import("rules/no_plusplus.zig");
 }
 

--- a/tests/rules/no_path_concat.zig
+++ b/tests/rules/no_path_concat.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-path-concat for dirname and filename path string concatenation" {
+    const source =
+        \\const first = __dirname + "/foo.js";
+        \\const second = __filename + "\\foo.js";
+        \\const third = "/tmp/" + __dirname;
+        \\const fourth = (__dirname) + `/foo.js`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_concat = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_path_concat.id));
+}
+
+test "does not report no-path-concat for non-path concatenation or path helpers" {
+    const source =
+        \\const name = __dirname + suffix;
+        \\const label = __filename + ".bak";
+        \\const joined = path.join(__dirname, "foo.js");
+        \\const dynamic = __dirname + `${name}.js`;
+        \\const ordinary = dirname + "/foo.js";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_concat = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_path_concat.id));
+}
+
+test "can disable no-path-concat" {
+    const source =
+        \\const first = __dirname + "/foo.js";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_path_concat = false,
+        .no_useless_concat = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_path_concat.id));
+}


### PR DESCRIPTION
## Summary
- add the no-path-concat rule for __dirname/__filename path string concatenation
- wire the rule into options, CLI flags, and binary-expression dispatch
- add focused rule tests under tests/rules/no_path_concat.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-path-concat

## Tests
- .zig-cache/o/133e9ea1ce283da3f761fbb724b9a5f2/root --seed=0x438a808c
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true