### PR TITLE
feat: port rule no-multi-spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-lonely-if`
 - `no-loss-of-precision`
 - `no-mixed-spaces-and-tabs`
+- `no-multi-spaces`
 - `no-multi-str`
 - `no-multiple-empty-lines`
 - `no-new`

--- a/src/core.zig
+++ b/src/core.zig
@@ -69,6 +69,7 @@ pub const Options = struct {
     no_lonely_if: bool = true,
     no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
+    no_multi_spaces: bool = true,
     no_mixed_spaces_and_tabs: bool = true,
     no_multiple_empty_lines: bool = true,
     no_new: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
+        } else if (std.mem.eql(u8, arg, "--no-multi-spaces=off")) {
+            options.no_multi_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-mixed-spaces-and-tabs=off")) {
             options.no_mixed_spaces_and_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-multiple-empty-lines=off")) {
@@ -423,6 +425,7 @@ fn printHelp() void {
         \\  --no-lonely-if=off        Disable no-lonely-if
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str
+        \\  --no-multi-spaces=off     Disable no-multi-spaces
         \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
         \\  --no-new=off              Disable no-new

--- a/src/rules/no_multi_spaces.zig
+++ b/src/rules/no_multi_spaces.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-multi-spaces";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    const source = tree.source;
+    var line_start: usize = 0;
+
+    while (line_start <= source.len) {
+        const line_end = findLineEnd(source, line_start);
+        try checkLine(allocator, diagnostics, tree, line_start, line_end);
+
+        if (line_end >= source.len) break;
+
+        line_start = line_end + 1;
+        if (source[line_end] == '\r' and line_start < source.len and source[line_start] == '\n') {
+            line_start += 1;
+        }
+    }
+}
+
+fn checkLine(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    line_start: usize,
+    line_end: usize,
+) Allocator.Error!void {
+    const source = tree.source;
+    var index = line_start;
+
+    while (index < line_end and (source[index] == ' ' or source[index] == '\t')) : (index += 1) {}
+
+    while (index < line_end) {
+        if (source[index] != ' ' or isInsideIgnoredSpan(tree, @intCast(index))) {
+            index += 1;
+            continue;
+        }
+
+        const start = index;
+        while (index < line_end and source[index] == ' ') : (index += 1) {}
+
+        if (index - start > 1) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Multiple spaces found before.",
+                .{ .start = @intCast(start), .end = @intCast(index) },
+            );
+        }
+    }
+}
+
+fn isInsideIgnoredSpan(tree: *const ast.Tree, offset: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.start <= offset and offset < comment.end) return true;
+    }
+
+    const data = tree.nodes.items(.data);
+    const spans = tree.nodes.items(.span);
+    for (data, spans) |node, span| {
+        switch (node) {
+            .string_literal, .template_element, .regexp_literal => {
+                if (span.start <= offset and offset < span.end) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -59,6 +59,7 @@ pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
+pub const no_multi_spaces = @import("no_multi_spaces.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_multiple_empty_lines = @import("no_multiple_empty_lines.zig");
 pub const no_new = @import("no_new.zig");
@@ -150,6 +151,9 @@ pub fn runBasic(
     }
     if (options.no_inline_comments) {
         try no_inline_comments.run(allocator, diagnostics, tree);
+    }
+    if (options.no_multi_spaces) {
+        try no_multi_spaces.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -215,6 +215,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_multi_spaces.zig");
+}
+
+comptime {
     _ = @import("rules/no_multiple_empty_lines.zig");
 }
 

--- a/tests/rules/no_multi_spaces.zig
+++ b/tests/rules/no_multi_spaces.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-multi-spaces for multiple spaces outside indentation" {
+    const source =
+        "const first =  1;\n" ++
+        "if (foo  === bar) {}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_multi_spaces.id));
+    try std.testing.expectEqualStrings(
+        "Multiple spaces found before.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "reports no-multi-spaces before end-of-line comments" {
+    const source = "const value = 1;  // comment\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multi_spaces.id));
+}
+
+test "does not report no-multi-spaces for indentation or inside literals and comments" {
+    const source =
+        "  const text = \"hello  world\";\n" ++
+        "const template = `hello  world`;\n" ++
+        "// comment  with spaces\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_spaces.id));
+}
+
+test "can disable no-multi-spaces" {
+    const source = "const value =  1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multi_spaces = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_spaces.id));
+}


### PR DESCRIPTION
Summary:
- add the no-multi-spaces rule for multiple spaces outside indentation
- skip spaces inside comments, strings, templates, and regex literals
- expose --no-multi-spaces=off and document the rule
- add focused tests in tests/rules/no_multi_spaces.zig

References:
- https://eslint.org/docs/latest/rules/no-multi-spaces
- https://github.com/eslint/eslint/blob/main/lib/rules/no-multi-spaces.js

Tests:
- .zig-cache/o/8b09c613ebbe5ec902d1f065f3411a17/root --seed=0xb3609caf
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true