### PR TITLE
feat: port rule no-process-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-plusplus`
 - `no-promise-executor-return`
 - `no-proto`
+- `no-process-env`
 - `no-prototype-builtins`
 - `no-regex-spaces`
 - `no-return-await`

--- a/src/core.zig
+++ b/src/core.zig
@@ -79,6 +79,7 @@ pub const Options = struct {
     no_plusplus: bool = true,
     no_promise_executor_return: bool = true,
     no_proto: bool = true,
+    no_process_env: bool = true,
     no_prototype_builtins: bool = true,
     no_regex_spaces: bool = true,
     no_return_await: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -146,6 +146,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_promise_executor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
             options.no_proto = false;
+        } else if (std.mem.eql(u8, arg, "--no-process-env=off")) {
+            options.no_process_env = false;
         } else if (std.mem.eql(u8, arg, "--no-prototype-builtins=off")) {
             options.no_prototype_builtins = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -397,6 +399,7 @@ fn printHelp() void {
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto
+        \\  --no-process-env=off      Disable no-process-env
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await

--- a/src/rules/no_process_env.zig
+++ b/src/rules/no_process_env.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-process-env";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isProcessEnvAccess(tree, member)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Avoid direct use of process.env.",
+        tree.span(index),
+    );
+}
+
+fn isProcessEnvAccess(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    const property = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "env")) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, "process");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -69,6 +69,7 @@ pub const no_path_concat = @import("no_path_concat.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
 pub const no_proto = @import("no_proto.zig");
+pub const no_process_env = @import("no_process_env.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
@@ -729,6 +730,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_iterator) {
             try no_iterator.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.no_process_env) {
+            try no_process_env.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -251,6 +251,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_process_env.zig");
+}
+
+comptime {
     _ = @import("rules/no_prototype_builtins.zig");
 }
 

--- a/tests/rules/no_process_env.zig
+++ b/tests/rules/no_process_env.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-process-env for process env member access" {
+    const source =
+        \\const nodeEnv = process.env.NODE_ENV;
+        \\process.env.DEBUG = "1";
+        \\const env = process["env"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_process_env.id));
+}
+
+test "does not report no-process-env for other objects or dynamic properties" {
+    const source =
+        \\const env = config.env;
+        \\const env2 = process[envName];
+        \\const value = process.envName;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_process_env.id));
+}
+
+test "can disable no-process-env" {
+    const source =
+        \\const nodeEnv = process.env.NODE_ENV;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_process_env = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_process_env.id));
+}


### PR DESCRIPTION
## Summary
- add the no-process-env rule for direct process.env member access
- wire the rule into options, CLI flags, and member-expression dispatch
- add focused rule tests under tests/rules/no_process_env.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-process-env

## Tests
- .zig-cache/o/c243d24ced0632efc6705223922a75b3/root --seed=0xc235a45c
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true