### PR TITLE
feat: port rule require-yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `prefer-regex-literals`
 - `prefer-template`
 - `radix`
+- `require-yield`
 - `spaced-comment`
 - `symbol-description`
 - `use-isnan`

--- a/src/core.zig
+++ b/src/core.zig
@@ -154,6 +154,7 @@ pub const Options = struct {
     prefer_regex_literals: bool = true,
     prefer_template: bool = true,
     radix: bool = true,
+    require_yield: bool = true,
     spaced_comment: bool = true,
     symbol_description: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -296,6 +296,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
+        } else if (std.mem.eql(u8, arg, "--require-yield=off")) {
+            options.require_yield = false;
         } else if (std.mem.eql(u8, arg, "--spaced-comment=off")) {
             options.spaced_comment = false;
         } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {
@@ -571,6 +573,7 @@ fn printHelp() void {
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --radix=off               Disable radix
+        \\  --require-yield=off       Disable require-yield
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/require_yield.zig
+++ b/src/rules/require_yield.zig
@@ -1,0 +1,56 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "require-yield";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!function.generator or function.body == .null) return;
+    if (containsYield(tree, function.body)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "This generator function does not have 'yield'.",
+        tree.span(index),
+    );
+}
+
+fn containsYield(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .yield_expression => true,
+        .function,
+        .arrow_function_expression,
+        => false,
+        inline else => |node| nodeContainsYield(tree, node),
+    };
+}
+
+fn nodeContainsYield(tree: *const ast.Tree, node: anytype) bool {
+    const T = @TypeOf(node);
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (containsYield(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (containsYield(tree, child)) return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -141,6 +141,7 @@ pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operat
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
+pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
@@ -352,7 +353,7 @@ const BasicVisitor = struct {
     pub fn enter_function(
         self: *BasicVisitor,
         function: ast.Function,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_args) {
@@ -360,6 +361,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.require_yield) {
+            try require_yield.check(self.allocator, self.diagnostics, ctx.tree, function, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -539,6 +539,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/require_yield.zig");
+}
+
+comptime {
     _ = @import("rules/spaced_comment.zig");
 }
 

--- a/tests/rules/require_yield.zig
+++ b/tests/rules/require_yield.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports require-yield for generators without their own yield" {
+    const source =
+        \\function* empty() {}
+        \\function* onlyNested() {
+        \\  function* nested() {
+        \\    yield value;
+        \\  }
+        \\}
+        \\const obj = {
+        \\  *emptyMethod() {}
+        \\};
+        \\class Example {
+        \\  *emptyMethod() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.require_yield.id));
+}
+
+test "does not report require-yield for generators with yield or non-generators" {
+    const source =
+        \\function* values() {
+        \\  yield value;
+        \\}
+        \\function* delegate() {
+        \\  yield* values();
+        \\}
+        \\const obj = {
+        \\  *method() {
+        \\    if (ready) {
+        \\      yield value;
+        \\    }
+        \\  }
+        \\};
+        \\function normal() {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_yield.id));
+}
+
+test "can disable require-yield" {
+    const source =
+        \\function* empty() {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .require_yield = false,
+        .no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_yield.id));
+}


### PR DESCRIPTION
## Summary
- Add require-yield core rule support for generator functions and methods
- Ignore yields from nested functions so only the current generator body counts
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- git diff --check
- CLI fixture: invalid generators report 3 require-yield diagnostics, valid generators report 0 diagnostics, --require-yield=off reports 0 diagnostics

Note: zig build test -Doptimize=ReleaseFast -j1 still terminates with signal KILL in this local environment, matching prior local runs; CI runs the full test suite.