### PR TITLE
perf: index use-before-define initializers

### DIFF
--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -42,6 +42,7 @@ pub fn run(
         .init_ranges = &init_ranges,
     };
     try traverser.basic.traverse(InitVisitor, tree, &visitor);
+    std.mem.sort(InitRange, init_ranges.items, {}, lessThanInitRange);
 
     var reference_iter = symbol_table.iterReferences();
     while (reference_iter.next()) |entry| {
@@ -131,10 +132,34 @@ const InitVisitor = struct {
 };
 
 fn isInInitializer(symbol_id: SymbolId, reference_span: ast.Span, init_ranges: []const InitRange) bool {
-    for (init_ranges) |range| {
-        if (range.symbol_id == symbol_id and spanInside(reference_span, range.span)) return true;
+    const start = lowerBoundInitRange(init_ranges, symbol_id);
+
+    for (init_ranges[start..]) |range| {
+        if (range.symbol_id != symbol_id) break;
+        if (spanInside(reference_span, range.span)) return true;
     }
     return false;
+}
+
+fn lessThanInitRange(_: void, lhs: InitRange, rhs: InitRange) bool {
+    return @intFromEnum(lhs.symbol_id) < @intFromEnum(rhs.symbol_id);
+}
+
+fn lowerBoundInitRange(init_ranges: []const InitRange, symbol_id: SymbolId) usize {
+    const needle = @intFromEnum(symbol_id);
+    var low: usize = 0;
+    var high: usize = init_ranges.len;
+
+    while (low < high) {
+        const middle = low + (high - low) / 2;
+        if (@intFromEnum(init_ranges[middle].symbol_id) < needle) {
+            low = middle + 1;
+        } else {
+            high = middle;
+        }
+    }
+
+    return low;
 }
 
 fn spanInside(span: ast.Span, container: ast.Span) bool {

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -48,6 +48,22 @@ test "does not report no-use-before-define for references after declarations" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "reports no-use-before-define for repeated initializer self references" {
+    const source =
+        \\var a = a;
+        \\var a = a;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_redeclare = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "can disable no-use-before-define" {
     const source =
         \\a;


### PR DESCRIPTION
## Summary
- sort `no-use-before-define` initializer ranges by symbol before checking references
- binary-search the matching symbol range instead of scanning every initializer for every reference
- add a regression test for repeated initializer self references on the same symbol

## Validation
- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=ReleaseFast -j1`
- 15MB single-file fixture: baseline 18.36s / 21.96s, optimized steady-state 0.61s-0.63s
- 1000-file direct CLI loop stayed in the same 0.03s-0.05s range
