### PR TITLE
feat: port rule no-extra-bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-else-return`
 - `no-eval`
 - `no-ex-assign`
+- `no-extra-bind`
 - `no-extra-label`
 - `no-extra-semi`
 - `no-extra-boolean-cast`

--- a/src/core.zig
+++ b/src/core.zig
@@ -54,6 +54,7 @@ pub const Options = struct {
     no_else_return: bool = true,
     no_eval: bool = true,
     no_ex_assign: bool = true,
+    no_extra_bind: bool = true,
     no_extra_label: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,6 +96,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-ex-assign=off")) {
             options.no_ex_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-extra-bind=off")) {
+            options.no_extra_bind = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-label=off")) {
             options.no_extra_label = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-semi=off")) {
@@ -418,6 +420,7 @@ fn printHelp() void {
         \\  --no-else-return=off    Disable no-else-return
         \\  --no-eval=off           Disable no-eval
         \\  --no-ex-assign=off      Disable no-ex-assign
+        \\  --no-extra-bind=off     Disable no-extra-bind
         \\  --no-extra-label=off    Disable no-extra-label
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast

--- a/src/rules/no_extra_bind.zig
+++ b/src/rules/no_extra_bind.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-extra-bind";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (call.optional) return;
+
+    const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return,
+    };
+    if (callee_member.optional) return;
+
+    const method = propertyName(tree, callee_member) orelse return;
+    if (!std.mem.eql(u8, method, "bind")) return;
+
+    const target = unwrapTransparent(tree, callee_member.object);
+    const has_bound_arguments = call.arguments.len > 1;
+
+    const is_extra = switch (tree.data(target)) {
+        .arrow_function_expression => true,
+        .function => |function| !has_bound_arguments and !functionUsesThis(tree, function),
+        else => false,
+    };
+    if (!is_extra) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "The function binding is unnecessary.",
+        tree.span(index),
+    );
+}
+
+fn functionUsesThis(tree: *const ast.Tree, function: ast.Function) bool {
+    if (function.body == .null) return false;
+
+    const body = switch (tree.data(function.body)) {
+        .function_body => |body| body,
+        else => return false,
+    };
+    return rangeUsesThis(tree, body.body);
+}
+
+fn rangeUsesThis(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |child| {
+        if (nodeUsesThis(tree, child)) return true;
+    }
+    return false;
+}
+
+fn nodeUsesThis(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .this_expression => true,
+        .function,
+        .class,
+        .arrow_function_expression,
+        => false,
+        .expression_statement => |statement| nodeUsesThis(tree, statement.expression),
+        .return_statement => |statement| nodeUsesThis(tree, statement.argument),
+        .throw_statement => |statement| nodeUsesThis(tree, statement.argument),
+        .block_statement => |block| rangeUsesThis(tree, block.body),
+        .static_block => |block| rangeUsesThis(tree, block.body),
+        .if_statement => |statement| nodeUsesThis(tree, statement.@"test") or
+            nodeUsesThis(tree, statement.consequent) or
+            nodeUsesThis(tree, statement.alternate),
+        .while_statement => |statement| nodeUsesThis(tree, statement.@"test") or
+            nodeUsesThis(tree, statement.body),
+        .do_while_statement => |statement| nodeUsesThis(tree, statement.@"test") or
+            nodeUsesThis(tree, statement.body),
+        .for_statement => |statement| nodeUsesThis(tree, statement.init) or
+            nodeUsesThis(tree, statement.@"test") or
+            nodeUsesThis(tree, statement.update) or
+            nodeUsesThis(tree, statement.body),
+        .for_in_statement => |statement| nodeUsesThis(tree, statement.left) or
+            nodeUsesThis(tree, statement.right) or
+            nodeUsesThis(tree, statement.body),
+        .for_of_statement => |statement| nodeUsesThis(tree, statement.left) or
+            nodeUsesThis(tree, statement.right) or
+            nodeUsesThis(tree, statement.body),
+        .switch_statement => |statement| {
+            if (nodeUsesThis(tree, statement.discriminant)) return true;
+            for (tree.extra(statement.cases)) |case_index| {
+                if (nodeUsesThis(tree, case_index)) return true;
+            }
+            return false;
+        },
+        .switch_case => |switch_case| nodeUsesThis(tree, switch_case.@"test") or
+            rangeUsesThis(tree, switch_case.consequent),
+        .try_statement => |statement| nodeUsesThis(tree, statement.block) or
+            nodeUsesThis(tree, statement.handler) or
+            nodeUsesThis(tree, statement.finalizer),
+        .catch_clause => |clause| nodeUsesThis(tree, clause.body),
+        .labeled_statement => |statement| nodeUsesThis(tree, statement.body),
+        .with_statement => |statement| nodeUsesThis(tree, statement.object) or
+            nodeUsesThis(tree, statement.body),
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator| {
+                if (nodeUsesThis(tree, declarator)) return true;
+            }
+            return false;
+        },
+        .variable_declarator => |declarator| nodeUsesThis(tree, declarator.init),
+        .parenthesized_expression => |expression| nodeUsesThis(tree, expression.expression),
+        .chain_expression => |expression| nodeUsesThis(tree, expression.expression),
+        .member_expression => |expression| nodeUsesThis(tree, expression.object) or
+            nodeUsesThis(tree, expression.property),
+        .call_expression => |expression| nodeUsesThis(tree, expression.callee) or
+            rangeUsesThis(tree, expression.arguments),
+        .new_expression => |expression| nodeUsesThis(tree, expression.callee) or
+            rangeUsesThis(tree, expression.arguments),
+        .assignment_expression => |expression| nodeUsesThis(tree, expression.left) or
+            nodeUsesThis(tree, expression.right),
+        .binary_expression => |expression| nodeUsesThis(tree, expression.left) or
+            nodeUsesThis(tree, expression.right),
+        .logical_expression => |expression| nodeUsesThis(tree, expression.left) or
+            nodeUsesThis(tree, expression.right),
+        .conditional_expression => |expression| nodeUsesThis(tree, expression.@"test") or
+            nodeUsesThis(tree, expression.consequent) or
+            nodeUsesThis(tree, expression.alternate),
+        .unary_expression => |expression| nodeUsesThis(tree, expression.argument),
+        .update_expression => |expression| nodeUsesThis(tree, expression.argument),
+        .await_expression => |expression| nodeUsesThis(tree, expression.argument),
+        .yield_expression => |expression| nodeUsesThis(tree, expression.argument),
+        .sequence_expression => |expression| rangeUsesThis(tree, expression.expressions),
+        .array_expression => |expression| rangeUsesThis(tree, expression.elements),
+        .object_expression => |expression| rangeUsesThis(tree, expression.properties),
+        .object_property => |property| nodeUsesThis(tree, property.key) or nodeUsesThis(tree, property.value),
+        .spread_element => |element| nodeUsesThis(tree, element.argument),
+        else => false,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -44,6 +44,7 @@ pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
 pub const no_eval = @import("no_eval.zig");
 pub const no_ex_assign = @import("no_ex_assign.zig");
+pub const no_extra_bind = @import("no_extra_bind.zig");
 pub const no_extra_label = @import("no_extra_label.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
@@ -813,6 +814,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.no_extra_bind) {
+            try no_extra_bind.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -151,6 +151,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_extra_bind.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_label.zig");
 }
 

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-extra-bind for functions that do not use this" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\}.bind(context);
+        \\const second = function () {
+        \\  return value;
+        \\}.bind();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_bind.id));
+    try std.testing.expectEqualStrings("The function binding is unnecessary.", result.diagnostics[0].message);
+}
+
+test "reports no-extra-bind for arrow functions" {
+    const source =
+        \\const first = (() => value).bind(context);
+        \\const second = (() => this.value).bind(context);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_bind.id));
+}
+
+test "does not report no-extra-bind when this or bound arguments are used" {
+    const source =
+        \\const first = function () {
+        \\  return this.value;
+        \\}.bind(context);
+        \\const second = function (value) {
+        \\  return value + 1;
+        \\}.bind(context, value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_bind.id));
+}
+
+test "does not count this inside nested functions" {
+    const source =
+        \\const first = function () {
+        \\  function nested() {
+        \\    return this.value;
+        \\  }
+        \\  return nested();
+        \\}.bind(context);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_extra_bind.id));
+}
+
+test "can disable no-extra-bind" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\}.bind(context);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_bind = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_bind.id));
+}


### PR DESCRIPTION
Summary:
- add the no-extra-bind rule for unnecessary function bindings
- expose --no-extra-bind=off and document the rule
- add focused tests in tests/rules/no_extra_bind.zig

References:
- https://eslint.org/docs/latest/rules/no-extra-bind
- https://github.com/eslint/eslint/blob/main/lib/rules/no-extra-bind.js

Tests:
- .zig-cache/o/b70e6a8dcf612fb6ee95fe917ffaa0b7/root --seed=0x22474428
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
