### PR TITLE
feat: port rule no-multiple-empty-lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-loss-of-precision`
 - `no-mixed-spaces-and-tabs`
 - `no-multi-str`
+- `no-multiple-empty-lines`
 - `no-new`
 - `no-nested-ternary`
 - `no-negated-condition`

--- a/src/core.zig
+++ b/src/core.zig
@@ -69,6 +69,7 @@ pub const Options = struct {
     no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
     no_mixed_spaces_and_tabs: bool = true,
+    no_multiple_empty_lines: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
     no_negated_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-mixed-spaces-and-tabs=off")) {
             options.no_mixed_spaces_and_tabs = false;
+        } else if (std.mem.eql(u8, arg, "--no-multiple-empty-lines=off")) {
+            options.no_multiple_empty_lines = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
             options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
@@ -419,6 +421,7 @@ fn printHelp() void {
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
+        \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-negated-condition=off Disable no-negated-condition

--- a/src/rules/no_multiple_empty_lines.zig
+++ b/src/rules/no_multiple_empty_lines.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-multiple-empty-lines";
+
+const max_empty_lines = 2;
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var line_start: usize = 0;
+    var empty_lines: usize = 0;
+
+    while (line_start <= source.len) {
+        const line_end = findLineEnd(source, line_start);
+
+        if (isEmptyLine(source[line_start..line_end])) {
+            empty_lines += 1;
+            if (empty_lines > max_empty_lines) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "More than 2 blank lines not allowed.",
+                    .{ .start = @intCast(line_start), .end = @intCast(line_end) },
+                );
+            }
+        } else {
+            empty_lines = 0;
+        }
+
+        if (line_end >= source.len) break;
+
+        line_start = line_end + 1;
+        if (source[line_end] == '\r' and line_start < source.len and source[line_start] == '\n') {
+            line_start += 1;
+        }
+    }
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn isEmptyLine(line: []const u8) bool {
+    for (line) |char| {
+        if (!isBlankWhitespace(char)) return false;
+    }
+    return true;
+}
+
+fn isBlankWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == 0x0B or char == 0x0C;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -59,6 +59,7 @@ pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
+pub const no_multiple_empty_lines = @import("no_multiple_empty_lines.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
 pub const no_negated_condition = @import("no_negated_condition.zig");
@@ -142,6 +143,9 @@ pub fn runBasic(
     }
     if (options.no_irregular_whitespace) {
         try no_irregular_whitespace.run(allocator, diagnostics, tree);
+    }
+    if (options.no_multiple_empty_lines) {
+        try no_multiple_empty_lines.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -211,6 +211,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_multiple_empty_lines.zig");
+}
+
+comptime {
     _ = @import("rules/no_negated_condition.zig");
 }
 

--- a/tests/rules/no_multiple_empty_lines.zig
+++ b/tests/rules/no_multiple_empty_lines.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-multiple-empty-lines after more than two consecutive blank lines" {
+    const source =
+        "const first = 1;\n" ++
+        "\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multiple_empty_lines.id));
+    try std.testing.expectEqualStrings(
+        "More than 2 blank lines not allowed.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "counts whitespace-only lines as empty lines" {
+    const source =
+        "const first = 1;\n" ++
+        " \n" ++
+        "\t\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_trailing_spaces = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_multiple_empty_lines.id));
+}
+
+test "does not report no-multiple-empty-lines for two blank lines" {
+    const source =
+        "const first = 1;\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multiple_empty_lines.id));
+}
+
+test "can disable no-multiple-empty-lines" {
+    const source = "const first = 1;\n\n\n\nconst second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multiple_empty_lines = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multiple_empty_lines.id));
+}


### PR DESCRIPTION
Summary:
- add the no-multiple-empty-lines rule with default max 2 blank lines behavior
- count whitespace-only lines as blank lines
- expose --no-multiple-empty-lines=off and document the rule
- add focused tests in tests/rules/no_multiple_empty_lines.zig

References:
- https://eslint.org/docs/latest/rules/no-multiple-empty-lines
- https://github.com/eslint/eslint/blob/main/lib/rules/no-multiple-empty-lines.js

Tests:
- .zig-cache/o/cea09c59019baa51ce97b3a036ce5fcf/root --seed=0xa28608ea
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true