### PR TITLE
feat: port typescript-eslint no-non-null-asserted-optional-chain

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -171,5 +171,6 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
+| [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -184,6 +184,7 @@ pub const Options = struct {
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
+    typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_tslint_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
             options.typescript_eslint_no_empty_interface = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
+            options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
             options.typescript_eslint_no_require_imports = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
@@ -796,6 +798,7 @@ fn printHelp() void {
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
+        \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --semantic-errors=off     Disable parser semantic errors

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -172,6 +172,7 @@ pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
+pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
@@ -226,6 +227,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_ban_tslint_comment) {
         try typescript_eslint_ban_tslint_comment.run(allocator, diagnostics, tree);
+    }
+    if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
+        try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/src/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
+++ b/src/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
@@ -1,0 +1,93 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-non-null-asserted-optional-chain";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+
+    pub fn enter_ts_non_null_expression(
+        self: *Visitor,
+        expression: ast.TSNonNullExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isChainExpression(ctx.tree, expression.expression)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_chain_expression(
+        self: *Visitor,
+        expression: ast.ChainExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isNonNullExpression(ctx.tree, expression.expression)) {
+            try self.addDiagnostic(ctx.tree, expression.expression);
+        }
+
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .@"error",
+            id,
+            "Optional chain expressions can return undefined by design - using a non-null assertion is unsafe and wrong.",
+            tree.span(index),
+        );
+    }
+};
+
+fn isChainExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapParenthesized(tree, index);
+    if (unwrapped == .null) return false;
+    return switch (tree.data(unwrapped)) {
+        .chain_expression => true,
+        else => false,
+    };
+}
+
+fn isNonNullExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .ts_non_null_expression => true,
+        else => false,
+    };
+}
+
+fn unwrapParenthesized(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -659,6 +659,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_non_null_asserted_optional_chain.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_require_imports.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
+++ b/tests/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-non-null-asserted-optional-chain for asserted optional chains" {
+    const source =
+        \\(foo?.bar)!;
+        \\foo?.bar!;
+        \\(foo?.())!;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_non_null_asserted_optional_chain.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_non_null_asserted_optional_chain.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-non-null-asserted-optional-chain for inner chain assertions" {
+    const source =
+        \\foo?.bar!.baz;
+        \\foo?.bar!.baz();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_non_null_asserted_optional_chain.id));
+}
+
+test "can disable @typescript-eslint/no-non-null-asserted-optional-chain" {
+    const source =
+        \\foo?.bar!;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_non_null_asserted_optional_chain = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_non_null_asserted_optional_chain.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-non-null-asserted-optional-chain
- report non-null assertions on optional chain results as error-level diagnostics
- preserve TS 3.9+ behavior by allowing inner assertions like foo?.bar!.baz
- expose a CLI disable flag and update rule status docs

## Verification
- zig test -O ReleaseFast --test-filter no-non-null-asserted-optional-chain --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for --typescript-eslint-no-non-null-asserted-optional-chain=off