### PR TITLE
perf: preallocate reference lookup maps

### DIFF
--- a/src/rules/no_class_assign.zig
+++ b/src/rules/no_class_assign.zig
@@ -87,6 +87,7 @@ fn buildReferenceLookup(
 ) Allocator.Error!ReferenceLookup {
     var lookup = ReferenceLookup.init(allocator);
     errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
 
     var iter = symbol_table.iterReferences();
     while (iter.next()) |entry| {

--- a/src/rules/no_const_assign.zig
+++ b/src/rules/no_const_assign.zig
@@ -87,6 +87,7 @@ fn buildReferenceLookup(
 ) Allocator.Error!ReferenceLookup {
     var lookup = ReferenceLookup.init(allocator);
     errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
 
     var iter = symbol_table.iterReferences();
     while (iter.next()) |entry| {

--- a/src/rules/no_ex_assign.zig
+++ b/src/rules/no_ex_assign.zig
@@ -87,6 +87,7 @@ fn buildReferenceLookup(
 ) Allocator.Error!ReferenceLookup {
     var lookup = ReferenceLookup.init(allocator);
     errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
 
     var iter = symbol_table.iterReferences();
     while (iter.next()) |entry| {

--- a/src/rules/no_func_assign.zig
+++ b/src/rules/no_func_assign.zig
@@ -87,6 +87,7 @@ fn buildReferenceLookup(
 ) Allocator.Error!ReferenceLookup {
     var lookup = ReferenceLookup.init(allocator);
     errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
 
     var iter = symbol_table.iterReferences();
     while (iter.next()) |entry| {

--- a/src/rules/no_import_assign.zig
+++ b/src/rules/no_import_assign.zig
@@ -141,6 +141,7 @@ fn buildReferenceLookup(
 ) Allocator.Error!ReferenceLookup {
     var lookup = ReferenceLookup.init(allocator);
     errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
 
     var iter = symbol_table.iterReferences();
     while (iter.next()) |entry| {


### PR DESCRIPTION
## Summary
- reserve reference lookup map capacity before filling it
- apply the same allocation optimization to all rules that build `NodeIndex -> SymbolId` lookup maps

## Root cause
The cached reference lookup maps grew incrementally while loading every semantic reference. Large files pay several hash map growth/re-hash costs before the map reaches its final size.

## Validation
- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=ReleaseFast -j1`
- A/B on the same 32MB generated fixture: baseline steady-state `1.31-1.32s`, preallocated `1.19-1.22s`; first run `1.90s -> 1.53s`
- `npm run bench -- --runs=7 --warmups=2 --skip-eslint`: `utoo-lint` median `45.4 ms`, `oxlint` `55.5 ms`, `biome` `204.1 ms`
