### PR TITLE
feat: port rule no-duplicate-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-comma-operator`
 - `no-continue`
 - `no-debugger`
+- `no-duplicate-imports`
 - `no-dupe-args`
 - `no-dupe-class-members`
 - `no-dupe-else-if`

--- a/src/core.zig
+++ b/src/core.zig
@@ -45,6 +45,7 @@ pub const Options = struct {
     no_dupe_args: bool = true,
     no_dupe_class_members: bool = true,
     no_dupe_keys: bool = true,
+    no_duplicate_imports: bool = true,
     no_delete_var: bool = true,
     no_div_regex: bool = true,
     no_empty: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,6 +72,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_dupe_else_if = false;
         } else if (std.mem.eql(u8, arg, "--no-duplicate-case=off")) {
             options.no_duplicate_case = false;
+        } else if (std.mem.eql(u8, arg, "--no-duplicate-imports=off")) {
+            options.no_duplicate_imports = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-args=off")) {
             options.no_dupe_args = false;
         } else if (std.mem.eql(u8, arg, "--no-dupe-class-members=off")) {
@@ -430,6 +432,7 @@ fn printHelp() void {
         \\  --no-debugger=off         Disable no-debugger
         \\  --no-dupe-else-if=off     Disable no-dupe-else-if
         \\  --no-duplicate-case=off   Disable no-duplicate-case
+        \\  --no-duplicate-imports=off Disable no-duplicate-imports
         \\  --no-dupe-args=off        Disable no-dupe-args
         \\  --no-dupe-class-members=off Disable no-dupe-class-members
         \\  --no-dupe-keys=off        Disable no-dupe-keys

--- a/src/rules/no_duplicate_imports.zig
+++ b/src/rules/no_duplicate_imports.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-duplicate-imports";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+) Allocator.Error!void {
+    var seen_sources: std.ArrayList([]const u8) = .empty;
+    defer seen_sources.deinit(allocator);
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        const source = importSource(tree, declaration) orelse continue;
+
+        if (contains(seen_sources.items, source)) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(statement_index),
+                "Duplicate import from \"{s}\".",
+                .{source},
+            );
+            continue;
+        }
+
+        try seen_sources.append(allocator, source);
+    }
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn contains(items: []const []const u8, source: []const u8) bool {
+    for (items) |item| {
+        if (std.mem.eql(u8, item, source)) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -35,6 +35,7 @@ pub const no_duplicate_case = @import("no_duplicate_case.zig");
 pub const no_dupe_args = @import("no_dupe_args.zig");
 pub const no_dupe_class_members = @import("no_dupe_class_members.zig");
 pub const no_dupe_keys = @import("no_dupe_keys.zig");
+pub const no_duplicate_imports = @import("no_duplicate_imports.zig");
 pub const no_delete_var = @import("no_delete_var.zig");
 pub const no_div_regex = @import("no_div_regex.zig");
 pub const no_empty = @import("no_empty.zig");
@@ -305,6 +306,18 @@ const BasicVisitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     options: core.Options,
+
+    pub fn enter_program(
+        self: *BasicVisitor,
+        program: ast.Program,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_duplicate_imports) {
+            try no_duplicate_imports.check(self.allocator, self.diagnostics, ctx.tree, program);
+        }
+        return .proceed;
+    }
 
     pub fn enter_function(
         self: *BasicVisitor,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -123,6 +123,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_duplicate_imports.zig");
+}
+
+comptime {
     _ = @import("rules/no_empty.zig");
 }
 

--- a/tests/rules/no_duplicate_imports.zig
+++ b/tests/rules/no_duplicate_imports.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-duplicate-imports for repeated module sources" {
+    const source =
+        \\import foo from "alpha";
+        \\import { bar } from "alpha";
+        \\import "beta";
+        \\import "beta";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
+    try std.testing.expectEqualStrings("Duplicate import from \"alpha\".", result.diagnostics[0].message);
+}
+
+test "does not report no-duplicate-imports for distinct module sources" {
+    const source =
+        \\import foo from "alpha";
+        \\import { bar } from "beta";
+        \\import "gamma";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_duplicate_imports.id));
+}
+
+test "can disable no-duplicate-imports" {
+    const source =
+        \\import foo from "alpha";
+        \\import { bar } from "alpha";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_duplicate_imports = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_duplicate_imports.id));
+}


### PR DESCRIPTION
Summary:
- add the no-duplicate-imports rule for repeated static imports
- expose --no-duplicate-imports=off and document the rule
- add focused tests in tests/rules/no_duplicate_imports.zig

References:
- https://eslint.org/docs/latest/rules/no-duplicate-imports
- https://github.com/eslint/eslint/blob/main/lib/rules/no-duplicate-imports.js

Tests:
- .zig-cache/o/3a186b26e44210b77ee752a9ec2ac44f/root --seed=0xe5df641e
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true