### PR TITLE
feat: port rule dot-notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet. The first rules are:
 
 - `curly`
+- `dot-notation`
 - `default-case`
 - `default-case-last`
 - `eol-last`

--- a/src/core.zig
+++ b/src/core.zig
@@ -18,6 +18,7 @@ pub const Severity = enum {
 
 pub const Options = struct {
     curly: bool = true,
+    dot_notation: bool = true,
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,8 @@ pub fn main(init: std.process.Init) !void {
             return;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
+        } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
+            options.dot_notation = false;
         } else if (std.mem.eql(u8, arg, "--default-case=off")) {
             options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
@@ -414,6 +416,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --curly=off              Disable curly
+        \\  --dot-notation=off       Disable dot-notation
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last

--- a/src/rules/dot_notation.zig
+++ b/src/rules/dot_notation.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "dot-notation";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!member.computed or member.property == .null) return;
+
+    const property_name = switch (tree.data(member.property)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => return,
+    };
+    if (!isAsciiIdentifierName(property_name)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "['{s}'] is better written in dot notation.",
+        .{property_name},
+    );
+}
+
+fn isAsciiIdentifierName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (!isIdentifierStart(name[0])) return false;
+
+    for (name[1..]) |char| {
+        if (!isIdentifierPart(char)) return false;
+    }
+    return true;
+}
+
+fn isIdentifierStart(char: u8) bool {
+    return std.ascii.isAlphabetic(char) or char == '_' or char == '$';
+}
+
+fn isIdentifierPart(char: u8) bool {
+    return isIdentifierStart(char) or std.ascii.isDigit(char);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -7,6 +7,7 @@ const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const curly = @import("curly.zig");
+pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
@@ -956,6 +957,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.dot_notation) {
+            try dot_notation.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
         if (self.options.no_caller) {
             try no_caller.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -3,6 +3,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/dot_notation.zig");
+}
+
+comptime {
     _ = @import("rules/default_case.zig");
 }
 

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports dot-notation for computed string properties that can use dot access" {
+    const source =
+        \\object["property"];
+        \\object["_private"];
+        \\object["$value"];
+        \\object["property1"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.dot_notation.id));
+    try std.testing.expectEqualStrings(
+        "['property'] is better written in dot notation.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report dot-notation when bracket access is required" {
+    const source =
+        \\object["not-valid"];
+        \\object["123"];
+        \\object[""];
+        \\object[property];
+        \\object[call()];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
+}
+
+test "can disable dot-notation" {
+    const source =
+        \\object["property"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
+}

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -9,6 +9,7 @@ test "reports no-extend-native for native prototype assignments" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
         .eol_last = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
@@ -31,6 +32,7 @@ test "reports no-extend-native for Object defineProperty calls" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
         .eol_last = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
@@ -56,6 +58,7 @@ test "does not report no-extend-native for shadowed constructors or ordinary obj
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
         .eol_last = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
@@ -74,6 +77,7 @@ test "can disable no-extend-native" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
         .eol_last = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,


### PR DESCRIPTION
Summary:
- add the dot-notation rule for computed string property access
- expose --dot-notation=off and document the rule
- add focused tests in tests/rules/dot_notation.zig

References:
- https://eslint.org/docs/latest/rules/dot-notation
- https://github.com/eslint/eslint/blob/main/lib/rules/dot-notation.js

Tests:
- .zig-cache/o/c480f130e354a83e89b0de146abca0e4/root --seed=0x11970b63
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true