### PR TITLE
feat: port rule no-inline-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-global-is-nan`
 - `no-implied-eval`
 - `no-import-assign`
+- `no-inline-comments`
 - `no-irregular-whitespace`
 - `no-iterator`
 - `no-labels`

--- a/src/core.zig
+++ b/src/core.zig
@@ -62,6 +62,7 @@ pub const Options = struct {
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     no_irregular_whitespace: bool = true,
+    no_inline_comments: bool = true,
     no_iterator: bool = true,
     no_labels: bool = true,
     no_lone_blocks: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,6 +112,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_import_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
             options.no_irregular_whitespace = false;
+        } else if (std.mem.eql(u8, arg, "--no-inline-comments=off")) {
+            options.no_inline_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-iterator=off")) {
             options.no_iterator = false;
         } else if (std.mem.eql(u8, arg, "--no-labels=off")) {
@@ -414,6 +416,7 @@ fn printHelp() void {
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
+        \\  --no-inline-comments=off   Disable no-inline-comments
         \\  --no-iterator=off          Disable no-iterator
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks

--- a/src/rules/no_inline_comments.zig
+++ b/src/rules/no_inline_comments.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-inline-comments";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+
+    for (tree.comments) |comment| {
+        const start: usize = comment.start;
+        const end: usize = comment.end;
+        const line_start = findLineStart(source, start);
+        const line_end = findLineEnd(source, start);
+
+        const has_code_before = hasNonWhitespace(source[line_start..start]);
+        const has_code_after = comment.type == .block and end <= line_end and hasNonWhitespace(source[end..line_end]);
+
+        if (has_code_before or has_code_after) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unexpected comment inline with code.",
+                .{ .start = @intCast(start), .end = @intCast(end) },
+            );
+        }
+    }
+}
+
+fn findLineStart(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index > 0) {
+        const previous = index - 1;
+        if (source[previous] == '\n' or source[previous] == '\r') break;
+        index = previous;
+    }
+    return index;
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn hasNonWhitespace(source: []const u8) bool {
+    for (source) |char| {
+        if (char != ' ' and char != '\t' and char != 0x0B and char != 0x0C) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -51,6 +51,7 @@ pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
+pub const no_inline_comments = @import("no_inline_comments.zig");
 pub const no_irregular_whitespace = @import("no_irregular_whitespace.zig");
 pub const no_iterator = @import("no_iterator.zig");
 pub const no_labels = @import("no_labels.zig");
@@ -146,6 +147,9 @@ pub fn runBasic(
     }
     if (options.no_multiple_empty_lines) {
         try no_multiple_empty_lines.run(allocator, diagnostics, tree);
+    }
+    if (options.no_inline_comments) {
+        try no_inline_comments.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -179,6 +179,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_inline_comments.zig");
+}
+
+comptime {
     _ = @import("rules/no_irregular_whitespace.zig");
 }
 

--- a/tests/rules/no_inline_comments.zig
+++ b/tests/rules/no_inline_comments.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-inline-comments for comments sharing a line with code" {
+    const source =
+        "const first = 1; // inline\n" ++
+        "/* leading */ const second = 2;\n" ++
+        "const third = 3; /* trailing */\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_inline_comments.id));
+    try std.testing.expectEqualStrings(
+        "Unexpected comment inline with code.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report no-inline-comments for standalone comments" {
+    const source =
+        "// line comment\n" ++
+        "const first = 1;\n" ++
+        "/* block comment */\n" ++
+        "const second = 2;\n" ++
+        "/* multi\n" ++
+        " * line\n" ++
+        " */\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inline_comments.id));
+}
+
+test "can disable no-inline-comments" {
+    const source = "const value = 1; // inline\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inline_comments.id));
+}


### PR DESCRIPTION
Summary:
- add the no-inline-comments rule for line and block comments sharing a line with code
- expose --no-inline-comments=off and document the rule
- add focused tests in tests/rules/no_inline_comments.zig

References:
- https://eslint.org/docs/latest/rules/no-inline-comments
- https://github.com/eslint/eslint/blob/main/lib/rules/no-inline-comments.js

Tests:
- .zig-cache/o/efed414883465843e61013612e93be74/root --seed=0xfed7a275
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true