### PR TITLE
feat: port rule no-param-reassign

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -107,6 +107,7 @@ pub const Options = struct {
     no_octal: bool = true,
     no_octal_escape: bool = true,
     no_object_constructor: bool = true,
+    no_param_reassign: bool = true,
     no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_promise_executor_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,6 +202,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_octal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-object-constructor=off")) {
             options.no_object_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--no-param-reassign=off")) {
+            options.no_param_reassign = false;
         } else if (std.mem.eql(u8, arg, "--no-path-concat=off")) {
             options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
@@ -543,6 +545,7 @@ fn printHelp() void {
         \\  --no-octal=off            Disable no-octal
         \\  --no-octal-escape=off     Disable no-octal-escape
         \\  --no-object-constructor=off Disable no-object-constructor
+        \\  --no-param-reassign=off   Disable no-param-reassign
         \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-promise-executor-return=off Disable no-promise-executor-return

--- a/src/rules/no_param_reassign.zig
+++ b/src/rules/no_param_reassign.zig
@@ -1,0 +1,306 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-param-reassign";
+
+const ParamSet = std.StringHashMapUnmanaged(void);
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    var params: ParamSet = .empty;
+    defer params.deinit(allocator);
+
+    try collectFormalParameters(allocator, tree, function.params, &params);
+    if (params.size == 0 or function.body == .null) return;
+
+    try scanNode(allocator, diagnostics, tree, &params, function.body);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+) Allocator.Error!void {
+    var params: ParamSet = .empty;
+    defer params.deinit(allocator);
+
+    try collectFormalParameters(allocator, tree, expression.params, &params);
+    if (params.size == 0) return;
+
+    try scanNode(allocator, diagnostics, tree, &params, expression.body);
+}
+
+fn collectFormalParameters(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    out: *ParamSet,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try collectBinding(allocator, tree, parameter.pattern, out),
+            .ts_parameter_property => |property| try collectBinding(allocator, tree, property.parameter, out),
+            else => {},
+        }
+    }
+
+    try collectBinding(allocator, tree, params.rest, out);
+}
+
+fn collectBinding(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    out: *ParamSet,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try out.put(allocator, tree.string(identifier.name), {}),
+        .assignment_pattern => |pattern| try collectBinding(allocator, tree, pattern.left, out),
+        .binding_rest_element => |element| try collectBinding(allocator, tree, element.argument, out),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try collectBinding(allocator, tree, element, out);
+            }
+            try collectBinding(allocator, tree, pattern.rest, out);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try collectBinding(allocator, tree, property.value, out);
+            }
+            try collectBinding(allocator, tree, pattern.rest, out);
+        },
+        else => {},
+    }
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .assignment_expression => |expression| {
+            try checkTarget(allocator, diagnostics, tree, params, expression.left);
+            try scanNode(allocator, diagnostics, tree, params, expression.right);
+        },
+        .update_expression => |expression| try checkTarget(allocator, diagnostics, tree, params, expression.argument),
+        .function => |function| try scanNestedFunction(allocator, diagnostics, tree, params, function),
+        .arrow_function_expression => |expression| try scanNestedArrowFunction(allocator, diagnostics, tree, params, expression),
+        .class,
+        => return,
+        inline else => |node| try scanChildren(allocator, diagnostics, tree, params, @TypeOf(node), node),
+    }
+}
+
+fn scanNestedFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    function: ast.Function,
+) Allocator.Error!void {
+    if (function.body == .null) return;
+
+    var filtered = try filterShadowedParams(allocator, tree, params, function.params, function.body);
+    defer filtered.deinit(allocator);
+
+    if (filtered.size == 0) return;
+    try scanNode(allocator, diagnostics, tree, &filtered, function.body);
+}
+
+fn scanNestedArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    expression: ast.ArrowFunctionExpression,
+) Allocator.Error!void {
+    var filtered = try filterShadowedParams(allocator, tree, params, expression.params, expression.body);
+    defer filtered.deinit(allocator);
+
+    if (filtered.size == 0) return;
+    try scanNode(allocator, diagnostics, tree, &filtered, expression.body);
+}
+
+fn filterShadowedParams(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    params_index: ast.NodeIndex,
+    body_index: ast.NodeIndex,
+) Allocator.Error!ParamSet {
+    var shadows: ParamSet = .empty;
+    defer shadows.deinit(allocator);
+
+    try collectFormalParameters(allocator, tree, params_index, &shadows);
+    try collectLocalDeclarations(allocator, tree, body_index, &shadows);
+
+    var filtered: ParamSet = .empty;
+    errdefer filtered.deinit(allocator);
+
+    var iterator = params.iterator();
+    while (iterator.next()) |entry| {
+        const name = entry.key_ptr.*;
+        if (!shadows.contains(name)) try filtered.put(allocator, name, {});
+    }
+
+    return filtered;
+}
+
+fn collectLocalDeclarations(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    out: *ParamSet,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                try collectBinding(allocator, tree, declarator.id, out);
+            }
+        },
+        .function => |function| {
+            try collectBinding(allocator, tree, function.id, out);
+            return;
+        },
+        .class => |class| {
+            try collectBinding(allocator, tree, class.id, out);
+            return;
+        },
+        .arrow_function_expression => return,
+        inline else => |node| try collectLocalDeclarationChildren(allocator, tree, @TypeOf(node), node, out),
+    }
+}
+
+fn collectLocalDeclarationChildren(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    comptime T: type,
+    node: T,
+    out: *ParamSet,
+) Allocator.Error!void {
+    if (@typeInfo(T) != .@"struct") return;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            try collectLocalDeclarations(allocator, tree, @field(node, field.name), out);
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                try collectLocalDeclarations(allocator, tree, child, out);
+            }
+        }
+    }
+}
+
+fn scanChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    comptime T: type,
+    node: T,
+) Allocator.Error!void {
+    if (@typeInfo(T) != .@"struct") return;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            try scanNode(allocator, diagnostics, tree, params, @field(node, field.name));
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                try scanNode(allocator, diagnostics, tree, params, child);
+            }
+        }
+    }
+}
+
+fn checkTarget(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params: *const ParamSet,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| {
+            const name = tree.string(identifier.name);
+            if (!params.contains(name)) return;
+
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(index),
+                "Assignment to function parameter '{s}'.",
+                .{name},
+            );
+        },
+        .assignment_pattern => |pattern| try checkTarget(allocator, diagnostics, tree, params, pattern.left),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkTarget(allocator, diagnostics, tree, params, element);
+            }
+            try checkTarget(allocator, diagnostics, tree, params, pattern.rest);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkTarget(allocator, diagnostics, tree, params, property.value);
+            }
+            try checkTarget(allocator, diagnostics, tree, params, pattern.rest);
+        },
+        .binding_rest_element => |element| try checkTarget(allocator, diagnostics, tree, params, element.argument),
+        else => {},
+    }
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -97,6 +97,7 @@ pub const no_new_wrappers = @import("no_new_wrappers.zig");
 pub const no_octal = @import("no_octal.zig");
 pub const no_octal_escape = @import("no_octal_escape.zig");
 pub const no_object_constructor = @import("no_object_constructor.zig");
