### PR TITLE
feat: port rule no-trailing-spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-ternary`
 - `no-template-curly-in-string`
 - `no-throw-literal`
+- `no-trailing-spaces`
 - `no-undef-init`
 - `no-unneeded-ternary`
 - `no-unsafe-finally`

--- a/src/core.zig
+++ b/src/core.zig
@@ -97,6 +97,7 @@ pub const Options = struct {
     no_ternary: bool = true,
     no_template_curly_in_string: bool = true,
     no_throw_literal: bool = true,
+    no_trailing_spaces: bool = true,
     no_undef_init: bool = true,
     no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -182,6 +182,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_template_curly_in_string = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
+        } else if (std.mem.eql(u8, arg, "--no-trailing-spaces=off")) {
+            options.no_trailing_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
             options.no_undef_init = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
@@ -433,6 +435,7 @@ fn printHelp() void {
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-template-curly-in-string=off Disable no-template-curly-in-string
         \\  --no-throw-literal=off    Disable no-throw-literal
+        \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-undef-init=off       Disable no-undef-init
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally

--- a/src/rules/no_trailing_spaces.zig
+++ b/src/rules/no_trailing_spaces.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-trailing-spaces";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var line_start: usize = 0;
+    var index: usize = 0;
+
+    while (index <= source.len) {
+        const line_end = findLineEnd(source, index);
+        var trailing_start = line_end;
+
+        while (trailing_start > line_start and isTrailingWhitespace(source[trailing_start - 1])) {
+            trailing_start -= 1;
+        }
+
+        if (trailing_start < line_end) {
+            try addDiagnostic(allocator, diagnostics, trailing_start, line_end);
+        }
+
+        if (line_end >= source.len) break;
+
+        index = line_end + 1;
+        if (source[line_end] == '\r' and index < source.len and source[index] == '\n') {
+            index += 1;
+        }
+        line_start = index;
+    }
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    start: usize,
+    end: usize,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Trailing spaces not allowed.",
+        .{ .start = @intCast(start), .end = @intCast(end) },
+    );
+}
+
+fn isTrailingWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == 0x0B or char == 0x0C;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -87,6 +87,7 @@ pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
+pub const no_trailing_spaces = @import("no_trailing_spaces.zig");
 pub const no_undef_init = @import("no_undef_init.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
@@ -114,6 +115,9 @@ pub fn runBasic(
 ) Allocator.Error!void {
     if (options.no_warning_comments) {
         try no_warning_comments.run(allocator, diagnostics, tree);
+    }
+    if (options.no_trailing_spaces) {
+        try no_trailing_spaces.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -319,6 +319,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_trailing_spaces.zig");
+}
+
+comptime {
     _ = @import("rules/no_undef_init.zig");
 }
 

--- a/tests/rules/no_trailing_spaces.zig
+++ b/tests/rules/no_trailing_spaces.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-trailing-spaces for line endings with spaces or tabs" {
+    const source =
+        "const first = 1; \n" ++
+        "const second = 2;\t\n" ++
+        "  \n" ++
+        "const third = 3;\r\n" ++
+        "const fourth = 4;\t\r\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_trailing_spaces.id));
+}
+
+test "does not report no-trailing-spaces for clean lines" {
+    const source =
+        "const first = 1;\n" ++
+        "\n" ++
+        "// comment\n" ++
+        "const second = 2;\r\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_trailing_spaces.id));
+}
+
+test "can disable no-trailing-spaces" {
+    const source = "const value = 1; \n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_trailing_spaces = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_trailing_spaces.id));
+}


### PR DESCRIPTION
## Summary
- add the no-trailing-spaces rule
- scan source lines for trailing spaces, tabs, vertical tabs, and form feeds
- add a CLI off switch and README entry

## Reference
- https://eslint.org/docs/latest/rules/no-trailing-spaces

## Tests
- zig test -OReleaseFast --dep utoo_lint -Mroot=tests/all.zig -OReleaseFast --dep parser -Mutoo_lint=src/root.zig -OReleaseFast --dep util -Mparser=vendor/yuku/src/parser/root.zig -OReleaseFast -Mutil=vendor/yuku/src/util/root.zig
- .zig-cache/o/12a2aaca32ad75d597be1877342c6baa/root --seed=0x8b017020
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true