### PR TITLE
feat: port rule prefer-exponentiation-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `eqeqeq`
 - `no-unused-vars`
 - `no-undef`
+- `prefer-exponentiation-operator`
 - `radix`
 - `use-isnan`
 - `yoda`

--- a/src/core.zig
+++ b/src/core.zig
@@ -145,6 +145,7 @@ pub const Options = struct {
     use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_undef: bool = true,
+    prefer_exponentiation_operator: bool = true,
     radix: bool = true,
     parser_semantic_errors: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -278,6 +278,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unused_vars = false;
         } else if (std.mem.eql(u8, arg, "--no-undef=off")) {
             options.no_undef = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
+            options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -543,6 +545,7 @@ fn printHelp() void {
         \\  --use-isnan=off           Disable use-isnan
         \\  --no-unused-vars=off      Disable no-unused-vars
         \\  --no-undef=off            Disable no-undef
+        \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --radix=off               Disable radix
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.radix;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.radix;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);

--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-exponentiation-operator";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (call.arguments.len == 2 and isGlobalMathPowCall(ctx.tree, self.symbol_table, call.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Use the exponentiation operator (**) instead of Math.pow.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isGlobalMathPowCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property_name, "pow")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Math") and isUnresolvedReference(symbol_table, object);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -132,6 +132,7 @@ pub const no_warning_comments = @import("no_warning_comments.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
+pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const radix = @import("radix.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
@@ -291,6 +292,10 @@ pub fn runSemantic(
 
     if (options.no_promise_executor_return) {
         try no_promise_executor_return.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_exponentiation_operator) {
+        try prefer_exponentiation_operator.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.radix) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -503,6 +503,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_exponentiation_operator.zig");
+}
+
+comptime {
     _ = @import("rules/radix.zig");
 }
 

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-exponentiation-operator for Math.pow calls" {
+    const source =
+        \\Math.pow(base, exponent);
+        \\(Math).pow(2, 8);
+        \\Math["pow"](2, 8);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_exponentiation_operator.id));
+    try std.testing.expectEqualStrings(
+        "Use the exponentiation operator (**) instead of Math.pow.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report prefer-exponentiation-operator for other calls or shadowed Math" {
+    const source =
+        \\Math.max(base, exponent);
+        \\Math.pow(base);
+        \\Math.pow(base, exponent, modulo);
+        \\const Math = { pow() {} };
+        \\Math.pow(base, exponent);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "can disable prefer-exponentiation-operator" {
+    const source =
+        \\Math.pow(base, exponent);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .prefer_exponentiation_operator = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_exponentiation_operator.id));
+}


### PR DESCRIPTION
Summary:
- add the prefer-exponentiation-operator rule for Math.pow calls
- expose --prefer-exponentiation-operator=off and document the rule
- add focused tests in tests/rules/prefer_exponentiation_operator.zig

References:
- https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
- https://github.com/eslint/eslint/blob/main/lib/rules/prefer-exponentiation-operator.js

Tests:
- .zig-cache/o/05bb5249042a90ab0cf766cb286596f3/root --seed=0x151269f8
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true