### PR TITLE
feat: port rule no-unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-throw-literal`
 - `no-tabs`
 - `no-trailing-spaces`
+- `no-unreachable`
 - `no-undef-init`
 - `unicode-bom`
 - `no-unneeded-ternary`

--- a/src/core.zig
+++ b/src/core.zig
@@ -107,6 +107,7 @@ pub const Options = struct {
     no_throw_literal: bool = true,
     no_tabs: bool = true,
     no_trailing_spaces: bool = true,
+    no_unreachable: bool = true,
     no_undef_init: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,6 +202,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-trailing-spaces=off")) {
             options.no_trailing_spaces = false;
+        } else if (std.mem.eql(u8, arg, "--no-unreachable=off")) {
+            options.no_unreachable = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
             options.no_undef_init = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
@@ -465,6 +467,7 @@ fn printHelp() void {
         \\  --no-throw-literal=off    Disable no-throw-literal
         \\  --no-tabs=off             Disable no-tabs
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
+        \\  --no-unreachable=off      Disable no-unreachable
         \\  --no-undef-init=off       Disable no-undef-init
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary

--- a/src/rules/no_unreachable.zig
+++ b/src/rules/no_unreachable.zig
@@ -1,0 +1,65 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-unreachable";
+
+pub fn checkRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+) Allocator.Error!void {
+    var is_unreachable = false;
+
+    for (tree.extra(range)) |statement| {
+        if (is_unreachable and !isHoistedDeclaration(tree, statement)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unreachable code.",
+                tree.span(statement),
+            );
+        }
+
+        if (alwaysExits(tree, statement)) {
+            is_unreachable = true;
+        }
+    }
+}
+
+fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .return_statement,
+        .throw_statement,
+        .break_statement,
+        .continue_statement,
+        => true,
+        .block_statement => |block| rangeAlwaysExits(tree, block.body),
+        .if_statement => |statement| statement.alternate != .null and
+            alwaysExits(tree, statement.consequent) and
+            alwaysExits(tree, statement.alternate),
+        else => false,
+    };
+}
+
+fn rangeAlwaysExits(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    if (range.len == 0) return false;
+
+    const statements = tree.extra(range);
+    return alwaysExits(tree, statements[statements.len - 1]);
+}
+
+fn isHoistedDeclaration(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .function => |function| function.type == .function_declaration or function.type == .ts_declare_function,
+        .variable_declaration => |declaration| declaration.kind == .@"var",
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -97,6 +97,7 @@ pub const no_ternary = @import("no_ternary.zig");
 pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_trailing_spaces = @import("no_trailing_spaces.zig");
+pub const no_unreachable = @import("no_unreachable.zig");
 pub const no_undef_init = @import("no_undef_init.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
@@ -449,6 +450,9 @@ const BasicVisitor = struct {
         if (self.options.no_case_declarations) {
             try no_case_declarations.check(self.allocator, self.diagnostics, ctx.tree, switch_case);
         }
+        if (self.options.no_unreachable) {
+            try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, switch_case.consequent);
+        }
         return .proceed;
     }
 
@@ -562,6 +566,9 @@ const BasicVisitor = struct {
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
+        if (self.options.no_unreachable) {
+            try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
+        }
         return .proceed;
     }
 
@@ -576,6 +583,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_empty_function) {
             try no_empty_function.check(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
+        if (self.options.no_unreachable) {
+            try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -359,6 +359,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unreachable.zig");
+}
+
+comptime {
     _ = @import("rules/no_undef_init.zig");
 }
 

--- a/tests/rules/no_unreachable.zig
+++ b/tests/rules/no_unreachable.zig
@@ -1,0 +1,128 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unreachable after abrupt statements" {
+    const source =
+        \\function first() {
+        \\  return 1;
+        \\  call();
+        \\}
+        \\function second() {
+        \\  throw error;
+        \\  call();
+        \\}
+        \\while (ready) {
+        \\  break;
+        \\  call();
+        \\}
+        \\while (ready) {
+        \\  continue;
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unreachable.id));
+    try std.testing.expectEqualStrings("Unreachable code.", result.diagnostics[0].message);
+}
+
+test "reports no-unreachable after if statements where both branches exit" {
+    const source =
+        \\function run(value) {
+        \\  if (value) {
+        \\    return 1;
+        \\  } else {
+        \\    throw error;
+        \\  }
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_else_return = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unreachable.id));
+}
+
+test "does not report no-unreachable for reachable statements or hoisted declarations" {
+    const source =
+        \\function first(value) {
+        \\  if (value) {
+        \\    return 1;
+        \\  }
+        \\  call();
+        \\}
+        \\function second() {
+        \\  return;
+        \\  function later() {}
+        \\  var hoisted = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable.id));
+}
+
+test "reports no-unreachable in switch cases" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    break;
+        \\    call();
+        \\  default:
+        \\    throw error;
+        \\    call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .default_case_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unreachable.id));
+}
+
+test "can disable no-unreachable" {
+    const source =
+        \\function run() {
+        \\  return;
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unreachable = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable.id));
+}


### PR DESCRIPTION
Summary:
- add the no-unreachable rule for statements after abrupt control flow
- expose --no-unreachable=off and document the rule
- add focused tests in tests/rules/no_unreachable.zig

References:
- https://eslint.org/docs/latest/rules/no-unreachable
- https://github.com/eslint/eslint/blob/main/lib/rules/no-unreachable.js

Tests:
- .zig-cache/o/f3892e4b36d102a9d87dd8f26d0e07c3/root --seed=0xc850f03d
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
