### PR TITLE
feat: port rule spaced-comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `prefer-regex-literals`
 - `prefer-template`
 - `radix`
+- `spaced-comment`
 - `symbol-description`
 - `use-isnan`
 - `valid-typeof`

--- a/src/core.zig
+++ b/src/core.zig
@@ -151,6 +151,7 @@ pub const Options = struct {
     prefer_regex_literals: bool = true,
     prefer_template: bool = true,
     radix: bool = true,
+    spaced_comment: bool = true,
     symbol_description: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -290,6 +290,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
+        } else if (std.mem.eql(u8, arg, "--spaced-comment=off")) {
+            options.spaced_comment = false;
         } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -138,6 +138,7 @@ pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operat
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
+pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
@@ -182,6 +183,9 @@ pub fn runBasic(
     }
     if (options.no_multi_spaces) {
         try no_multi_spaces.run(allocator, diagnostics, tree);
+    }
+    if (options.spaced_comment) {
+        try spaced_comment.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "spaced-comment";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    for (tree.comments) |comment| {
+        if (hasExpectedSpacing(tree, comment)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Expected space or tab after comment marker.",
+            .{ .start = comment.start, .end = comment.end },
+        );
+    }
+}
+
+fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment) bool {
+    const value = tree.string(comment.value);
+    if (value.len == 0) return true;
+    if (isWhitespace(value[0])) return true;
+
+    return switch (comment.type) {
+        .line => value[0] == '/',
+        .block => value[0] == '*' or value[0] == '!',
+    };
+}
+
+fn isWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -527,6 +527,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/spaced_comment.zig");
+}
+
+comptime {
     _ = @import("rules/symbol_description.zig");
 }
 

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports spaced-comment for comments without spacing" {
+    const source =
+        \\//missing space
+        \\/*missing space */
+        \\const value = 1; //inline missing space
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.spaced_comment.id));
+}
+
+test "does not report spaced-comment for spaced comments and common markers" {
+    const source =
+        \\// line comment
+        \\// another line comment
+        \\///
+        \\/// <reference path="types.d.ts" />
+        \\/* block comment */
+        \\/**
+        \\ * jsdoc
+        \\ */
+        \\/*! license */
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.spaced_comment.id));
+}
+
+test "can disable spaced-comment" {
+    const source =
+        \\//missing space
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .spaced_comment = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.spaced_comment.id));
+}


### PR DESCRIPTION
Summary:
- add the spaced-comment rule for line and block comments without leading spacing
- allow common comment markers for triple-slash, JSDoc, and license comments
- expose --spaced-comment=off and document the rule
- add focused tests in tests/rules/spaced_comment.zig

References:
- https://eslint.org/docs/latest/rules/spaced-comment

Tests:
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI fixture: comments without spacing report 2 diagnostics and exit 1
- CLI fixture: --spaced-comment=off reports 0 diagnostics and exits 0
- git diff --check

Note:
- zig build test -Doptimize=ReleaseFast -j1 compiled but the local test runner process was terminated with signal KILL before producing assertion output.
