### PR TITLE
feat: port rule no-implicit-coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-func-assign`
 - `no-global-is-finite`
 - `no-global-is-nan`
+- `no-implicit-coercion`
 - `no-implied-eval`
 - `no-import-assign`
 - `no-inline-comments`

--- a/src/core.zig
+++ b/src/core.zig
@@ -64,6 +64,7 @@ pub const Options = struct {
     no_func_assign: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
+    no_implicit_coercion: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     no_irregular_whitespace: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
             options.no_global_is_nan = false;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-coercion=off")) {
+            options.no_implicit_coercion = false;
         } else if (std.mem.eql(u8, arg, "--no-implied-eval=off")) {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
@@ -436,6 +438,7 @@ fn printHelp() void {
         \\  --no-func-assign=off      Disable no-func-assign
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
+        \\  --no-implicit-coercion=off Disable no-implicit-coercion
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace

--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -1,0 +1,232 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-implicit-coercion";
+
+pub fn checkUnaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (expression.operator) {
+        .logical_not => {
+            if (isDoubleNegation(tree, expression)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `Boolean()` instead of double negation.");
+            }
+        },
+        .bitwise_not => {
+            if (isIndexOfCall(tree, expression.argument)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use an explicit comparison instead of bitwise negation.");
+            }
+        },
+        .positive => {
+            if (!isNumeric(tree, expression.argument)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of unary plus.");
+            }
+        },
+        .negate => {
+            if (isNegatedExpression(tree, expression.argument)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of double negation.");
+            }
+        },
+        else => {},
+    }
+}
+
+pub fn checkBinaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (expression.operator) {
+        .add => {
+            if (isConcatWithEmptyString(tree, expression)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of string concatenation.");
+            }
+        },
+        .subtract => {
+            if (isZeroLiteral(tree, expression.right) and !isNumeric(tree, expression.left)) {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of subtracting zero.");
+            }
+        },
+        .multiply => {
+            if ((isOneLiteral(tree, expression.left) and !isNumeric(tree, expression.right)) or
+                (isOneLiteral(tree, expression.right) and !isNumeric(tree, expression.left)))
+            {
+                try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of multiplying by one.");
+            }
+        },
+        else => {},
+    }
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator == .add_assign and isEmptyStringLiteral(tree, expression.right)) {
+        try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of appending an empty string.");
+    }
+}
+
+fn isDoubleNegation(tree: *const ast.Tree, expression: ast.UnaryExpression) bool {
+    const inner = switch (tree.data(unwrapTransparent(tree, expression.argument))) {
+        .unary_expression => |unary| unary,
+        else => return false,
+    };
+    return inner.operator == .logical_not;
+}
+
+fn isNegatedExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const inner = switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |unary| unary,
+        else => return false,
+    };
+    return inner.operator == .negate and !isNumeric(tree, inner.argument);
+}
+
+fn isIndexOfCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const call = switch (tree.data(unwrapTransparent(tree, index))) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    if (call.optional) return false;
+
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.optional) return false;
+
+    const name = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, name, "indexOf") or std.mem.eql(u8, name, "lastIndexOf");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isEmptyStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value).len == 0,
+        .template_literal => |literal| literal.expressions.len == 0 and
+            literal.quasis.len == 1 and isEmptyTemplateElement(tree, literal.quasis),
+        else => false,
+    };
+}
+
+fn isEmptyTemplateElement(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    const quasi_index = tree.extra(range)[0];
+    return switch (tree.data(quasi_index)) {
+        .template_element => |element| tree.string(element.cooked).len == 0,
+        else => false,
+    };
+}
+
+fn isConcatWithEmptyString(tree: *const ast.Tree, expression: ast.BinaryExpression) bool {
+    return (isEmptyStringLiteral(tree, expression.left) and !isStringType(tree, expression.right)) or
+        (isEmptyStringLiteral(tree, expression.right) and !isStringType(tree, expression.left));
+}
+
+fn isStringType(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return isStringLiteral(tree, index) or isNamedCall(tree, index, "String");
+}
+
+fn isStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => true,
+        .template_literal => |literal| literal.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn isZeroLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return numericLiteralEquals(tree, index, "0");
+}
+
+fn isOneLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return numericLiteralEquals(tree, index, "1");
+}
+
+fn numericLiteralEquals(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .numeric_literal => |literal| std.mem.eql(u8, tree.string(literal.raw), expected),
+        else => false,
+    };
+}
+
+fn isNumeric(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .numeric_literal => true,
+        .call_expression => |call| isNamedCallExpression(tree, call),
+        else => false,
+    };
+}
+
+fn isNamedCall(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    const call = switch (tree.data(unwrapTransparent(tree, index))) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const callee_name = callCalleeName(tree, call) orelse return false;
+    return std.mem.eql(u8, callee_name, name);
+}
+
+fn isNamedCallExpression(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const name = callCalleeName(tree, call) orelse return false;
+    return std.mem.eql(u8, name, "Number") or
+        std.mem.eql(u8, name, "parseInt") or
+        std.mem.eql(u8, name, "parseFloat");
+}
+
+fn callCalleeName(tree: *const ast.Tree, call: ast.CallExpression) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    message: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnostic(allocator, diagnostics, .warning, id, message, tree.span(index));
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -54,6 +54,7 @@ pub const no_for_in = @import("no_for_in.zig");
 pub const no_func_assign = @import("no_func_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
+pub const no_implicit_coercion = @import("no_implicit_coercion.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_inline_comments = @import("no_inline_comments.zig");
@@ -729,6 +730,9 @@ const BasicVisitor = struct {
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
+        if (self.options.no_implicit_coercion) {
+            try no_implicit_coercion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         return .proceed;
     }
 
@@ -759,6 +763,9 @@ const BasicVisitor = struct {
         if (self.options.no_useless_concat) {
             try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
+        if (self.options.no_implicit_coercion) {
+            try no_implicit_coercion.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_path_concat) {
             try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
@@ -779,6 +786,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_void) {
             try no_void.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_implicit_coercion) {
+            try no_implicit_coercion.checkUnaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -191,6 +191,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_implicit_coercion.zig");
+}
+
+comptime {
     _ = @import("rules/no_implied_eval.zig");
 }
 

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-implicit-coercion for boolean coercion" {
+    const source =
+        \\const first = !!value;
+        \\const second = ~items.indexOf(value);
+        \\const third = ~items.lastIndexOf(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expectEqualStrings("Use `Boolean()` instead of double negation.", result.diagnostics[0].message);
+}
+
+test "reports no-implicit-coercion for number coercion" {
+    const source =
+        \\const first = +value;
+        \\const second = -(-value);
+        \\const third = value - 0;
+        \\const fourth = value * 1;
+        \\const fifth = 1 * value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+}
+
+test "reports no-implicit-coercion for string coercion" {
+    const source =
+        \\const first = "" + value;
+        \\const second = value + "";
+        \\let third = value;
+        \\third += "";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+}
+
+test "does not report no-implicit-coercion for explicit conversions" {
+    const source =
+        \\const first = Boolean(value);
+        \\const second = items.indexOf(value) !== -1;
+        \\const third = Number(value);
+        \\const fourth = String(value);
+        \\const fifth = `${value}`;
+        \\const sixth = +1;
+        \\const seventh = -(-1);
+        \\const eighth = 1 - 0;
+        \\const ninth = 1 * Number(value);
+        \\const tenth = "" + "value";
+        \\const eleventh = `value` + "";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implicit_coercion.id));
+}
+
+test "can disable no-implicit-coercion" {
+    const source =
+        \\const first = !!value;
+        \\const second = +value;
+        \\const third = "" + value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_implicit_coercion = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implicit_coercion.id));
+}


### PR DESCRIPTION
Summary:
- add the no-implicit-coercion rule for default boolean, number, and string shorthand coercions
- expose --no-implicit-coercion=off and document the rule
- add focused tests in tests/rules/no_implicit_coercion.zig

References:
- https://eslint.org/docs/latest/rules/no-implicit-coercion
- https://github.com/eslint/eslint/blob/main/lib/rules/no-implicit-coercion.js

Tests:
- .zig-cache/o/834a872b034227b746e72d572a2a6aad/root --seed=0xcc348b99
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true