### PR TITLE
feat: port rule no-object-constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-new-wrappers`
 - `no-octal`
 - `no-octal-escape`
+- `no-object-constructor`
 - `no-path-concat`
 - `no-plusplus`
 - `no-promise-executor-return`

--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
     no_new_wrappers: bool = true,
     no_octal: bool = true,
     no_octal_escape: bool = true,
+    no_object_constructor: bool = true,
     no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_promise_executor_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -164,6 +164,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_octal = false;
         } else if (std.mem.eql(u8, arg, "--no-octal-escape=off")) {
             options.no_octal_escape = false;
+        } else if (std.mem.eql(u8, arg, "--no-object-constructor=off")) {
+            options.no_object_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-path-concat=off")) {
             options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
@@ -454,6 +456,7 @@ fn printHelp() void {
         \\  --no-new-wrappers=off     Disable no-new-wrappers
         \\  --no-octal=off            Disable no-octal
         \\  --no-octal-escape=off     Disable no-octal-escape
+        \\  --no-object-constructor=off Disable no-object-constructor
         \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-promise-executor-return=off Disable no-promise-executor-return

--- a/src/rules/no_object_constructor.zig
+++ b/src/rules/no_object_constructor.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-object-constructor";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (call.arguments.len == 0 and isGlobalObjectReference(ctx.tree, self.symbol_table, call.callee)) {
+            try self.report(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (expression.arguments.len == 0 and isGlobalObjectReference(ctx.tree, self.symbol_table, expression.callee)) {
+            try self.report(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    fn report(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Do not use the Object constructor.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isGlobalObjectReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Object") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -78,6 +78,7 @@ pub const no_new_symbol = @import("no_new_symbol.zig");
 pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
 pub const no_octal_escape = @import("no_octal_escape.zig");
+pub const no_object_constructor = @import("no_object_constructor.zig");
 pub const no_path_concat = @import("no_path_concat.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
@@ -247,6 +248,10 @@ pub fn runSemantic(
 
     if (options.no_new_object) {
         try no_new_object.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_object_constructor) {
+        try no_object_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_symbol) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -287,6 +287,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_object_constructor.zig");
+}
+
+comptime {
     _ = @import("rules/no_path_concat.zig");
 }
 

--- a/tests/rules/no_object_constructor.zig
+++ b/tests/rules/no_object_constructor.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-object-constructor for empty Object calls and constructors" {
+    const source =
+        \\const first = Object();
+        \\const second = new Object();
+        \\const third = new (Object)();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new_object = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_object_constructor.id));
+    try std.testing.expectEqualStrings("Do not use the Object constructor.", result.diagnostics[0].message);
+}
+
+test "does not report no-object-constructor with arguments or shadowed Object" {
+    const source =
+        \\const first = Object(value);
+        \\const second = new Object(value);
+        \\function local(Object) {
+        \\  const first = Object();
+        \\  const second = new Object();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new_object = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_object_constructor.id));
+}
+
+test "can disable no-object-constructor" {
+    const source =
+        \\const first = Object();
+        \\const second = new Object();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new_object = false,
+        .no_object_constructor = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_object_constructor.id));
+}


### PR DESCRIPTION
Summary:
- add the no-object-constructor rule for empty Object calls and constructors
- expose --no-object-constructor=off and document the rule
- add focused tests in tests/rules/no_object_constructor.zig

References:
- https://eslint.org/docs/latest/rules/no-object-constructor
- https://github.com/eslint/eslint/blob/main/lib/rules/no-object-constructor.js

Tests:
- .zig-cache/o/572816899c9a67b016309ff2d2aafff7/root --seed=0x8bf4748a
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
