### PR TITLE
feat: port rule no-inner-declarations

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -80,6 +80,7 @@ pub const Options = struct {
     no_import_assign: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,
+    no_inner_declarations: bool = true,
     no_iterator: bool = true,
     no_label_var: bool = true,
     no_labels: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -148,6 +148,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_irregular_whitespace = false;
         } else if (std.mem.eql(u8, arg, "--no-inline-comments=off")) {
             options.no_inline_comments = false;
+        } else if (std.mem.eql(u8, arg, "--no-inner-declarations=off")) {
+            options.no_inner_declarations = false;
         } else if (std.mem.eql(u8, arg, "--no-iterator=off")) {
             options.no_iterator = false;
         } else if (std.mem.eql(u8, arg, "--no-label-var=off")) {
@@ -513,6 +515,7 @@ fn printHelp() void {
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments
+        \\  --no-inner-declarations=off Disable no-inner-declarations
         \\  --no-iterator=off          Disable no-iterator
         \\  --no-label-var=off         Disable no-label-var
         \\  --no-labels=off           Disable no-labels

--- a/src/rules/no_inner_declarations.zig
+++ b/src/rules/no_inner_declarations.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-inner-declarations";
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (function.type != .function_declaration) return;
+    if (!isInnerDeclaration(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Move function declaration to program root or function body root.",
+        tree.span(index),
+    );
+}
+
+fn isInnerDeclaration(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.parent() orelse return false;
+
+    switch (tree.data(parent)) {
+        .program,
+        .function_body,
+        => return false,
+
+        .export_named_declaration,
+        .export_default_declaration,
+        => {
+            const grandparent = ctx.path.ancestor(2) orelse return true;
+            return switch (tree.data(grandparent)) {
+                .program,
+                .function_body,
+                => false,
+                else => true,
+            };
+        },
+
+        else => return true,
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -69,6 +69,7 @@ pub const no_implicit_coercion = @import("no_implicit_coercion.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_inline_comments = @import("no_inline_comments.zig");
+pub const no_inner_declarations = @import("no_inner_declarations.zig");
 pub const no_irregular_whitespace = @import("no_irregular_whitespace.zig");
 pub const no_iterator = @import("no_iterator.zig");
 pub const no_label_var = @import("no_label_var.zig");
@@ -368,6 +369,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.no_inner_declarations) {
+            try no_inner_declarations.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -251,6 +251,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_inner_declarations.zig");
+}
+
+comptime {
     _ = @import("rules/no_irregular_whitespace.zig");
 }
 

--- a/tests/rules/no_inner_declarations.zig
+++ b/tests/rules/no_inner_declarations.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-inner-declarations for function declarations inside blocks" {
+    const source =
+        \\if (foo) {
+        \\  function bar() {}
+        \\}
+        \\while (foo) {
+        \\  function baz() {}
+        \\}
+        \\{
+        \\  function qux() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_constant_condition = false,
+        .no_lone_blocks = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_inner_declarations.id));
+}
+
+test "does not report no-inner-declarations for root function declarations" {
+    const source =
+        \\function topLevel() {}
+        \\function outer() {
+        \\  function inner() {}
+        \\  const fn = function expression() {};
+        \\}
+        \\export function exported() {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inner_declarations.id));
+}
+
+test "can disable no-inner-declarations" {
+    const source =
+        \\if (foo) {
+        \\  function bar() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inner_declarations = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inner_declarations.id));
+}


### PR DESCRIPTION
## Summary
- add no-inner-declarations default function declaration checks for nested blocks
- allow declarations at program and function body roots, including exported declarations
- wire the rule into options, CLI disable flag, and basic visitor traversal

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting no-inner-declarations
- CLI fixture for --no-inner-declarations=off