### PR TITLE
feat: port rule no-dupe-class-members

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-continue`
 - `no-debugger`
 - `no-dupe-args`
+- `no-dupe-class-members`
 - `no-dupe-else-if`
 - `no-dupe-keys`
 - `no-delete-var`

--- a/src/core.zig
+++ b/src/core.zig
@@ -43,6 +43,7 @@ pub const Options = struct {
     no_dupe_else_if: bool = true,
     no_duplicate_case: bool = true,
     no_dupe_args: bool = true,
+    no_dupe_class_members: bool = true,
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_div_regex: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -74,6 +74,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_duplicate_case = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-args=off")) {
             options.no_dupe_args = false;
+        } else if (std.mem.eql(u8, arg, "--no-dupe-class-members=off")) {
+            options.no_dupe_class_members = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-keys=off")) {
             options.no_dupe_keys = false;
         } else if (std.mem.eql(u8, arg, "--no-delete-var=off")) {
@@ -423,6 +425,7 @@ fn printHelp() void {
         \\  --no-dupe-else-if=off     Disable no-dupe-else-if
         \\  --no-duplicate-case=off   Disable no-duplicate-case
         \\  --no-dupe-args=off        Disable no-dupe-args
+        \\  --no-dupe-class-members=off Disable no-dupe-class-members
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-div-regex=off        Disable no-div-regex

--- a/src/rules/no_dupe_class_members.zig
+++ b/src/rules/no_dupe_class_members.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-dupe-class-members";
+
+const MemberKind = enum {
+    constructor,
+    method_or_field,
+    get,
+    set,
+};
+
+const Member = struct {
+    name: []const u8,
+    static: bool,
+    kind: MemberKind,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+) Allocator.Error!void {
+    var members: std.ArrayList(Member) = .empty;
+    defer members.deinit(allocator);
+
+    for (tree.extra(body.body)) |member_index| {
+        const member = memberInfo(tree, member_index) orelse continue;
+        if (!isDuplicate(members.items, member)) {
+            try members.append(allocator, member);
+            continue;
+        }
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Duplicate class member.",
+            tree.span(member_index),
+        );
+    }
+}
+
+fn isDuplicate(existing_members: []const Member, candidate: Member) bool {
+    for (existing_members) |existing| {
+        if (existing.static != candidate.static) continue;
+        if (!std.mem.eql(u8, existing.name, candidate.name)) continue;
+
+        if ((existing.kind == .get and candidate.kind == .set) or
+            (existing.kind == .set and candidate.kind == .get))
+        {
+            continue;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+fn memberInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?Member {
+    return switch (tree.data(index)) {
+        .method_definition => |method| methodInfo(tree, method),
+        .property_definition => |property| propertyInfo(tree, property),
+        else => null,
+    };
+}
+
+fn methodInfo(tree: *const ast.Tree, method: ast.MethodDefinition) ?Member {
+    const name = if (method.kind == .constructor and !method.static)
+        "constructor"
+    else
+        staticKeyName(tree, method.key, method.computed) orelse return null;
+
+    const kind: MemberKind = switch (method.kind) {
+        .constructor => .constructor,
+        .get => .get,
+        .set => .set,
+        .method => .method_or_field,
+    };
+
+    return .{ .name = name, .static = method.static, .kind = kind };
+}
+
+fn propertyInfo(tree: *const ast.Tree, property: ast.PropertyDefinition) ?Member {
+    const name = staticKeyName(tree, property.key, property.computed) orelse return null;
+    return .{ .name = name, .static = property.static, .kind = .method_or_field };
+}
+
+fn staticKeyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| if (computed) null else tree.string(identifier.name),
+        .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -33,6 +33,7 @@ pub const no_debugger = @import("no_debugger.zig");
 pub const no_dupe_else_if = @import("no_dupe_else_if.zig");
 pub const no_duplicate_case = @import("no_duplicate_case.zig");
 pub const no_dupe_args = @import("no_dupe_args.zig");
+pub const no_dupe_class_members = @import("no_dupe_class_members.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_div_regex = @import("no_div_regex.zig");
@@ -950,6 +951,18 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_class_body(
+        self: *BasicVisitor,
+        body: ast.ClassBody,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_dupe_class_members) {
+            try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -111,6 +111,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_dupe_class_members.zig");
+}
+
+comptime {
     _ = @import("rules/no_dupe_else_if.zig");
 }
 

--- a/tests/rules/no_dupe_class_members.zig
+++ b/tests/rules/no_dupe_class_members.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-dupe-class-members for duplicate methods and fields" {
+    const source =
+        \\class Example {
+        \\  value() {}
+        \\  value() {}
+        \\  field = 1;
+        \\  field = 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_dupe_class_members.id));
+    try std.testing.expectEqualStrings("Duplicate class member.", result.diagnostics[0].message);
+}
+
+test "reports no-dupe-class-members for constructors and static members" {
+    const source =
+        \\class Example {
+        \\  constructor() {}
+        \\  constructor(value) {}
+        \\  static value() {}
+        \\  static value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_dupe_class_members.id));
+}
+
+test "does not report no-dupe-class-members for allowed combinations" {
+    const source =
+        \\class Example {
+        \\  get value() { return this.x; }
+        \\  set value(next) { this.x = next; }
+        \\  value2() {}
+        \\  static value2() {}
+        \\  [dynamic]() {}
+        \\  dynamic() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_class_members.id));
+}
+
+test "can disable no-dupe-class-members" {
+    const source =
+        \\class Example {
+        \\  value() {}
+        \\  value() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_dupe_class_members = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_class_members.id));
+}


### PR DESCRIPTION
Summary:
- add the no-dupe-class-members rule for repeated class members
- expose --no-dupe-class-members=off and document the rule
- add focused tests in tests/rules/no_dupe_class_members.zig

References:
- https://eslint.org/docs/latest/rules/no-dupe-class-members
- https://github.com/eslint/eslint/blob/main/lib/rules/no-dupe-class-members.js

Tests:
- .zig-cache/o/4846e0aaaf5bbd3c2bd6b990b0e9fc99/root --seed=0x2530df6f
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true