### PR TITLE
feat: port rule unicode-bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-throw-literal`
 - `no-trailing-spaces`
 - `no-undef-init`
+- `unicode-bom`
 - `no-unneeded-ternary`
 - `no-unsafe-finally`
 - `no-unsafe-negation`

--- a/src/core.zig
+++ b/src/core.zig
@@ -100,6 +100,7 @@ pub const Options = struct {
     no_throw_literal: bool = true,
     no_trailing_spaces: bool = true,
     no_undef_init: bool = true,
+    unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -188,6 +188,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_trailing_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
             options.no_undef_init = false;
+        } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
+            options.unicode_bom = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
             options.no_unneeded_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
@@ -440,6 +442,7 @@ fn printHelp() void {
         \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-undef-init=off       Disable no-undef-init
+        \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -105,6 +105,7 @@ pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 pub const radix = @import("radix.zig");
+pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const yoda = @import("yoda.zig");
 
@@ -122,6 +123,9 @@ pub fn runBasic(
     }
     if (options.eol_last) {
         try eol_last.run(allocator, diagnostics, tree);
+    }
+    if (options.unicode_bom) {
+        try unicode_bom.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/src/rules/unicode_bom.zig
+++ b/src/rules/unicode_bom.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "unicode-bom";
+
+const bom = "\xEF\xBB\xBF";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    if (!std.mem.startsWith(u8, tree.source, bom)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected Unicode BOM (Byte Order Mark).",
+        .{ .start = 0, .end = bom.len },
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -395,6 +395,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/unicode_bom.zig");
+}
+
+comptime {
     _ = @import("rules/use_isnan.zig");
 }
 

--- a/tests/rules/unicode_bom.zig
+++ b/tests/rules/unicode_bom.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports unicode-bom when source starts with a byte order mark" {
+    const source = "\xEF\xBB\xBFconst value = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.unicode_bom.id));
+    try std.testing.expectEqualStrings(
+        "Unexpected Unicode BOM (Byte Order Mark).",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report unicode-bom for ordinary source" {
+    const source = "const value = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.unicode_bom.id));
+}
+
+test "can disable unicode-bom" {
+    const source = "\xEF\xBB\xBFconst value = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .unicode_bom = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.unicode_bom.id));
+}


### PR DESCRIPTION
Summary:
- add the unicode-bom rule with the default disallow-BOM behavior
- expose --unicode-bom=off and document the rule
- add focused tests in tests/rules/unicode_bom.zig

References:
- https://eslint.org/docs/latest/rules/unicode-bom
- https://github.com/eslint/eslint/blob/main/lib/rules/unicode-bom.js

Tests:
- .zig-cache/o/775c5f920aa6625a92e460e36dee8bfc/root --seed=0xcd24c24
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true