### PR TITLE
feat: port rule no-unused-labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-undef-init`
 - `unicode-bom`
 - `no-unneeded-ternary`
+- `no-unused-labels`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-useless-computed-key`

--- a/src/core.zig
+++ b/src/core.zig
@@ -116,6 +116,7 @@ pub const Options = struct {
     no_undef_init: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
+    no_unused_labels: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_useless_computed_key: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -220,6 +220,8 @@ pub fn main(init: std.process.Init) !void {
             options.unicode_bom = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
             options.no_unneeded_ternary = false;
+        } else if (std.mem.eql(u8, arg, "--no-unused-labels=off")) {
+            options.no_unused_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
@@ -486,6 +488,7 @@ fn printHelp() void {
         \\  --no-undef-init=off       Disable no-undef-init
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
+        \\  --no-unused-labels=off   Disable no-unused-labels
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-computed-key=off Disable no-useless-computed-key

--- a/src/rules/no_unused_labels.zig
+++ b/src/rules/no_unused_labels.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unused-labels";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.LabeledStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const label_name = labelName(tree, statement.label) orelse return;
+    if (containsLabelReference(tree, statement.body, label_name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unused label.",
+        tree.span(index),
+    );
+}
+
+fn labelName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .label_identifier => |label| tree.string(label.name),
+        else => null,
+    };
+}
+
+fn containsLabelReference(tree: *const ast.Tree, index: ast.NodeIndex, label_name: []const u8) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .break_statement => |statement| sameLabel(tree, statement.label, label_name),
+        .continue_statement => |statement| sameLabel(tree, statement.label, label_name),
+        .block_statement => |block| rangeContainsLabelReference(tree, block.body, label_name),
+        .static_block => |block| rangeContainsLabelReference(tree, block.body, label_name),
+        .if_statement => |statement| containsLabelReference(tree, statement.consequent, label_name) or
+            containsLabelReference(tree, statement.alternate, label_name),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const switch_case = switch (tree.data(case_index)) {
+                    .switch_case => |switch_case| switch_case,
+                    else => continue,
+                };
+                if (rangeContainsLabelReference(tree, switch_case.consequent, label_name)) return true;
+            }
+            return false;
+        },
+        .for_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .for_in_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .for_of_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .do_while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .with_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .labeled_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .try_statement => |statement| {
+            if (containsLabelReference(tree, statement.block, label_name)) return true;
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return false,
+                };
+                if (containsLabelReference(tree, handler.body, label_name)) return true;
+            }
+            return containsLabelReference(tree, statement.finalizer, label_name);
+        },
+        .function,
+        .class,
+        => false,
+        else => false,
+    };
+}
+
+fn rangeContainsLabelReference(tree: *const ast.Tree, range: ast.IndexRange, label_name: []const u8) bool {
+    for (tree.extra(range)) |child| {
+        if (containsLabelReference(tree, child, label_name)) return true;
+    }
+    return false;
+}
+
+fn sameLabel(tree: *const ast.Tree, index: ast.NodeIndex, label_name: []const u8) bool {
+    const name = labelName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, label_name);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -113,6 +113,7 @@ pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
+pub const no_unused_labels = @import("no_unused_labels.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_warning_comments = @import("no_warning_comments.zig");
 pub const no_var = @import("no_var.zig");
@@ -545,6 +546,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_extra_label) {
             try no_extra_label.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        if (self.options.no_unused_labels) {
+            try no_unused_labels.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.no_labels) {
             try no_labels.check(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -395,6 +395,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unused_labels.zig");
+}
+
+comptime {
     _ = @import("rules/no_unsafe_finally.zig");
 }
 

--- a/tests/rules/no_unused_labels.zig
+++ b/tests/rules/no_unused_labels.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unused-labels for labels without labeled break or continue" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+        \\block: {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unused_labels.id));
+    try std.testing.expectEqualStrings("Unused label.", result.diagnostics[0].message);
+}
+
+test "does not report no-unused-labels for used labels" {
+    const source =
+        \\outer: while (ready) {
+        \\  break outer;
+        \\}
+        \\loop: while (ready) {
+        \\  continue loop;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_labels.id));
+}
+
+test "does not count label references inside nested functions" {
+    const source =
+        \\outer: while (ready) {
+        \\  function nested() {
+        \\    break outer;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_labels.id));
+}
+
+test "can disable no-unused-labels" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .no_unused_labels = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_labels.id));
+}


### PR DESCRIPTION
Summary:
- add the no-unused-labels rule for unused labeled statements
- expose --no-unused-labels=off and document the rule
- add focused tests in tests/rules/no_unused_labels.zig

References:
- https://eslint.org/docs/latest/rules/no-unused-labels
- https://github.com/eslint/eslint/blob/main/lib/rules/no-unused-labels.js

Tests:
- .zig-cache/o/a76b01280845d58b8f3ea37cb4bf0cff/root --seed=0x647462e4
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true
