### PR TITLE
feat: port rule for-direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `default-case`
 - `default-case-last`
 - `eol-last`
+- `for-direction`
 - `guard-for-in`
 - `linebreak-style`
 - `new-parens`

--- a/src/core.zig
+++ b/src/core.zig
@@ -22,6 +22,7 @@ pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,
+    for_direction: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     new_parens: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,6 +32,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case_last = false;
         } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
             options.eol_last = false;
+        } else if (std.mem.eql(u8, arg, "--for-direction=off")) {
+            options.for_direction = false;
         } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
@@ -436,6 +438,7 @@ fn printHelp() void {
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last
+        \\  --for-direction=off       Disable for-direction
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
         \\  --new-parens=off          Disable new-parens

--- a/src/rules/for_direction.zig
+++ b/src/rules/for_direction.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "for-direction";
+
+const Direction = enum {
+    increasing,
+    decreasing,
+
+    fn opposite(self: Direction) Direction {
+        return switch (self) {
+            .increasing => .decreasing,
+            .decreasing => .increasing,
+        };
+    }
+};
+
+const UpdateCounter = struct {
+    name: []const u8,
+    direction: Direction,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ForStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (statement.@"test" == .null or statement.update == .null) return;
+
+    if (!updateMovesOpposite(tree, statement.@"test", statement.update)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "The update clause in this loop moves the variable in the wrong direction.",
+        tree.span(index),
+    );
+}
+
+fn expectedDirection(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    counter_name: []const u8,
+) ?Direction {
+    const expression = switch (tree.data(unwrapTransparent(tree, index))) {
+        .binary_expression => |expression| expression,
+        else => return null,
+    };
+
+    const left_name = identifierName(tree, expression.left);
+    const right_name = identifierName(tree, expression.right);
+
+    return switch (expression.operator) {
+        .less_than,
+        .less_than_or_equal,
+        => if (matchesName(left_name, counter_name))
+            .increasing
+        else if (matchesName(right_name, counter_name))
+            .decreasing
+        else
+            null,
+
+        .greater_than,
+        .greater_than_or_equal,
+        => if (matchesName(left_name, counter_name))
+            .decreasing
+        else if (matchesName(right_name, counter_name))
+            .increasing
+        else
+            null,
+
+        else => null,
+    };
+}
+
+fn updateMovesOpposite(
+    tree: *const ast.Tree,
+    test_index: ast.NodeIndex,
+    update_index: ast.NodeIndex,
+) bool {
+    switch (tree.data(unwrapTransparent(tree, update_index))) {
+        .sequence_expression => |sequence| {
+            for (tree.extra(sequence.expressions)) |expression| {
+                if (updateMovesOpposite(tree, test_index, expression)) return true;
+            }
+            return false;
+        },
+        else => {
+            const update = updateCounter(tree, update_index) orelse return false;
+            const expected = expectedDirection(tree, test_index, update.name) orelse return false;
+            return update.direction == expected.opposite();
+        },
+    }
+}
+
+fn matchesName(maybe_name: ?[]const u8, name: []const u8) bool {
+    const value = maybe_name orelse return false;
+    return std.mem.eql(u8, value, name);
+}
+
+fn updateCounter(tree: *const ast.Tree, index: ast.NodeIndex) ?UpdateCounter {
+    switch (tree.data(unwrapTransparent(tree, index))) {
+        .update_expression => |expression| {
+            const name = identifierName(tree, expression.argument) orelse return null;
+            const direction: Direction = switch (expression.operator) {
+                .increment => .increasing,
+                .decrement => .decreasing,
+            };
+            return .{ .name = name, .direction = direction };
+        },
+        .assignment_expression => |expression| return assignmentUpdateCounter(tree, expression),
+        else => return null,
+    }
+}
+
+fn assignmentUpdateCounter(tree: *const ast.Tree, expression: ast.AssignmentExpression) ?UpdateCounter {
+    const left_name = identifierName(tree, expression.left) orelse return null;
+
+    switch (expression.operator) {
+        .add_assign => {
+            const direction = signedDirection(tree, expression.right) orelse .increasing;
+            return .{ .name = left_name, .direction = direction };
+        },
+        .subtract_assign => {
+            const direction = if (signedDirection(tree, expression.right)) |direction|
+                direction.opposite()
+            else
+                Direction.decreasing;
+            return .{ .name = left_name, .direction = direction };
+        },
+        .assign => {
+            const binary = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+                .binary_expression => |binary| binary,
+                else => return null,
+            };
+            return assignmentBinaryUpdateCounter(tree, left_name, binary);
+        },
+        else => return null,
+    }
+}
+
+fn assignmentBinaryUpdateCounter(
+    tree: *const ast.Tree,
+    left_name: []const u8,
+    binary: ast.BinaryExpression,
+) ?UpdateCounter {
+    switch (binary.operator) {
+        .add => {
+            if (identifierName(tree, binary.left)) |name| {
+                if (std.mem.eql(u8, name, left_name)) {
+                    const direction = signedDirection(tree, binary.right) orelse .increasing;
+                    return .{ .name = left_name, .direction = direction };
+                }
+            }
+            if (identifierName(tree, binary.right)) |name| {
+                if (std.mem.eql(u8, name, left_name)) {
+                    const direction = signedDirection(tree, binary.left) orelse .increasing;
+                    return .{ .name = left_name, .direction = direction };
+                }
+            }
+            return null;
+        },
+        .subtract => {
+            if (identifierName(tree, binary.left)) |name| {
+                if (std.mem.eql(u8, name, left_name)) {
+                    const direction = if (signedDirection(tree, binary.right)) |direction|
+                        direction.opposite()
+                    else
+                        Direction.decreasing;
+                    return .{ .name = left_name, .direction = direction };
+                }
+            }
+            return null;
+        },
+        else => return null,
+    }
+}
+
+fn signedDirection(tree: *const ast.Tree, index: ast.NodeIndex) ?Direction {
+    if (index == .null) return null;
+
+    switch (tree.data(unwrapTransparent(tree, index))) {
+        .numeric_literal => |literal| {
+            const raw = tree.string(literal.raw);
+            if (std.mem.startsWith(u8, raw, "-")) return .decreasing;
+            return .increasing;
+        },
+        .unary_expression => |expression| {
+            const direction = signedDirection(tree, expression.argument) orelse return null;
+            return switch (expression.operator) {
+                .negate => direction.opposite(),
+                .positive => direction,
+                else => null,
+            };
+        },
+        else => return null,
+    }
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -11,6 +11,7 @@ pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
+pub const for_direction = @import("for_direction.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -445,7 +446,7 @@ const BasicVisitor = struct {
     pub fn enter_for_statement(
         self: *BasicVisitor,
         statement: ast.ForStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
@@ -456,6 +457,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_constant_condition and statement.@"test" != .null) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        if (self.options.for_direction) {
+            try for_direction.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -19,6 +19,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/for_direction.zig");
+}
+
+comptime {
     _ = @import("rules/guard_for_in.zig");
 }
 

--- a/tests/rules/for_direction.zig
+++ b/tests/rules/for_direction.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports for-direction for update expressions moving away from the stop condition" {
+    const source =
+        \\for (let i = 0; i < 10; i--) {
+        \\  work(i);
+        \\}
+        \\for (let j = 10; j >= 0; ++j) {
+        \\  work(j);
+        \\}
+        \\for (let k = 0; 10 > k; --k) {
+        \\  work(k);
+        \\}
+        \\for (let l = 10; 0 <= l; l++) {
+        \\  work(l);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.for_direction.id));
+}
+
+test "reports for-direction for assignment updates moving in the wrong direction" {
+    const source =
+        \\for (let i = 0; i < 10; i -= 1) {
+        \\  work(i);
+        \\}
+        \\for (let j = 10; j > 0; j += 1) {
+        \\  work(j);
+        \\}
+        \\for (let k = 0; k < 10; k = k - 1) {
+        \\  work(k);
+        \\}
+        \\for (let l = 10; l > 0; l = 1 + l) {
+        \\  work(l);
+        \\}
+        \\for (let m = 0; m < 10; other++, m--) {
+        \\  work(m);
+        \\}
+        \\for (let n = 0; n < 10; n += -1) {
+        \\  work(n);
+        \\}
+        \\for (let p = 10; p > 0; p -= -1) {
+        \\  work(p);
+        \\}
+        \\for (let q = 0, limit = 10; q < limit; limit++) {
+        \\  work(q);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.for_direction.id));
+}
+
+test "does not report for-direction for terminating update directions" {
+    const source =
+        \\for (let i = 0; i < 10; i++) {
+        \\  work(i);
+        \\}
+        \\for (let j = 10; j > 0; j--) {
+        \\  work(j);
+        \\}
+        \\for (let k = 0; 10 > k; k += 1) {
+        \\  work(k);
+        \\}
+        \\for (let l = 10; 0 <= l; l -= 1) {
+        \\  work(l);
+        \\}
+        \\for (let m = 0; m !== 10; m--) {
+        \\  work(m);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.for_direction.id));
+}
+
+test "can disable for-direction" {
+    const source =
+        \\for (let i = 0; i < 10; i--) {
+        \\  work(i);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .for_direction = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.for_direction.id));
+}


### PR DESCRIPTION
## Summary
- Add for-direction core rule support for for-loop update direction checks
- Register the rule in default options, CLI switch, README, and tests
- Cover ++/--, +=/-=, assignment updates, sequence updates, and right-side counters

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- git diff --cached --check
- CLI fixture: invalid loops report 5 for-direction diagnostics, valid loops report 0 for-direction diagnostics, --for-direction=off reports 0 diagnostics

Note: running the local test binary still terminates with signal KILL in this environment, matching prior local runs; CI runs the full test suite.