### PR TITLE
feat: port rule no-warning-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-useless-concat`
 - `no-useless-catch`
 - `no-useless-rename`
+- `no-warning-comments`
 - `no-void`
 - `no-with`
 - `no-var`

--- a/src/core.zig
+++ b/src/core.zig
@@ -105,6 +105,7 @@ pub const Options = struct {
     no_useless_concat: bool = true,
     no_useless_catch: bool = true,
     no_useless_rename: bool = true,
+    no_warning_comments: bool = true,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -198,6 +198,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
             options.no_useless_rename = false;
+        } else if (std.mem.eql(u8, arg, "--no-warning-comments=off")) {
+            options.no_warning_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -437,6 +439,7 @@ fn printHelp() void {
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-rename=off   Disable no-useless-rename
+        \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/rules/no_warning_comments.zig
+++ b/src/rules/no_warning_comments.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-warning-comments";
+
+const terms = [_][]const u8{
+    "todo",
+    "fixme",
+    "xxx",
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    for (tree.comments) |comment| {
+        const match = warningTermAtStart(tree, comment) orelse continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            .{ .start = comment.start, .end = comment.end },
+            "Unexpected '{s}' comment.",
+            .{match},
+        );
+    }
+}
+
+fn warningTermAtStart(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {
+    const value = tree.string(comment.value);
+    const trimmed = trimLeftWhitespace(value);
+
+    inline for (terms) |term| {
+        if (startsWithWholeWordIgnoreCase(trimmed, term)) return term;
+    }
+
+    return null;
+}
+
+fn trimLeftWhitespace(value: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index < value.len and isWhitespace(value[index])) : (index += 1) {}
+    return value[index..];
+}
+
+fn isWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}
+
+fn startsWithWholeWordIgnoreCase(value: []const u8, term: []const u8) bool {
+    if (value.len < term.len) return false;
+    if (!std.ascii.eqlIgnoreCase(value[0..term.len], term)) return false;
+    if (value.len == term.len) return true;
+
+    return !isAsciiIdentifierPart(value[term.len]);
+}
+
+fn isAsciiIdentifierPart(char: u8) bool {
+    return std.ascii.isAlphanumeric(char) or char == '_' or char == '$';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -97,6 +97,7 @@ pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
+pub const no_warning_comments = @import("no_warning_comments.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
@@ -110,6 +111,10 @@ pub fn runBasic(
     tree: *const ast.Tree,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.no_warning_comments) {
+        try no_warning_comments.run(allocator, diagnostics, tree);
+    }
+
     var visitor = BasicVisitor{
         .allocator = allocator,
         .diagnostics = diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -363,6 +363,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_warning_comments.zig");
+}
+
+comptime {
     _ = @import("rules/no_var.zig");
 }
 

--- a/tests/rules/no_warning_comments.zig
+++ b/tests/rules/no_warning_comments.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-warning-comments for default warning terms at comment start" {
+    const source =
+        \\// TODO: handle this case
+        \\/* fixme rewrite this */
+        \\// xxx
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_warning_comments.id));
+}
+
+test "does not report no-warning-comments away from start or as partial words" {
+    const source =
+        \\// this TODO is not at the start
+        \\// todoing is not the whole word
+        \\/* * TODO decoration is not ignored by default */
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_warning_comments.id));
+}
+
+test "can disable no-warning-comments" {
+    const source =
+        \\// TODO: handle this case
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_warning_comments = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_warning_comments.id));
+}


### PR DESCRIPTION
## Summary
- add the no-warning-comments rule with the default warning terms
- scan parsed comments for todo, fixme, and xxx at the comment start
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/no-warning-comments

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/d2113bc7f01d97165a825fd57b72071d/root --seed=0x2332839
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true