### PR TITLE
feat: port rule no-extra-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-else-return`
 - `no-eval`
 - `no-ex-assign`
+- `no-extra-label`
 - `no-extra-semi`
 - `no-extra-boolean-cast`
 - `no-floating-decimal`

--- a/src/core.zig
+++ b/src/core.zig
@@ -54,6 +54,7 @@ pub const Options = struct {
     no_else_return: bool = true,
     no_eval: bool = true,
     no_ex_assign: bool = true,
+    no_extra_label: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_floating_decimal: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,6 +96,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-ex-assign=off")) {
             options.no_ex_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-extra-label=off")) {
+            options.no_extra_label = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-semi=off")) {
             options.no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-boolean-cast=off")) {
@@ -416,6 +418,7 @@ fn printHelp() void {
         \\  --no-else-return=off    Disable no-else-return
         \\  --no-eval=off           Disable no-eval
         \\  --no-ex-assign=off      Disable no-ex-assign
+        \\  --no-extra-label=off    Disable no-extra-label
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-floating-decimal=off Disable no-floating-decimal

--- a/src/rules/no_extra_label.zig
+++ b/src/rules/no_extra_label.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-extra-label";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.LabeledStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const label_name = labelName(tree, statement.label) orelse return;
+    if (containsLabelReference(tree, statement.body, label_name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "This label is unnecessary.",
+        tree.span(index),
+    );
+}
+
+fn labelName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .label_identifier => |label| tree.string(label.name),
+        else => null,
+    };
+}
+
+fn containsLabelReference(tree: *const ast.Tree, index: ast.NodeIndex, label_name: []const u8) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .break_statement => |statement| sameLabel(tree, statement.label, label_name),
+        .continue_statement => |statement| sameLabel(tree, statement.label, label_name),
+        .block_statement => |block| rangeContainsLabelReference(tree, block.body, label_name),
+        .static_block => |block| rangeContainsLabelReference(tree, block.body, label_name),
+        .if_statement => |statement| containsLabelReference(tree, statement.consequent, label_name) or
+            containsLabelReference(tree, statement.alternate, label_name),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const switch_case = switch (tree.data(case_index)) {
+                    .switch_case => |switch_case| switch_case,
+                    else => continue,
+                };
+                if (rangeContainsLabelReference(tree, switch_case.consequent, label_name)) return true;
+            }
+            return false;
+        },
+        .for_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .for_in_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .for_of_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .do_while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .with_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .labeled_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .try_statement => |statement| {
+            if (containsLabelReference(tree, statement.block, label_name)) return true;
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return false,
+                };
+                if (containsLabelReference(tree, handler.body, label_name)) return true;
+            }
+            return containsLabelReference(tree, statement.finalizer, label_name);
+        },
+        .function,
+        .class,
+        => false,
+        else => false,
+    };
+}
+
+fn rangeContainsLabelReference(tree: *const ast.Tree, range: ast.IndexRange, label_name: []const u8) bool {
+    for (tree.extra(range)) |child| {
+        if (containsLabelReference(tree, child, label_name)) return true;
+    }
+    return false;
+}
+
+fn sameLabel(tree: *const ast.Tree, index: ast.NodeIndex, label_name: []const u8) bool {
+    const name = labelName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, label_name);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -44,6 +44,7 @@ pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
 pub const no_eval = @import("no_eval.zig");
 pub const no_ex_assign = @import("no_ex_assign.zig");
+pub const no_extra_label = @import("no_extra_label.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_floating_decimal = @import("no_floating_decimal.zig");
@@ -531,10 +532,13 @@ const BasicVisitor = struct {
 
     pub fn enter_labeled_statement(
         self: *BasicVisitor,
-        _: ast.LabeledStatement,
+        statement: ast.LabeledStatement,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_extra_label) {
+            try no_extra_label.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
         if (self.options.no_labels) {
             try no_labels.check(self.allocator, self.diagnostics, ctx.tree, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -151,6 +151,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_extra_label.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_boolean_cast.zig");
 }
 

--- a/tests/rules/no_extra_label.zig
+++ b/tests/rules/no_extra_label.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-extra-label for labels without labeled break or continue" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+        \\block: {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_label.id));
+    try std.testing.expectEqualStrings("This label is unnecessary.", result.diagnostics[0].message);
+}
+
+test "does not report no-extra-label when labeled break or continue uses the label" {
+    const source =
+        \\outer: while (ready) {
+        \\  break outer;
+        \\}
+        \\loop: while (ready) {
+        \\  continue loop;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_label.id));
+}
+
+test "does not count label references inside nested functions" {
+    const source =
+        \\outer: while (ready) {
+        \\  function nested() {
+        \\    break outer;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_labels = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_extra_label.id));
+}
+
+test "can disable no-extra-label" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_label.id));
+}


### PR DESCRIPTION
Summary:
- add the no-extra-label rule for unnecessary labels
- expose --no-extra-label=off and document the rule
- add focused tests in tests/rules/no_extra_label.zig

References:
- https://eslint.org/docs/latest/rules/no-extra-label
- https://github.com/eslint/eslint/blob/main/lib/rules/no-extra-label.js

Tests:
- .zig-cache/o/4809172f8b8bda1a4b4f4b15b4c30abc/root --seed=0x13421823
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
