### PR TITLE
feat: port rule no-continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-console`
 - `no-constructor-return`
 - `no-comma-operator`
+- `no-continue`
 - `no-debugger`
 - `no-dupe-args`
 - `no-dupe-else-if`

--- a/src/core.zig
+++ b/src/core.zig
@@ -36,6 +36,7 @@ pub const Options = struct {
     no_control_regex: bool = true,
     no_console: bool = true,
     no_comma_operator: bool = true,
+    no_continue: bool = true,
     no_constructor_return: bool = true,
     no_debugger: bool = true,
     no_dupe_else_if: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -60,6 +60,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_console = false;
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
             options.no_comma_operator = false;
+        } else if (std.mem.eql(u8, arg, "--no-continue=off")) {
+            options.no_continue = false;
         } else if (std.mem.eql(u8, arg, "--no-constructor-return=off")) {
             options.no_constructor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-debugger=off")) {
@@ -392,6 +394,7 @@ fn printHelp() void {
         \\  --no-control-regex=off   Disable no-control-regex
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
+        \\  --no-continue=off         Disable no-continue
         \\  --no-constructor-return=off Disable no-constructor-return
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-dupe-else-if=off     Disable no-dupe-else-if

--- a/src/rules/no_continue.zig
+++ b/src/rules/no_continue.zig
@@ -1,0 +1,23 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-continue";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected use of continue statement.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const no_const_assign = @import("no_const_assign.zig");
 pub const no_control_regex = @import("no_control_regex.zig");
 pub const no_comma_operator = @import("no_comma_operator.zig");
 pub const no_console = @import("no_console.zig");
+pub const no_continue = @import("no_continue.zig");
 pub const no_constructor_return = @import("no_constructor_return.zig");
 pub const no_debugger = @import("no_debugger.zig");
 pub const no_dupe_else_if = @import("no_dupe_else_if.zig");
@@ -507,6 +508,18 @@ const BasicVisitor = struct {
         }
         if (self.options.no_return_assign) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_continue_statement(
+        self: *BasicVisitor,
+        _: ast.ContinueStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_continue) {
+            try no_continue.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_continue.zig");
+}
+
+comptime {
     _ = @import("rules/no_constructor_return.zig");
 }
 

--- a/tests/rules/no_continue.zig
+++ b/tests/rules/no_continue.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-continue for continue statements" {
+    const source =
+        "for (let i = 0; i < 3; i++) {\n" ++
+        "  if (i === 1) continue;\n" ++
+        "}\n" ++
+        "outer: for (let j = 0; j < 3; j++) {\n" ++
+        "  continue outer;\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_continue.id));
+    try std.testing.expectEqualStrings(
+        "Unexpected use of continue statement.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report no-continue for break statements" {
+    const source =
+        "for (let i = 0; i < 3; i++) {\n" ++
+        "  if (i === 1) break;\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_continue.id));
+}
+
+test "can disable no-continue" {
+    const source = "for (let i = 0; i < 3; i++) { continue; }\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_continue = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_continue.id));
+}


### PR DESCRIPTION
Summary:
- add the no-continue rule for continue statements
- expose --no-continue=off and document the rule
- add focused tests in tests/rules/no_continue.zig

References:
- https://eslint.org/docs/latest/rules/no-continue
- https://github.com/eslint/eslint/blob/main/lib/rules/no-continue.js

Tests:
- .zig-cache/o/f5c5a430ff792cd7fbbcfa07af8ce3bb/root --seed=0xd05fdf7
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
