### PR TITLE
feat: port typescript-eslint no-empty-interface

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -170,5 +170,6 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
+            options.typescript_eslint_no_empty_interface = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
             options.typescript_eslint_no_require_imports = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
@@ -793,6 +795,7 @@ fn printHelp() void {
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --semantic-errors=off     Disable parser semantic errors

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -171,6 +171,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
@@ -640,6 +641,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_interface_declaration(
+        self: *BasicVisitor,
+        interface_declaration: ast.TSInterfaceDeclaration,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_empty_interface) {
+            try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_empty_interface.zig
+++ b/src/rules/typescript_eslint_no_empty_interface.zig
@@ -1,0 +1,38 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-empty-interface";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    interface_declaration: ast.TSInterfaceDeclaration,
+) Allocator.Error!void {
+    const body = switch (tree.data(interface_declaration.body)) {
+        .ts_interface_body => |interface_body| interface_body,
+        else => return,
+    };
+
+    if (body.body.len != 0) return;
+
+    const message =
+        if (interface_declaration.extends.len == 0)
+            "An empty interface is equivalent to `{}`."
+        else if (interface_declaration.extends.len == 1)
+            "An interface declaring no members is equivalent to its supertype."
+        else
+            return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(interface_declaration.id),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_empty_interface.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_require_imports.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_empty_interface.zig
+++ b/tests/rules/typescript_eslint_no_empty_interface.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-empty-interface for empty interfaces" {
+    const source =
+        \\interface Empty {}
+        \\interface SingleExtends extends Base {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_interface.id));
+}
+
+test "does not report @typescript-eslint/no-empty-interface for non-empty or multi-extends interfaces" {
+    const source =
+        \\interface WithMember {
+        \\  value: string;
+        \\}
+        \\interface MultiExtends extends Base, Other {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_interface.id));
+}
+
+test "can disable @typescript-eslint/no-empty-interface" {
+    const source =
+        \\interface Empty {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_empty_interface = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_interface.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-empty-interface for empty TS interfaces
- cover empty single-extends interfaces with fishlint's default allowSingleExtends=false behavior
- expose a CLI disable flag and update rule status docs

## Verification
- zig test -O ReleaseFast --test-filter no-empty-interface --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for --typescript-eslint-no-empty-interface=off