### PR TITLE
feat: port rule no-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-delete-var`
 - `no-div-regex`
 - `no-duplicate-case`
+- `no-empty`
 - `no-empty-block-statements`
 - `no-empty-character-class`
 - `no-empty-function`

--- a/src/core.zig
+++ b/src/core.zig
@@ -47,6 +47,7 @@ pub const Options = struct {
     no_dupe_keys: bool = true,
     no_delete_var: bool = true,
     no_div_regex: bool = true,
+    no_empty: bool = true,
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_function: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -82,6 +82,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_delete_var = false;
         } else if (std.mem.eql(u8, arg, "--no-div-regex=off")) {
             options.no_div_regex = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty=off")) {
+            options.no_empty = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
@@ -433,6 +435,7 @@ fn printHelp() void {
         \\  --no-dupe-keys=off        Disable no-dupe-keys
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-div-regex=off        Disable no-div-regex
+        \\  --no-empty=off            Disable no-empty
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-function=off Disable no-empty-function

--- a/src/rules/no_empty.zig
+++ b/src/rules/no_empty.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-empty";
+
+pub fn checkBlockStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.BlockStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (block.body.len != 0) return;
+    if (hasCommentInsideBraces(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Empty block statement.",
+        tree.span(index),
+    );
+}
+
+fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (tree.source.len == 0 or start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    const open = std.mem.indexOfScalar(u8, source, '{') orelse return false;
+    const close = std.mem.lastIndexOfScalar(u8, source, '}') orelse return false;
+    if (open >= close) return false;
+
+    return containsOnlyWhitespaceAndHasComment(source[open + 1 .. close]);
+}
+
+fn containsOnlyWhitespaceAndHasComment(source: []const u8) bool {
+    var has_comment = false;
+    var index: usize = 0;
+
+    while (index < source.len) {
+        switch (source[index]) {
+            ' ', '\t', '\n', '\r', 0x0B, 0x0C => index += 1,
+            '/' => {
+                if (index + 1 >= source.len) return false;
+
+                switch (source[index + 1]) {
+                    '/' => {
+                        has_comment = true;
+                        index += 2;
+                        while (index < source.len and source[index] != '\n' and source[index] != '\r') {
+                            index += 1;
+                        }
+                    },
+                    '*' => {
+                        has_comment = true;
+                        index += 2;
+                        var closed = false;
+                        while (index + 1 < source.len) : (index += 1) {
+                            if (source[index] == '*' and source[index + 1] == '/') {
+                                index += 2;
+                                closed = true;
+                                break;
+                            }
+                        }
+                        if (!closed) return false;
+                    },
+                    else => return false,
+                }
+            },
+            else => return false,
+        }
+    }
+
+    return has_comment;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -37,6 +37,7 @@ pub const no_dupe_class_members = @import("no_dupe_class_members.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_div_regex = @import("no_div_regex.zig");
+pub const no_empty = @import("no_empty.zig");
 pub const no_empty_block_statements = @import("no_empty_block_statements.zig");
 pub const no_empty_character_class = @import("no_empty_character_class.zig");
 pub const no_empty_function = @import("no_empty_function.zig");
@@ -606,6 +607,9 @@ const BasicVisitor = struct {
             if (ctx.path.parent()) |parent| {
                 try no_lone_blocks.check(self.allocator, self.diagnostics, ctx.tree, block, index, parent);
             }
+        }
+        if (self.options.no_empty) {
+            try no_empty.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -123,6 +123,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_empty.zig");
+}
+
+comptime {
     _ = @import("rules/no_empty_block_statements.zig");
 }
 

--- a/tests/rules/no_empty.zig
+++ b/tests/rules/no_empty.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-empty for empty block statements" {
+    const source =
+        \\if (ready) {}
+        \\while (ready) {
+        \\}
+        \\try {} catch (error) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_empty.id));
+    try std.testing.expectEqualStrings("Empty block statement.", result.diagnostics[0].message);
+}
+
+test "does not report no-empty for non-empty or commented blocks" {
+    const source =
+        \\if (ready) { run(); }
+        \\if (waiting) { /* empty */ }
+        \\try { work(); } catch (error) {
+        \\  // ignored
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty.id));
+}
+
+test "can disable no-empty" {
+    const source =
+        \\if (ready) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty.id));
+}


### PR DESCRIPTION
Summary:
- add the no-empty rule for empty block statements
- expose --no-empty=off and document the rule
- add focused tests in tests/rules/no_empty.zig

References:
- https://eslint.org/docs/latest/rules/no-empty
- https://github.com/eslint/eslint/blob/main/lib/rules/no-empty.js

Tests:
- .zig-cache/o/d9d570ff79505ae54e6c611784f5f2a6/root --seed=0x5151e309
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true