### PR TITLE
perf: combine reassignment rule traversal

### DIFF
--- a/src/rules/reassignment_rules.zig
+++ b/src/rules/reassignment_rules.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+const no_class_assign = @import("no_class_assign.zig");
+const no_const_assign = @import("no_const_assign.zig");
+const no_ex_assign = @import("no_ex_assign.zig");
+const no_func_assign = @import("no_func_assign.zig");
+const no_import_assign = @import("no_import_assign.zig");
+
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
+pub fn shouldRun(options: core.Options) bool {
+    return options.no_class_assign or
+        options.no_const_assign or
+        options.no_ex_assign or
+        options.no_func_assign or
+        options.no_import_assign;
+}
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: core.Options,
+) Allocator.Error!void {
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .reference_lookup = &reference_lookup,
+        .options = options,
+    };
+    defer visitor.namespace_import_names.deinit(allocator);
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    reference_lookup: *const ReferenceLookup,
+    options: core.Options,
+    namespace_import_names: std.StringHashMapUnmanaged(void) = .empty,
+
+    pub fn enter_import_namespace_specifier(
+        self: *Visitor,
+        specifier: ast.ImportNamespaceSpecifier,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.options.no_import_assign) return .proceed;
+
+        const name = bindingIdentifierName(ctx.tree, specifier.local) orelse return .proceed;
+        try self.namespace_import_names.put(self.allocator, name, {});
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.left, index);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkTarget(ctx.tree, expression.argument, index);
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.options.no_import_assign) return .proceed;
+
+        if (isObjectAssignCall(ctx.tree, self.reference_lookup, call.callee) and call.arguments.len > 0) {
+            const first = ctx.tree.extra(call.arguments)[0];
+            if (self.namespaceSymbolFromExpression(ctx.tree, first) != .none) {
+                try self.addDiagnostic(ctx.tree, index, no_import_assign.id, "Imported bindings are read-only.");
+            }
+        }
+        return .proceed;
+    }
+
+    fn checkTarget(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        target: ast.NodeIndex,
+        diagnostic_node: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const identifier = unwrapTransparent(tree, target);
+        const symbol_id = if (isIdentifierReference(tree, identifier))
+            self.reference_lookup.get(identifier) orelse .none
+        else
+            .none;
+
+        if (symbol_id != .none) {
+            const symbol = self.symbol_table.getSymbol(symbol_id);
+
+            if (self.options.no_ex_assign and symbol.flags.catch_var) {
+                try self.addDiagnostic(tree, diagnostic_node, no_ex_assign.id, "Do not reassign catch parameters.");
+            }
+            if (self.options.no_class_assign and symbol.flags.class) {
+                try self.addDiagnostic(tree, diagnostic_node, no_class_assign.id, "Class declarations should not be reassigned.");
+            }
+            if (self.options.no_const_assign and symbol.flags.const_var) {
+                try self.addDiagnostic(tree, diagnostic_node, no_const_assign.id, "Constant bindings should not be reassigned.");
+            }
+            if (self.options.no_func_assign and symbol.flags.function) {
+                try self.addDiagnostic(tree, diagnostic_node, no_func_assign.id, "Function declarations should not be reassigned.");
+            }
+            if (self.options.no_import_assign and symbol.flags.import) {
+                try self.addDiagnostic(tree, diagnostic_node, no_import_assign.id, "Imported bindings are read-only.");
+            }
+        }
+
+        if (self.options.no_import_assign and self.isForbiddenNamespaceMember(tree, target)) {
+            try self.addDiagnostic(tree, diagnostic_node, no_import_assign.id, "Imported bindings are read-only.");
+        }
+    }
+
+    fn isForbiddenNamespaceMember(self: *Visitor, tree: *const ast.Tree, target: ast.NodeIndex) bool {
+        const member = switch (tree.data(unwrapTransparent(tree, target))) {
+            .member_expression => |member| member,
+            else => return false,
+        };
+
+        return self.namespaceSymbolFromExpression(tree, member.object) != .none;
+    }
+
+    fn namespaceSymbolFromExpression(self: *Visitor, tree: *const ast.Tree, expression: ast.NodeIndex) traverser.semantic.SymbolId {
+        const identifier = unwrapTransparent(tree, expression);
+        if (!isIdentifierReference(tree, identifier)) return .none;
+
+        const symbol_id = self.reference_lookup.get(identifier) orelse return .none;
+        if (symbol_id == .none) return .none;
+
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.import) return .none;
+
+        const name = tree.string(symbol.name);
+        if (!self.namespace_import_names.contains(name)) return .none;
+
+        return symbol_id;
+    }
+
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        rule_id: []const u8,
+        message: []const u8,
+    ) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            rule_id,
+            message,
+            tree.span(index),
+        );
+    }
+};
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn isObjectAssignCall(
+    tree: *const ast.Tree,
+    reference_lookup: *const ReferenceLookup,
+    callee: ast.NodeIndex,
+) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property_name, "assign")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Object") and isUnresolvedReference(reference_lookup, object);
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    reference_lookup: *const ReferenceLookup,
+    node: ast.NodeIndex,
+) bool {
+    return (reference_lookup.get(node) orelse return false) == .none;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -155,6 +155,7 @@ pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const radix = @import("radix.zig");
+const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
@@ -242,10 +243,6 @@ pub fn runSemantic(
         try no_eval.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_ex_assign) {
-        try no_ex_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
-    }
-
     if (options.no_extend_native) {
         try no_extend_native.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
@@ -254,16 +251,8 @@ pub fn runSemantic(
         try no_alert.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_class_assign) {
-        try no_class_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
-    }
-
-    if (options.no_const_assign) {
-        try no_const_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
-    }
-
-    if (options.no_func_assign) {
-        try no_func_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    if (reassignment_rules.shouldRun(options)) {
+        try reassignment_rules.run(allocator, diagnostics, tree, semantic_result.symbol_table, options);
     }
 
     if (options.no_global_assign) {
@@ -284,10 +273,6 @@ pub fn runSemantic(
 
     if (options.no_label_var) {
         try no_label_var.run(allocator, diagnostics, tree, semantic_result);
-    }
-
-    if (options.no_import_assign) {
-        try no_import_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_func) {


### PR DESCRIPTION
## Summary
- run reassignment-style semantic rules through one shared traversal
- build the `NodeIndex -> SymbolId` lookup once for `no-ex-assign`, `no-class-assign`, `no-const-assign`, `no-func-assign`, and `no-import-assign`
- keep the existing individual rule modules and rule IDs unchanged

## Root cause
After caching reference lookup maps, the next hotspot was duplicated work across related reassignment rules: each rule still built the same lookup and walked the AST independently. Large files pay that repeated traversal and hash lookup cost several times.

## Validation
- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=ReleaseFast -j1`
- A/B on the same 48MB generated fixture: baseline steady-state `1.91-1.95s`, combined traversal `1.45-1.49s`; first run `2.19s -> 1.60s`
- Sequential 1000-file benchmark stayed at the noise floor: baseline `utoo-lint` median `35.5 ms`, combined `35.5 ms`
