### PR TITLE
feat: port typescript-eslint no-confusing-non-null-assertion

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -170,6 +170,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
+            options.typescript_eslint_no_confusing_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
             options.typescript_eslint_no_empty_interface = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
@@ -797,6 +799,7 @@ fn printHelp() void {
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -171,6 +171,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
@@ -1014,6 +1015,9 @@ const BasicVisitor = struct {
         if (self.options.no_implicit_coercion) {
             try no_implicit_coercion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
+        if (self.options.typescript_eslint_no_confusing_non_null_assertion) {
+            try typescript_eslint_no_confusing_non_null_assertion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         return .proceed;
     }
 
@@ -1061,6 +1065,9 @@ const BasicVisitor = struct {
         }
         if (self.options.yoda) {
             try yoda.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.typescript_eslint_no_confusing_non_null_assertion) {
+            try typescript_eslint_no_confusing_non_null_assertion.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_confusing_non_null_assertion.zig
+++ b/src/rules/typescript_eslint_no_confusing_non_null_assertion.zig
@@ -1,0 +1,84 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-confusing-non-null-assertion";
+
+pub fn checkBinaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (expression.operator) {
+        .equal, .strict_equal => {},
+        else => return,
+    }
+
+    if (!hasConfusingLeftNonNullAssertion(tree, expression.left)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Confusing combinations of non-null assertion and equal test like \"a! == b\", which looks very similar to not equal \"a !== b\".",
+        tree.span(index),
+    );
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+    if (!hasConfusingLeftNonNullAssertion(tree, expression.left)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Confusing combinations of non-null assertion and equal test like \"a! = b\", which looks very similar to not equal \"a != b\".",
+        tree.span(index),
+    );
+}
+
+fn hasConfusingLeftNonNullAssertion(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    const span = tree.span(index);
+    if (span.start >= span.end or span.end > tree.source.len) return false;
+
+    if (previousNonWhitespace(tree.source[span.start..span.end]) != '!') return false;
+    return nextNonWhitespace(tree.source[span.end..]) != ')';
+}
+
+fn previousNonWhitespace(source: []const u8) ?u8 {
+    var index = source.len;
+    while (index > 0) {
+        index -= 1;
+        const char = source[index];
+        if (!isWhitespace(char)) return char;
+    }
+    return null;
+}
+
+fn nextNonWhitespace(source: []const u8) ?u8 {
+    var index: usize = 0;
+    while (index < source.len) : (index += 1) {
+        const char = source[index];
+        if (!isWhitespace(char)) return char;
+    }
+    return null;
+}
+
+fn isWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_confusing_non_null_assertion.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_empty_interface.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_confusing_non_null_assertion.zig
+++ b/tests/rules/typescript_eslint_no_confusing_non_null_assertion.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-confusing-non-null-assertion for confusing equality and assignment" {
+    const source =
+        \\a! == b;
+        \\a! === b;
+        \\a! = b;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eqeqeq = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_confusing_non_null_assertion.id));
+}
+
+test "does not report @typescript-eslint/no-confusing-non-null-assertion for parenthesized assertions or inequality" {
+    const source =
+        \\(a!) == b;
+        \\a! != b;
+        \\a! !== b;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eqeqeq = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_confusing_non_null_assertion.id));
+}
+
+test "can disable @typescript-eslint/no-confusing-non-null-assertion" {
+    const source =
+        \\a! == b;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eqeqeq = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_confusing_non_null_assertion = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_confusing_non_null_assertion.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-confusing-non-null-assertion with fishlint-compatible default warning behavior
- wire the rule into CLI options, docs, and traversal
- add focused tests for equality, assignment, parenthesized assertions, inequality, and disabling

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_no_confusing_non_null_assertion.zig tests/all.zig tests/rules/typescript_eslint_no_confusing_non_null_assertion.zig
- zig test -O ReleaseFast --test-filter no-confusing-non-null-assertion --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for default warning and --typescript-eslint-no-confusing-non-null-assertion=off