### PR TITLE
feat: port rule no-buffer-constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-alert`
 - `no-array-constructor`
 - `no-await-in-loop`
+- `no-buffer-constructor`
 - `no-caller`
 - `no-case-declarations`
 - `no-class-assign`

--- a/src/core.zig
+++ b/src/core.zig
@@ -23,6 +23,7 @@ pub const Options = struct {
     no_array_constructor: bool = true,
     no_await_in_loop: bool = true,
     no_alert: bool = true,
+    no_buffer_constructor: bool = true,
     no_caller: bool = true,
     no_case_declarations: bool = true,
     no_class_assign: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_await_in_loop = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
+        } else if (std.mem.eql(u8, arg, "--no-buffer-constructor=off")) {
+            options.no_buffer_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-caller=off")) {
             options.no_caller = false;
         } else if (std.mem.eql(u8, arg, "--no-case-declarations=off")) {
@@ -345,6 +347,7 @@ fn printHelp() void {
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-await-in-loop=off    Disable no-await-in-loop
         \\  --no-alert=off            Disable no-alert
+        \\  --no-buffer-constructor=off Disable no-buffer-constructor
         \\  --no-caller=off           Disable no-caller
         \\  --no-case-declarations=off Disable no-case-declarations
         \\  --no-class-assign=off     Disable no-class-assign

--- a/src/rules/no_buffer_constructor.zig
+++ b/src/rules/no_buffer_constructor.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-buffer-constructor";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalBufferReference(ctx.tree, self.symbol_table, expression.callee)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalBufferReference(ctx.tree, self.symbol_table, call.callee)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Do not use the Buffer constructor.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isGlobalBufferReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Buffer") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -13,6 +13,7 @@ pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_await_in_loop = @import("no_await_in_loop.zig");
+pub const no_buffer_constructor = @import("no_buffer_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_case_declarations = @import("no_case_declarations.zig");
 pub const no_class_assign = @import("no_class_assign.zig");
@@ -127,6 +128,10 @@ pub fn runSemantic(
 
     if (options.no_array_constructor) {
         try no_array_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_buffer_constructor) {
+        try no_buffer_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_extra_boolean_cast) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -23,6 +23,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_buffer_constructor.zig");
+}
+
+comptime {
     _ = @import("rules/no_array_constructor.zig");
 }
 

--- a/tests/rules/no_buffer_constructor.zig
+++ b/tests/rules/no_buffer_constructor.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-buffer-constructor for global Buffer calls and constructors" {
+    const source =
+        \\const first = Buffer("abc");
+        \\const second = new Buffer("abc");
+        \\const third = new (Buffer)("abc");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_buffer_constructor.id));
+}
+
+test "does not report no-buffer-constructor for safe APIs or shadowed Buffer" {
+    const source =
+        \\const first = Buffer.from("abc");
+        \\const second = Buffer.alloc(10);
+        \\function local(Buffer) {
+        \\  const third = Buffer("abc");
+        \\  const fourth = new Buffer("abc");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_buffer_constructor.id));
+}
+
+test "can disable no-buffer-constructor" {
+    const source =
+        \\const first = Buffer("abc");
+        \\const second = new Buffer("abc");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_buffer_constructor = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_buffer_constructor.id));
+}


### PR DESCRIPTION
## Summary
- add the no-buffer-constructor rule for global Buffer() and new Buffer() usage
- wire the rule into options, CLI flags, and semantic rule dispatch
- add focused rule tests under tests/rules/no_buffer_constructor.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-buffer-constructor

## Tests
- .zig-cache/o/df4cd8512775372d08e92cad1ae98d1b/root --seed=0x95c66297
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true