### PR TITLE
feat: port rule no-global-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-floating-decimal`
 - `no-for-in`
 - `no-func-assign`
+- `no-global-assign`
 - `no-global-is-finite`
 - `no-global-is-nan`
 - `no-implicit-coercion`

--- a/src/core.zig
+++ b/src/core.zig
@@ -63,6 +63,7 @@ pub const Options = struct {
     no_floating_decimal: bool = true,
     no_for_in: bool = true,
     no_func_assign: bool = true,
+    no_global_assign: bool = true,
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_implicit_coercion: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -114,6 +114,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-func-assign=off")) {
             options.no_func_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-global-assign=off")) {
+            options.no_global_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-finite=off")) {
             options.no_global_is_finite = false;
         } else if (std.mem.eql(u8, arg, "--no-global-is-nan=off")) {
@@ -441,6 +443,7 @@ fn printHelp() void {
         \\  --no-floating-decimal=off Disable no-floating-decimal
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-func-assign=off      Disable no-func-assign
+        \\  --no-global-assign=off    Disable no-global-assign
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implicit-coercion=off Disable no-implicit-coercion

--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -1,0 +1,183 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-global-assign";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument);
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+    ) Allocator.Error!void {
+        if (target == .null) return;
+
+        const unwrapped = unwrapTransparent(tree, target);
+        switch (tree.data(unwrapped)) {
+            .identifier_reference => |identifier| try self.checkIdentifier(tree, identifier.name, unwrapped),
+            .assignment_pattern => |pattern| try self.checkTarget(tree, pattern.left),
+            .binding_rest_element => |element| try self.checkTarget(tree, element.argument),
+            .array_pattern => |pattern| {
+                for (tree.extra(pattern.elements)) |element| {
+                    try self.checkTarget(tree, element);
+                }
+                try self.checkTarget(tree, pattern.rest);
+            },
+            .object_pattern => |pattern| {
+                for (tree.extra(pattern.properties)) |property_index| {
+                    const property = switch (tree.data(property_index)) {
+                        .binding_property => |property| property,
+                        else => continue,
+                    };
+                    try self.checkTarget(tree, property.value);
+                }
+                try self.checkTarget(tree, pattern.rest);
+            },
+            else => {},
+        }
+    }
+
+    fn checkIdentifier(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        name_string: ast.String,
+        node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const name = tree.string(name_string);
+        if (!isReadonlyGlobal(name)) return;
+        if (!isUnresolvedReference(self.symbol_table, node)) return;
+
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(node),
+            "Read-only global '{s}' should not be modified.",
+            .{name},
+        );
+    }
+};
+
+fn isReadonlyGlobal(name: []const u8) bool {
+    const readonly_globals = [_][]const u8{
+        "Array",
+        "ArrayBuffer",
+        "BigInt",
+        "BigInt64Array",
+        "BigUint64Array",
+        "Boolean",
+        "DataView",
+        "Date",
+        "Error",
+        "EvalError",
+        "Float32Array",
+        "Float64Array",
+        "Function",
+        "Infinity",
+        "Int8Array",
+        "Int16Array",
+        "Int32Array",
+        "Intl",
+        "JSON",
+        "Map",
+        "Math",
+        "NaN",
+        "Number",
+        "Object",
+        "Promise",
+        "RangeError",
+        "ReferenceError",
+        "Reflect",
+        "RegExp",
+        "Set",
+        "String",
+        "Symbol",
+        "SyntaxError",
+        "TypeError",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "Uint16Array",
+        "Uint32Array",
+        "URIError",
+        "WeakMap",
+        "WeakSet",
+        "undefined",
+    };
+
+    for (readonly_globals) |global| {
+        if (std.mem.eql(u8, name, global)) return true;
+    }
+    return false;
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -53,6 +53,7 @@ pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_floating_decimal = @import("no_floating_decimal.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_func_assign = @import("no_func_assign.zig");
+pub const no_global_assign = @import("no_global_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implicit_coercion = @import("no_implicit_coercion.zig");
@@ -225,6 +226,10 @@ pub fn runSemantic(
 
     if (options.no_func_assign) {
         try no_func_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_global_assign) {
+        try no_global_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_global_is_finite) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -187,6 +187,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_global_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_global_is_finite.zig");
 }
 

--- a/tests/rules/no_global_assign.zig
+++ b/tests/rules/no_global_assign.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-global-assign for assignments to read-only globals" {
+    const source =
+        \\Object = null;
+        \\NaN = 1;
+        \\undefined = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_global_assign.id));
+    try std.testing.expectEqualStrings("Read-only global 'Object' should not be modified.", result.diagnostics[0].message);
+}
+
+test "reports no-global-assign for updates and destructuring assignments" {
+    const source =
+        \\Infinity++;
+        \\({ Array } = source);
+        \\[Map] = source;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_global_assign.id));
+}
+
+test "does not report no-global-assign for shadowed names or property writes" {
+    const source =
+        \\let Object = null;
+        \\Object = {};
+        \\globalThis.Object = {};
+        \\Number.value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_global_assign.id));
+}
+
+test "can disable no-global-assign" {
+    const source =
+        \\Object = null;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_global_assign = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_global_assign.id));
+}


### PR DESCRIPTION
Summary:
- add the no-global-assign rule for writes to read-only global names
- expose --no-global-assign=off and document the rule
- add focused tests in tests/rules/no_global_assign.zig

References:
- https://eslint.org/docs/latest/rules/no-global-assign
- https://github.com/eslint/eslint/blob/main/lib/rules/no-global-assign.js

Tests:
- .zig-cache/o/70172fc316c28d4f5862134e3ab13f0e/root --seed=0xfd777fc9
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true