### PR TITLE
feat: port typescript-eslint no-this-alias

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -174,4 +174,5 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
+| [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,
+    typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -393,6 +393,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
             options.typescript_eslint_no_require_imports = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-this-alias=off")) {
+            options.typescript_eslint_no_this_alias = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
             options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
@@ -803,6 +805,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
+        \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -175,6 +175,7 @@ pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescrip
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
+pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
@@ -647,6 +648,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
+        if (self.options.typescript_eslint_no_this_alias) {
+            try typescript_eslint_no_this_alias.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
         return .proceed;
     }
 
@@ -1017,6 +1021,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_confusing_non_null_assertion) {
             try typescript_eslint_no_confusing_non_null_assertion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.typescript_eslint_no_this_alias) {
+            try typescript_eslint_no_this_alias.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_this_alias.zig
+++ b/src/rules/typescript_eslint_no_this_alias.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-this-alias";
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    switch (tree.data(declarator.id)) {
+        .binding_identifier => {},
+        else => return,
+    }
+
+    if (!isThisExpression(tree, declarator.init)) return;
+
+    try reportIfDisallowed(allocator, diagnostics, tree, declarator.id);
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    switch (tree.data(expression.left)) {
+        .identifier_reference => {},
+        else => return,
+    }
+
+    if (!isThisExpression(tree, expression.right)) return;
+
+    try reportIfDisallowed(allocator, diagnostics, tree, expression.left);
+}
+
+fn reportIfDisallowed(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    target: ast.NodeIndex,
+) Allocator.Error!void {
+    if (isAllowedSelfAlias(tree, target)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Unexpected aliasing of 'this' to local variable.",
+        tree.span(target),
+    );
+}
+
+fn isAllowedSelfAlias(tree: *const ast.Tree, target: ast.NodeIndex) bool {
+    const span = tree.span(target);
+    if (span.end > tree.source.len or span.start > span.end) return false;
+    return std.mem.eql(u8, tree.source[span.start..span.end], "self");
+}
+
+fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .this_expression => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -671,6 +671,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_this_alias.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_prefer_as_const.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_this_alias.zig
+++ b/tests/rules/typescript_eslint_no_this_alias.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-this-alias for disallowed aliases" {
+    const source =
+        \\const that = this;
+        \\let context;
+        \\context = this;
+        \\const wrapped = (this);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_this_alias.id));
+}
+
+test "does not report @typescript-eslint/no-this-alias for fishlint allowed self aliases or destructuring" {
+    const source =
+        \\const self = this;
+        \\let self;
+        \\self = this;
+        \\const { props } = this;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_this_alias.id));
+}
+
+test "can disable @typescript-eslint/no-this-alias" {
+    const source =
+        \\const that = this;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_this_alias = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_this_alias.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-this-alias with fishlint's allowedNames: ['self'] behavior
- wire the rule into CLI options, docs, and traversal
- add focused tests for disallowed aliases, allowed self aliases, destructuring, and disabling

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_no_this_alias.zig tests/all.zig tests/rules/typescript_eslint_no_this_alias.zig
- zig test -O ReleaseFast --test-filter no-this-alias --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- local @typescript-eslint plugin cross-check for allowedNames: ['self']
- CLI smoke for default error and --typescript-eslint-no-this-alias=off