### PR TITLE
feat: port rule no-nonoctal-decimal-escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-multi-spaces`
 - `no-multi-str`
 - `no-multiple-empty-lines`
+- `no-nonoctal-decimal-escape`
 - `no-new`
 - `no-nested-ternary`
 - `no-negated-condition`

--- a/src/core.zig
+++ b/src/core.zig
@@ -84,6 +84,7 @@ pub const Options = struct {
     no_multi_spaces: bool = true,
     no_mixed_spaces_and_tabs: bool = true,
     no_multiple_empty_lines: bool = true,
+    no_nonoctal_decimal_escape: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
     no_negated_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,6 +156,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_mixed_spaces_and_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-multiple-empty-lines=off")) {
             options.no_multiple_empty_lines = false;
+        } else if (std.mem.eql(u8, arg, "--no-nonoctal-decimal-escape=off")) {
+            options.no_nonoctal_decimal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
             options.no_new = false;
         } else if (std.mem.eql(u8, arg, "--no-nested-ternary=off")) {
@@ -474,6 +476,7 @@ fn printHelp() void {
         \\  --no-multi-spaces=off     Disable no-multi-spaces
         \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
+        \\  --no-nonoctal-decimal-escape=off Disable no-nonoctal-decimal-escape
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary
         \\  --no-negated-condition=off Disable no-negated-condition

--- a/src/rules/no_nonoctal_decimal_escape.zig
+++ b/src/rules/no_nonoctal_decimal_escape.zig
@@ -1,0 +1,43 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-nonoctal-decimal-escape";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!hasNonoctalDecimalEscape(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Non-octal decimal escape sequences should not be used.",
+        tree.span(index),
+    );
+}
+
+fn hasNonoctalDecimalEscape(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return false;
+
+    const source = tree.source[start..end];
+    var offset: usize = 0;
+    while (offset + 1 < source.len) : (offset += 1) {
+        if (source[offset] != '\\') continue;
+        if (source[offset + 1] == '8' or source[offset + 1] == '9') return true;
+
+        offset += 1;
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -74,6 +74,7 @@ pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
 pub const no_multi_spaces = @import("no_multi_spaces.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_multiple_empty_lines = @import("no_multiple_empty_lines.zig");
+pub const no_nonoctal_decimal_escape = @import("no_nonoctal_decimal_escape.zig");
 pub const no_new = @import("no_new.zig");
 pub const no_nested_ternary = @import("no_nested_ternary.zig");
 pub const no_negated_condition = @import("no_negated_condition.zig");
@@ -707,6 +708,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_multi_str) {
             try no_multi_str.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.no_nonoctal_decimal_escape) {
+            try no_nonoctal_decimal_escape.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         if (self.options.no_octal_escape) {
             try no_octal_escape.check(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -271,6 +271,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_nonoctal_decimal_escape.zig");
+}
+
+comptime {
     _ = @import("rules/no_negated_condition.zig");
 }
 

--- a/tests/rules/no_nonoctal_decimal_escape.zig
+++ b/tests/rules/no_nonoctal_decimal_escape.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-nonoctal-decimal-escape for decimal escape sequences" {
+    const source =
+        \\const first = "\8";
+        \\const second = '\9';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_nonoctal_decimal_escape.id));
+}
+
+test "does not report no-nonoctal-decimal-escape for ordinary strings" {
+    const source =
+        \\const first = "8";
+        \\const second = "9";
+        \\const third = "\\8";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_nonoctal_decimal_escape.id));
+}
+
+test "can disable no-nonoctal-decimal-escape" {
+    const source =
+        \\const first = "\8";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_nonoctal_decimal_escape = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_nonoctal_decimal_escape.id));
+}


### PR DESCRIPTION
Summary:
- add the no-nonoctal-decimal-escape rule for \8 and \9 string escapes
- expose --no-nonoctal-decimal-escape=off and document the rule
- add focused tests in tests/rules/no_nonoctal_decimal_escape.zig

References:
- https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape
- https://github.com/eslint/eslint/blob/main/lib/rules/no-nonoctal-decimal-escape.js

Tests:
- .zig-cache/o/f70f6ece1d0a809f46c88ddffea42c9e/root --seed=0x42d22e69
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true