### PR TITLE
feat: port rule prefer-destructuring

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -163,6 +163,7 @@ pub const Options = struct {
     no_undef: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_promise_reject_errors: bool = true,
+    prefer_destructuring: bool = true,
     prefer_regex_literals: bool = true,
     prefer_rest_params: bool = true,
     prefer_spread: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -345,6 +345,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--prefer-promise-reject-errors=off")) {
             options.prefer_promise_reject_errors = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-destructuring=off")) {
+            options.prefer_destructuring = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
         } else if (std.mem.eql(u8, arg, "--prefer-rest-params=off")) {
@@ -748,6 +750,7 @@ fn printHelp() void {
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
+        \\  --prefer-destructuring=off Disable prefer-destructuring
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-destructuring";
+
+pub fn checkVariableDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+) Allocator.Error!void {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+        if (!shouldPreferObjectDestructuring(tree, declarator)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Use object destructuring.",
+            tree.span(declarator.id),
+        );
+    }
+}
+
+fn shouldPreferObjectDestructuring(tree: *const ast.Tree, declarator: ast.VariableDeclarator) bool {
+    if (declarator.init == .null) return false;
+
+    const local_name = bindingIdentifierName(tree, declarator.id) orelse return false;
+
+    const member = switch (tree.data(unwrapTransparent(tree, declarator.init))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.optional) return false;
+
+    const property_name = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, local_name, property_name);
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -148,6 +148,7 @@ pub const no_with = @import("no_with.zig");
 pub const object_shorthand = @import("object_shorthand.zig");
 pub const one_var = @import("one_var.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
+pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
@@ -810,6 +811,9 @@ const BasicVisitor = struct {
         }
         if (self.options.one_var) {
             try one_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
+        }
+        if (self.options.prefer_destructuring) {
+            try prefer_destructuring.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -567,6 +567,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_destructuring.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_exponentiation_operator.zig");
 }
 

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-destructuring for object property variable declarators" {
+    const source =
+        \\const first = object.first;
+        \\let second = object["second"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+}
+
+test "does not report prefer-destructuring for renamed dynamic or assignment cases" {
+    const source =
+        \\const renamed = object.first;
+        \\const value = object[key];
+        \\const zero = array[0];
+        \\const maybe = object?.maybe;
+        \\target = object.target;
+        \\const { direct } = object;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_destructuring.id));
+}
+
+test "can disable prefer-destructuring" {
+    const source =
+        \\const first = object.first;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_destructuring = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_destructuring.id));
+}


### PR DESCRIPTION
## Summary
- add prefer-destructuring coverage for variable declarator object member reads
- match fishlint's current config by ignoring assignments, arrays, renamed properties, dynamic computed properties, and optional chains
- wire rule option and CLI disable flag

## Verification
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture with --threads=1 prefer-destructuring enabled/disabled