### PR TITLE
feat: port rule linebreak-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `default-case`
 - `default-case-last`
 - `eol-last`
+- `linebreak-style`
 - `no-async-promise-executor`
 - `no-alert`
 - `no-array-constructor`

--- a/src/core.zig
+++ b/src/core.zig
@@ -20,6 +20,7 @@ pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,
+    linebreak_style: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
     no_await_in_loop: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case_last = false;
         } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
             options.eol_last = false;
+        } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
+            options.linebreak_style = false;
         } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
             options.no_async_promise_executor = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
@@ -366,6 +368,7 @@ fn printHelp() void {
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last
+        \\  --linebreak-style=off     Disable linebreak-style
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-await-in-loop=off    Disable no-await-in-loop

--- a/src/rules/linebreak_style.zig
+++ b/src/rules/linebreak_style.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "linebreak-style";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var index: usize = 0;
+
+    while (std.mem.indexOfPos(u8, source, index, "\r\n")) |start| {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Expected linebreaks to be 'LF' but found 'CRLF'.",
+            .{ .start = @intCast(start), .end = @intCast(start + 2) },
+        );
+
+        index = start + 2;
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -9,6 +9,7 @@ const Allocator = std.mem.Allocator;
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
+pub const linebreak_style = @import("linebreak_style.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
@@ -134,6 +135,9 @@ pub fn runBasic(
     }
     if (options.no_mixed_spaces_and_tabs) {
         try no_mixed_spaces_and_tabs.run(allocator, diagnostics, tree);
+    }
+    if (options.linebreak_style) {
+        try linebreak_style.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -11,6 +11,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/linebreak_style.zig");
+}
+
+comptime {
     _ = @import("rules/eqeqeq.zig");
 }
 

--- a/tests/rules/linebreak_style.zig
+++ b/tests/rules/linebreak_style.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports linebreak-style for CRLF line endings" {
+    const source =
+        "const first = 1;\r\n" ++
+        "const second = 2;\r\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.linebreak_style.id));
+    try std.testing.expectEqualStrings(
+        "Expected linebreaks to be 'LF' but found 'CRLF'.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report linebreak-style for LF line endings" {
+    const source =
+        "const first = 1;\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.linebreak_style.id));
+}
+
+test "can disable linebreak-style" {
+    const source = "const value = 1;\r\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .linebreak_style = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.linebreak_style.id));
+}


### PR DESCRIPTION
Summary:
- add the linebreak-style rule with default LF line ending reporting
- expose --linebreak-style=off and document the rule
- add focused tests in tests/rules/linebreak_style.zig

References:
- https://eslint.org/docs/latest/rules/linebreak-style
- https://github.com/eslint/eslint/blob/main/lib/rules/linebreak-style.js

Tests:
- .zig-cache/o/307284407a6cdfa9a1e2ddc68054c01f/root --seed=0xac86393b
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true