### PR TITLE
feat: port rule new-parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `eol-last`
 - `guard-for-in`
 - `linebreak-style`
+- `new-parens`
 - `no-async-promise-executor`
 - `no-alert`
 - `no-array-constructor`

--- a/src/core.zig
+++ b/src/core.zig
@@ -22,6 +22,7 @@ pub const Options = struct {
     eol_last: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
+    new_parens: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
     no_await_in_loop: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,6 +32,8 @@ pub fn main(init: std.process.Init) !void {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
             options.linebreak_style = false;
+        } else if (std.mem.eql(u8, arg, "--new-parens=off")) {
+            options.new_parens = false;
         } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
             options.no_async_promise_executor = false;
         } else if (std.mem.eql(u8, arg, "--no-array-constructor=off")) {
@@ -414,6 +416,7 @@ fn printHelp() void {
         \\  --eol-last=off            Disable eol-last
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
+        \\  --new-parens=off          Disable new-parens
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor
         \\  --no-await-in-loop=off    Disable no-await-in-loop

--- a/src/rules/new_parens.zig
+++ b/src/rules/new_parens.zig
@@ -1,0 +1,46 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "new-parens";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NewExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.arguments.len != 0) return;
+    if (hasTrailingParen(tree, index)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Missing '()' invoking a constructor.",
+        tree.span(index),
+    );
+}
+
+fn hasTrailingParen(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return false;
+
+    var offset = end;
+    while (offset > start) {
+        offset -= 1;
+        switch (tree.source[offset]) {
+            ' ', '\t', '\n', '\r', 0x0B, 0x0C => {},
+            ')' => return true,
+            else => return false,
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -11,6 +11,7 @@ pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
+pub const new_parens = @import("new_parens.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
@@ -902,6 +903,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_new_require) {
             try no_new_require.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.new_parens) {
+            try new_parens.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -19,6 +19,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/new_parens.zig");
+}
+
+comptime {
     _ = @import("rules/eqeqeq.zig");
 }
 

--- a/tests/rules/new_parens.zig
+++ b/tests/rules/new_parens.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports new-parens for constructors without parentheses" {
+    const source =
+        \\const first = new Widget;
+        \\const second = new namespace.Widget;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.new_parens.id));
+}
+
+test "does not report new-parens when parentheses or arguments are present" {
+    const source =
+        \\const first = new Widget();
+        \\const second = new Widget(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.new_parens.id));
+}
+
+test "can disable new-parens" {
+    const source =
+        \\const first = new Widget;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .new_parens = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.new_parens.id));
+}


### PR DESCRIPTION
Summary:
- add the new-parens rule for constructor calls without parentheses
- expose --new-parens=off and document the rule
- add focused tests in tests/rules/new_parens.zig

References:
- https://eslint.org/docs/latest/rules/new-parens
- https://github.com/eslint/eslint/blob/main/lib/rules/new-parens.js

Tests:
- .zig-cache/o/5b708c66313f5f6931b3414d98feea31/root --seed=0x4596519d
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true