### PR TITLE
feat: port rule guard-for-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `default-case`
 - `default-case-last`
 - `eol-last`
+- `guard-for-in`
 - `linebreak-style`
 - `no-async-promise-executor`
 - `no-alert`

--- a/src/core.zig
+++ b/src/core.zig
@@ -20,6 +20,7 @@ pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,
+    guard_for_in: bool = true,
     linebreak_style: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case_last = false;
         } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
             options.eol_last = false;
+        } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
+            options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
             options.linebreak_style = false;
         } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
@@ -380,6 +382,7 @@ fn printHelp() void {
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last
+        \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor

--- a/src/rules/guard_for_in.zig
+++ b/src/rules/guard_for_in.zig
@@ -1,0 +1,65 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "guard-for-in";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ForInStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (isGuarded(tree, statement.body)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+        tree.span(index),
+    );
+}
+
+fn isGuarded(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .empty_statement,
+        .if_statement,
+        => true,
+        .block_statement => |block| blockIsGuarded(tree, block.body),
+        else => false,
+    };
+}
+
+fn blockIsGuarded(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    if (range.len == 0) return true;
+
+    const statements = tree.extra(range);
+    const first_if = switch (tree.data(statements[0])) {
+        .if_statement => |statement| statement,
+        else => return false,
+    };
+
+    if (range.len == 1) return true;
+
+    return consequentIsContinue(tree, first_if.consequent);
+}
+
+fn consequentIsContinue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .continue_statement => true,
+        .block_statement => |block| blk: {
+            if (block.body.len != 1) break :blk false;
+            const statements = tree.extra(block.body);
+            break :blk switch (tree.data(statements[0])) {
+                .continue_statement => true,
+                else => false,
+            };
+        },
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -9,6 +9,7 @@ const Allocator = std.mem.Allocator;
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
+pub const guard_for_in = @import("guard_for_in.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
@@ -542,10 +543,13 @@ const BasicVisitor = struct {
 
     pub fn enter_for_in_statement(
         self: *BasicVisitor,
-        _: ast.ForInStatement,
+        statement: ast.ForInStatement,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.guard_for_in) {
+            try guard_for_in.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
         if (self.options.no_for_in) {
             try no_for_in.check(self.allocator, self.diagnostics, ctx.tree, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -11,6 +11,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/guard_for_in.zig");
+}
+
+comptime {
     _ = @import("rules/linebreak_style.zig");
 }
 

--- a/tests/rules/guard_for_in.zig
+++ b/tests/rules/guard_for_in.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports guard-for-in for unguarded for-in loops" {
+    const source =
+        \\for (const key in object) {
+        \\  call(key);
+        \\}
+        \\for (const key in object) call(key);
+        \\for (const key in object) {
+        \\  if (Object.hasOwn(object, key)) call(key);
+        \\  call(key);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.guard_for_in.id));
+}
+
+test "allows guard-for-in when the body is an if statement or only contains an if statement" {
+    const source =
+        \\for (const key in object) if (Object.hasOwn(object, key)) call(key);
+        \\for (const key in object) {
+        \\  if (Object.hasOwn(object, key)) call(key);
+        \\}
+        \\for (const key in object);
+        \\for (const key in object) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.guard_for_in.id));
+}
+
+test "allows guard-for-in when a leading guard continues before later statements" {
+    const source =
+        \\for (const key in object) {
+        \\  if (!Object.hasOwn(object, key)) continue;
+        \\  call(key);
+        \\}
+        \\for (const key in object) {
+        \\  if (!Object.hasOwn(object, key)) {
+        \\    continue;
+        \\  }
+        \\  call(key);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.guard_for_in.id));
+}
+
+test "can disable guard-for-in" {
+    const source =
+        \\for (const key in object) {
+        \\  call(key);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .guard_for_in = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.guard_for_in.id));
+}


### PR DESCRIPTION
Summary:
- add the guard-for-in rule for unguarded for-in loop bodies
- expose --guard-for-in=off and document the rule
- add focused tests in tests/rules/guard_for_in.zig

References:
- https://eslint.org/docs/latest/rules/guard-for-in
- https://github.com/eslint/eslint/blob/main/lib/rules/guard-for-in.js

Tests:
- .zig-cache/o/c5221d231a52cfee2c753ebd3b1621d1/root --seed=0x2b71697b
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
