### PR TITLE
feat: port rule no-bitwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-alert`
 - `no-array-constructor`
 - `no-await-in-loop`
+- `no-bitwise`
 - `no-buffer-constructor`
 - `no-caller`
 - `no-case-declarations`

--- a/src/core.zig
+++ b/src/core.zig
@@ -29,6 +29,7 @@ pub const Options = struct {
     no_array_constructor: bool = true,
     no_await_in_loop: bool = true,
     no_alert: bool = true,
+    no_bitwise: bool = true,
     no_buffer_constructor: bool = true,
     no_caller: bool = true,
     no_case_declarations: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_await_in_loop = false;
         } else if (std.mem.eql(u8, arg, "--no-alert=off")) {
             options.no_alert = false;
+        } else if (std.mem.eql(u8, arg, "--no-bitwise=off")) {
+            options.no_bitwise = false;
         } else if (std.mem.eql(u8, arg, "--no-buffer-constructor=off")) {
             options.no_buffer_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-caller=off")) {

--- a/src/rules/no_bitwise.zig
+++ b/src/rules/no_bitwise.zig
@@ -1,0 +1,82 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-bitwise";
+
+pub fn checkBinaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isBitwiseBinaryOperator(expression.operator)) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isBitwiseAssignmentOperator(expression.operator)) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkUnaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .bitwise_not) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected use of bitwise operator.",
+        tree.span(index),
+    );
+}
+
+fn isBitwiseBinaryOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .bitwise_or,
+        .bitwise_xor,
+        .bitwise_and,
+        .left_shift,
+        .right_shift,
+        .unsigned_right_shift,
+        => true,
+        else => false,
+    };
+}
+
+fn isBitwiseAssignmentOperator(operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .left_shift_assign,
+        .right_shift_assign,
+        .unsigned_right_shift_assign,
+        .bitwise_or_assign,
+        .bitwise_xor_assign,
+        .bitwise_and_assign,
+        => true,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -19,6 +19,7 @@ pub const no_alert = @import("no_alert.zig");
 pub const eqeqeq = @import("eqeqeq.zig");
 pub const no_array_constructor = @import("no_array_constructor.zig");
 pub const no_await_in_loop = @import("no_await_in_loop.zig");
+pub const no_bitwise = @import("no_bitwise.zig");
 pub const no_buffer_constructor = @import("no_buffer_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_case_declarations = @import("no_case_declarations.zig");
@@ -818,6 +819,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_bitwise) {
+            try no_bitwise.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
@@ -833,6 +837,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_bitwise) {
+            try no_bitwise.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_compare_neg_zero) {
             try no_compare_neg_zero.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
@@ -875,6 +882,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_bitwise) {
+            try no_bitwise.checkUnaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_delete_var) {
             try no_delete_var.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -47,6 +47,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_bitwise.zig");
+}
+
+comptime {
     _ = @import("rules/no_buffer_constructor.zig");
 }
 

--- a/tests/rules/no_bitwise.zig
+++ b/tests/rules/no_bitwise.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-bitwise for bitwise binary and unary operators" {
+    const source =
+        \\const a = left | right;
+        \\const b = left ^ right;
+        \\const c = left & right;
+        \\const d = left << right;
+        \\const e = left >> right;
+        \\const f = left >>> right;
+        \\const g = ~value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_bitwise.id));
+}
+
+test "reports no-bitwise for bitwise assignment operators" {
+    const source =
+        \\value |= mask;
+        \\value ^= mask;
+        \\value &= mask;
+        \\value <<= bits;
+        \\value >>= bits;
+        \\value >>>= bits;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_bitwise.id));
+}
+
+test "does not report no-bitwise for logical or arithmetic operators" {
+    const source =
+        \\const a = left || right;
+        \\const b = left && right;
+        \\const c = left + right;
+        \\const d = !value;
+        \\value += amount;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_bitwise.id));
+}
+
+test "can disable no-bitwise" {
+    const source =
+        \\const value = left | right;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_bitwise = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_bitwise.id));
+}


### PR DESCRIPTION
Summary:
- add the no-bitwise rule for bitwise binary, assignment, and unary operators
- expose --no-bitwise=off and document the rule
- add focused tests in tests/rules/no_bitwise.zig

References:
- https://eslint.org/docs/latest/rules/no-bitwise

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: bitwise operators report 3 diagnostics and exit 1
- CLI fixture: --no-bitwise=off reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 compiled but the local test runner process was terminated with signal KILL before producing assertion output.
