### PR TITLE
feat: port rule one-var

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -155,6 +155,7 @@ pub const Options = struct {
     no_with: bool = true,
     no_var: bool = true,
     object_shorthand: bool = true,
+    one_var: bool = true,
     operator_assignment: bool = true,
     eqeqeq: bool = true,
     use_isnan: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -327,6 +327,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
+        } else if (std.mem.eql(u8, arg, "--one-var=off")) {
+            options.one_var = false;
         } else if (std.mem.eql(u8, arg, "--object-shorthand=off")) {
             options.object_shorthand = false;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
@@ -737,6 +739,7 @@ fn printHelp() void {
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
+        \\  --one-var=off             Disable one-var
         \\  --object-shorthand=off    Disable object-shorthand
         \\  --operator-assignment=off Disable operator-assignment
         \\  --eqeqeq=off              Disable eqeqeq

--- a/src/rules/one_var.zig
+++ b/src/rules/one_var.zig
@@ -1,0 +1,37 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "one-var";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (declaration.declarators.len < 2) return;
+    if (isForStatementInit(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Split variable declarations into multiple statements.",
+        tree.span(index),
+    );
+}
+
+fn isForStatementInit(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    const parent_index = ctx.path.ancestor(1) orelse return false;
+    return switch (tree.data(parent_index)) {
+        .for_statement => |statement| statement.init == index,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -146,6 +146,7 @@ pub const no_var = @import("no_var.zig");
 pub const no_void = @import("no_void.zig");
 pub const no_with = @import("no_with.zig");
 pub const object_shorthand = @import("object_shorthand.zig");
+pub const one_var = @import("one_var.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
@@ -806,6 +807,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
+        }
+        if (self.options.one_var) {
+            try one_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -559,6 +559,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/one_var.zig");
+}
+
+comptime {
     _ = @import("rules/operator_assignment.zig");
 }
 

--- a/tests/rules/one_var.zig
+++ b/tests/rules/one_var.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports one-var for combined variable declarations" {
+    const source =
+        \\let first = 1, second = 2;
+        \\const third = 3, fourth = 4;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.one_var.id));
+}
+
+test "does not report one-var for separate declarations or for loop init" {
+    const source =
+        \\let first = 1;
+        \\let second = 2;
+        \\for (let i = 0, j = 10; i < j; i++) {
+        \\  second += i;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.one_var.id));
+}
+
+test "can disable one-var" {
+    const source =
+        \\let first = 1, second = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .one_var = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.one_var.id));
+}


### PR DESCRIPTION
## Summary
- add one-var rule coverage for fishlint's never mode
- ignore multi-declarator for-loop initializers to match ESLint behavior
- wire rule option and CLI disable flag

## Verification
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture with --threads=1 one-var enabled/disabled