### PR TITLE
feat: port rule eol-last

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 
 - `default-case`
 - `default-case-last`
+- `eol-last`
 - `no-async-promise-executor`
 - `no-alert`
 - `no-array-constructor`

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
+    eol_last: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
     no_await_in_loop: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
             options.default_case_last = false;
+        } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
+            options.eol_last = false;
         } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
             options.no_async_promise_executor = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
@@ -357,6 +359,7 @@ fn printHelp() void {
         \\Options:
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
+        \\  --eol-last=off            Disable eol-last
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-await-in-loop=off    Disable no-await-in-loop

--- a/src/rules/eol_last.zig
+++ b/src/rules/eol_last.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "eol-last";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    if (source.len == 0 or source[source.len - 1] == '\n') return;
+
+    const start = source.len - 1;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Newline required at end of file but not found.",
+        .{ .start = @intCast(start), .end = @intCast(source.len) },
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
+pub const eol_last = @import("eol_last.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
@@ -118,6 +119,9 @@ pub fn runBasic(
     }
     if (options.no_trailing_spaces) {
         try no_trailing_spaces.run(allocator, diagnostics, tree);
+    }
+    if (options.eol_last) {
+        try eol_last.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -7,6 +7,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/eol_last.zig");
+}
+
+comptime {
     _ = @import("rules/eqeqeq.zig");
 }
 

--- a/tests/rules/eol_last.zig
+++ b/tests/rules/eol_last.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports eol-last when a non-empty file does not end with a newline" {
+    const source = "const value = 1;";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.eol_last.id));
+    try std.testing.expectEqualStrings(
+        "Newline required at end of file but not found.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report eol-last when source ends with a newline" {
+    const source = "const value = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.eol_last.id));
+}
+
+test "does not report eol-last for empty source" {
+    var result = try lint.lintSource(std.testing.allocator, "", "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.eol_last.id));
+}
+
+test "can disable eol-last" {
+    const source = "const value = 1;";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.eol_last.id));
+}


### PR DESCRIPTION
Summary:
- add the eol-last rule with the default newline-at-EOF behavior
- expose --eol-last=off and document the rule
- add focused tests in tests/rules/eol_last.zig

References:
- https://eslint.org/docs/latest/rules/eol-last
- https://github.com/eslint/eslint/blob/main/lib/rules/eol-last.js

Tests:
- .zig-cache/o/224823a175b6266345545cbfc4374b83/root --seed=0xb349c86
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true