### PR TITLE
feat: port rule no-process-exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-promise-executor-return`
 - `no-proto`
 - `no-process-env`
+- `no-process-exit`
 - `no-prototype-builtins`
 - `no-regex-spaces`
 - `no-return-await`

--- a/src/core.zig
+++ b/src/core.zig
@@ -80,6 +80,7 @@ pub const Options = struct {
     no_promise_executor_return: bool = true,
     no_proto: bool = true,
     no_process_env: bool = true,
+    no_process_exit: bool = true,
     no_prototype_builtins: bool = true,
     no_regex_spaces: bool = true,
     no_return_await: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -148,6 +148,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_proto = false;
         } else if (std.mem.eql(u8, arg, "--no-process-env=off")) {
             options.no_process_env = false;
+        } else if (std.mem.eql(u8, arg, "--no-process-exit=off")) {
+            options.no_process_exit = false;
         } else if (std.mem.eql(u8, arg, "--no-prototype-builtins=off")) {
             options.no_prototype_builtins = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -400,6 +402,7 @@ fn printHelp() void {
         \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto
         \\  --no-process-env=off      Disable no-process-env
+        \\  --no-process-exit=off     Disable no-process-exit
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await

--- a/src/rules/no_process_exit.zig
+++ b/src/rules/no_process_exit.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-process-exit";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isProcessExitCall(tree, call.callee)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not use process.exit().",
+        tree.span(index),
+    );
+}
+
+fn isProcessExitCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "exit")) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, "process");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -70,6 +70,7 @@ pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
 pub const no_proto = @import("no_proto.zig");
 pub const no_process_env = @import("no_process_env.zig");
+pub const no_process_exit = @import("no_process_exit.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
@@ -683,6 +684,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_call) {
             try no_useless_call.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.no_process_exit) {
+            try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -255,6 +255,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_process_exit.zig");
+}
+
+comptime {
     _ = @import("rules/no_prototype_builtins.zig");
 }
 

--- a/tests/rules/no_process_exit.zig
+++ b/tests/rules/no_process_exit.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-process-exit for process exit calls" {
+    const source =
+        \\process.exit(1);
+        \\process["exit"](0);
+        \\(process.exit)();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_process_exit.id));
+}
+
+test "does not report no-process-exit for references or other objects" {
+    const source =
+        \\const exit = process.exit;
+        \\runner.exit(1);
+        \\process[method](0);
+        \\process.exitCode = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_process_exit.id));
+}
+
+test "can disable no-process-exit" {
+    const source =
+        \\process.exit(1);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_process_exit = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_process_exit.id));
+}


### PR DESCRIPTION
## Summary
- add the no-process-exit rule for direct process.exit() calls
- wire the rule into options, CLI flags, and call-expression dispatch
- add focused rule tests under tests/rules/no_process_exit.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-process-exit

## Tests
- .zig-cache/o/4c0d474eea5c2e3c9e7e8a78bcdd64cf/root --seed=0xc8a2b45d
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true