### PR TITLE
feat: port rule no-shadow-restricted-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-self-assign`
 - `no-self-compare`
 - `no-setter-return`
+- `no-shadow-restricted-names`
 - `no-sequences`
 - `no-sparse-arrays`
 - `no-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     no_self_assign: bool = true,
     no_self_compare: bool = true,
     no_setter_return: bool = true,
+    no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -168,6 +168,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_self_compare = false;
         } else if (std.mem.eql(u8, arg, "--no-setter-return=off")) {
             options.no_setter_return = false;
+        } else if (std.mem.eql(u8, arg, "--no-shadow-restricted-names=off")) {
+            options.no_shadow_restricted_names = false;
         } else if (std.mem.eql(u8, arg, "--no-sequences=off")) {
             options.no_sequences = false;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
@@ -416,6 +418,7 @@ fn printHelp() void {
         \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare
         \\  --no-setter-return=off    Disable no-setter-return
+        \\  --no-shadow-restricted-names=off Disable no-shadow-restricted-names
         \\  --no-sequences=off        Disable no-sequences
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary

--- a/src/rules/no_shadow_restricted_names.zig
+++ b/src/rules/no_shadow_restricted_names.zig
@@ -1,0 +1,130 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-shadow-restricted-names";
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, function.id, false);
+    try checkFormalParameters(allocator, diagnostics, tree, function.params);
+}
+
+pub fn checkFormalParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern, false),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter, false),
+            else => {},
+        }
+    }
+
+    try checkBinding(allocator, diagnostics, tree, params.rest, false);
+}
+
+pub fn checkVariableDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+) Allocator.Error!void {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+
+        try checkBinding(allocator, diagnostics, tree, declarator.id, declarator.init == .null);
+    }
+}
+
+pub fn checkBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    allow_uninitialized_undefined: bool,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try checkIdentifier(
+            allocator,
+            diagnostics,
+            tree,
+            identifier,
+            index,
+            allow_uninitialized_undefined,
+        ),
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left, false),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument, false),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBinding(allocator, diagnostics, tree, element, false);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, false);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBinding(allocator, diagnostics, tree, property.value, false);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, false);
+        },
+        else => {},
+    }
+}
+
+fn checkIdentifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    identifier: ast.BindingIdentifier,
+    index: ast.NodeIndex,
+    allow_uninitialized_undefined: bool,
+) Allocator.Error!void {
+    const name = tree.string(identifier.name);
+    if (allow_uninitialized_undefined and std.mem.eql(u8, name, "undefined")) return;
+    if (!isRestrictedName(name)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Do not shadow the restricted name '{s}'.",
+        .{name},
+    );
+}
+
+fn isRestrictedName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "undefined") or
+        std.mem.eql(u8, name, "NaN") or
+        std.mem.eql(u8, name, "Infinity") or
+        std.mem.eql(u8, name, "arguments") or
+        std.mem.eql(u8, name, "eval") or
+        std.mem.eql(u8, name, "globalThis");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -80,6 +80,7 @@ pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
 pub const no_setter_return = @import("no_setter_return.zig");
+pub const no_shadow_restricted_names = @import("no_shadow_restricted_names.zig");
 pub const no_sequences = @import("no_sequences.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
@@ -229,6 +230,21 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_class(
+        self: *BasicVisitor,
+        class: ast.Class,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
         }
         return .proceed;
     }
@@ -398,6 +414,9 @@ const BasicVisitor = struct {
         if (self.options.no_useless_catch) {
             try no_useless_catch.check(self.allocator, self.diagnostics, ctx.tree, clause, index);
         }
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, clause.param, false);
+        }
         return .proceed;
     }
 
@@ -529,6 +548,9 @@ const BasicVisitor = struct {
         if (self.options.no_undef_init) {
             try no_undef_init.check(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
+        }
         return .proceed;
     }
 
@@ -591,6 +613,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, expression.body);
+        }
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);
         }
         return .proceed;
     }
@@ -827,6 +852,33 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_rename) {
             try no_useless_rename.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, index);
+        }
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_import_default_specifier(
+        self: *BasicVisitor,
+        specifier: ast.ImportDefaultSpecifier,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_import_namespace_specifier(
+        self: *BasicVisitor,
+        specifier: ast.ImportNamespaceSpecifier,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_shadow_restricted_names) {
+            try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -319,6 +319,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_shadow_restricted_names.zig");
+}
+
+comptime {
     _ = @import("rules/no_unneeded_ternary.zig");
 }
 

--- a/tests/rules/no_shadow_restricted_names.zig
+++ b/tests/rules/no_shadow_restricted_names.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-shadow-restricted-names for restricted declarations" {
+    const source =
+        \\function NaN() {}
+        \\!function(Infinity) {};
+        \\const undefined = 5;
+        \\try {} catch (eval) {}
+        \\import globalThis from "foo";
+        \\import { undefined } from "bar";
+        \\import * as arguments from "baz";
+        \\class Infinity {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_const_assign = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_eval = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
+}
+
+test "reports no-shadow-restricted-names inside binding patterns" {
+    const source =
+        \\function f({ NaN }, [Infinity], ...eval) {}
+        \\const { undefined: alias = 1, value: globalThis } = source;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
+}
+
+test "does not report no-shadow-restricted-names for allowed names or uninitialized undefined" {
+    const source =
+        \\let Object;
+        \\function f(a, b) {}
+        \\let undefined;
+        \\var undefined;
+        \\import { undefined as undef } from "bar";
+        \\const foo = globalThis;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_undef_init = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow_restricted_names.id));
+}
+
+test "can disable no-shadow-restricted-names" {
+    const source =
+        \\const NaN = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_shadow_restricted_names = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow_restricted_names.id));
+}


### PR DESCRIPTION
## Summary
- add the no-shadow-restricted-names rule
- cover restricted names in declarations, parameters, catch bindings, imports, classes, and binding patterns
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/no-shadow-restricted-names

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/7498c32373b32df14b6c9a4a72c2392a/root --seed=0x6d6b3765
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true