### PR TITLE
feat: port rule no-useless-escape

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -140,6 +140,7 @@ pub const Options = struct {
     no_useless_concat: bool = true,
     no_useless_constructor: bool = true,
     no_useless_catch: bool = true,
+    no_useless_escape: bool = true,
     no_useless_rename: bool = true,
     no_unused_expressions: bool = true,
     no_warning_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -268,6 +268,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
             options.no_useless_catch = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-escape=off")) {
+            options.no_useless_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
             options.no_useless_rename = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-expressions=off")) {
@@ -570,6 +572,7 @@ fn printHelp() void {
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-constructor=off Disable no-useless-constructor
         \\  --no-useless-catch=off    Disable no-useless-catch
+        \\  --no-useless-escape=off   Disable no-useless-escape
         \\  --no-useless-rename=off   Disable no-useless-rename
         \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-warning-comments=off Disable no-warning-comments

--- a/src/rules/no_useless_escape.zig
+++ b/src/rules/no_useless_escape.zig
@@ -1,0 +1,196 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-escape";
+
+pub fn checkStringLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const source = sourceSlice(tree, index) orelse return;
+    if (source.len < 2) return;
+
+    const delimiter = source[0];
+    try checkStringLike(allocator, diagnostics, source[1 .. source.len - 1], tree.span(index), delimiter, false);
+}
+
+pub fn checkTemplateLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.TemplateLiteral,
+) Allocator.Error!void {
+    const quasis = tree.extra(literal.quasis);
+
+    for (quasis) |quasi| {
+        const source = sourceSlice(tree, quasi) orelse continue;
+        try checkStringLike(allocator, diagnostics, source, tree.span(quasi), '`', true);
+    }
+}
+
+pub fn checkRegExpLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkRegExpPattern(
+        allocator,
+        diagnostics,
+        tree.string(literal.pattern),
+        tree.span(index),
+    );
+}
+
+fn checkStringLike(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    source: []const u8,
+    span: ast.Span,
+    delimiter: u8,
+    is_template: bool,
+) Allocator.Error!void {
+    var offset: usize = 0;
+
+    while (offset < source.len) {
+        if (source[offset] != '\\' or offset + 1 >= source.len) {
+            offset += 1;
+            continue;
+        }
+
+        const escaped = source[offset + 1];
+        if (!isNecessaryStringEscape(source, offset, escaped, delimiter, is_template)) {
+            try addDiagnostic(allocator, diagnostics, span, escaped);
+        }
+
+        offset += 2;
+    }
+}
+
+fn isNecessaryStringEscape(
+    source: []const u8,
+    offset: usize,
+    escaped: u8,
+    delimiter: u8,
+    is_template: bool,
+) bool {
+    if (escaped == delimiter or escaped == '\\') return true;
+
+    if (is_template and escaped == '$') {
+        return offset + 2 < source.len and source[offset + 2] == '{';
+    }
+
+    return switch (escaped) {
+        '0'...'9',
+        'b',
+        'f',
+        'n',
+        'r',
+        't',
+        'v',
+        'x',
+        'u',
+        '\n',
+        '\r',
+        => true,
+        else => false,
+    };
+}
+
+fn checkRegExpPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    pattern: []const u8,
+    span: ast.Span,
+) Allocator.Error!void {
+    var offset: usize = 0;
+    var in_class = false;
+
+    while (offset < pattern.len) {
+        const char = pattern[offset];
+        if (char == '[') in_class = true;
+        if (char == ']' and in_class) in_class = false;
+
+        if (char != '\\' or offset + 1 >= pattern.len) {
+            offset += 1;
+            continue;
+        }
+
+        const escaped = pattern[offset + 1];
+        if (!isNecessaryRegExpEscape(escaped, in_class)) {
+            try addDiagnostic(allocator, diagnostics, span, escaped);
+        }
+
+        offset += 2;
+    }
+}
+
+fn isNecessaryRegExpEscape(escaped: u8, in_class: bool) bool {
+    if (std.ascii.isAlphanumeric(escaped)) return true;
+
+    if (in_class) {
+        return switch (escaped) {
+            '\\',
+            ']',
+            '^',
+            '-',
+            => true,
+            else => false,
+        };
+    }
+
+    return switch (escaped) {
+        '\\',
+        '/',
+        '^',
+        '$',
+        '.',
+        '*',
+        '+',
+        '?',
+        '(',
+        ')',
+        '[',
+        ']',
+        '{',
+        '}',
+        '|',
+        => true,
+        else => false,
+    };
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    span: ast.Span,
+    escaped: u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        span,
+        "Unnecessary escape character: \\{c}.",
+        .{escaped},
+    );
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+
+    if (start >= end or end > tree.source.len) return null;
+    return tree.source[start..end];
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -129,6 +129,7 @@ pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_useless_constructor = @import("no_useless_constructor.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
+pub const no_useless_escape = @import("no_useless_escape.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
 pub const no_unused_expressions = @import("no_unused_expressions.zig");
 pub const no_unused_labels = @import("no_unused_labels.zig");
@@ -808,6 +809,9 @@ const BasicVisitor = struct {
         if (self.options.no_template_curly_in_string) {
             try no_template_curly_in_string.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
+        if (self.options.no_useless_escape) {
+            try no_useless_escape.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, index);
+        }
         return .proceed;
     }
 
@@ -819,6 +823,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_script_url) {
             try no_script_url.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_useless_escape) {
+            try no_useless_escape.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);
         }
         return .proceed;
     }
@@ -1232,6 +1239,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_regex_spaces) {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_useless_escape) {
+            try no_useless_escape.checkRegExpLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -491,6 +491,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_escape.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_rename.zig");
 }
 

--- a/tests/rules/no_useless_escape.zig
+++ b/tests/rules/no_useless_escape.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-escape for unnecessary string and template escapes" {
+    const source =
+        \\const a = "\#";
+        \\const b = '\"';
+        \\const c = `\#`;
+        \\const d = `\a ${value}`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_escape.id));
+}
+
+test "reports no-useless-escape for unnecessary regular expression escapes" {
+    const source =
+        \\const a = /\#/;
+        \\const b = /[\#]/;
+        \\const c = /\-/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_useless_escape.id));
+}
+
+test "does not report no-useless-escape for necessary escapes" {
+    const source =
+        \\const a = "\"";
+        \\const b = '\'';
+        \\const c = "\\";
+        \\const d = "\n\t\x20\u0020";
+        \\const e = `\`${value}\${literal}`;
+        \\const f = /\d+\.\w+\/x/;
+        \\const g = /[\]\-\^]/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_escape.id));
+}
+
+test "can disable no-useless-escape" {
+    const source =
+        \\const a = "\#";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_escape = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_escape.id));
+}


### PR DESCRIPTION
## Summary
- add no-useless-escape checks for string literals, template literal quasis, and regular expression literals
- wire the rule into options, CLI disable flag, and basic visitor traversal
- add tests for reported escapes, necessary escapes, regex escapes, and disable behavior

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting no-useless-escape
- CLI fixture for --no-useless-escape=off