### PR TITLE
feat: port typescript-eslint prefer-as-const

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -170,3 +170,4 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_prefer_as_const: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
+            options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -789,6 +791,7 @@ fn printHelp() void {
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -171,6 +171,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
@@ -598,6 +599,42 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_unused_expressions) {
             try no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_as_expression(
+        self: *BasicVisitor,
+        expression: ast.TSAsExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_prefer_as_const) {
+            try typescript_eslint_prefer_as_const.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_type_assertion(
+        self: *BasicVisitor,
+        assertion: ast.TSTypeAssertion,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_prefer_as_const) {
+            try typescript_eslint_prefer_as_const.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_variable_declarator(
+        self: *BasicVisitor,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_prefer_as_const) {
+            try typescript_eslint_prefer_as_const.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         return .proceed;
     }
@@ -1235,6 +1272,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
+        }
+        if (self.options.typescript_eslint_prefer_as_const) {
+            try typescript_eslint_prefer_as_const.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_prefer_as_const.zig
+++ b/src/rules/typescript_eslint_prefer_as_const.zig
@@ -1,0 +1,126 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/prefer-as-const";
+
+pub fn checkAsExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.TSAsExpression,
+) Allocator.Error!void {
+    try compareTypes(allocator, diagnostics, tree, expression.expression, expression.type_annotation, true);
+}
+
+pub fn checkTypeAssertion(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    assertion: ast.TSTypeAssertion,
+) Allocator.Error!void {
+    try compareTypes(allocator, diagnostics, tree, assertion.expression, assertion.type_annotation, true);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+) Allocator.Error!void {
+    if (property.value == .null or property.type_annotation == .null) return;
+    try compareTypes(allocator, diagnostics, tree, property.value, annotationType(tree, property.type_annotation), false);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    if (declarator.init == .null) return;
+    const type_annotation = bindingTypeAnnotation(tree, declarator.id);
+    if (type_annotation == .null) return;
+    try compareTypes(allocator, diagnostics, tree, declarator.init, annotationType(tree, type_annotation), false);
+}
+
+fn compareTypes(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    value_node: ast.NodeIndex,
+    type_node: ast.NodeIndex,
+    can_fix: bool,
+) Allocator.Error!void {
+    if (type_node == .null) return;
+
+    const value_raw = literalRaw(tree, value_node) orelse return;
+    const type_literal = switch (tree.data(type_node)) {
+        .ts_literal_type => |literal_type| literal_type.literal,
+        else => return,
+    };
+    const type_raw = literalRaw(tree, type_literal) orelse return;
+
+    if (!std.mem.eql(u8, value_raw, type_raw)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        if (can_fix)
+            "Expected a `const` instead of a literal type assertion."
+        else
+            "Expected a `const` assertion instead of a literal type annotation.",
+        tree.span(type_node),
+    );
+}
+
+fn annotationType(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    return switch (tree.data(index)) {
+        .ts_type_annotation => |annotation| annotation.type_annotation,
+        else => .null,
+    };
+}
+
+fn bindingTypeAnnotation(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| identifier.type_annotation,
+        else => .null,
+    };
+}
+
+fn literalRaw(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const literal = unwrapParenthesized(tree, index);
+    switch (tree.data(literal)) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        => {},
+        else => return null,
+    }
+
+    const span = tree.span(literal);
+    if (span.end > tree.source.len or span.start > span.end) return null;
+    return tree.source[span.start..span.end];
+}
+
+fn unwrapParenthesized(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_prefer_as_const.zig");
+}
+
+comptime {
     _ = @import("rules/unicode_bom.zig");
 }
 

--- a/tests/rules/typescript_eslint_prefer_as_const.zig
+++ b/tests/rules/typescript_eslint_prefer_as_const.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/prefer-as-const for literal assertions" {
+    const source =
+        \\const a = 'alpha' as 'alpha';
+        \\const b = <42>42;
+        \\const c = true as true;
+        \\const d = 10n as 10n;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_prefer_as_const.id));
+}
+
+test "reports @typescript-eslint/prefer-as-const for literal type annotations" {
+    const source =
+        \\const a: 'alpha' = 'alpha';
+        \\class Example {
+        \\  field: 42 = 42;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_prefer_as_const.id));
+}
+
+test "does not report @typescript-eslint/prefer-as-const for nonmatching literal types" {
+    const source =
+        \\const a = 'alpha' as string;
+        \\const b = 1 as 2;
+        \\const c: 'alpha' = 'beta';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_prefer_as_const.id));
+}
+
+test "can disable @typescript-eslint/prefer-as-const" {
+    const source =
+        \\const a = 'alpha' as 'alpha';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_as_const = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_prefer_as_const.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/prefer-as-const for TS literal assertions
- cover literal variable and class property annotations
- expose a CLI disable flag and update rule status docs

## Verification
- zig test -O ReleaseFast --test-filter prefer-as-const --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for --typescript-eslint-prefer-as-const=off