### PR TITLE
feat: port rule no-mixed-spaces-and-tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-lone-blocks`
 - `no-lonely-if`
 - `no-loss-of-precision`
+- `no-mixed-spaces-and-tabs`
 - `no-multi-str`
 - `no-new`
 - `no-nested-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -66,6 +66,7 @@ pub const Options = struct {
     no_lonely_if: bool = true,
     no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
+    no_mixed_spaces_and_tabs: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
     no_negated_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -120,6 +120,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
+        } else if (std.mem.eql(u8, arg, "--no-mixed-spaces-and-tabs=off")) {
+            options.no_mixed_spaces_and_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
             options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
@@ -410,6 +412,7 @@ fn printHelp() void {
         \\  --no-lonely-if=off        Disable no-lonely-if
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str
+        \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-negated-condition=off Disable no-negated-condition

--- a/src/rules/no_mixed_spaces_and_tabs.zig
+++ b/src/rules/no_mixed_spaces_and_tabs.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-mixed-spaces-and-tabs";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var line_start: usize = 0;
+    var line_number: usize = 1;
+
+    while (line_start <= source.len) : (line_number += 1) {
+        const line_end = findLineEnd(source, line_start);
+        if (!isIgnoredCommentLine(source, tree.comments, line_number)) {
+            if (mixedIndentSpan(source, line_start, line_end)) |span| {
+                if (!isInsideIgnoredLiteral(tree, span.start)) {
+                    try core.addDiagnostic(
+                        allocator,
+                        diagnostics,
+                        .warning,
+                        id,
+                        "Mixed spaces and tabs.",
+                        span,
+                    );
+                }
+            }
+        }
+
+        if (line_end >= source.len) break;
+
+        line_start = line_end + 1;
+        if (source[line_end] == '\r' and line_start < source.len and source[line_start] == '\n') {
+            line_start += 1;
+        }
+    }
+}
+
+fn mixedIndentSpan(source: []const u8, line_start: usize, line_end: usize) ?ast.Span {
+    if (line_start >= line_end) return null;
+
+    const first = source[line_start];
+    if (!isIndent(first)) return null;
+
+    var index = line_start + 1;
+    while (index < line_end and source[index] == first) : (index += 1) {}
+
+    if (index >= line_end or !isIndent(source[index])) return null;
+
+    const end = index + 1;
+    return .{
+        .start = @intCast(end - 2),
+        .end = @intCast(end),
+    };
+}
+
+fn isIgnoredCommentLine(source: []const u8, comments: []const ast.Comment, line_number: usize) bool {
+    for (comments) |comment| {
+        if (comment.type != .block) continue;
+
+        const start_line = lineNumberAtOffset(source, comment.start);
+        if (line_number <= start_line) continue;
+
+        const end_line = lineNumberAtOffset(source, comment.end);
+        if (line_number <= end_line) return true;
+    }
+
+    return false;
+}
+
+fn isInsideIgnoredLiteral(tree: *const ast.Tree, offset: u32) bool {
+    const data = tree.nodes.items(.data);
+    const spans = tree.nodes.items(.span);
+
+    for (data, spans) |node, span| {
+        switch (node) {
+            .string_literal, .template_element => {
+                if (span.start <= offset and offset < span.end) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+fn lineNumberAtOffset(source: []const u8, offset: u32) usize {
+    var line: usize = 1;
+    var index: usize = 0;
+    const end: usize = @min(offset, source.len);
+
+    while (index < end) : (index += 1) {
+        if (source[index] == '\n') line += 1;
+    }
+
+    return line;
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn isIndent(char: u8) bool {
+    return char == ' ' or char == '\t';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -55,6 +55,7 @@ pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
+pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
@@ -130,6 +131,9 @@ pub fn runBasic(
     }
     if (options.no_tabs) {
         try no_tabs.run(allocator, diagnostics, tree);
+    }
+    if (options.no_mixed_spaces_and_tabs) {
+        try no_mixed_spaces_and_tabs.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -195,6 +195,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_mixed_spaces_and_tabs.zig");
+}
+
+comptime {
     _ = @import("rules/no_multi_str.zig");
 }
 

--- a/tests/rules/no_mixed_spaces_and_tabs.zig
+++ b/tests/rules/no_mixed_spaces_and_tabs.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-mixed-spaces-and-tabs for mixed indentation" {
+    const source =
+        "if (ok) {\n" ++
+        " \tfoo();\n" ++
+        "\t bar();\n" ++
+        "  baz();\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
+}
+
+test "does not report no-mixed-spaces-and-tabs for pure spaces or tabs" {
+    const source =
+        "if (ok) {\n" ++
+        "  foo();\n" ++
+        "\tbar();\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
+}
+
+test "ignores mixed indentation inside block comment continuation and template literals" {
+    const source =
+        "/* block\n" ++
+        " \tcomment\n" ++
+        "*/\n" ++
+        "const text = `\n" ++
+        " \tinside\n" ++
+        "`;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
+}
+
+test "can disable no-mixed-spaces-and-tabs" {
+    const source = "if (ok) {\n \tfoo();\n}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_mixed_spaces_and_tabs = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
+}


### PR DESCRIPTION
Summary:
- add the no-mixed-spaces-and-tabs rule for default mixed indentation reporting
- skip block comment continuation lines and string/template literal spans
- expose --no-mixed-spaces-and-tabs=off and document the rule
- add focused tests in tests/rules/no_mixed_spaces_and_tabs.zig

References:
- https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs
- https://github.com/eslint/eslint/blob/main/lib/rules/no-mixed-spaces-and-tabs.js

Tests:
- .zig-cache/o/ea4ffed8903a10d9ce31386d62b4269f/root --seed=0xfa31e09
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true