### PR TITLE
feat: port rule curly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
+- `curly`
 - `default-case`
 - `default-case-last`
 - `eol-last`

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    curly: bool = true,
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,8 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
+        } else if (std.mem.eql(u8, arg, "--curly=off")) {
+            options.curly = false;
         } else if (std.mem.eql(u8, arg, "--default-case=off")) {
             options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
@@ -411,6 +413,7 @@ fn printHelp() void {
         \\  utoo-lint [options] [file-or-directory ...]
         \\
         \\Options:
+        \\  --curly=off              Disable curly
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last

--- a/src/rules/curly.zig
+++ b/src/rules/curly.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "curly";
+
+pub fn checkIfStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+) Allocator.Error!void {
+    try checkBody(allocator, diagnostics, tree, statement.consequent);
+
+    if (statement.alternate == .null) return;
+    if (tree.data(statement.alternate) == .if_statement) return;
+
+    try checkBody(allocator, diagnostics, tree, statement.alternate);
+}
+
+pub fn checkBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+) Allocator.Error!void {
+    if (body == .null) return;
+    if (tree.data(body) == .block_statement) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected a block statement.",
+        tree.span(body),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -6,6 +6,7 @@ const ast = parser.ast;
 const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
+pub const curly = @import("curly.zig");
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
@@ -357,6 +358,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
@@ -384,6 +388,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+        }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
@@ -399,6 +406,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+        }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
@@ -414,6 +424,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+        }
         if (self.options.no_cond_assign and statement.@"test" != .null) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
@@ -603,11 +616,26 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+        }
         if (self.options.guard_for_in) {
             try guard_for_in.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.no_for_in) {
             try no_for_in.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_for_of_statement(
+        self: *BasicVisitor,
+        statement: ast.ForOfStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.curly) {
+            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1,4 +1,8 @@
 comptime {
+    _ = @import("rules/curly.zig");
+}
+
+comptime {
     _ = @import("rules/default_case.zig");
 }
 

--- a/tests/rules/curly.zig
+++ b/tests/rules/curly.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports curly for control statements without block bodies" {
+    const source =
+        \\if (ready) run();
+        \\else stop();
+        \\while (ready) run();
+        \\do run(); while (ready);
+        \\for (let i = 0; i < 3; i++) run();
+        \\for (const key in object) run();
+        \\for (const item of items) run();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.curly.id));
+}
+
+test "does not report curly for block bodies or else-if chains" {
+    const source =
+        \\if (ready) { run(); }
+        \\else if (waiting) { wait(); }
+        \\else { stop(); }
+        \\while (ready) { run(); }
+        \\do { run(); } while (ready);
+        \\for (let i = 0; i < 3; i++) { run(); }
+        \\for (const key in object) { run(); }
+        \\for (const item of items) { run(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.curly.id));
+}
+
+test "can disable curly" {
+    const source =
+        \\if (ready) run();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.curly.id));
+}

--- a/tests/rules/no_continue.zig
+++ b/tests/rules/no_continue.zig
@@ -12,6 +12,7 @@ test "reports no-continue for continue statements" {
         "}\n";
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .no_plusplus = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
@@ -32,6 +33,7 @@ test "does not report no-continue for break statements" {
         "}\n";
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .no_plusplus = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,

--- a/tests/rules/no_eq_null.zig
+++ b/tests/rules/no_eq_null.zig
@@ -10,6 +10,7 @@ test "reports no-eq-null for loose null comparisons" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .eqeqeq = false,
         .no_undef = false,
@@ -30,6 +31,7 @@ test "does not report no-eq-null for strict null comparisons or non-null loose c
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .eqeqeq = false,
         .no_undef = false,
@@ -44,6 +46,7 @@ test "can disable no-eq-null" {
     const source = "if (value == null) call(value);";
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .eqeqeq = false,
         .no_eq_null = false,


### PR DESCRIPTION
Summary:
- add the curly rule for control statements without block bodies
- expose --curly=off and document the rule
- add focused tests in tests/rules/curly.zig

References:
- https://eslint.org/docs/latest/rules/curly
- https://github.com/eslint/eslint/blob/main/lib/rules/curly.js

Tests:
- .zig-cache/o/5b0aff5a6dcac111eda75a0ccecf2fa4/root --seed=0x587199e0
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true