### PR TITLE
feat: port rule prefer-regex-literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-unused-vars`
 - `no-undef`
 - `prefer-exponentiation-operator`
+- `prefer-regex-literals`
 - `radix`
 - `use-isnan`
 - `yoda`

--- a/src/core.zig
+++ b/src/core.zig
@@ -146,6 +146,7 @@ pub const Options = struct {
     no_unused_vars: bool = true,
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
+    prefer_regex_literals: bool = true,
     radix: bool = true,
     parser_semantic_errors: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -280,6 +280,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_undef = false;
         } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
             options.prefer_exponentiation_operator = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
+            options.prefer_regex_literals = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -546,6 +548,7 @@ fn printHelp() void {
         \\  --no-unused-vars=off      Disable no-unused-vars
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
+        \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --radix=off               Disable radix
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.radix;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);

--- a/src/rules/prefer_regex_literals.zig
+++ b/src/rules/prefer_regex_literals.zig
@@ -1,0 +1,138 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-regex-literals";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments)) {
+            try self.report(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments)) {
+            try self.report(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    fn report(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Use a regular expression literal instead of the RegExp constructor.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isStaticRegExpConstructor(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+    argument_range: ast.IndexRange,
+) bool {
+    const arguments = tree.extra(argument_range);
+    if (arguments.len == 0 or arguments.len > 2) return false;
+    if (!isGlobalRegExpReference(tree, symbol_table, callee)) return false;
+
+    const pattern = arguments[0];
+    if (!isStringLiteral(tree, pattern)) return false;
+
+    if (arguments.len == 2 and !isStringLiteral(tree, arguments[1])) return false;
+    return true;
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn isStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -133,6 +133,7 @@ pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
+pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const radix = @import("radix.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
@@ -296,6 +297,10 @@ pub fn runSemantic(
 
     if (options.prefer_exponentiation_operator) {
         try prefer_exponentiation_operator.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_regex_literals) {
+        try prefer_regex_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.radix) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -507,6 +507,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_regex_literals.zig");
+}
+
+comptime {
     _ = @import("rules/radix.zig");
 }
 

--- a/tests/rules/prefer_regex_literals.zig
+++ b/tests/rules/prefer_regex_literals.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-regex-literals for static RegExp constructors" {
+    const source =
+        \\RegExp("abc");
+        \\new RegExp("abc");
+        \\new RegExp("abc", "u");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_regex_literals.id));
+    try std.testing.expectEqualStrings(
+        "Use a regular expression literal instead of the RegExp constructor.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report prefer-regex-literals for dynamic patterns or shadowed RegExp" {
+    const source =
+        \\RegExp(pattern);
+        \\RegExp("abc", flags);
+        \\RegExp("abc", "u", "extra");
+        \\const RegExp = function () {};
+        \\RegExp("abc");
+        \\new RegExp("abc");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_regex_literals.id));
+}
+
+test "can disable prefer-regex-literals" {
+    const source =
+        \\RegExp("abc");
+        \\new RegExp("abc");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .prefer_regex_literals = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_regex_literals.id));
+}


### PR DESCRIPTION
Summary:
- add the prefer-regex-literals rule for static RegExp constructors
- expose --prefer-regex-literals=off and document the rule
- add focused tests in tests/rules/prefer_regex_literals.zig

References:
- https://eslint.org/docs/latest/rules/prefer-regex-literals
- https://github.com/eslint/eslint/blob/main/lib/rules/prefer-regex-literals.js

Tests:
- .zig-cache/o/e8ec5dddccc068ceaac993ee4f71547f/root --seed=0xc166ea0c
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- rg -n "[Bb]iome" README.md src tests .github npm scripts build.zig || true