### PR TITLE
perf: skip optional chain assertion rule without tokens

### DIFF
--- a/src/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
+++ b/src/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
@@ -1,9 +1,10 @@
 const parser = @import("parser");
 const core = @import("../core.zig");
+const std = @import("std");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-non-null-asserted-optional-chain";
 
@@ -12,6 +13,9 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    if (std.mem.indexOf(u8, tree.source, "?.") == null) return;
+    if (std.mem.indexOf(u8, tree.source, "!") == null) return;
+
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,


### PR DESCRIPTION
## Summary
- Skip @typescript-eslint/no-non-null-asserted-optional-chain when source does not contain `?.` or `!`
- Avoid an extra basic AST traversal for files that cannot report this rule

## Performance
- 1000 generated TS files: base 40.623 ms median, current 40.494 ms median, ~0.3% faster
- 50k generated TS files: base 2369.051 ms median, current 2346.689 ms median, ~0.9% faster

## Verification
- `zig build -Doptimize=ReleaseFast -j1`
- `zig build test --summary all` (553/553 passed)
- `npm run codspeed -- --target=fixtures/perf-next --time=100 --warmup-time=0`
