### PR TITLE
feat: port rule array-callback-return

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    array_callback_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,
     dot_notation: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,6 +55,8 @@ pub fn main(init: std.process.Init) !void {
             thread_count_override = parsed;
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
             options.constructor_super = false;
+        } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
+            options.array_callback_return = false;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
         } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
@@ -598,6 +600,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --threads=N              Number of worker threads to use
+        \\  --array-callback-return=off Disable array-callback-return
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly
         \\  --dot-notation=off       Disable dot-notation

--- a/src/rules/array_callback_return.zig
+++ b/src/rules/array_callback_return.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "array-callback-return";
+
+const Completion = enum {
+    continues,
+    valid_terminal,
+    invalid_return,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    _: ast.NodeIndex,
+) Allocator.Error!void {
+    const callback = callbackArgument(tree, call) orelse return;
+    if (callbackReturnsValue(tree, callback)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected to return a value in array callback.",
+        tree.span(callback),
+    );
+}
+
+fn callbackArgument(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return null;
+
+    const callee = unwrapTransparent(tree, call.callee);
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const method = propertyName(tree, member) orelse return null;
+    if (std.mem.eql(u8, method, "forEach")) return null;
+
+    if (isArrayFromCall(tree, member, method)) {
+        if (arguments.len < 2) return null;
+        return callbackIfFunction(tree, arguments[1]);
+    }
+
+    if (!isArrayCallbackMethod(method)) return null;
+    return callbackIfFunction(tree, arguments[0]);
+}
+
+fn callbackIfFunction(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function,
+        .arrow_function_expression,
+        => unwrapTransparent(tree, index),
+        else => null,
+    };
+}
+
+fn isArrayFromCall(tree: *const ast.Tree, member: ast.MemberExpression, method: []const u8) bool {
+    return std.mem.eql(u8, method, "from") and isIdentifierReferenceNamed(tree, member.object, "Array");
+}
+
+fn isArrayCallbackMethod(method: []const u8) bool {
+    const methods = [_][]const u8{
+        "every",
+        "filter",
+        "find",
+        "findIndex",
+        "findLast",
+        "findLastIndex",
+        "flatMap",
+        "map",
+        "reduce",
+        "reduceRight",
+        "some",
+        "sort",
+        "toSorted",
+    };
+
+    for (methods) |candidate| {
+        if (std.mem.eql(u8, method, candidate)) return true;
+    }
+
+    return false;
+}
+
+fn callbackReturnsValue(tree: *const ast.Tree, callback: ast.NodeIndex) bool {
+    return switch (tree.data(callback)) {
+        .function => |function| functionReturnsValue(tree, function.body),
+        .arrow_function_expression => |arrow| if (arrow.expression)
+            !isVoidExpression(tree, arrow.body)
+        else
+            functionReturnsValue(tree, arrow.body),
+        else => true,
+    };
+}
+
+fn functionReturnsValue(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    if (body_index == .null) return true;
+
+    const body = switch (tree.data(body_index)) {
+        .function_body => |body| body,
+        else => return true,
+    };
+
+    return rangeCompletion(tree, body.body) == .valid_terminal;
+}
+
+fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
+    for (tree.extra(range)) |statement| {
+        switch (statementCompletion(tree, statement)) {
+            .continues => {},
+            .valid_terminal => return .valid_terminal,
+            .invalid_return => return .invalid_return,
+        }
+    }
+
+    return .continues;
+}
+
+fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex) Completion {
+    if (index == .null) return .continues;
+
+    return switch (tree.data(index)) {
+        .return_statement => |statement| returnCompletion(tree, statement),
+        .throw_statement => .valid_terminal,
+        .block_statement => |block| rangeCompletion(tree, block.body),
+        .if_statement => |statement| ifCompletion(tree, statement),
+        .try_statement => |statement| tryCompletion(tree, statement),
+        else => .continues,
+    };
+}
+
+fn returnCompletion(tree: *const ast.Tree, statement: ast.ReturnStatement) Completion {
+    if (statement.argument == .null) return .valid_terminal;
+    if (isVoidExpression(tree, statement.argument)) return .invalid_return;
+    return .valid_terminal;
+}
+
+fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement) Completion {
+    const consequent = statementCompletion(tree, statement.consequent);
+    if (consequent == .invalid_return) return .invalid_return;
+
+    if (statement.alternate == .null) return .continues;
+    const alternate = statementCompletion(tree, statement.alternate);
+    if (alternate == .invalid_return) return .invalid_return;
+
+    if (consequent == .valid_terminal and alternate == .valid_terminal) return .valid_terminal;
+    return .continues;
+}
+
+fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion {
+    if (statement.finalizer != .null) {
+        const finalizer = statementCompletion(tree, statement.finalizer);
+        if (finalizer != .continues) return finalizer;
+    }
+
+    const block = statementCompletion(tree, statement.block);
+    if (block == .invalid_return) return .invalid_return;
+    if (statement.handler == .null) return block;
+
+    const handler_node = switch (tree.data(statement.handler)) {
+        .catch_clause => |handler| handler.body,
+        else => return .continues,
+    };
+    const handler = statementCompletion(tree, handler_node);
+    if (handler == .invalid_return) return .invalid_return;
+
+    if (block == .valid_terminal and handler == .valid_terminal) return .valid_terminal;
+    return .continues;
+}
+
+fn isVoidExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |expression| expression.operator == .void,
+        else => false,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -7,6 +7,7 @@ const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const curly = @import("curly.zig");
+pub const array_callback_return = @import("array_callback_return.zig");
 pub const constructor_super = @import("constructor_super.zig");
 pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
@@ -1009,6 +1010,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.array_callback_return) {
+            try array_callback_return.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
         if (self.options.no_console) {
             try no_console.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1,4 +1,8 @@
 comptime {
+    _ = @import("rules/array_callback_return.zig");
+}
+
+comptime {
     _ = @import("rules/constructor_super.zig");
 }
 

--- a/tests/rules/array_callback_return.zig
+++ b/tests/rules/array_callback_return.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports array-callback-return when callbacks can fall through" {
+    const source =
+        \\items.map((item) => {
+        \\  if (item) {
+        \\    return item * 2;
+        \\  }
+        \\});
+        \\items.filter(function(item) {
+        \\  return void item;
+        \\});
+        \\Array.from(items, function(item) {
+        \\  item.toString();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .no_void = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.array_callback_return.id));
+}
+
+test "does not report array-callback-return for callbacks that return on all paths" {
+    const source =
+        \\items.map((item) => item * 2);
+        \\items.filter(function(item) {
+        \\  if (item) {
+        \\    return item;
+        \\  }
+        \\  return;
+        \\});
+        \\items.some((item) => {
+        \\  if (item) {
+        \\    return true;
+        \\  }
+        \\  throw error;
+        \\});
+        \\Array.from(items, (item) => item.id);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
+}
+
+test "ignores forEach callbacks and non-function callback references" {
+    const source =
+        \\items.forEach((item) => {
+        \\  item.toString();
+        \\});
+        \\items.map(callback);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
+}
+
+test "can disable array-callback-return" {
+    const source =
+        \\items.map((item) => {
+        \\  item.toString();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .array_callback_return = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
+}


### PR DESCRIPTION
## Summary
- add array-callback-return rule coverage
- wire rule option and CLI disable flag
- add tests for fallthrough callbacks, implicit returns, void returns, Array.from, forEach ignore, and disable flag

## Verification
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture with --threads=1 array-callback-return enabled/disabled