### PR TITLE
feat: port rule no-this-before-super

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -132,6 +132,7 @@ pub const Options = struct {
     no_ternary: bool = true,
     no_template_curly_in_string: bool = true,
     no_throw_literal: bool = true,
+    no_this_before_super: bool = true,
     no_tabs: bool = true,
     no_trailing_spaces: bool = true,
     no_unreachable: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -283,6 +283,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_template_curly_in_string = false;
         } else if (std.mem.eql(u8, arg, "--no-throw-literal=off")) {
             options.no_throw_literal = false;
+        } else if (std.mem.eql(u8, arg, "--no-this-before-super=off")) {
+            options.no_this_before_super = false;
         } else if (std.mem.eql(u8, arg, "--no-tabs=off")) {
             options.no_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-trailing-spaces=off")) {
@@ -713,6 +715,7 @@ fn printHelp() void {
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-template-curly-in-string=off Disable no-template-curly-in-string
         \\  --no-throw-literal=off    Disable no-throw-literal
+        \\  --no-this-before-super=off Disable no-this-before-super
         \\  --no-tabs=off             Disable no-tabs
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-unreachable=off      Disable no-unreachable

--- a/src/rules/no_this_before_super.zig
+++ b/src/rules/no_this_before_super.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-this-before-super";
+
+const Constructor = struct {
+    method: ast.MethodDefinition,
+    index: ast.NodeIndex,
+};
+
+const Flow = struct {
+    has_super: bool,
+    continues: bool = true,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    if (class.super_class == .null) return;
+
+    const constructor = constructorMethod(tree, class) orelse return;
+    const function = switch (tree.data(constructor.method.value)) {
+        .function => |function| function,
+        else => return,
+    };
+    if (function.body == .null) return;
+
+    const body = switch (tree.data(function.body)) {
+        .function_body => |body| body,
+        else => return,
+    };
+
+    _ = try scanStatementRange(allocator, diagnostics, tree, body.body, .{ .has_super = false });
+}
+
+fn constructorMethod(tree: *const ast.Tree, class: ast.Class) ?Constructor {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return null,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (method.kind == .constructor and !method.static) {
+            return .{ .method = method, .index = member_index };
+        }
+    }
+
+    return null;
+}
+
+fn scanStatementRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    incoming: Flow,
+) Allocator.Error!Flow {
+    var flow = incoming;
+
+    for (tree.extra(range)) |statement| {
+        if (!flow.continues) break;
+        flow = try scanNode(allocator, diagnostics, tree, statement, flow);
+    }
+
+    return flow;
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    incoming: Flow,
+) Allocator.Error!Flow {
+    if (index == .null or !incoming.continues) return incoming;
+
+    switch (tree.data(index)) {
+        .this_expression => {
+            if (!incoming.has_super) {
+                try addDiagnostic(allocator, diagnostics, tree, index);
+            }
+            return incoming;
+        },
+        .super => {
+            if (!incoming.has_super) {
+                try addDiagnostic(allocator, diagnostics, tree, index);
+            }
+            return incoming;
+        },
+        .call_expression => |call| {
+            if (tree.data(unwrapTransparent(tree, call.callee)) == .super) {
+                var flow = try scanExpressionRange(allocator, diagnostics, tree, call.arguments, incoming);
+                flow.has_super = true;
+                return flow;
+            }
+            return scanChildren(allocator, diagnostics, tree, @TypeOf(call), call, incoming);
+        },
+        .block_statement => |block| return scanStatementRange(allocator, diagnostics, tree, block.body, incoming),
+        .if_statement => |statement| return scanIfStatement(allocator, diagnostics, tree, statement, incoming),
+        .return_statement => |statement| {
+            var flow = try scanChildren(allocator, diagnostics, tree, @TypeOf(statement), statement, incoming);
+            flow.continues = false;
+            return flow;
+        },
+        .throw_statement => |statement| {
+            var flow = try scanChildren(allocator, diagnostics, tree, @TypeOf(statement), statement, incoming);
+            flow.continues = false;
+            return flow;
+        },
+        .function,
+        .arrow_function_expression,
+        .class,
+        => return incoming,
+        inline else => |node| return scanChildren(allocator, diagnostics, tree, @TypeOf(node), node, incoming),
+    }
+}
+
+fn scanIfStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    incoming: Flow,
+) Allocator.Error!Flow {
+    const consequent = try scanNode(allocator, diagnostics, tree, statement.consequent, incoming);
+    const alternate = if (statement.alternate != .null)
+        try scanNode(allocator, diagnostics, tree, statement.alternate, incoming)
+    else
+        incoming;
+
+    return mergeBranches(consequent, alternate);
+}
+
+fn mergeBranches(left: Flow, right: Flow) Flow {
+    if (left.continues and right.continues) {
+        return .{ .has_super = left.has_super and right.has_super };
+    }
+    if (left.continues) return left;
+    if (right.continues) return right;
+    return .{ .has_super = left.has_super and right.has_super, .continues = false };
+}
+
+fn scanExpressionRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    incoming: Flow,
+) Allocator.Error!Flow {
+    var flow = incoming;
+
+    for (tree.extra(range)) |expression| {
+        flow = try scanNode(allocator, diagnostics, tree, expression, flow);
+    }
+
+    return flow;
+}
+
+fn scanChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    comptime T: type,
+    node: T,
+    incoming: Flow,
+) Allocator.Error!Flow {
+    if (@typeInfo(T) != .@"struct") return incoming;
+
+    var flow = incoming;
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            flow = try scanNode(allocator, diagnostics, tree, @field(node, field.name), flow);
+        } else if (field.type == ast.IndexRange) {
+            flow = try scanExpressionRange(allocator, diagnostics, tree, @field(node, field.name), flow);
+        }
+    }
+
+    return flow;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected use of 'this' or 'super' before 'super()'.",
+        tree.span(index),
+    );
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -123,6 +123,7 @@ pub const no_tabs = @import("no_tabs.zig");
 pub const no_ternary = @import("no_ternary.zig");
 pub const no_template_curly_in_string = @import("no_template_curly_in_string.zig");
 pub const no_throw_literal = @import("no_throw_literal.zig");
