### PR TITLE
feat: port rule no-negated-condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`
+- `no-negated-condition`
 - `no-new-native-nonconstructor`
 - `no-obj-calls`
 - `no-new-func`

--- a/src/core.zig
+++ b/src/core.zig
@@ -67,6 +67,7 @@ pub const Options = struct {
     no_multi_str: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
+    no_negated_condition: bool = true,
     no_new_native_nonconstructor: bool = true,
     no_new_func: bool = true,
     no_new_require: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,6 +122,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
             options.no_nested_ternary = false;
+        } else if (std.mem.eql(u8, arg, "--no-negated-condition=off")) {
+            options.no_negated_condition = false;
         } else if (std.mem.eql(u8, arg, "--no-new-native-nonconstructor=off")) {
             options.no_new_native_nonconstructor = false;
         } else if (std.mem.eql(u8, arg, "--no-new-func=off")) {
@@ -401,6 +403,7 @@ fn printHelp() void {
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
+        \\  --no-negated-condition=off Disable no-negated-condition
         \\  --no-new-native-nonconstructor=off Disable no-new-native-nonconstructor
         \\  --no-new-func=off         Disable no-new-func
         \\  --no-new-require=off      Disable no-new-require

--- a/src/rules/no_negated_condition.zig
+++ b/src/rules/no_negated_condition.zig
@@ -1,0 +1,81 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-negated-condition";
+
+pub fn checkIfStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasElseWithoutCondition(tree, statement)) return;
+    if (!isNegatedCondition(tree, statement.@"test")) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkConditionalExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isNegatedCondition(tree, expression.@"test")) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn hasElseWithoutCondition(tree: *const ast.Tree, statement: ast.IfStatement) bool {
+    if (statement.alternate == .null) return false;
+
+    return switch (tree.data(statement.alternate)) {
+        .if_statement => false,
+        else => true,
+    };
+}
+
+fn isNegatedCondition(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |expression| expression.operator == .logical_not,
+        .binary_expression => |expression| expression.operator == .not_equal or expression.operator == .strict_not_equal,
+        else => false,
+    };
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected negated condition.",
+        tree.span(index),
+    );
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -57,6 +57,7 @@ pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
+pub const no_negated_condition = @import("no_negated_condition.zig");
 pub const no_new_native_nonconstructor = @import("no_new_native_nonconstructor.zig");
 pub const no_new_func = @import("no_new_func.zig");
 pub const no_new_require = @import("no_new_require.zig");
@@ -281,6 +282,9 @@ const BasicVisitor = struct {
         if (self.options.no_lonely_if) {
             try no_lonely_if.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
+        if (self.options.no_negated_condition) {
+            try no_negated_condition.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
         return .proceed;
     }
 
@@ -346,6 +350,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_ternary) {
             try no_ternary.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.no_negated_condition) {
+            try no_negated_condition.checkConditionalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -195,6 +195,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_negated_condition.zig");
+}
+
+comptime {
     _ = @import("rules/no_new.zig");
 }
 

--- a/tests/rules/no_negated_condition.zig
+++ b/tests/rules/no_negated_condition.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-negated-condition for if else and ternary tests" {
+    const source =
+        \\if (!ready) {
+        \\  wait();
+        \\} else {
+        \\  run();
+        \\}
+        \\const value = count !== expected ? left : right;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_negated_condition.id));
+}
+
+test "does not report no-negated-condition without plain else or with positive tests" {
+    const source =
+        \\if (!ready) {
+        \\  wait();
+        \\}
+        \\if (count !== expected) {
+        \\  left();
+        \\} else if (fallback) {
+        \\  right();
+        \\}
+        \\if (ready) {
+        \\  run();
+        \\} else {
+        \\  wait();
+        \\}
+        \\const value = ready ? left : right;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_negated_condition.id));
+}
+
+test "can disable no-negated-condition" {
+    const source =
+        \\if (!ready) {
+        \\  wait();
+        \\} else {
+        \\  run();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_negated_condition = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_negated_condition.id));
+}


### PR DESCRIPTION
## Summary
- add the no-negated-condition rule
- report negated if/else conditions and negated ternary tests
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/no-negated-condition
- https://github.com/eslint/eslint/blob/main/lib/rules/no-negated-condition.js

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/2ca6c1912ebaae61405ada1d64b8b863/root --seed=0x5335c0b
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true