### PR TITLE
feat: port rule no-undef-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-ternary`
 - `no-template-curly-in-string`
 - `no-throw-literal`
+- `no-undef-init`
 - `no-unneeded-ternary`
 - `no-unsafe-finally`
 - `no-unsafe-negation`

--- a/src/core.zig
+++ b/src/core.zig
@@ -95,6 +95,7 @@ pub const Options = struct {
     no_ternary: bool = true,
     no_template_curly_in_string: bool = true,
     no_throw_literal: bool = true,
+    no_undef_init: bool = true,
     no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -178,6 +178,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_template_curly_in_string = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
+        } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
+            options.no_undef_init = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
             options.no_unneeded_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
@@ -419,6 +421,7 @@ fn printHelp() void {
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-template-curly-in-string=off Disable no-template-curly-in-string
         \\  --no-throw-literal=off    Disable no-throw-literal
+        \\  --no-undef-init=off       Disable no-undef-init
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation

--- a/src/rules/no_undef_init.zig
+++ b/src/rules/no_undef_init.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-undef-init";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+) Allocator.Error!void {
+    if (declaration.kind == .@"const") return;
+
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+
+        if (!isUndefinedReference(tree, declarator.init)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Do not initialize variables to undefined.",
+            tree.span(declarator.init),
+        );
+    }
+}
+
+fn isUndefinedReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -85,6 +85,7 @@ pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
+pub const no_undef_init = @import("no_undef_init.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
@@ -524,6 +525,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_var) {
             try no_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        if (self.options.no_undef_init) {
+            try no_undef_init.check(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -315,6 +315,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_undef_init.zig");
+}
+
+comptime {
     _ = @import("rules/no_unneeded_ternary.zig");
 }
 

--- a/tests/rules/no_undef_init.zig
+++ b/tests/rules/no_undef_init.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-undef-init for var and let initializers" {
+    const source =
+        \\var first = undefined;
+        \\let second = undefined;
+        \\let third = (undefined);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_var = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_undef_init.id));
+}
+
+test "does not report no-undef-init for const or useful initializers" {
+    const source =
+        \\const first = undefined;
+        \\let second;
+        \\let third = void 0;
+        \\let fourth = value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_void = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_undef_init.id));
+}
+
+test "can disable no-undef-init" {
+    const source =
+        \\let value = undefined;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef_init = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_undef_init.id));
+}


### PR DESCRIPTION
## Summary
- add the no-undef-init rule for var and let variables initialized to undefined
- wire the rule into options, CLI flags, and variable-declaration dispatch
- add focused rule tests under tests/rules/no_undef_init.zig

## Reference
- ESLint rule docs: https://eslint.org/docs/latest/rules/no-undef-init

## Tests
- .zig-cache/o/5ecd8dd8d909c067e2fa6eeeb6cc9fab/root --seed=0x212762d6
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true