### PR TITLE
perf: cache assignment reference lookups

### DIFF
--- a/src/rules/no_class_assign.zig
+++ b/src/rules/no_class_assign.zig
@@ -8,16 +8,22 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-class-assign";
 
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .reference_lookup = &reference_lookup,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +33,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    reference_lookup: *const ReferenceLookup,
 
     pub fn enter_assignment_expression(
         self: *Visitor,
@@ -57,7 +64,7 @@ const Visitor = struct {
         const identifier = unwrapTransparent(tree, target);
         if (!isIdentifierReference(tree, identifier)) return;
 
-        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        const symbol_id = self.reference_lookup.get(identifier) orelse return;
         if (symbol_id == .none) return;
 
         const symbol = self.symbol_table.getSymbol(symbol_id);
@@ -73,6 +80,21 @@ const Visitor = struct {
         );
     }
 };
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
     var current = index;
@@ -95,18 +117,4 @@ fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .identifier_reference => true,
         else => false,
     };
-}
-
-fn symbolForReferenceNode(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) traverser.semantic.SymbolId {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id);
-        }
-    }
-
-    return .none;
 }

--- a/src/rules/no_ex_assign.zig
+++ b/src/rules/no_ex_assign.zig
@@ -8,16 +8,22 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-ex-assign";
 
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .reference_lookup = &reference_lookup,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +33,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    reference_lookup: *const ReferenceLookup,
 
     pub fn enter_assignment_expression(
         self: *Visitor,
@@ -57,7 +64,7 @@ const Visitor = struct {
         const identifier = unwrapTransparent(tree, target);
         if (!isIdentifierReference(tree, identifier)) return;
 
-        const symbol_id = symbolForReferenceNode(self.symbol_table, identifier);
+        const symbol_id = self.reference_lookup.get(identifier) orelse return;
         if (symbol_id == .none) return;
 
         const symbol = self.symbol_table.getSymbol(symbol_id);
@@ -73,6 +80,21 @@ const Visitor = struct {
         );
     }
 };
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
     var current = index;
@@ -95,18 +117,4 @@ fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .identifier_reference => true,
         else => false,
     };
-}
-
-fn symbolForReferenceNode(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) traverser.semantic.SymbolId {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id);
-        }
-    }
-
-    return .none;
 }


### PR DESCRIPTION
## Summary

- cache semantic reference node -> symbol lookups in `no-ex-assign`
- apply the same cache to `no-class-assign`
- avoid scanning all references for each assignment/update expression

## Root cause

Both rules traversed the AST and, for each assignment/update target, scanned `symbol_table.iterReferences()` from the start to find the target node. Large files with many references and many assignments became O(assignments * references).

## Results

On a single generated 4.4 MB TypeScript file with default rules:

- before this PR: exceeded 10 seconds and was killed by the repro timeout
- after this PR: about 8.42 seconds

The remaining time is in other semantic rules and will be handled separately.

On the 1000-file benchmark corpus:

- `utoo-lint`: about 49.6 ms median
- `oxlint`: about 64.0 ms median
- `biome`: about 191.1 ms median

## Validation

- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=ReleaseFast -j1`
- default large-file repro: `../zig-out/bin/utoo-lint fixtures/one` in `benchmarks/`
- `npm run generate -- --files=1000 --statements=30` in `benchmarks/`
- `npm run bench -- --runs=5 --warmups=2 --skip-eslint` in `benchmarks/`