### PR TITLE
feat: port rule valid-typeof

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `prefer-regex-literals`
 - `radix`
 - `use-isnan`
+- `valid-typeof`
 - `yoda`
 - `parse` diagnostics from Yuku, including semantic early errors by default
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -149,6 +149,7 @@ pub const Options = struct {
     prefer_regex_literals: bool = true,
     radix: bool = true,
     parser_semantic_errors: bool = true,
+    valid_typeof: bool = true,
     yoda: bool = true,
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -284,6 +284,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_regex_literals = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
+        } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
+            options.valid_typeof = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
             options.parser_semantic_errors = false;
         } else if (std.mem.eql(u8, arg, "--yoda=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -137,6 +137,7 @@ pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const radix = @import("radix.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
+pub const valid_typeof = @import("valid_typeof.zig");
 pub const yoda = @import("yoda.zig");
 
 pub fn runBasic(
@@ -844,6 +845,9 @@ const BasicVisitor = struct {
         }
         if (self.options.use_isnan) {
             try use_isnan.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.valid_typeof) {
+            try valid_typeof.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_useless_concat) {
             try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/src/rules/valid_typeof.zig
+++ b/src/rules/valid_typeof.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "valid-typeof";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isTypeofComparisonOperator(expression.operator)) return;
+
+    const left_typeof = isTypeofExpression(tree, expression.left);
+    const right_typeof = isTypeofExpression(tree, expression.right);
+    if (left_typeof == right_typeof) return;
+
+    const literal_index = if (left_typeof) expression.right else expression.left;
+    const value = stringLiteralValue(tree, literal_index) orelse return;
+    if (isValidTypeofValue(value)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Invalid typeof comparison value.",
+        tree.span(index),
+    );
+}
+
+fn isTypeofComparisonOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isTypeofExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |unary| unary.operator == .typeof,
+        else => false,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn isValidTypeofValue(value: []const u8) bool {
+    return std.mem.eql(u8, value, "undefined") or
+        std.mem.eql(u8, value, "object") or
+        std.mem.eql(u8, value, "boolean") or
+        std.mem.eql(u8, value, "number") or
+        std.mem.eql(u8, value, "string") or
+        std.mem.eql(u8, value, "function") or
+        std.mem.eql(u8, value, "symbol") or
+        std.mem.eql(u8, value, "bigint");
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -523,5 +523,9 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/valid_typeof.zig");
+}
+
+comptime {
     _ = @import("rules/yoda.zig");
 }

--- a/tests/rules/valid_typeof.zig
+++ b/tests/rules/valid_typeof.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports valid-typeof for invalid typeof comparison strings" {
+    const source =
+        \\if (typeof value === "strnig") { use(value); }
+        \\if ("undefimed" !== typeof value) { use(value); }
+        \\if ((typeof value) == ("bool")) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eqeqeq = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.valid_typeof.id));
+}
+
+test "does not report valid-typeof for valid values or unrelated comparisons" {
+    const source =
+        \\if (typeof value === "undefined") { use(value); }
+        \\if (typeof value !== "object") { use(value); }
+        \\if (typeof value === "boolean") { use(value); }
+        \\if (typeof value === "number") { use(value); }
+        \\if (typeof value === "string") { use(value); }
+        \\if (typeof value === "function") { use(value); }
+        \\if (typeof value === "symbol") { use(value); }
+        \\if (typeof value === "bigint") { use(value); }
+        \\if (typeof value === expectedType) { use(value); }
+        \\if (value === "strnig") { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.valid_typeof.id));
+}
+
+test "can disable valid-typeof" {
+    const source =
+        \\if (typeof value === "strnig") { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .valid_typeof = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.valid_typeof.id));
+}


### PR DESCRIPTION
Summary:
- add the valid-typeof rule for typeof comparisons against invalid string values
- expose --valid-typeof=off and document the rule
- add focused tests in tests/rules/valid_typeof.zig

References:
- https://eslint.org/docs/latest/rules/valid-typeof

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: invalid typeof string reports 1 diagnostic and exits 1
- CLI fixture: --valid-typeof=off reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 and --test-filter valid-typeof both compiled but the local test runner process was terminated with signal KILL before producing assertion output.
