### PR TITLE
feat: port rule no-unused-expressions

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -141,6 +141,7 @@ pub const Options = struct {
     no_useless_constructor: bool = true,
     no_useless_catch: bool = true,
     no_useless_rename: bool = true,
+    no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -270,6 +270,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
             options.no_useless_rename = false;
+        } else if (std.mem.eql(u8, arg, "--no-unused-expressions=off")) {
+            options.no_unused_expressions = false;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments=off")) {
             options.no_warning_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
@@ -569,6 +571,7 @@ fn printHelp() void {
         \\  --no-useless-constructor=off Disable no-useless-constructor
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-rename=off   Disable no-useless-rename
+        \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with

--- a/src/rules/no_unused_expressions.zig
+++ b/src/rules/no_unused_expressions.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unused-expressions";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ExpressionStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (hasSideEffect(tree, statement.expression)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected an assignment or function call and instead saw an expression.",
+        tree.span(index),
+    );
+}
+
+fn hasSideEffect(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .assignment_expression,
+        .await_expression,
+        .call_expression,
+        .import_expression,
+        .new_expression,
+        .tagged_template_expression,
+        .update_expression,
+        .yield_expression,
+        => true,
+
+        .chain_expression => |chain| hasSideEffect(tree, chain.expression),
+        .parenthesized_expression => |parenthesized| hasSideEffect(tree, parenthesized.expression),
+        .sequence_expression => |sequence| hasLastExpressionSideEffect(tree, sequence),
+
+        else => false,
+    };
+}
+
+fn hasLastExpressionSideEffect(tree: *const ast.Tree, sequence: ast.SequenceExpression) bool {
+    const expressions = tree.extra(sequence.expressions);
+    if (expressions.len == 0) return false;
+
+    return hasSideEffect(tree, expressions[expressions.len - 1]);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -130,6 +130,7 @@ pub const no_useless_constructor = @import("no_useless_constructor.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
+pub const no_unused_expressions = @import("no_unused_expressions.zig");
 pub const no_unused_labels = @import("no_unused_labels.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_warning_comments = @import("no_warning_comments.zig");
@@ -525,6 +526,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_extra_semi) {
             try no_extra_semi.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_expression_statement(
+        self: *BasicVisitor,
+        statement: ast.ExpressionStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_unused_expressions) {
+            try no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -495,6 +495,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unused_expressions.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_vars.zig");
 }
 

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -13,6 +13,7 @@ test "reports dot-notation for computed string properties that can use dot acces
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
         .no_undef = false,
+        .no_unused_expressions = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/no_unused_expressions.zig
+++ b/tests/rules/no_unused_expressions.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unused-expressions for expressions without side effects" {
+    const source =
+        \\foo;
+        \\1;
+        \\`text`;
+        \\foo + bar;
+        \\foo && bar();
+        \\foo ? bar() : baz();
+        \\obj.prop;
+        \\[foo];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_unused_expressions.id));
+}
+
+test "does not report no-unused-expressions for expressions with side effects" {
+    const source =
+        \\foo();
+        \\foo?.();
+        \\new Foo();
+        \\value = 1;
+        \\value += 1;
+        \\value++;
+        \\tag`template`;
+        \\import("mod");
+        \\(foo());
+        \\(0, foo());
+        \\async function run() {
+        \\  await foo();
+        \\}
+        \\function* gen() {
+        \\  yield value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_plusplus = false,
+        .no_sequences = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_expressions.id));
+}
+
+test "can disable no-unused-expressions" {
+    const source =
+        \\foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_expressions.id));
+}


### PR DESCRIPTION
## Summary
- add no-unused-expressions rule for expression statements without side effects
- wire the rule into options, CLI disable flag, and basic visitor traversal
- add focused tests and isolate dot-notation diagnostics from the new default rule

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting no-unused-expressions
- CLI fixture for --no-unused-expressions=off