### PR TITLE
feat: port typescript-eslint no-require-imports

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -170,4 +170,5 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
+            options.typescript_eslint_no_require_imports = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
             options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
@@ -791,6 +793,7 @@ fn printHelp() void {
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -171,6 +171,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
@@ -336,6 +337,10 @@ pub fn runSemantic(
 
     if (options.no_object_constructor) {
         try no_object_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.typescript_eslint_no_require_imports) {
+        try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_symbol) {

--- a/src/rules/typescript_eslint_no_require_imports.zig
+++ b/src/rules/typescript_eslint_no_require_imports.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-require-imports";
+
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .reference_lookup = &reference_lookup,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    reference_lookup: *const ReferenceLookup,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.isGlobalRequireReference(ctx.tree, call.callee)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_external_module_reference(
+        self: *Visitor,
+        _: ast.TSExternalModuleReference,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.addDiagnostic(ctx.tree, index);
+        return .proceed;
+    }
+
+    fn isGlobalRequireReference(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        const name = identifierReferenceName(tree, index) orelse return false;
+        if (!std.mem.eql(u8, name, "require")) return false;
+
+        return (self.reference_lookup.get(index) orelse .none) == .none;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "A `require()` style import is forbidden.",
+            tree.span(index),
+        );
+    }
+};
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_require_imports.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_prefer_as_const.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_require_imports.zig
+++ b/tests/rules/typescript_eslint_no_require_imports.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-require-imports for require imports" {
+    const source =
+        \\const fs = require('fs');
+        \\import path = require('path');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_require_imports.id));
+}
+
+test "does not report @typescript-eslint/no-require-imports for local require functions" {
+    const source =
+        \\function require(name: string) {
+        \\  return name;
+        \\}
+        \\const fs = require('fs');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_require_imports.id));
+}
+
+test "can disable @typescript-eslint/no-require-imports" {
+    const source =
+        \\const fs = require('fs');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_require_imports = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_require_imports.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-require-imports for global require() calls
- report TS import-equals external module references
- preserve upstream behavior for locally-defined require bindings
- expose a CLI disable flag and update rule status docs

## Verification
- zig test -O ReleaseFast --test-filter no-require-imports --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for --typescript-eslint-no-require-imports=off