### PR TITLE
feat: port rule prefer-spread

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-undef`
 - `prefer-exponentiation-operator`
 - `prefer-regex-literals`
+- `prefer-spread`
 - `prefer-template`
 - `radix`
 - `require-yield`

--- a/src/core.zig
+++ b/src/core.zig
@@ -152,6 +152,7 @@ pub const Options = struct {
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_regex_literals: bool = true,
+    prefer_spread: bool = true,
     prefer_template: bool = true,
     radix: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,6 +292,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-spread=off")) {
+            options.prefer_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-template=off")) {
             options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
@@ -572,6 +574,7 @@ fn printHelp() void {
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
+        \\  --prefer-spread=off       Disable prefer-spread
         \\  --radix=off               Disable radix
         \\  --require-yield=off       Disable require-yield
         \\  --semantic-errors=off     Disable parser semantic errors

--- a/src/rules/prefer_spread.zig
+++ b/src/rules/prefer_spread.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-spread";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (call.optional) return;
+
+    const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return,
+    };
+    if (callee_member.optional) return;
+
+    const method = propertyName(tree, callee_member) orelse return;
+    if (!std.mem.eql(u8, method, "apply")) return;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len != 2) return;
+    if (!canPreserveThisArg(tree, callee_member.object, arguments[0])) return;
+    if (!isSpreadableArgument(tree, arguments[1])) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use spread syntax instead of apply().",
+        tree.span(index),
+    );
+}
+
+fn canPreserveThisArg(tree: *const ast.Tree, target: ast.NodeIndex, this_arg: ast.NodeIndex) bool {
+    const target_member = switch (tree.data(unwrapTransparent(tree, target))) {
+        .member_expression => |member| member,
+        else => return isNullOrUndefined(tree, this_arg),
+    };
+
+    if (target_member.optional) return false;
+    if (!isSimpleReference(tree, target_member.object)) return false;
+    return sameSource(tree, target_member.object, this_arg);
+}
+
+fn isSpreadableArgument(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .array_expression,
+        .spread_element,
+        => false,
+        else => true,
+    };
+}
+
+fn isNullOrUndefined(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        else => false,
+    };
+}
+
+fn isSimpleReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference,
+        .this_expression,
+        => true,
+        .member_expression => |member| !member.optional and isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
+        else => false,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn sameSource(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_source = sourceSlice(tree, unwrapTransparent(tree, left)) orelse return false;
+    const right_source = sourceSlice(tree, unwrapTransparent(tree, right)) orelse return false;
+
+    return std.mem.eql(u8, left_source, right_source);
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+
+    if (start >= end or end > tree.source.len) return null;
+    return tree.source[start..end];
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -139,6 +139,7 @@ pub const no_with = @import("no_with.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
+pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
 pub const require_yield = @import("require_yield.zig");
@@ -972,6 +973,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_extra_bind) {
             try no_extra_bind.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.prefer_spread) {
+            try prefer_spread.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -531,6 +531,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_spread.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_template.zig");
 }
 

--- a/tests/rules/prefer_spread.zig
+++ b/tests/rules/prefer_spread.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-spread for apply calls that can use spread syntax" {
+    const source =
+        \\fn.apply(null, args);
+        \\fn.apply(undefined, args);
+        \\obj.method.apply(obj, args);
+        \\this.method.apply(this, args);
+        \\obj.nested.method.apply(obj.nested, args);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_call = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_spread.id));
+}
+
+test "does not report prefer-spread when spread conversion is unsafe or covered by no-useless-call" {
+    const source =
+        \\fn.apply(context, args);
+        \\obj.method.apply(other, args);
+        \\fn.call(null, first, second);
+        \\fn.apply(null, [first, second]);
+        \\fn.apply(null, ...args);
+        \\fn?.apply(null, args);
+        \\obj.method.apply?.(obj, args);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_call = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_spread.id));
+}
+
+test "can disable prefer-spread" {
+    const source =
+        \\fn.apply(null, args);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_spread = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_spread.id));
+}


### PR DESCRIPTION
## Summary
- Add prefer-spread core rule support for safe `apply()` to spread conversions
- Support null/undefined this args and method calls whose this arg matches the receiver
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture: invalid apply calls report 5 prefer-spread diagnostics, valid calls report 0 diagnostics, --prefer-spread=off reports 0 diagnostics