+pub const no_this_before_super = @import("no_this_before_super.zig");
 pub const no_trailing_spaces = @import("no_trailing_spaces.zig");
 pub const no_unreachable = @import("no_unreachable.zig");
 pub const no_undef_init = @import("no_undef_init.zig");
@@ -401,6 +402,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.constructor_super) {
             try constructor_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
+        if (self.options.no_this_before_super) {
+            try no_this_before_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -463,6 +463,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_this_before_super.zig");
+}
+
+comptime {
     _ = @import("rules/no_trailing_spaces.zig");
 }
 

--- a/tests/rules/no_this_before_super.zig
+++ b/tests/rules/no_this_before_super.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-this-before-super before derived constructor super calls" {
+    const source =
+        \\class UsesThis extends Base {
+        \\  constructor() {
+        \\    this.value = 1;
+        \\    super();
+        \\  }
+        \\}
+        \\class UsesSuperProperty extends Base {
+        \\  constructor() {
+        \\    super.method();
+        \\    super();
+        \\  }
+        \\}
+        \\class Conditional extends Base {
+        \\  constructor(flag) {
+        \\    if (flag) {
+        \\      super();
+        \\    }
+        \\    this.value = 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .constructor_super = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_this_before_super.id));
+}
+
+test "does not report no-this-before-super after guaranteed super calls" {
+    const source =
+        \\class Direct extends Base {
+        \\  constructor() {
+        \\    super();
+        \\    this.value = 1;
+        \\  }
+        \\}
+        \\class Branches extends Base {
+        \\  constructor(flag) {
+        \\    if (flag) {
+        \\      super();
+        \\    } else {
+        \\      super();
+        \\    }
+        \\    this.value = 1;
+        \\  }
+        \\}
+        \\class ReturnBranch extends Base {
+        \\  constructor(flag) {
+        \\    if (flag) {
+        \\      return {};
+        \\    }
+        \\    super();
+        \\    this.value = 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .constructor_super = false,
+        .no_constructor_return = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_this_before_super.id));
+}
+
+test "ignores nested functions and base classes" {
+    const source =
+        \\class Derived extends Base {
+        \\  constructor() {
+        \\    const read = () => this.value;
+        \\    function nested() {
+        \\      return this.value;
+        \\    }
+        \\    super();
+        \\  }
+        \\}
+        \\class BaseOnly {
+        \\  constructor() {
+        \\    this.value = 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_this_before_super.id));
+}
+
+test "can disable no-this-before-super" {
+    const source =
+        \\class Derived extends Base {
+        \\  constructor() {
+        \\    this.value = 1;
+        \\    super();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_this_before_super = false,
+        .constructor_super = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_this_before_super.id));
+}


### PR DESCRIPTION
## Summary
- add no-this-before-super rule coverage for derived constructors
- track constructor flow through super calls, branches, return/throw, and nested scopes
- wire rule option and CLI disable flag

## Verification
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture with --threads=1 no-this-before-super enabled/disabled