### PR TITLE
feat: port rule prefer-rest-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-undef`
 - `prefer-exponentiation-operator`
 - `prefer-regex-literals`
+- `prefer-rest-params`
 - `prefer-spread`
 - `prefer-template`
 - `radix`

--- a/src/core.zig
+++ b/src/core.zig
@@ -152,6 +152,7 @@ pub const Options = struct {
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_regex_literals: bool = true,
+    prefer_rest_params: bool = true,
     prefer_spread: bool = true,
     prefer_template: bool = true,
     radix: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,6 +292,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-rest-params=off")) {
+            options.prefer_rest_params = false;
         } else if (std.mem.eql(u8, arg, "--prefer-spread=off")) {
             options.prefer_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-template=off")) {
@@ -574,6 +576,7 @@ fn printHelp() void {
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
+        \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread
         \\  --radix=off               Disable radix
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/prefer_rest_params.zig
+++ b/src/rules/prefer_rest_params.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-rest-params";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (function.body == .null) return;
+    if (hasRestParameter(tree, function.params)) return;
+    if (bindingNamed(tree, function.id, "arguments")) return;
+    if (paramsContainBinding(tree, function.params, "arguments")) return;
+    if (bodyDeclaresArguments(tree, function.body)) return;
+    if (!bodyUsesArguments(tree, function.body)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use the rest parameters instead of 'arguments'.",
+        tree.span(index),
+    );
+}
+
+fn hasRestParameter(tree: *const ast.Tree, params_index: ast.NodeIndex) bool {
+    const params = formalParameters(tree, params_index) orelse return false;
+    return params.rest != .null;
+}
+
+fn paramsContainBinding(tree: *const ast.Tree, params_index: ast.NodeIndex, name: []const u8) bool {
+    const params = formalParameters(tree, params_index) orelse return false;
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| if (bindingNamed(tree, parameter.pattern, name)) return true,
+            .ts_parameter_property => |property| if (bindingNamed(tree, property.parameter, name)) return true,
+            else => {},
+        }
+    }
+
+    return bindingNamed(tree, params.rest, name);
+}
+
+fn formalParameters(tree: *const ast.Tree, params_index: ast.NodeIndex) ?ast.FormalParameters {
+    if (params_index == .null) return null;
+    return switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => null,
+    };
+}
+
+fn bodyDeclaresArguments(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                if (bindingNamed(tree, declarator.id, "arguments")) return true;
+            }
+            return false;
+        },
+        .function => |function| function.type == .function_declaration and bindingNamed(tree, function.id, "arguments"),
+        .arrow_function_expression => false,
+        inline else => |node| nodeDeclaresArguments(tree, node),
+    };
+}
+
+fn nodeDeclaresArguments(tree: *const ast.Tree, node: anytype) bool {
+    const T = @TypeOf(node);
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (bodyDeclaresArguments(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (bodyDeclaresArguments(tree, child)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+fn bodyUsesArguments(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "arguments"),
+        .function,
+        .arrow_function_expression,
+        => false,
+        inline else => |node| nodeUsesArguments(tree, node),
+    };
+}
+
+fn nodeUsesArguments(tree: *const ast.Tree, node: anytype) bool {
+    const T = @TypeOf(node);
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (bodyUsesArguments(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (bodyUsesArguments(tree, child)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+fn bindingNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .formal_parameter => |parameter| bindingNamed(tree, parameter.pattern, name),
+        .assignment_pattern => |pattern| bindingNamed(tree, pattern.left, name),
+        .binding_rest_element => |element| bindingNamed(tree, element.argument, name),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                if (bindingNamed(tree, element, name)) return true;
+            }
+            return bindingNamed(tree, pattern.rest, name);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                if (bindingNamed(tree, property.value, name)) return true;
+            }
+            return bindingNamed(tree, pattern.rest, name);
+        },
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -139,6 +139,7 @@ pub const no_with = @import("no_with.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
+pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
@@ -365,6 +366,9 @@ const BasicVisitor = struct {
         }
         if (self.options.require_yield) {
             try require_yield.check(self.allocator, self.diagnostics, ctx.tree, function, index);
+        }
+        if (self.options.prefer_rest_params) {
+            try prefer_rest_params.check(self.allocator, self.diagnostics, ctx.tree, function, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -531,6 +531,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_rest_params.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_spread.zig");
 }
 

--- a/tests/rules/prefer_rest_params.zig
+++ b/tests/rules/prefer_rest_params.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-rest-params for current function arguments usage" {
+    const source =
+        \\function first() {
+        \\  return arguments[0];
+        \\}
+        \\const second = function () {
+        \\  return arguments.length;
+        \\};
+        \\const obj = {
+        \\  method() {
+        \\    return arguments[0];
+        \\  }
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_rest_params.id));
+}
+
+test "does not report prefer-rest-params for rest params or nested rest usage" {
+    const source =
+        \\function withRest(...args) {
+        \\  return arguments[0];
+        \\}
+        \\function nestedOnly() {
+        \\  function inner(...args) {
+        \\    return arguments[0];
+        \\  }
+        \\}
+        \\const arrow = () => arguments;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_rest_params.id));
+}
+
+test "does not report prefer-rest-params when arguments is shadowed in scripts" {
+    const source =
+        \\function parameter(arguments) {
+        \\  return arguments;
+        \\}
+        \\function local() {
+        \\  var arguments = value;
+        \\  return arguments;
+        \\}
+        \\function arguments() {
+        \\  return arguments;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", .{
+        .no_shadow_restricted_names = false,
+        .no_var = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_rest_params.id));
+}
+
+test "can disable prefer-rest-params" {
+    const source =
+        \\function first() {
+        \\  return arguments[0];
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_rest_params = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_rest_params.id));
+}


### PR DESCRIPTION
## Summary
- Add prefer-rest-params core rule support for ordinary functions using `arguments`
- Ignore functions with rest parameters, nested function usage, arrow functions, and shadowed `arguments` bindings
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture: invalid functions report 3 prefer-rest-params diagnostics, valid functions report 0 diagnostics, --prefer-rest-params=off reports 0 diagnostics