### PR TITLE
feat: port rule symbol-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `prefer-exponentiation-operator`
 - `prefer-regex-literals`
 - `radix`
+- `symbol-description`
 - `use-isnan`
 - `valid-typeof`
 - `yoda`

--- a/src/core.zig
+++ b/src/core.zig
@@ -148,6 +148,7 @@ pub const Options = struct {
     prefer_exponentiation_operator: bool = true,
     prefer_regex_literals: bool = true,
     radix: bool = true,
+    symbol_description: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -284,6 +284,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_regex_literals = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
+        } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {
+            options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix or options.symbol_description;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -135,6 +135,7 @@ pub const no_with = @import("no_with.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const radix = @import("radix.zig");
+pub const symbol_description = @import("symbol_description.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
@@ -306,6 +307,10 @@ pub fn runSemantic(
 
     if (options.radix) {
         try radix.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.symbol_description) {
+        try symbol_description.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {

--- a/src/rules/symbol_description.zig
+++ b/src/rules/symbol_description.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "symbol-description";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (call.arguments.len == 0 and isGlobalSymbolReference(ctx.tree, self.symbol_table, call.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Expected Symbol to have a description.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isGlobalSymbolReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Symbol") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -515,6 +515,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/symbol_description.zig");
+}
+
+comptime {
     _ = @import("rules/unicode_bom.zig");
 }
 

--- a/tests/rules/symbol_description.zig
+++ b/tests/rules/symbol_description.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports symbol-description for Symbol calls without a description" {
+    const source =
+        \\const foo = Symbol();
+        \\const bar = (Symbol)();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.symbol_description.id));
+}
+
+test "does not report symbol-description with arguments or shadowed Symbol" {
+    const source =
+        \\const foo = Symbol("foo");
+        \\const bar = Symbol(undefined);
+        \\function local(Symbol) {
+        \\  const baz = Symbol();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.symbol_description.id));
+}
+
+test "can disable symbol-description" {
+    const source =
+        \\const foo = Symbol();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .symbol_description = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.symbol_description.id));
+}


### PR DESCRIPTION
Summary:
- add the symbol-description rule for global Symbol() calls without arguments
- use semantic symbol resolution to avoid shadowed Symbol false positives
- expose --symbol-description=off and document the rule
- add focused tests in tests/rules/symbol_description.zig

References:
- https://eslint.org/docs/latest/rules/symbol-description

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: Symbol() reports 1 diagnostic and exits 1
- CLI fixture: --symbol-description=off reports 0 diagnostics and exits 0
- CLI fixture: shadowed Symbol reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 compiled but the local test runner process was terminated with signal KILL before producing assertion output.
