### PR TITLE
feat: port rule yoda

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-undef`
 - `radix`
 - `use-isnan`
+- `yoda`
 - `parse` diagnostics from Yuku, including semantic early errors by default
 
 ## Prerequisites

--- a/src/core.zig
+++ b/src/core.zig
@@ -114,6 +114,7 @@ pub const Options = struct {
     no_undef: bool = true,
     radix: bool = true,
     parser_semantic_errors: bool = true,
+    yoda: bool = true,
 };
 
 pub const Diagnostic = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -216,6 +216,8 @@ pub fn main(init: std.process.Init) !void {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
             options.parser_semantic_errors = false;
+        } else if (std.mem.eql(u8, arg, "--yoda=off")) {
+            options.yoda = false;
         } else {
             try targets.append(allocator, arg);
         }
@@ -444,6 +446,7 @@ fn printHelp() void {
         \\  --no-undef=off            Disable no-undef
         \\  --radix=off               Disable radix
         \\  --semantic-errors=off     Disable parser semantic errors
+        \\  --yoda=off                Disable yoda
         \\
     , .{});
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -102,6 +102,7 @@ pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 pub const radix = @import("radix.zig");
 pub const use_isnan = @import("use_isnan.zig");
+pub const yoda = @import("yoda.zig");
 
 pub fn runBasic(
     allocator: Allocator,
@@ -663,6 +664,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_path_concat) {
             try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.yoda) {
+            try yoda.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/src/rules/yoda.zig
+++ b/src/rules/yoda.zig
@@ -1,0 +1,82 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "yoda";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isComparisonOperator(expression.operator)) return;
+    if (!isLiteralLike(tree, expression.left) or isLiteralLike(tree, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected literal to be on the right side of comparison.",
+        tree.span(index),
+    );
+}
+
+fn isComparisonOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isLiteralLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal,
+        .numeric_literal,
+        .boolean_literal,
+        .null_literal,
+        .bigint_literal,
+        .regexp_literal,
+        => true,
+        .template_literal => |literal| literal.expressions.len == 0,
+        .unary_expression => |expression| isNegativeNumericLiteral(tree, expression),
+        else => false,
+    };
+}
+
+fn isNegativeNumericLiteral(tree: *const ast.Tree, expression: ast.UnaryExpression) bool {
+    if (expression.operator != .negate) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, expression.argument))) {
+        .numeric_literal => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -381,3 +381,7 @@ comptime {
 comptime {
     _ = @import("rules/use_isnan.zig");
 }
+
+comptime {
+    _ = @import("rules/yoda.zig");
+}

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports yoda for literals on the left side" {
+    const source =
+        \\if ("red" === color) {}
+        \\if (0 < count) {}
+        \\if (true !== enabled) {}
+        \\if (`ready` == state) {}
+        \\if (-1 >= value) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eqeqeq = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.yoda.id));
+}
+
+test "does not report yoda when literals are on the right side or both sides" {
+    const source =
+        \\if (color === "red") {}
+        \\if (count > 0) {}
+        \\if (enabled !== true) {}
+        \\if ("red" === "blue") {}
+        \\if (value in object) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eqeqeq = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.yoda.id));
+}
+
+test "can disable yoda" {
+    const source =
+        \\if ("red" === color) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .yoda = false,
+        .eqeqeq = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.yoda.id));
+}


### PR DESCRIPTION
## Summary
- add the yoda rule using the default never behavior
- report comparisons where a literal-like value is on the left side
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/yoda
- https://github.com/eslint/eslint/blob/main/lib/rules/yoda.js

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/bbccf3dad8a2f1489d1a09c7941b11e8/root --seed=0x38eeac56
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true