### PR TITLE
feat: port typescript-eslint prefer-namespace-keyword

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -176,3 +176,4 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
+| [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -189,6 +189,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
+    typescript_eslint_prefer_namespace_keyword: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -397,6 +397,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_this_alias = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
             options.typescript_eslint_prefer_as_const = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-namespace-keyword=off")) {
+            options.typescript_eslint_prefer_namespace_keyword = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -807,6 +809,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
+        \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("types
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
+pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
@@ -662,6 +663,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_empty_interface) {
             try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_module_declaration(
+        self: *BasicVisitor,
+        declaration: ast.TSModuleDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_prefer_namespace_keyword) {
+            try typescript_eslint_prefer_namespace_keyword.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_prefer_namespace_keyword.zig
+++ b/src/rules/typescript_eslint_prefer_namespace_keyword.zig
@@ -1,0 +1,31 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/prefer-namespace-keyword";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSModuleDeclaration,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (declaration.kind != .module) return;
+
+    switch (tree.data(declaration.id)) {
+        .string_literal => return,
+        else => {},
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
+        tree.span(index),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -679,6 +679,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_prefer_namespace_keyword.zig");
+}
+
+comptime {
     _ = @import("rules/unicode_bom.zig");
 }
 

--- a/tests/rules/typescript_eslint_prefer_namespace_keyword.zig
+++ b/tests/rules/typescript_eslint_prefer_namespace_keyword.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/prefer-namespace-keyword for custom module declarations" {
+    const source =
+        \\module Internal {
+        \\  export const value = 1;
+        \\}
+        \\declare module Declared {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_prefer_namespace_keyword.id));
+}
+
+test "does not report @typescript-eslint/prefer-namespace-keyword for namespace or ambient string modules" {
+    const source =
+        \\namespace Internal {
+        \\  export const value = 1;
+        \\}
+        \\declare module "external" {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_prefer_namespace_keyword.id));
+}
+
+test "can disable @typescript-eslint/prefer-namespace-keyword" {
+    const source =
+        \\module Internal {
+        \\  export const value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_prefer_namespace_keyword.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/prefer-namespace-keyword
- report custom TypeScript module declarations while allowing namespace declarations and ambient string modules
- wire the rule into CLI options, docs, traversal, and tests

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_prefer_namespace_keyword.zig tests/all.zig tests/rules/typescript_eslint_prefer_namespace_keyword.zig
- zig test -O ReleaseFast --test-filter prefer-namespace-keyword --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- local @typescript-eslint plugin cross-check
- CLI smoke for default error and --typescript-eslint-prefer-namespace-keyword=off