### PR TITLE
perf: skip no-require-imports without require

### DIFF
--- a/src/rules/typescript_eslint_no_require_imports.zig
+++ b/src/rules/typescript_eslint_no_require_imports.zig
@@ -16,6 +16,8 @@ pub fn run(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    if (std.mem.indexOf(u8, tree.source, "require") == null) return;
+
     var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
     defer reference_lookup.deinit();
 


### PR DESCRIPTION
## Summary
- Skip @typescript-eslint/no-require-imports rule work when source does not contain `require`
- Avoid building the rule reference lookup for files that cannot report this rule

## Performance
- 1000 generated TS files: base 37.701 ms median, current 37.534 ms median, ~0.4% faster
- 50k generated TS files: base 2070.195 ms median, current 2050.672 ms median, ~0.9% faster

## Verification
- `zig build -Doptimize=ReleaseFast -j1`
- `zig build test --summary all` (550/550 passed)
- `npm run codspeed -- --target=fixtures/perf-next --time=100 --warmup-time=0`