+pub const no_param_reassign = @import("no_param_reassign.zig");
 pub const no_path_concat = @import("no_path_concat.zig");
 pub const no_plusplus = @import("no_plusplus.zig");
 pub const no_promise_executor_return = @import("no_promise_executor_return.zig");
@@ -370,6 +371,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.no_param_reassign) {
+            try no_param_reassign.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
         }
         if (self.options.no_inner_declarations) {
             try no_inner_declarations.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
@@ -867,6 +871,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);
+        }
+        if (self.options.no_param_reassign) {
+            try no_param_reassign.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -363,6 +363,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_param_reassign.zig");
+}
+
+comptime {
     _ = @import("rules/no_path_concat.zig");
 }
 

--- a/tests/rules/no_param_reassign.zig
+++ b/tests/rules/no_param_reassign.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-param-reassign for assigning to function parameters" {
+    const source =
+        \\function run(value, count = 0, ...rest) {
+        \\  value = next;
+        \\  count += 1;
+        \\  rest++;
+        \\}
+        \\const arrow = (item) => item = next;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_plusplus = false,
+        .operator_assignment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
+test "reports no-param-reassign for destructured parameter bindings" {
+    const source =
+        \\function run({ value }, [count]) {
+        \\  value = next;
+        \\  count++;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_plusplus = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
+test "reports no-param-reassign for outer parameter writes inside nested functions" {
+    const source =
+        \\function run(value) {
+        \\  function nested() {
+        \\    value = next;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_inner_declarations = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
+test "does not report no-param-reassign for property writes or shadowed local assignments" {
+    const source =
+        \\function run(value) {
+        \\  value.name = next;
+        \\  other = value;
+        \\  function nested() {
+        \\    let value;
+        \\    value = next;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_param_reassign.id));
+}
+
+test "can disable no-param-reassign" {
+    const source =
+        \\function run(value) {
+        \\  value = next;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_param_reassign = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_param_reassign.id));
+}


### PR DESCRIPTION
## Summary
- add no-param-reassign checks for assignments and update expressions targeting function parameters
- support default/rest/destructured parameters and arrow functions
- preserve default ESLint behavior by ignoring parameter property writes while still detecting closure writes to outer parameters

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting no-param-reassign
- CLI fixture for --no-param-reassign=off