### PR TITLE
feat: port rule no-multi-assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-lonely-if`
 - `no-loss-of-precision`
 - `no-mixed-spaces-and-tabs`
+- `no-multi-assign`
 - `no-multi-spaces`
 - `no-multi-str`
 - `no-multiple-empty-lines`

--- a/src/core.zig
+++ b/src/core.zig
@@ -85,6 +85,7 @@ pub const Options = struct {
     no_lonely_if: bool = true,
     no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
+    no_multi_assign: bool = true,
     no_multi_spaces: bool = true,
     no_mixed_spaces_and_tabs: bool = true,
     no_multiple_empty_lines: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -158,6 +158,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
+        } else if (std.mem.eql(u8, arg, "--no-multi-assign=off")) {
+            options.no_multi_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-spaces=off")) {
             options.no_multi_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-mixed-spaces-and-tabs=off")) {

--- a/src/rules/no_multi_assign.zig
+++ b/src/rules/no_multi_assign.zig
@@ -1,0 +1,49 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-multi-assign";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isAssignmentExpression(tree, expression.right)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected chained assignment.",
+        tree.span(index),
+    );
+}
+
+fn isAssignmentExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .assignment_expression => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -75,6 +75,7 @@ pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
 pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
+pub const no_multi_assign = @import("no_multi_assign.zig");
 pub const no_multi_spaces = @import("no_multi_spaces.zig");
 pub const no_multi_str = @import("no_multi_str.zig");
 pub const no_multiple_empty_lines = @import("no_multiple_empty_lines.zig");
@@ -821,6 +822,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_bitwise) {
             try no_bitwise.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.no_multi_assign) {
+            try no_multi_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -275,6 +275,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_multi_assign.zig");
+}
+
+comptime {
     _ = @import("rules/no_multi_str.zig");
 }
 

--- a/tests/rules/no_multi_assign.zig
+++ b/tests/rules/no_multi_assign.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-multi-assign for chained assignments" {
+    const source =
+        \\let a, b, c, d;
+        \\a = b = c;
+        \\a = (b = c);
+        \\a = b = c = d;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_multi_assign.id));
+}
+
+test "does not report no-multi-assign for single assignments" {
+    const source =
+        \\let a, b, c;
+        \\a = b;
+        \\a += b;
+        \\a = condition ? b = c : c;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, lint.rules.no_multi_assign.id));
+}
+
+test "can disable no-multi-assign" {
+    const source =
+        \\let a, b, c;
+        \\a = b = c;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multi_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_assign.id));
+}


### PR DESCRIPTION
Summary:
- add the no-multi-assign rule for chained assignment expressions
- expose --no-multi-assign=off and document the rule
- add focused tests in tests/rules/no_multi_assign.zig

References:
- https://eslint.org/docs/latest/rules/no-multi-assign

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: chained assignments report 3 diagnostics and exit 1
- CLI fixture: --no-multi-assign=off reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 compiled but the local test runner process was terminated with signal KILL before producing assertion output.
