### PR TITLE
feat: port rule operator-assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-void`
 - `no-with`
 - `no-var`
+- `operator-assignment`
 - `eqeqeq`
 - `no-unused-vars`
 - `no-undef`

--- a/src/core.zig
+++ b/src/core.zig
@@ -145,6 +145,7 @@ pub const Options = struct {
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,
+    operator_assignment: bool = true,
     eqeqeq: bool = true,
     use_isnan: bool = true,
     no_unused_vars: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -278,6 +278,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
+        } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
+            options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
             options.eqeqeq = false;
         } else if (std.mem.eql(u8, arg, "--use-isnan=off")) {
@@ -561,6 +563,7 @@ fn printHelp() void {
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
+        \\  --operator-assignment=off Disable operator-assignment
         \\  --eqeqeq=off              Disable eqeqeq
         \\  --use-isnan=off           Disable use-isnan
         \\  --no-unused-vars=off      Disable no-unused-vars

--- a/src/rules/operator_assignment.zig
+++ b/src/rules/operator_assignment.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "operator-assignment";
+
+const Reference = union(enum) {
+    this,
+    identifier: []const u8,
+    member: struct {
+        object: *const Reference,
+        property: []const u8,
+    },
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    const binary = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+        .binary_expression => |binary| binary,
+        else => return,
+    };
+    if (!hasAssignmentOperator(binary.operator)) return;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
+    const right_left = (try referenceFromExpression(arena_allocator, tree, binary.left)) orelse return;
+    if (!referencesEqual(left, right_left)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Assignment can be replaced with operator assignment.",
+        tree.span(index),
+    );
+}
+
+fn hasAssignmentOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .add,
+        .subtract,
+        .multiply,
+        .divide,
+        .modulo,
+        .exponent,
+        .bitwise_or,
+        .bitwise_xor,
+        .bitwise_and,
+        .left_shift,
+        .right_shift,
+        .unsigned_right_shift,
+        => true,
+        else => false,
+    };
+}
+
+fn referenceFromExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!?*const Reference {
+    if (index == .null) return null;
+
+    switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| return try newReference(allocator, .{ .identifier = tree.string(identifier.name) }),
+        .this_expression => return newReference(allocator, .this),
+        .member_expression => |member| {
+            const object = (try referenceFromExpression(allocator, tree, member.object)) orelse return null;
+            const property = propertyName(tree, member) orelse return null;
+            return try newReference(allocator, .{ .member = .{
+                .object = object,
+                .property = property,
+            } });
+        },
+        else => return null,
+    }
+}
+
+fn newReference(allocator: Allocator, reference: Reference) Allocator.Error!*const Reference {
+    const owned = try allocator.create(Reference);
+    owned.* = reference;
+    return owned;
+}
+
+fn referencesEqual(left: *const Reference, right: *const Reference) bool {
+    switch (left.*) {
+        .this => return right.* == .this,
+        .identifier => |left_name| return switch (right.*) {
+            .identifier => |right_name| std.mem.eql(u8, left_name, right_name),
+            else => false,
+        },
+        .member => |left_member| return switch (right.*) {
+            .member => |right_member| std.mem.eql(u8, left_member.property, right_member.property) and
+                referencesEqual(left_member.object, right_member.object),
+            else => false,
+        },
+    }
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .identifier_reference => |identifier| tree.string(identifier.name),
+            .string_literal => |literal| tree.string(literal.value),
+            .numeric_literal => |literal| tree.string(literal.raw),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -136,6 +136,7 @@ pub const no_warning_comments = @import("no_warning_comments.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
+pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_template = @import("prefer_template.zig");
@@ -838,6 +839,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_multi_assign) {
             try no_multi_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.operator_assignment) {
+            try operator_assignment.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -519,6 +519,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/operator_assignment.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_exponentiation_operator.zig");
 }
 

--- a/tests/rules/operator_assignment.zig
+++ b/tests/rules/operator_assignment.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports operator-assignment for assignable binary self updates" {
+    const source =
+        \\let value = 1;
+        \\value = value + amount;
+        \\value = value - amount;
+        \\value = value * amount;
+        \\value = value / amount;
+        \\value = value % amount;
+        \\value = value ** amount;
+        \\value = value << amount;
+        \\value = value >>> amount;
+        \\obj.count = obj.count + amount;
+        \\this.total = this.total - amount;
+        \\obj["count"] = obj["count"] | mask;
+        \\obj[0] = obj[0] & mask;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_bitwise = false,
+        .no_multi_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.operator_assignment.id));
+}
+
+test "does not report operator-assignment when shorthand would change the expression" {
+    const source =
+        \\let value = 1;
+        \\value = amount + value;
+        \\value = value && amount;
+        \\value = value < amount;
+        \\value += amount;
+        \\obj.count = other.count + amount;
+        \\obj[getKey()] = obj[getKey()] + amount;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_bitwise = false,
+        .no_multi_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.operator_assignment.id));
+}
+
+test "can disable operator-assignment" {
+    const source =
+        \\let value = 1;
+        \\value = value + amount;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.operator_assignment.id));
+}


### PR DESCRIPTION
## Summary
- Add operator-assignment core rule support for `x = x <op> y` patterns
- Support identifiers plus member references for arithmetic, exponent, shift, and bitwise operators
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- git diff --check
- CLI fixture: invalid assignments report 6 operator-assignment diagnostics, valid assignments report 0 diagnostics, --operator-assignment=off reports 0 diagnostics

Note: zig build test -Doptimize=ReleaseFast -j1 still terminates with signal KILL in this local environment, matching prior local runs; CI runs the full test suite.