### PR TITLE
feat: port rule radix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `eqeqeq`
 - `no-unused-vars`
 - `no-undef`
+- `radix`
 - `use-isnan`
 - `parse` diagnostics from Yuku, including semantic early errors by default
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -112,6 +112,7 @@ pub const Options = struct {
     use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_undef: bool = true,
+    radix: bool = true,
     parser_semantic_errors: bool = true,
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -212,6 +212,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unused_vars = false;
         } else if (std.mem.eql(u8, arg, "--no-undef=off")) {
             options.no_undef = false;
+        } else if (std.mem.eql(u8, arg, "--radix=off")) {
+            options.radix = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
             options.parser_semantic_errors = false;
         } else {
@@ -440,6 +442,7 @@ fn printHelp() void {
         \\  --use-isnan=off           Disable use-isnan
         \\  --no-unused-vars=off      Disable no-unused-vars
         \\  --no-undef=off            Disable no-undef
+        \\  --radix=off               Disable radix
         \\  --semantic-errors=off     Disable parser semantic errors
         \\
     , .{});

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.radix;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);

--- a/src/rules/radix.zig
+++ b/src/rules/radix.zig
@@ -1,0 +1,172 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "radix";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalParseIntCall(ctx.tree, self.symbol_table, call.callee)) {
+            try self.checkArguments(ctx.tree, call, index);
+        }
+
+        return .proceed;
+    }
+
+    fn checkArguments(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(call.arguments);
+        if (arguments.len == 0) {
+            try self.addDiagnostic(tree, index, "Missing parameters.");
+            return;
+        }
+
+        if (arguments.len == 1) {
+            try self.addDiagnostic(tree, index, "Missing radix parameter.");
+            return;
+        }
+
+        if (!isValidRadix(tree, arguments[1])) {
+            try self.addDiagnostic(tree, index, "Invalid radix parameter, must be an integer between 2 and 36.");
+        }
+    }
+
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        message: []const u8,
+    ) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+        );
+    }
+};
+
+fn isGlobalParseIntCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return std.mem.eql(u8, name, "parseInt") and isUnresolvedReference(symbol_table, unwrapped);
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed or member.property == .null) return false;
+
+    const property = switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    if (!std.mem.eql(u8, property, "parseInt")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Number") and isUnresolvedReference(symbol_table, object);
+}
+
+fn isValidRadix(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+
+    switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| return !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .numeric_literal => |literal| return isValidNumericRadix(tree, literal, 1),
+        .unary_expression => |expression| {
+            if (expression.operator != .positive and expression.operator != .negate) return false;
+
+            const literal = switch (tree.data(unwrapTransparent(tree, expression.argument))) {
+                .numeric_literal => |literal| literal,
+                else => return false,
+            };
+            return isValidNumericRadix(tree, literal, if (expression.operator == .negate) -1 else 1);
+        },
+        .string_literal, .boolean_literal, .null_literal, .bigint_literal => return false,
+        else => return true,
+    }
+}
+
+fn isValidNumericRadix(tree: *const ast.Tree, literal: ast.NumericLiteral, sign: i64) bool {
+    const value = literal.value(tree);
+    const signed_value = value * @as(f64, @floatFromInt(sign));
+    return signed_value >= 2 and signed_value <= 36 and signed_value == @floor(signed_value);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -100,6 +100,7 @@ pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
+pub const radix = @import("radix.zig");
 pub const use_isnan = @import("use_isnan.zig");
 
 pub fn runBasic(
@@ -206,6 +207,10 @@ pub fn runSemantic(
 
     if (options.no_promise_executor_return) {
         try no_promise_executor_return.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.radix) {
+        try radix.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -375,5 +375,9 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/radix.zig");
+}
+
+comptime {
     _ = @import("rules/use_isnan.zig");
 }

--- a/tests/rules/radix.zig
+++ b/tests/rules/radix.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports radix for parseInt calls without radix" {
+    const source =
+        \\parseInt();
+        \\parseInt(value);
+        \\Number.parseInt(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.radix.id));
+}
+
+test "reports radix for invalid literal or undefined radix" {
+    const source =
+        \\parseInt(value, 1);
+        \\parseInt(value, 37);
+        \\parseInt(value, "10");
+        \\parseInt(value, undefined);
+        \\parseInt(value, -10);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.radix.id));
+}
+
+test "does not report radix for valid radix arguments or shadowed globals" {
+    const source =
+        \\parseInt(value, 10);
+        \\parseInt(value, 16);
+        \\parseInt(value, radix);
+        \\Number.parseInt(value, 10);
+        \\function shadowed(parseInt, Number) {
+        \\  parseInt(value);
+        \\  Number.parseInt(value);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_const_assign = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.radix.id));
+}
+
+test "can disable radix" {
+    const source =
+        \\parseInt(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .radix = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.radix.id));
+}


### PR DESCRIPTION
## Summary
- add the radix rule for global parseInt and Number.parseInt calls
- report missing radix parameters and invalid literal radix values
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/radix
- https://github.com/eslint/eslint/blob/main/lib/rules/radix.js

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/fc8c85a2a15fb4cdd4d5b252ef1594d7/root --seed=0x47e04c99
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true