### PR TITLE
feat: port rule getter-return

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `default-case-last`
 - `eol-last`
 - `for-direction`
+- `getter-return`
 - `guard-for-in`
 - `linebreak-style`
 - `new-parens`

--- a/src/core.zig
+++ b/src/core.zig
@@ -23,6 +23,7 @@ pub const Options = struct {
     default_case_last: bool = true,
     eol_last: bool = true,
     for_direction: bool = true,
+    getter_return: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     new_parens: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,8 @@ pub fn main(init: std.process.Init) !void {
             options.eol_last = false;
         } else if (std.mem.eql(u8, arg, "--for-direction=off")) {
             options.for_direction = false;
+        } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
+            options.getter_return = false;
         } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
@@ -439,6 +441,7 @@ fn printHelp() void {
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last
         \\  --for-direction=off       Disable for-direction
+        \\  --getter-return=off       Disable getter-return
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
         \\  --new-parens=off          Disable new-parens

--- a/src/rules/getter_return.zig
+++ b/src/rules/getter_return.zig
@@ -1,0 +1,226 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "getter-return";
+
+const Completion = enum {
+    continues,
+    valid_terminal,
+    invalid_return,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (!isGetterBody(tree, ctx)) return;
+    if (rangeAlwaysReturnsValue(tree, body.body)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected to return a value in getter.",
+        tree.span(index),
+    );
+}
+
+fn isGetterBody(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const function_index = ctx.path.ancestor(1) orelse return false;
+    if (tree.data(function_index) != .function) return false;
+
+    const parent = ctx.path.ancestor(2) orelse return false;
+    return switch (tree.data(parent)) {
+        .method_definition => |method| method.kind == .get and method.value == function_index,
+        .object_property => |property| isGetterProperty(tree, ctx, property, function_index),
+        else => false,
+    };
+}
+
+fn isGetterProperty(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    property: ast.ObjectProperty,
+    function_index: ast.NodeIndex,
+) bool {
+    if (property.value != function_index) return false;
+    if (property.kind == .get) return true;
+
+    if (!isPropertyNamed(tree, property, "get")) return false;
+    const object_index = ctx.path.ancestor(3) orelse return false;
+    return isPropertyDescriptorContext(tree, ctx, object_index);
+}
+
+fn isPropertyDescriptorContext(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+) bool {
+    if (isDefinePropertyDescriptor(tree, ctx, object_index)) return true;
+    if (isNestedDescriptorObject(tree, ctx, object_index)) return true;
+    return false;
+}
+
+fn isDefinePropertyDescriptor(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+) bool {
+    const parent = ctx.path.ancestor(4) orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 3 or arguments[2] != object_index) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "defineProperty");
+}
+
+fn isNestedDescriptorObject(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    object_index: ast.NodeIndex,
+) bool {
+    const property_index = ctx.path.ancestor(4) orelse return false;
+    const property = switch (tree.data(property_index)) {
+        .object_property => |property| property,
+        else => return false,
+    };
+    if (property.value != object_index) return false;
+
+    const descriptors_object = ctx.path.ancestor(5) orelse return false;
+    const call_index = ctx.path.ancestor(6) orelse return false;
+    const call = switch (tree.data(call_index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2 or arguments[1] != descriptors_object) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "create") or
+        isStaticMemberCall(tree, call.callee, "Object", "defineProperties");
+}
+
+fn rangeAlwaysReturnsValue(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    return rangeCompletion(tree, range) == .valid_terminal;
+}
+
+fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
+    for (tree.extra(range)) |statement| {
+        switch (statementCompletion(tree, statement)) {
+            .continues => {},
+            .valid_terminal => return .valid_terminal,
+            .invalid_return => return .invalid_return,
+        }
+    }
+
+    return .continues;
+}
+
+fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex) Completion {
+    if (index == .null) return .continues;
+
+    return switch (tree.data(index)) {
+        .return_statement => |statement| if (statement.argument != .null) .valid_terminal else .invalid_return,
+        .throw_statement => .valid_terminal,
+        .block_statement => |block| rangeCompletion(tree, block.body),
+        .if_statement => |statement| ifCompletion(tree, statement),
+        .try_statement => |statement| tryCompletion(tree, statement),
+        else => .continues,
+    };
+}
+
+fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement) Completion {
+    const consequent = statementCompletion(tree, statement.consequent);
+    if (consequent == .invalid_return) return .invalid_return;
+
+    if (statement.alternate == .null) return .continues;
+    const alternate = statementCompletion(tree, statement.alternate);
+    if (alternate == .invalid_return) return .invalid_return;
+
+    if (consequent == .valid_terminal and alternate == .valid_terminal) return .valid_terminal;
+    return .continues;
+}
+
+fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion {
+    if (statement.finalizer != .null) {
+        const finalizer = statementCompletion(tree, statement.finalizer);
+        if (finalizer != .continues) return finalizer;
+    }
+
+    const block = statementCompletion(tree, statement.block);
+    if (block == .invalid_return) return .invalid_return;
+    if (statement.handler == .null) return block;
+
+    const handler_node = switch (tree.data(statement.handler)) {
+        .catch_clause => |handler| handler.body,
+        else => return .continues,
+    };
+    const handler = statementCompletion(tree, handler_node);
+    if (handler == .invalid_return) return .invalid_return;
+
+    if (block == .valid_terminal and handler == .valid_terminal) return .valid_terminal;
+    return .continues;
+}
+
+fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name: []const u8, property_name: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, object_name) and
+        isIdentifierNameNamed(tree, member.property, property_name);
+}
+
+fn isPropertyNamed(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
+    if (property.computed) return false;
+
+    return switch (tree.data(property.key)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .string_literal => |literal| std.mem.eql(u8, tree.string(literal.value), name),
+        else => false,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -12,6 +12,7 @@ pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
 pub const for_direction = @import("for_direction.zig");
+pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -702,6 +703,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_empty_function) {
             try no_empty_function.check(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
+        if (self.options.getter_return) {
+            try getter_return.check(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);
         }
         if (self.options.no_unreachable) {
             try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -23,6 +23,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/getter_return.zig");
+}
+
+comptime {
     _ = @import("rules/guard_for_in.zig");
 }
 

--- a/tests/rules/getter_return.zig
+++ b/tests/rules/getter_return.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports getter-return for getters that do not return a value" {
+    const source =
+        \\class Example {
+        \\  get missing() {}
+        \\  get bare() {
+        \\    return;
+        \\  }
+        \\  get partial() {
+        \\    if (ready) {
+        \\      return 1;
+        \\    }
+        \\  }
+        \\}
+        \\const obj = {
+        \\  get missing() {},
+        \\  get bare() {
+        \\    return;
+        \\  },
+        \\  get nestedOnly() {
+        \\    function nested() {
+        \\      return 1;
+        \\    }
+        \\  },
+        \\  get unreachableValue() {
+        \\    return;
+        \\    return 1;
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.getter_return.id));
+}
+
+test "reports getter-return for descriptor getters that do not return a value" {
+    const source =
+        \\Object.defineProperty(target, "x", {
+        \\  get: function () {}
+        \\});
+        \\Object.defineProperties(target, {
+        \\  y: {
+        \\    get() {
+        \\      if (ready) {
+        \\        return 1;
+        \\      }
+        \\    }
+        \\  }
+        \\});
+        \\Object.create(proto, {
+        \\  z: {
+        \\    get: function () {
+        \\      return;
+        \\    }
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.getter_return.id));
+}
+
+test "does not report getter-return when all getter paths return or throw" {
+    const source =
+        \\class Example {
+        \\  get value() {
+        \\    return 1;
+        \\  }
+        \\  get branch() {
+        \\    if (ready) {
+        \\      return 1;
+        \\    } else {
+        \\      return 2;
+        \\    }
+        \\  }
+        \\  get error() {
+        \\    throw new Error("missing");
+        \\  }
+        \\}
+        \\const obj = {
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\  get branch() {
+        \\    if (ready) {
+        \\      throw new Error("missing");
+        \\    }
+        \\    return 2;
+        \\  },
+        \\  get: function () {}
+        \\};
+        \\Object.defineProperty(target, "x", {
+        \\  get: function () {
+        \\    return value;
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.getter_return.id));
+}
+
+test "can disable getter-return" {
+    const source =
+        \\class Example {
+        \\  get missing() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .getter_return = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.getter_return.id));
+}


### PR DESCRIPTION
## Summary
- Add getter-return core rule support for class getters, object getters, and descriptor getters
- Require getter code paths to return a value or throw, and flag bare return paths
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- git diff --check
- CLI fixture: invalid getters report 5 getter-return diagnostics, valid getters report 0 diagnostics, --getter-return=off reports 0 diagnostics

Note: zig build test -Doptimize=ReleaseFast -j1 still terminates with signal KILL in this local environment, matching prior local runs; CI runs the full test suite.