### PR TITLE
feat: port rule new-cap

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,7 @@ pub const Options = struct {
     getter_return: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
+    new_cap: bool = true,
     new_parens: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,6 +40,8 @@ pub fn main(init: std.process.Init) !void {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
             options.linebreak_style = false;
+        } else if (std.mem.eql(u8, arg, "--new-cap=off")) {
+            options.new_cap = false;
         } else if (std.mem.eql(u8, arg, "--new-parens=off")) {
             options.new_parens = false;
         } else if (std.mem.eql(u8, arg, "--no-async-promise-executor=off")) {
@@ -466,6 +468,7 @@ fn printHelp() void {
         \\  --getter-return=off       Disable getter-return
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
+        \\  --new-cap=off             Disable new-cap
         \\  --new-parens=off          Disable new-parens
         \\  --no-async-promise-executor=off Disable no-async-promise-executor
         \\  --no-array-constructor=off Disable no-array-constructor

--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "new-cap";
+
+pub fn checkNewExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NewExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = constructorName(tree, expression.callee) orelse return;
+    if (startsWithUppercase(name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "A constructor name should not start with a lowercase letter.",
+        tree.span(index),
+    );
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const callee = unwrapTransparent(tree, expression.callee);
+    const name = constructorName(tree, callee) orelse return;
+    if (!startsWithUppercase(name)) return;
+    if (isAllowedCallableBuiltin(tree, callee, name)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "A function with a name starting with an uppercase letter should only be used as a constructor.",
+        tree.span(index),
+    );
+}
+
+fn constructorName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .member_expression => |member| propertyName(tree, member),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isAllowedCallableBuiltin(tree: *const ast.Tree, callee: ast.NodeIndex, name: []const u8) bool {
+    if (tree.data(callee) != .identifier_reference) return false;
+
+    const builtins = [_][]const u8{
+        "Array",
+        "BigInt",
+        "Boolean",
+        "Date",
+        "Error",
+        "Number",
+        "Object",
+        "RegExp",
+        "String",
+        "Symbol",
+    };
+
+    for (builtins) |builtin| {
+        if (std.mem.eql(u8, name, builtin)) return true;
+    }
+
+    return false;
+}
+
+fn startsWithUppercase(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -15,6 +15,7 @@ pub const for_direction = @import("for_direction.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
+pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
 pub const no_alert = @import("no_alert.zig");
@@ -1016,6 +1017,9 @@ const BasicVisitor = struct {
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
+        if (self.options.new_cap) {
+            try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
         if (self.options.no_extra_bind) {
             try no_extra_bind.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -1038,6 +1042,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_new_require) {
             try no_new_require.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.new_cap) {
+            try new_cap.checkNewExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.new_parens) {
             try new_parens.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -35,6 +35,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/new_cap.zig");
+}
+
+comptime {
     _ = @import("rules/new_parens.zig");
 }
 

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports new-cap for lowercase constructors and uppercase function calls" {
+    const source =
+        \\new foo();
+        \\new namespace.foo();
+        \\Foo();
+        \\namespace.Foo();
+        \\namespace["Foo"]();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.new_cap.id));
+}
+
+test "does not report new-cap for conventional constructor usage or callable builtins" {
+    const source =
+        \\new Foo();
+        \\foo();
+        \\new namespace.Foo();
+        \\Array();
+        \\Boolean();
+        \\Date();
+        \\Error();
+        \\Number();
+        \\Object();
+        \\RegExp();
+        \\String();
+        \\Symbol();
+        \\BigInt();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.new_cap.id));
+}
+
+test "can disable new-cap" {
+    const source =
+        \\new foo();
+        \\Foo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .new_cap = false,
+        .no_new = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.new_cap.id));
+}


### PR DESCRIPTION
## Summary
- add new-cap checks for lowercase constructor usage and uppercase function calls
- support identifier and member callee names, including computed string properties
- preserve callable builtin exceptions such as Array, Boolean, Date, Error, Object, Number, RegExp, String, Symbol, and BigInt

## Tests
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- CLI fixture for reporting new-cap
- CLI fixture for --new-cap=off