### PR TITLE
feat: port rule prefer-promise-reject-errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This repo is a working scaffold, not a production linter yet. The first rules ar
 - `no-unused-vars`
 - `no-undef`
 - `prefer-exponentiation-operator`
+- `prefer-promise-reject-errors`
 - `prefer-regex-literals`
 - `prefer-rest-params`
 - `prefer-spread`

--- a/src/core.zig
+++ b/src/core.zig
@@ -152,6 +152,7 @@ pub const Options = struct {
     no_unused_vars: bool = true,
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
+    prefer_promise_reject_errors: bool = true,
     prefer_regex_literals: bool = true,
     prefer_rest_params: bool = true,
     prefer_spread: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,6 +292,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_undef = false;
         } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
             options.prefer_exponentiation_operator = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-promise-reject-errors=off")) {
+            options.prefer_promise_reject_errors = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
         } else if (std.mem.eql(u8, arg, "--prefer-rest-params=off")) {
@@ -578,6 +580,7 @@ fn printHelp() void {
         \\  --no-unused-vars=off      Disable no-unused-vars
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
+        \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread

--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -1,0 +1,274 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-promise-reject-errors";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isGlobalPromiseRejectCall(ctx.tree, self.symbol_table, call)) {
+            try checkRejectArgument(self.allocator, self.diagnostics, ctx.tree, call.arguments, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isGlobalPromiseReference(ctx.tree, self.symbol_table, expression.callee)) return .proceed;
+        const executor = promiseExecutor(ctx.tree, expression.arguments) orelse return .proceed;
+        const reject_name = executorRejectName(ctx.tree, executor) orelse return .proceed;
+
+        try scanExecutor(self.allocator, self.diagnostics, ctx.tree, reject_name, executor);
+        return .proceed;
+    }
+};
+
+fn isGlobalPromiseRejectCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    call: ast.CallExpression,
+) bool {
+    if (call.optional) return false;
+
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.optional or member.computed) return false;
+
+    if (!isIdentifierNameNamed(tree, member.property, "reject")) return false;
+    return isGlobalPromiseReference(tree, symbol_table, member.object);
+}
+
+fn promiseExecutor(tree: *const ast.Tree, arguments: ast.IndexRange) ?ast.NodeIndex {
+    if (arguments.len == 0) return null;
+
+    const executor = unwrapTransparent(tree, tree.extra(arguments)[0]);
+    return switch (tree.data(executor)) {
+        .arrow_function_expression,
+        .function,
+        => executor,
+        else => null,
+    };
+}
+
+fn executorRejectName(tree: *const ast.Tree, executor: ast.NodeIndex) ?[]const u8 {
+    const params_index = switch (tree.data(executor)) {
+        .function => |function| function.params,
+        .arrow_function_expression => |arrow| arrow.params,
+        else => return null,
+    };
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return null,
+    };
+
+    const items = tree.extra(params.items);
+    if (items.len < 2) return null;
+
+    const second = switch (tree.data(items[1])) {
+        .formal_parameter => |parameter| parameter.pattern,
+        else => return null,
+    };
+
+    return bindingIdentifierName(tree, second);
+}
+
+fn scanExecutor(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reject_name: []const u8,
+    executor: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (tree.data(executor)) {
+        .function => |function| try scanNode(allocator, diagnostics, tree, reject_name, function.body),
+        .arrow_function_expression => |arrow| try scanNode(allocator, diagnostics, tree, reject_name, arrow.body),
+        else => {},
+    }
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reject_name: []const u8,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .call_expression => |call| {
+            if (isRejectCall(tree, reject_name, call)) {
+                try checkRejectArgument(allocator, diagnostics, tree, call.arguments, index);
+            }
+            try scanChildren(allocator, diagnostics, tree, reject_name, call);
+        },
+        .function,
+        .arrow_function_expression,
+        .class,
+        => return,
+        inline else => |node| try scanChildren(allocator, diagnostics, tree, reject_name, node),
+    }
+}
+
+fn scanChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reject_name: []const u8,
+    node: anytype,
+) Allocator.Error!void {
+    const T = @TypeOf(node);
+    if (@typeInfo(T) != .@"struct") return;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            try scanNode(allocator, diagnostics, tree, reject_name, @field(node, field.name));
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                try scanNode(allocator, diagnostics, tree, reject_name, child);
+            }
+        }
+    }
+}
+
+fn isRejectCall(tree: *const ast.Tree, reject_name: []const u8, call: ast.CallExpression) bool {
+    if (call.optional) return false;
+    return isIdentifierReferenceNamed(tree, call.callee, reject_name);
+}
+
+fn checkRejectArgument(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    arguments: ast.IndexRange,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (arguments.len == 0) return;
+    const argument = tree.extra(arguments)[0];
+    if (!isInvalidRejectReason(tree, unwrapTransparent(tree, argument))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected the Promise rejection reason to be an Error.",
+        tree.span(index),
+    );
+}
+
+fn isInvalidRejectReason(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .template_literal,
+        => true,
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .binary_expression => |expression| expression.operator == .add,
+        else => false,
+    };
+}
+
+fn isGlobalPromiseReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    if (!isIdentifierReferenceNamed(tree, unwrapped, "Promise")) return false;
+    return isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -139,6 +139,7 @@ pub const no_with = @import("no_with.zig");
 pub const object_shorthand = @import("object_shorthand.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
+pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
@@ -317,6 +318,10 @@ pub fn runSemantic(
 
     if (options.prefer_regex_literals) {
         try prefer_regex_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_promise_reject_errors) {
+        try prefer_promise_reject_errors.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.radix) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -531,6 +531,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_promise_reject_errors.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_regex_literals.zig");
 }
 

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-promise-reject-errors for obvious non-error rejection reasons" {
+    const source =
+        \\Promise.reject("failed");
+        \\Promise.reject(1);
+        \\Promise.reject(`failed`);
+        \\Promise.reject(undefined);
+        \\Promise.reject("failed " + code);
+        \\new Promise((resolve, reject) => {
+        \\  reject("failed");
+        \\});
+        \\new Promise(function (resolve, reject) {
+        \\  if (failed) {
+        \\    reject(1);
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
+test "does not report prefer-promise-reject-errors for error-like rejection reasons" {
+    const source =
+        \\Promise.reject(new Error("failed"));
+        \\Promise.reject(error);
+        \\Promise.reject(Error("failed"));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
+test "does not report prefer-promise-reject-errors for shadowed Promise or nested reject calls" {
+    const source =
+        \\const Promise = {
+        \\  reject(value) {
+        \\    return value;
+        \\  }
+        \\};
+        \\Promise.reject("local");
+        \\new Promise((resolve, reject) => {
+        \\  function nested() {
+        \\    reject("nested");
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .no_shadow_restricted_names = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
+test "can disable prefer-promise-reject-errors" {
+    const source =
+        \\Promise.reject("failed");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_promise_reject_errors = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_promise_reject_errors.id));
+}


### PR DESCRIPTION
## Summary
- Add prefer-promise-reject-errors core rule support for Promise.reject and Promise executor reject calls
- Reuse semantic resolution so local Promise bindings are ignored
- Register the rule in default options, CLI switch, README, and tests

## Verification
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture: invalid promise rejections report 7 prefer-promise-reject-errors diagnostics, valid rejections report 0 diagnostics, --prefer-promise-reject-errors=off reports 0 diagnostics