### PR TITLE
feat: port rule no-useless-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-regex-spaces`
 - `no-return-await`
 - `no-return-assign`
+- `no-useless-return`
 - `no-script-url`
 - `no-self-assign`
 - `no-self-compare`

--- a/src/core.zig
+++ b/src/core.zig
@@ -105,6 +105,7 @@ pub const Options = struct {
     no_regex_spaces: bool = true,
     no_return_await: bool = true,
     no_return_assign: bool = true,
+    no_useless_return: bool = true,
     no_script_url: bool = true,
     no_self_assign: bool = true,
     no_self_compare: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -198,6 +198,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_return_await = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
             options.no_return_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-return=off")) {
+            options.no_useless_return = false;
         } else if (std.mem.eql(u8, arg, "--no-script-url=off")) {
             options.no_script_url = false;
         } else if (std.mem.eql(u8, arg, "--no-self-assign=off")) {
@@ -489,6 +491,7 @@ fn printHelp() void {
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign
+        \\  --no-useless-return=off   Disable no-useless-return
         \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign
         \\  --no-self-compare=off     Disable no-self-compare

--- a/src/rules/no_useless_return.zig
+++ b/src/rules/no_useless_return.zig
@@ -1,0 +1,77 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-useless-return";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ReturnStatement,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (statement.argument != .null) return;
+    if (!isRedundantReturn(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unnecessary return statement.",
+        tree.span(index),
+    );
+}
+
+fn isRedundantReturn(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .function_body => |body| return isLastInRange(tree, child, body.body),
+            .block_statement => |block| {
+                if (!isLastInRange(tree, child, block.body)) return false;
+                child = ancestor;
+            },
+            .switch_case => |case| {
+                if (!isLastInRange(tree, child, case.consequent)) return false;
+                child = ancestor;
+            },
+            .switch_statement => |statement| {
+                if (!isLastInRange(tree, child, statement.cases)) return false;
+                child = ancestor;
+            },
+            .if_statement => |statement| {
+                if (statement.consequent != child and statement.alternate != child) return false;
+                child = ancestor;
+            },
+            .while_statement,
+            .do_while_statement,
+            .for_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .try_statement,
+            .catch_clause,
+            => return false,
+            .function,
+            .arrow_function_expression,
+            .program,
+            => return false,
+            else => child = ancestor,
+        }
+    }
+
+    return false;
+}
+
+fn isLastInRange(tree: *const ast.Tree, index: ast.NodeIndex, range: ast.IndexRange) bool {
+    if (range.len == 0) return false;
+    const items = tree.extra(range);
+    return items[items.len - 1] == index;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -95,6 +95,7 @@ pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
+pub const no_useless_return = @import("no_useless_return.zig");
 pub const no_script_url = @import("no_script_url.zig");
 pub const no_self_assign = @import("no_self_assign.zig");
 pub const no_self_compare = @import("no_self_compare.zig");
@@ -540,6 +541,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_return_await) {
             try no_return_await.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
+        }
+        if (self.options.no_useless_return) {
+            try no_useless_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         if (self.options.no_return_assign) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -355,6 +355,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_return.zig");
+}
+
+comptime {
     _ = @import("rules/no_script_url.zig");
 }
 

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-return at natural function exits" {
+    const source =
+        \\function first() {
+        \\  work();
+        \\  return;
+        \\}
+        \\function second(flag) {
+        \\  if (flag) {
+        \\    return;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_return.id));
+    try std.testing.expectEqualStrings("Unnecessary return statement.", result.diagnostics[0].message);
+}
+
+test "reports no-useless-return in final switch cases" {
+    const source =
+        \\function check(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      run();
+        \\      return;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_useless_return.id));
+}
+
+test "does not report no-useless-return when return changes control flow" {
+    const source =
+        \\function first(flag) {
+        \\  if (flag) {
+        \\    return;
+        \\  }
+        \\  work();
+        \\}
+        \\function second(items) {
+        \\  while (items.length) {
+        \\    return;
+        \\  }
+        \\}
+        \\function third(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      return;
+        \\    case 2:
+        \\      work();
+        \\  }
+        \\}
+        \\function fourth() {
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_return.id));
+}
+
+test "can disable no-useless-return" {
+    const source =
+        \\function first() {
+        \\  return;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_return.id));
+}


### PR DESCRIPTION
Summary:
- add the no-useless-return rule for redundant bare returns
- expose --no-useless-return=off and document the rule
- add focused tests in tests/rules/no_useless_return.zig

References:
- https://eslint.org/docs/latest/rules/no-useless-return
- https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-return.js

Tests:
- .zig-cache/o/04f55af2c9381d8126a8116b2ca61d2f/root --seed=0x69f8d628
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true