### PR TITLE
feat: port rule no-useless-constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-useless-computed-key`
 - `no-useless-call`
 - `no-useless-concat`
+- `no-useless-constructor`
 - `no-useless-catch`
 - `no-useless-rename`
 - `no-warning-comments`

--- a/src/core.zig
+++ b/src/core.zig
@@ -127,6 +127,7 @@ pub const Options = struct {
     no_useless_computed_key: bool = true,
     no_useless_call: bool = true,
     no_useless_concat: bool = true,
+    no_useless_constructor: bool = true,
     no_useless_catch: bool = true,
     no_useless_rename: bool = true,
     no_warning_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -242,6 +242,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_call = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
             options.no_useless_concat = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-constructor=off")) {
+            options.no_useless_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
             options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
@@ -509,6 +511,7 @@ fn printHelp() void {
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
         \\  --no-useless-call=off     Disable no-useless-call
         \\  --no-useless-concat=off   Disable no-useless-concat
+        \\  --no-useless-constructor=off Disable no-useless-constructor
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-rename=off   Disable no-useless-rename
         \\  --no-warning-comments=off Disable no-warning-comments

--- a/src/rules/no_useless_constructor.zig
+++ b/src/rules/no_useless_constructor.zig
@@ -1,0 +1,227 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-constructor";
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (!isUselessConstructor(tree, class, method)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Useless constructor.",
+            tree.span(member_index),
+        );
+    }
+}
+
+fn isUselessConstructor(tree: *const ast.Tree, class: ast.Class, method: ast.MethodDefinition) bool {
+    if (method.kind != .constructor) return false;
+    if (method.static) return false;
+    if (method.decorators.len != 0) return false;
+    if (hasUsefulAccessibility(class, method)) return false;
+
+    const function = switch (tree.data(method.value)) {
+        .function => |function| function,
+        else => return false,
+    };
+    if (function.body == .null) return false;
+    if (hasParameterPropertyOrDecorators(tree, function.params)) return false;
+
+    const body = switch (tree.data(function.body)) {
+        .function_body => |body| body,
+        else => return false,
+    };
+
+    if (class.super_class == .null) {
+        return body.body.len == 0;
+    }
+
+    return isRedundantSuperCall(tree, body, function.params);
+}
+
+fn hasUsefulAccessibility(class: ast.Class, method: ast.MethodDefinition) bool {
+    return switch (method.accessibility) {
+        .private, .protected => true,
+        .public => class.super_class != .null,
+        .none => false,
+    };
+}
+
+fn hasParameterPropertyOrDecorators(tree: *const ast.Tree, params_index: ast.NodeIndex) bool {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return false,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| {
+                if (hasPatternDecorators(tree, parameter.pattern)) return true;
+            },
+            .ts_parameter_property => return true,
+            else => {},
+        }
+    }
+
+    return hasPatternDecorators(tree, params.rest);
+}
+
+fn hasPatternDecorators(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| identifier.decorators.len != 0,
+        .assignment_pattern => |pattern| pattern.decorators.len != 0 or hasPatternDecorators(tree, pattern.left),
+        .binding_rest_element => |element| element.decorators.len != 0 or hasPatternDecorators(tree, element.argument),
+        .array_pattern => |pattern| pattern.decorators.len != 0,
+        .object_pattern => |pattern| pattern.decorators.len != 0,
+        else => false,
+    };
+}
+
+fn isRedundantSuperCall(tree: *const ast.Tree, body: ast.FunctionBody, params_index: ast.NodeIndex) bool {
+    const statements = tree.extra(body.body);
+    if (statements.len != 1) return false;
+
+    const statement = switch (tree.data(statements[0])) {
+        .expression_statement => |statement| statement,
+        else => return false,
+    };
+
+    const call = switch (tree.data(unwrapTransparent(tree, statement.expression))) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    if (tree.data(unwrapTransparent(tree, call.callee)) != .super) return false;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return false,
+    };
+    if (!allParamsSimple(tree, params)) return false;
+
+    const arguments = tree.extra(call.arguments);
+    if (isSpreadArguments(tree, arguments)) return true;
+
+    return isPassingThrough(tree, params, arguments);
+}
+
+fn allParamsSimple(tree: *const ast.Tree, params: ast.FormalParameters) bool {
+    for (tree.extra(params.items)) |item_index| {
+        const pattern = formalParameterPattern(tree, item_index) orelse return false;
+        if (!isSimpleParameter(tree, pattern)) return false;
+    }
+
+    return params.rest == .null or isSimpleParameter(tree, params.rest);
+}
+
+fn isPassingThrough(tree: *const ast.Tree, params: ast.FormalParameters, arguments: []const ast.NodeIndex) bool {
+    const params_len = params.items.len + @as(usize, if (params.rest == .null) 0 else 1);
+    if (params_len != arguments.len) return false;
+
+    var argument_index: usize = 0;
+    for (tree.extra(params.items)) |item_index| {
+        const pattern = formalParameterPattern(tree, item_index) orelse return false;
+        if (!isValidPair(tree, pattern, arguments[argument_index])) return false;
+        argument_index += 1;
+    }
+
+    if (params.rest != .null and !isValidPair(tree, params.rest, arguments[argument_index])) return false;
+    return true;
+}
+
+fn formalParameterPattern(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    return switch (tree.data(index)) {
+        .formal_parameter => |parameter| parameter.pattern,
+        else => null,
+    };
+}
+
+fn isSimpleParameter(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .binding_identifier => true,
+        .binding_rest_element => |element| switch (tree.data(element.argument)) {
+            .binding_identifier => true,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn isSpreadArguments(tree: *const ast.Tree, arguments: []const ast.NodeIndex) bool {
+    if (arguments.len != 1) return false;
+
+    const spread = switch (tree.data(arguments[0])) {
+        .spread_element => |spread| spread,
+        else => return false,
+    };
+
+    return isIdentifierReferenceNamed(tree, spread.argument, "arguments");
+}
+
+fn isValidPair(tree: *const ast.Tree, param: ast.NodeIndex, argument: ast.NodeIndex) bool {
+    if (isBindingReferencePair(tree, param, argument)) return true;
+
+    const rest = switch (tree.data(param)) {
+        .binding_rest_element => |rest| rest,
+        else => return false,
+    };
+    const spread = switch (tree.data(argument)) {
+        .spread_element => |spread| spread,
+        else => return false,
+    };
+
+    return isBindingReferencePair(tree, rest.argument, spread.argument);
+}
+
+fn isBindingReferencePair(tree: *const ast.Tree, binding: ast.NodeIndex, reference: ast.NodeIndex) bool {
+    const binding_name = switch (tree.data(binding)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+
+    return isIdentifierReferenceNamed(tree, reference, binding_name);
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -115,6 +115,7 @@ pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_useless_computed_key = @import("no_useless_computed_key.zig");
 pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
+pub const no_useless_constructor = @import("no_useless_constructor.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
@@ -326,6 +327,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
+        }
+        if (self.options.no_useless_constructor) {
+            try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -439,6 +439,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_constructor.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_catch.zig");
 }
 

--- a/tests/rules/no_useless_constructor.zig
+++ b/tests/rules/no_useless_constructor.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-constructor for empty constructors without superclasses" {
+    const source =
+        \\class First {
+        \\  constructor() {}
+        \\}
+        \\class Second {
+        \\  constructor(value) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_constructor.id));
+    try std.testing.expectEqualStrings("Useless constructor.", result.diagnostics[0].message);
+}
+
+test "reports no-useless-constructor for pass-through super calls" {
+    const source =
+        \\class First extends Base {
+        \\  constructor(...args) {
+        \\    super(...args);
+        \\  }
+        \\}
+        \\class Second extends Base {
+        \\  constructor(a, b) {
+        \\    super(a, b);
+        \\  }
+        \\}
+        \\class Third extends Base {
+        \\  constructor() {
+        \\    super(...arguments);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_useless_constructor.id));
+}
+
+test "does not report no-useless-constructor for useful constructors" {
+    const source =
+        \\class First extends Base {
+        \\  constructor(a = sideEffect()) {
+        \\    super(a);
+        \\  }
+        \\}
+        \\class Second extends Base {
+        \\  constructor(a) {
+        \\    super(transform(a));
+        \\  }
+        \\}
+        \\class Third {
+        \\  constructor() {
+        \\    this.value = 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_constructor.id));
+}
+
+test "can disable no-useless-constructor" {
+    const source =
+        \\class First {
+        \\  constructor() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_constructor.id));
+}


### PR DESCRIPTION
Summary:
- add the no-useless-constructor rule for redundant class constructors
- expose --no-useless-constructor=off and document the rule
- add focused tests in tests/rules/no_useless_constructor.zig

References:
- https://eslint.org/docs/latest/rules/no-useless-constructor
- https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-constructor.js

Tests:
- .zig-cache/o/b382ba395cdc0e2a7b6a249a653e42c7/root --seed=0x288364e7
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true