### PR TITLE
feat: port rule no-tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-ternary`
 - `no-template-curly-in-string`
 - `no-throw-literal`
+- `no-tabs`
 - `no-trailing-spaces`
 - `no-undef-init`
 - `unicode-bom`

--- a/src/core.zig
+++ b/src/core.zig
@@ -98,6 +98,7 @@ pub const Options = struct {
     no_ternary: bool = true,
     no_template_curly_in_string: bool = true,
     no_throw_literal: bool = true,
+    no_tabs: bool = true,
     no_trailing_spaces: bool = true,
     no_undef_init: bool = true,
     unicode_bom: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -184,6 +184,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_template_curly_in_string = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
+        } else if (std.mem.eql(u8, arg, "--no-tabs=off")) {
+            options.no_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-trailing-spaces=off")) {
             options.no_trailing_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
@@ -440,6 +442,7 @@ fn printHelp() void {
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-template-curly-in-string=off Disable no-template-curly-in-string
         \\  --no-throw-literal=off    Disable no-throw-literal
+        \\  --no-tabs=off             Disable no-tabs
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-undef-init=off       Disable no-undef-init
         \\  --unicode-bom=off         Disable unicode-bom

--- a/src/rules/no_tabs.zig
+++ b/src/rules/no_tabs.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-tabs";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var index: usize = 0;
+
+    while (std.mem.indexOfScalarPos(u8, source, index, '\t')) |start| {
+        var end = start + 1;
+        while (end < source.len and source[end] == '\t') : (end += 1) {}
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unexpected tab character.",
+            .{ .start = @intCast(start), .end = @intCast(end) },
+        );
+
+        index = end;
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -85,6 +85,7 @@ pub const no_setter_return = @import("no_setter_return.zig");
 pub const no_shadow_restricted_names = @import("no_shadow_restricted_names.zig");
 pub const no_sequences = @import("no_sequences.zig");
 pub const no_sparse_arrays = @import("no_sparse_arrays.zig");
+pub const no_tabs = @import("no_tabs.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
@@ -126,6 +127,9 @@ pub fn runBasic(
     }
     if (options.unicode_bom) {
         try unicode_bom.run(allocator, diagnostics, tree);
+    }
+    if (options.no_tabs) {
+        try no_tabs.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -311,6 +311,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_tabs.zig");
+}
+
+comptime {
     _ = @import("rules/no_ternary.zig");
 }
 

--- a/tests/rules/no_tabs.zig
+++ b/tests/rules/no_tabs.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-tabs for tab characters" {
+    const source =
+        "const\tfirst = 1;\n" ++
+        "\tconst second = 2;\n" ++
+        "const third\t\t= 3;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_tabs.id));
+}
+
+test "does not report no-tabs for spaces" {
+    const source =
+        "const first = 1;\n" ++
+        "  const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_tabs.id));
+}
+
+test "can disable no-tabs" {
+    const source = "const\tvalue = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_tabs.id));
+}


### PR DESCRIPTION
Summary:
- add the no-tabs rule with default tab-character reporting
- expose --no-tabs=off and document the rule
- add focused tests in tests/rules/no_tabs.zig

References:
- https://eslint.org/docs/latest/rules/no-tabs
- https://github.com/eslint/eslint/blob/main/lib/rules/no-tabs.js

Tests:
- .zig-cache/o/40bb4c1806f1cd0b537fdb6ecbed397a/root --seed=0x387894ad
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true