### PR TITLE
feat: port rule prefer-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-undef`
 - `prefer-exponentiation-operator`
 - `prefer-regex-literals`
+- `prefer-template`
 - `radix`
 - `symbol-description`
 - `use-isnan`

--- a/src/core.zig
+++ b/src/core.zig
@@ -149,6 +149,7 @@ pub const Options = struct {
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_regex_literals: bool = true,
+    prefer_template: bool = true,
     radix: bool = true,
     symbol_description: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -286,6 +286,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-template=off")) {
+            options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {

--- a/src/rules/prefer_template.zig
+++ b/src/rules/prefer_template.zig
@@ -1,0 +1,55 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "prefer-template";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .add) return;
+
+    const left_static_string = isStaticStringLike(tree, expression.left);
+    const right_static_string = isStaticStringLike(tree, expression.right);
+    if (!left_static_string and !right_static_string) return;
+    if (left_static_string and right_static_string) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use a template literal instead of string concatenation.",
+        tree.span(index),
+    );
+}
+
+fn isStaticStringLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => true,
+        .template_literal => |template| template.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -136,6 +136,7 @@ pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
+pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
@@ -867,6 +868,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_concat) {
             try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.prefer_template) {
+            try prefer_template.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_implicit_coercion) {
             try no_implicit_coercion.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -519,6 +519,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_template.zig");
+}
+
+comptime {
     _ = @import("rules/radix.zig");
 }
 

--- a/tests/rules/prefer_template.zig
+++ b/tests/rules/prefer_template.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-template for string concatenation with expressions" {
+    const source =
+        \\const a = "hello " + name;
+        \\const b = name + "!";
+        \\const c = `hello ` + name;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_template.id));
+}
+
+test "does not report prefer-template for non-string or static-only concatenation" {
+    const source =
+        \\const a = left + right;
+        \\const b = "hello " + "world";
+        \\const c = `hello ` + "world";
+        \\const d = `hello ${name}`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_concat = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_template.id));
+}
+
+test "can disable prefer-template" {
+    const source =
+        \\const value = "hello " + name;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_template = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_template.id));
+}


### PR DESCRIPTION
Summary:
- add the prefer-template rule for string concatenation with expressions
- keep pure static string concatenation under no-useless-concat
- expose --prefer-template=off and document the rule
- add focused tests in tests/rules/prefer_template.zig

References:
- https://eslint.org/docs/latest/rules/prefer-template

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: string concatenation with expressions reports 2 diagnostics and exits 1
- CLI fixture: --prefer-template=off reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 compiled but the local test runner process was terminated with signal KILL before producing assertion output.
