### PR TITLE
feat: port rule no-fallthrough

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -70,6 +70,7 @@ pub const Options = struct {
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
     no_floating_decimal: bool = true,
+    no_fallthrough: bool = true,
     no_for_in: bool = true,
     no_func_assign: bool = true,
     no_global_assign: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -128,6 +128,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_extra_boolean_cast = false;
         } else if (std.mem.eql(u8, arg, "--no-floating-decimal=off")) {
             options.no_floating_decimal = false;
+        } else if (std.mem.eql(u8, arg, "--no-fallthrough=off")) {
+            options.no_fallthrough = false;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-func-assign=off")) {
@@ -505,6 +507,7 @@ fn printHelp() void {
         \\  --no-extra-semi=off      Disable no-extra-semi
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-floating-decimal=off Disable no-floating-decimal
+        \\  --no-fallthrough=off      Disable no-fallthrough
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-func-assign=off      Disable no-func-assign
         \\  --no-global-assign=off    Disable no-global-assign

--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-fallthrough";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+) Allocator.Error!void {
+    const cases = tree.extra(statement.cases);
+    if (cases.len < 2) return;
+
+    for (cases[0 .. cases.len - 1], cases[1..]) |case_index, next_case_index| {
+        const switch_case = switch (tree.data(case_index)) {
+            .switch_case => |switch_case| switch_case,
+            else => continue,
+        };
+
+        if (switch_case.consequent.len == 0) continue;
+        if (caseAlwaysExits(tree, switch_case)) continue;
+        if (hasFallthroughComment(tree, switch_case, next_case_index)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Expected a 'break' statement before this case.",
+            tree.span(case_index),
+        );
+    }
+}
+
+fn caseAlwaysExits(tree: *const ast.Tree, switch_case: ast.SwitchCase) bool {
+    const statements = tree.extra(switch_case.consequent);
+    if (statements.len == 0) return false;
+
+    return alwaysExits(tree, statements[statements.len - 1]);
+}
+
+fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .break_statement,
+        .continue_statement,
+        .return_statement,
+        .throw_statement,
+        => true,
+
+        .block_statement => |block| rangeAlwaysExits(tree, block.body),
+        .if_statement => |statement| statement.alternate != .null and
+            alwaysExits(tree, statement.consequent) and
+            alwaysExits(tree, statement.alternate),
+
+        else => false,
+    };
+}
+
+fn rangeAlwaysExits(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    const statements = tree.extra(range);
+    if (statements.len == 0) return false;
+
+    return alwaysExits(tree, statements[statements.len - 1]);
+}
+
+fn hasFallthroughComment(tree: *const ast.Tree, switch_case: ast.SwitchCase, next_case_index: ast.NodeIndex) bool {
+    const statements = tree.extra(switch_case.consequent);
+    if (statements.len == 0) return false;
+
+    const last_span = tree.span(statements[statements.len - 1]);
+    const next_span = tree.span(next_case_index);
+    const start: u32 = last_span.end;
+    const end: u32 = next_span.start;
+    if (start > end) return false;
+
+    for (tree.comments) |comment| {
+        if (comment.start < start or comment.end > end) continue;
+        if (isFallthroughComment(tree.string(comment.value))) return true;
+    }
+
+    return false;
+}
+
+fn isFallthroughComment(comment: []const u8) bool {
+    var buffer: [256]u8 = undefined;
+    const len = @min(comment.len, buffer.len);
+
+    for (comment[0..len], 0..) |byte, index| {
+        buffer[index] = std.ascii.toLower(byte);
+    }
+
+    const lower = buffer[0..len];
+    return std.mem.indexOf(u8, lower, "fallthrough") != null or
+        std.mem.indexOf(u8, lower, "fall through") != null or
+        std.mem.indexOf(u8, lower, "falls through") != null;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -60,6 +60,7 @@ pub const no_extra_label = @import("no_extra_label.zig");
 pub const no_extra_boolean_cast = @import("no_extra_boolean_cast.zig");
 pub const no_extra_semi = @import("no_extra_semi.zig");
 pub const no_floating_decimal = @import("no_floating_decimal.zig");
+pub const no_fallthrough = @import("no_fallthrough.zig");
 pub const no_for_in = @import("no_for_in.zig");
 pub const no_func_assign = @import("no_func_assign.zig");
 pub const no_global_assign = @import("no_global_assign.zig");
@@ -561,6 +562,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_duplicate_case) {
             try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
+        if (self.options.no_fallthrough) {
+            try no_fallthrough.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -215,6 +215,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_fallthrough.zig");
+}
+
+comptime {
     _ = @import("rules/no_for_in.zig");
 }
 

--- a/tests/rules/no_fallthrough.zig
+++ b/tests/rules/no_fallthrough.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-fallthrough for non-empty cases without abrupt completion" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    one();
+        \\  case 2:
+        \\    two();
+        \\  default:
+        \\    three();
+        \\}
+        \\switch (other) {
+        \\  default:
+        \\    fallback();
+        \\  case 1:
+        \\    one();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_fallthrough.id));
+}
+
+test "does not report no-fallthrough for break, return, throw, empty case, or fallthrough comments" {
+    const source =
+        \\function run(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      one();
+        \\      break;
+        \\    case 2:
+        \\      return two();
+        \\    case 3:
+        \\      throw error;
+        \\    case 4:
+        \\    case 5:
+        \\      five();
+        \\      // falls through
+        \\    default:
+        \\      done();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
+}
+
+test "can disable no-fallthrough" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    one();
+        \\  case 2:
+        \\    two();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_fallthrough = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
+}


### PR DESCRIPTION
## Summary
- add no-fallthrough checks for switch cases that fall into following cases
- allow empty cases, abrupt completions, and fallthrough comments
- wire the rule into options, CLI disable flag, and switch traversal

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting no-fallthrough
- CLI fixture for --no-fallthrough=off