### PR TITLE
feat: port rule no-eq-null

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-empty-pattern`
 - `no-empty-static-block`
 - `no-else-return`
+- `no-eq-null`
 - `no-eval`
 - `no-ex-assign`
 - `no-extra-bind`

--- a/src/core.zig
+++ b/src/core.zig
@@ -52,6 +52,7 @@ pub const Options = struct {
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
+    no_eq_null: bool = true,
     no_eval: bool = true,
     no_ex_assign: bool = true,
     no_extra_bind: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -92,6 +92,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_static_block = false;
         } else if (std.mem.eql(u8, arg, "--no-else-return=off")) {
             options.no_else_return = false;
+        } else if (std.mem.eql(u8, arg, "--no-eq-null=off")) {
+            options.no_eq_null = false;
         } else if (std.mem.eql(u8, arg, "--no-eval=off")) {
             options.no_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-ex-assign=off")) {
@@ -420,6 +422,7 @@ fn printHelp() void {
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return
+        \\  --no-eq-null=off        Disable no-eq-null
         \\  --no-eval=off           Disable no-eval
         \\  --no-ex-assign=off      Disable no-ex-assign
         \\  --no-extra-bind=off     Disable no-extra-bind

--- a/src/rules/no_eq_null.zig
+++ b/src/rules/no_eq_null.zig
@@ -1,0 +1,48 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-eq-null";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .equal and expression.operator != .not_equal) return;
+    if (!isNullLiteral(tree, expression.left) and !isNullLiteral(tree, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use strict equality operators when comparing with null.",
+        tree.span(index),
+    );
+}
+
+fn isNullLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -42,6 +42,7 @@ pub const no_empty_function = @import("no_empty_function.zig");
 pub const no_empty_pattern = @import("no_empty_pattern.zig");
 pub const no_empty_static_block = @import("no_empty_static_block.zig");
 pub const no_else_return = @import("no_else_return.zig");
+pub const no_eq_null = @import("no_eq_null.zig");
 pub const no_eval = @import("no_eval.zig");
 pub const no_ex_assign = @import("no_ex_assign.zig");
 pub const no_extra_bind = @import("no_extra_bind.zig");
@@ -738,6 +739,9 @@ const BasicVisitor = struct {
         }
         if (self.options.eqeqeq) {
             try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_eq_null) {
+            try no_eq_null.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_self_compare) {
             try no_self_compare.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -147,6 +147,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_eq_null.zig");
+}
+
+comptime {
     _ = @import("rules/no_ex_assign.zig");
 }
 

--- a/tests/rules/no_eq_null.zig
+++ b/tests/rules/no_eq_null.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-eq-null for loose null comparisons" {
+    const source =
+        \\if (value == null) call(value);
+        \\if (null != value) call(value);
+        \\if ((value) == (null)) call(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .eqeqeq = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_eq_null.id));
+    try std.testing.expectEqualStrings("Use strict equality operators when comparing with null.", result.diagnostics[0].message);
+}
+
+test "does not report no-eq-null for strict null comparisons or non-null loose comparisons" {
+    const source =
+        \\if (value === null) call(value);
+        \\if (value !== null) call(value);
+        \\if (value == undefined) call(value);
+        \\if (value == 0) call(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .eqeqeq = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_eq_null.id));
+}
+
+test "can disable no-eq-null" {
+    const source = "if (value == null) call(value);";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .eqeqeq = false,
+        .no_eq_null = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_eq_null.id));
+}


### PR DESCRIPTION
Summary:
- add the no-eq-null rule for loose null comparisons
- expose --no-eq-null=off and document the rule
- add focused tests in tests/rules/no_eq_null.zig

References:
- https://eslint.org/docs/latest/rules/no-eq-null
- https://github.com/eslint/eslint/blob/main/lib/rules/no-eq-null.js

Tests:
- .zig-cache/o/5f8291a4f4925ce932493ddca45f5927/root --seed=0xbb3a4649
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
