### PR TITLE
feat: port rule no-extend-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-eq-null`
 - `no-eval`
 - `no-ex-assign`
+- `no-extend-native`
 - `no-extra-bind`
 - `no-extra-label`
 - `no-extra-semi`

--- a/src/core.zig
+++ b/src/core.zig
@@ -55,6 +55,7 @@ pub const Options = struct {
     no_eq_null: bool = true,
     no_eval: bool = true,
     no_ex_assign: bool = true,
+    no_extend_native: bool = true,
     no_extra_bind: bool = true,
     no_extra_label: bool = true,
     no_extra_semi: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,6 +98,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-ex-assign=off")) {
             options.no_ex_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-extend-native=off")) {
+            options.no_extend_native = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-bind=off")) {
             options.no_extra_bind = false;
         } else if (std.mem.eql(u8, arg, "--no-extra-label=off")) {
@@ -431,6 +433,7 @@ fn printHelp() void {
         \\  --no-eq-null=off        Disable no-eq-null
         \\  --no-eval=off           Disable no-eval
         \\  --no-ex-assign=off      Disable no-ex-assign
+        \\  --no-extend-native=off  Disable no-extend-native
         \\  --no-extra-bind=off     Disable no-extra-bind
         \\  --no-extra-label=off    Disable no-extra-label
         \\  --no-extra-semi=off      Disable no-extra-semi

--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-extend-native";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const left_member = switch (ctx.tree.data(unwrapTransparent(ctx.tree, expression.left))) {
+            .member_expression => |member| member,
+            else => return .proceed,
+        };
+        if (left_member.optional) return .proceed;
+
+        if (nativePrototypeName(ctx.tree, self.symbol_table, left_member.object)) |name| {
+            try report(self.allocator, self.diagnostics, ctx.tree, index, name);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (call.optional) return .proceed;
+        if (!isObjectDefinePropertyCall(ctx.tree, self.symbol_table, call.callee)) return .proceed;
+
+        const arguments = ctx.tree.extra(call.arguments);
+        if (arguments.len == 0) return .proceed;
+
+        if (nativePrototypeName(ctx.tree, self.symbol_table, arguments[0])) |name| {
+            try report(self.allocator, self.diagnostics, ctx.tree, index, name);
+        }
+
+        return .proceed;
+    }
+};
+
+fn nativePrototypeName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?[]const u8 {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    if (member.optional) return null;
+
+    const property_name = propertyName(tree, member) orelse return null;
+    if (!std.mem.eql(u8, property_name, "prototype")) return null;
+
+    const object = unwrapTransparent(tree, member.object);
+    const name = identifierReferenceName(tree, object) orelse return null;
+    if (!isNativeConstructor(name) or !isUnresolvedReference(symbol_table, object)) return null;
+
+    return name;
+}
+
+fn isObjectDefinePropertyCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.optional) return false;
+
+    const method = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, method, "defineProperty") and !std.mem.eql(u8, method, "defineProperties")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Object") and isUnresolvedReference(symbol_table, object);
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isNativeConstructor(name: []const u8) bool {
+    const constructors = [_][]const u8{
+        "Array",
+        "ArrayBuffer",
+        "BigInt",
+        "BigInt64Array",
+        "BigUint64Array",
+        "Boolean",
+        "DataView",
+        "Date",
+        "Error",
+        "EvalError",
+        "Float32Array",
+        "Float64Array",
+        "Function",
+        "Int8Array",
+        "Int16Array",
+        "Int32Array",
+        "Map",
+        "Number",
+        "Object",
+        "Promise",
+        "RangeError",
+        "ReferenceError",
+        "RegExp",
+        "Set",
+        "String",
+        "Symbol",
+        "SyntaxError",
+        "TypeError",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "Uint16Array",
+        "Uint32Array",
+        "URIError",
+        "WeakMap",
+        "WeakSet",
+    };
+
+    for (constructors) |constructor| {
+        if (std.mem.eql(u8, name, constructor)) return true;
+    }
+    return false;
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "{s} prototype is read only, properties should not be added.",
+        .{name},
+    );
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -45,6 +45,7 @@ pub const no_else_return = @import("no_else_return.zig");
 pub const no_eq_null = @import("no_eq_null.zig");
 pub const no_eval = @import("no_eval.zig");
 pub const no_ex_assign = @import("no_ex_assign.zig");
+pub const no_extend_native = @import("no_extend_native.zig");
 pub const no_extra_bind = @import("no_extra_bind.zig");
 pub const no_extra_label = @import("no_extra_label.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
@@ -204,6 +205,10 @@ pub fn runSemantic(
 
     if (options.no_ex_assign) {
         try no_ex_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_extend_native) {
+        try no_extend_native.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_alert) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -155,6 +155,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_extend_native.zig");
+}
+
+comptime {
     _ = @import("rules/no_extra_bind.zig");
 }
 

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-extend-native for native prototype assignments" {
+    const source =
+        \\String.prototype.trimLeft = function () {};
+        \\Array.prototype["first"] = function () {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqualStrings("String prototype is read only, properties should not be added.", result.diagnostics[0].message);
+}
+
+test "reports no-extend-native for Object defineProperty calls" {
+    const source =
+        \\Object.defineProperty(Date.prototype, "week", { value: function () {} });
+        \\Object.defineProperties(Map.prototype, {
+        \\  first: { value: function () {} },
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extend_native.id));
+}
+
+test "does not report no-extend-native for shadowed constructors or ordinary objects" {
+    const source =
+        \\const String = {};
+        \\String.prototype.trimLeft = function () {};
+        \\const local = { prototype: {} };
+        \\local.prototype.trimLeft = function () {};
+        \\const Object = {
+        \\  defineProperty() {},
+        \\};
+        \\Object.defineProperty(Array.prototype, "first", {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extend_native.id));
+}
+
+test "can disable no-extend-native" {
+    const source =
+        \\String.prototype.trimLeft = function () {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_extend_native = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extend_native.id));
+}


### PR DESCRIPTION
Summary:
- add the no-extend-native rule for native prototype assignments and Object defineProperty calls
- expose --no-extend-native=off and document the rule
- add focused tests in tests/rules/no_extend_native.zig

References:
- https://eslint.org/docs/latest/rules/no-extend-native
- https://github.com/eslint/eslint/blob/main/lib/rules/no-extend-native.js

Tests:
- .zig-cache/o/1e24780aecabdeab7c4508b277ea67cf/root --seed=0x91defbb7
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true