### PR TITLE
feat: port rule no-irregular-whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-nan`
 - `no-implied-eval`
 - `no-import-assign`
+- `no-irregular-whitespace`
 - `no-iterator`
 - `no-labels`
 - `no-lone-blocks`

--- a/src/core.zig
+++ b/src/core.zig
@@ -61,6 +61,7 @@ pub const Options = struct {
     no_global_is_nan: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
+    no_irregular_whitespace: bool = true,
     no_iterator: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -110,6 +110,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
             options.no_import_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
+            options.no_irregular_whitespace = false;
         } else if (std.mem.eql(u8, arg, "--no-iterator=off")) {
             options.no_iterator = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
@@ -409,6 +411,7 @@ fn printHelp() void {
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
+        \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-iterator=off          Disable no-iterator
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks

--- a/src/rules/no_irregular_whitespace.zig
+++ b/src/rules/no_irregular_whitespace.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-irregular-whitespace";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var index: usize = 0;
+
+    while (index < source.len) {
+        if (irregularWhitespaceLen(source[index..])) |len| {
+            const end = index + len;
+            if (!isInsideStringLiteral(tree, @intCast(index))) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Irregular whitespace not allowed.",
+                    .{ .start = @intCast(index), .end = @intCast(end) },
+                );
+            }
+            index = end;
+            continue;
+        }
+
+        index += 1;
+    }
+}
+
+fn irregularWhitespaceLen(source: []const u8) ?usize {
+    if (source.len == 0) return null;
+
+    switch (source[0]) {
+        0x0B, 0x0C => return 1,
+        0xC2 => {
+            if (startsWith(source, &.{ 0xC2, 0x85 }) or startsWith(source, &.{ 0xC2, 0xA0 })) return 2;
+        },
+        0xE1 => {
+            if (startsWith(source, &.{ 0xE1, 0x9A, 0x80 }) or startsWith(source, &.{ 0xE1, 0xA0, 0x8E })) return 3;
+        },
+        0xE2 => {
+            if (source.len >= 3 and source[1] == 0x80 and source[2] >= 0x80 and source[2] <= 0x8B) return 3;
+            if (startsWith(source, &.{ 0xE2, 0x80, 0xA8 }) or
+                startsWith(source, &.{ 0xE2, 0x80, 0xA9 }) or
+                startsWith(source, &.{ 0xE2, 0x80, 0xAF }) or
+                startsWith(source, &.{ 0xE2, 0x81, 0x9F }))
+            {
+                return 3;
+            }
+        },
+        0xE3 => {
+            if (startsWith(source, &.{ 0xE3, 0x80, 0x80 })) return 3;
+        },
+        0xEF => {
+            if (startsWith(source, &.{ 0xEF, 0xBB, 0xBF })) return 3;
+        },
+        else => {},
+    }
+
+    return null;
+}
+
+fn startsWith(source: []const u8, bytes: []const u8) bool {
+    return std.mem.startsWith(u8, source, bytes);
+}
+
+fn isInsideStringLiteral(tree: *const ast.Tree, offset: u32) bool {
+    const data = tree.nodes.items(.data);
+    const spans = tree.nodes.items(.span);
+
+    for (data, spans) |node, span| {
+        switch (node) {
+            .string_literal => {
+                if (span.start <= offset and offset < span.end) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -51,6 +51,7 @@ pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
+pub const no_irregular_whitespace = @import("no_irregular_whitespace.zig");
 pub const no_iterator = @import("no_iterator.zig");
 pub const no_labels = @import("no_labels.zig");
 pub const no_lone_blocks = @import("no_lone_blocks.zig");
@@ -138,6 +139,9 @@ pub fn runBasic(
     }
     if (options.linebreak_style) {
         try linebreak_style.run(allocator, diagnostics, tree);
+    }
+    if (options.no_irregular_whitespace) {
+        try no_irregular_whitespace.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -179,6 +179,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_irregular_whitespace.zig");
+}
+
+comptime {
     _ = @import("rules/no_iterator.zig");
 }
 

--- a/tests/rules/no_irregular_whitespace.zig
+++ b/tests/rules/no_irregular_whitespace.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-irregular-whitespace outside strings" {
+    const nbsp = "\xC2\xA0";
+    const source =
+        "const" ++ nbsp ++ "first = 1;\n" ++
+        "//" ++ nbsp ++ "comment\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_irregular_whitespace.id));
+    try std.testing.expectEqualStrings(
+        "Irregular whitespace not allowed.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report no-irregular-whitespace inside strings by default" {
+    const nbsp = "\xC2\xA0";
+    const source = "const value = \"hello" ++ nbsp ++ "world\";\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_irregular_whitespace.id));
+}
+
+test "reports no-irregular-whitespace inside template literals" {
+    const nbsp = "\xC2\xA0";
+    const source = "const value = `hello" ++ nbsp ++ "world`;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_irregular_whitespace.id));
+}
+
+test "can disable no-irregular-whitespace" {
+    const source = "const\xC2\xA0value = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_irregular_whitespace = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_irregular_whitespace.id));
+}


### PR DESCRIPTION
Summary:
- add the no-irregular-whitespace rule with default string-skipping behavior
- scan irregular UTF-8 whitespace byte sequences outside string literals
- expose --no-irregular-whitespace=off and document the rule
- add focused tests in tests/rules/no_irregular_whitespace.zig

References:
- https://eslint.org/docs/latest/rules/no-irregular-whitespace
- https://github.com/eslint/eslint/blob/main/lib/rules/no-irregular-whitespace.js

Tests:
- .zig-cache/o/0ddc995ee14972244a9b1d8728b675a0/root --seed=0x27120dd6
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true