### PR TITLE
feat: port rule object-shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-void`
 - `no-with`
 - `no-var`
+- `object-shorthand`
 - `operator-assignment`
 - `eqeqeq`
 - `no-unused-vars`

--- a/src/core.zig
+++ b/src/core.zig
@@ -145,6 +145,7 @@ pub const Options = struct {
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,
+    object_shorthand: bool = true,
     operator_assignment: bool = true,
     eqeqeq: bool = true,
     use_isnan: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -278,6 +278,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
+        } else if (std.mem.eql(u8, arg, "--object-shorthand=off")) {
+            options.object_shorthand = false;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
             options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -569,6 +571,7 @@ fn printHelp() void {
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
+        \\  --object-shorthand=off    Disable object-shorthand
         \\  --operator-assignment=off Disable operator-assignment
         \\  --eqeqeq=off              Disable eqeqeq
         \\  --use-isnan=off           Disable use-isnan

--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "object-shorthand";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (property.computed or property.shorthand or property.kind != .init) return;
+
+    if (!canUseShorthand(tree, property)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected property shorthand.",
+        tree.span(index),
+    );
+}
+
+fn canUseShorthand(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
+    const key_name = switch (tree.data(property.key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+
+    if (identifierReferenceNamed(tree, property.value, key_name)) return true;
+    return isAnonymousFunctionExpression(tree, property.value);
+}
+
+fn identifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isAnonymousFunctionExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function => |function| function.type == .function_expression and function.id == .null,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -136,6 +136,7 @@ pub const no_warning_comments = @import("no_warning_comments.zig");
 pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
+pub const object_shorthand = @import("object_shorthand.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
@@ -1063,6 +1064,18 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_object_property(
+        self: *BasicVisitor,
+        property: ast.ObjectProperty,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.object_shorthand) {
+            try object_shorthand.check(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -519,6 +519,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/object_shorthand.zig");
+}
+
+comptime {
     _ = @import("rules/operator_assignment.zig");
 }
 

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports object-shorthand for redundant property and method forms" {
+    const source =
+        \\const foo = 1;
+        \\const obj = {
+        \\  foo: foo,
+        \\  bar: function () {
+        \\    return 1;
+        \\  },
+        \\  asyncValue: async function () {
+        \\    return 2;
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
+test "does not report object-shorthand for non-shorthandable properties" {
+    const source =
+        \\const foo = 1;
+        \\const obj = {
+        \\  foo,
+        \\  foo: bar,
+        \\  "foo": foo,
+        \\  [foo]: foo,
+        \\  bar: function named() {
+        \\    return 1;
+        \\  },
+        \\  get value() {
+        \\    return foo;
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.object_shorthand.id));
+}
+
+test "can disable object-shorthand" {
+    const source =
+        \\const obj = {
+        \\  foo: foo,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .object_shorthand = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.object_shorthand.id));
+}


### PR DESCRIPTION
## Summary
- Add object-shorthand core rule support for redundant property and anonymous function property forms
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture: invalid object properties report 3 object-shorthand diagnostics, valid properties report 0 diagnostics, --object-shorthand=off reports 0 diagnostics