### PR TITLE
feat: port rule no-invalid-regexp

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -82,6 +82,7 @@ pub const Options = struct {
     no_implicit_coercion: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
+    no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,
     no_inner_declarations: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -183,6 +183,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
             options.no_import_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
+            options.no_invalid_regexp = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
             options.no_irregular_whitespace = false;
         } else if (std.mem.eql(u8, arg, "--no-inline-comments=off")) {
@@ -670,6 +672,7 @@ fn printHelp() void {
         \\  --no-implicit-coercion=off Disable no-implicit-coercion
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
+        \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments
         \\  --no-inner-declarations=off Disable no-inner-declarations

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,7 +27,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix or options.symbol_description;
+    const needs_semantic = options.parser_semantic_errors or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_invalid_regexp or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_unused_vars or options.no_undef or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix or options.symbol_description;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);

--- a/src/rules/no_invalid_regexp.zig
+++ b/src/rules/no_invalid_regexp.zig
@@ -1,0 +1,196 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-invalid-regexp";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.check(ctx.tree, call.callee, call.arguments, index);
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.check(ctx.tree, expression.callee, expression.arguments, index);
+        return .proceed;
+    }
+
+    fn check(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+        argument_range: ast.IndexRange,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(argument_range);
+        if (arguments.len == 0) return;
+        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+
+        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
+        const flags = if (arguments.len >= 2) stringLiteralValue(tree, arguments[1]) orelse return else "";
+
+        const message = validateRegExp(pattern, flags) orelse return;
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Invalid regular expression: {s}.",
+            .{message},
+        );
+    }
+};
+
+fn validateRegExp(pattern: []const u8, flags: []const u8) ?[]const u8 {
+    if (validateFlags(flags)) |message| return message;
+    return validatePattern(pattern);
+}
+
+fn validateFlags(flags: []const u8) ?[]const u8 {
+    var seen: u32 = 0;
+
+    for (flags) |flag| {
+        const valid = switch (flag) {
+            'd', 'g', 'i', 'm', 's', 'u', 'v', 'y' => true,
+            else => false,
+        };
+        if (!valid) return "invalid flags";
+
+        const bit: u5 = @intCast(flag - 'a');
+        if ((seen & (@as(u32, 1) << bit)) != 0) return "duplicate flags";
+        seen |= @as(u32, 1) << bit;
+    }
+
+    const u_bit = @as(u32, 1) << ('u' - 'a');
+    const v_bit = @as(u32, 1) << ('v' - 'a');
+    if ((seen & u_bit) != 0 and (seen & v_bit) != 0) return "incompatible flags";
+
+    return null;
+}
+
+fn validatePattern(pattern: []const u8) ?[]const u8 {
+    var group_depth: usize = 0;
+    var in_class = false;
+    var escaped = false;
+
+    for (pattern) |char| {
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+
+        if (char == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (in_class) {
+            if (char == ']') in_class = false;
+            continue;
+        }
+
+        switch (char) {
+            '[' => in_class = true,
+            '(' => group_depth += 1,
+            ')' => {
+                if (group_depth == 0) return "unmatched ')'";
+                group_depth -= 1;
+            },
+            else => {},
+        }
+    }
+
+    if (escaped) return "trailing escape";
+    if (in_class) return "unterminated character class";
+    if (group_depth != 0) return "unterminated group";
+
+    return null;
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -74,6 +74,7 @@ pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_inline_comments = @import("no_inline_comments.zig");
 pub const no_inner_declarations = @import("no_inner_declarations.zig");
+pub const no_invalid_regexp = @import("no_invalid_regexp.zig");
 pub const no_irregular_whitespace = @import("no_irregular_whitespace.zig");
 pub const no_iterator = @import("no_iterator.zig");
 pub const no_label_var = @import("no_label_var.zig");
@@ -274,6 +275,10 @@ pub fn runSemantic(
 
     if (options.no_label_var) {
         try no_label_var.run(allocator, diagnostics, tree, semantic_result);
+    }
+
+    if (options.no_invalid_regexp) {
+        try no_invalid_regexp.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_func) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -271,6 +271,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_invalid_regexp.zig");
+}
+
+comptime {
     _ = @import("rules/no_irregular_whitespace.zig");
 }
 

--- a/tests/rules/no_invalid_regexp.zig
+++ b/tests/rules/no_invalid_regexp.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-invalid-regexp for invalid RegExp constructor arguments" {
+    const source =
+        \\RegExp("(", "g");
+        \\new RegExp("[abc", "i");
+        \\RegExp("abc", "zz");
+        \\RegExp("abc", "gg");
+        \\RegExp("abc", "uv");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_regex_literals = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
+}
+
+test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
+    const source =
+        \\RegExp("abc", "gi");
+        \\new RegExp("[abc]", "u");
+        \\RegExp(pattern, flags);
+        \\function local(RegExp) {
+        \\  RegExp("(", "z");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_regex_literals = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_regexp.id));
+}
+
+test "can disable no-invalid-regexp" {
+    const source =
+        \\RegExp("(", "g");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_invalid_regexp = false,
+        .prefer_regex_literals = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_regexp.id));
+}


### PR DESCRIPTION
## Summary
- add no-invalid-regexp coverage for static RegExp constructor calls
- validate static string patterns and flags, including invalid/duplicate flags, u/v incompatibility, and common unterminated patterns
- wire semantic pass, rule option, CLI disable flag, and tests

## Verification
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build -Doptimize=ReleaseFast -j1
- zig build test -Doptimize=ReleaseFast -j1
- git diff --check
- CLI fixture with --threads=1 no-invalid-regexp enabled/disabled