### PR TITLE
feat: port typescript-eslint no-extra-non-null-assertion

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -172,6 +172,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
+| [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -185,6 +185,7 @@ pub const Options = struct {
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
+    typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -389,6 +389,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_confusing_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
             options.typescript_eslint_no_empty_interface = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-non-null-assertion=off")) {
+            options.typescript_eslint_no_extra_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
             options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
@@ -805,6 +807,7 @@ fn printHelp() void {
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
+        \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -173,6 +173,7 @@ pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_c
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
+pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
@@ -663,6 +664,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_empty_interface) {
             try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_non_null_expression(
+        self: *BasicVisitor,
+        expression: ast.TSNonNullExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_extra_non_null_assertion) {
+            try typescript_eslint_no_extra_non_null_assertion.checkNonNullExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         return .proceed;
     }
@@ -1170,6 +1183,9 @@ const BasicVisitor = struct {
         if (self.options.prefer_spread) {
             try prefer_spread.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
+        if (self.options.typescript_eslint_no_extra_non_null_assertion) {
+            try typescript_eslint_no_extra_non_null_assertion.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
         return .proceed;
     }
 
@@ -1228,6 +1244,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_env) {
             try no_process_env.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.typescript_eslint_no_extra_non_null_assertion) {
+            try typescript_eslint_no_extra_non_null_assertion.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_extra_non_null_assertion.zig
+++ b/src/rules/typescript_eslint_no_extra_non_null_assertion.zig
@@ -1,0 +1,63 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-extra-non-null-assertion";
+
+pub fn checkNonNullExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.TSNonNullExpression,
+) Allocator.Error!void {
+    if (!isNonNullExpression(tree, expression.expression)) return;
+    try addDiagnostic(allocator, diagnostics, tree, expression.expression);
+}
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.MemberExpression,
+) Allocator.Error!void {
+    if (!expression.optional) return;
+    if (!isNonNullExpression(tree, expression.object)) return;
+    try addDiagnostic(allocator, diagnostics, tree, expression.object);
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.CallExpression,
+) Allocator.Error!void {
+    if (!expression.optional) return;
+    if (!isNonNullExpression(tree, expression.callee)) return;
+    try addDiagnostic(allocator, diagnostics, tree, expression.callee);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Forbidden extra non-null assertion.",
+        tree.span(index),
+    );
+}
+
+fn isNonNullExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .ts_non_null_expression => true,
+        else => false,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_extra_non_null_assertion.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_non_null_asserted_optional_chain.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_extra_non_null_assertion.zig
+++ b/tests/rules/typescript_eslint_no_extra_non_null_assertion.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-extra-non-null-assertion for nested assertions and optional chains" {
+    const source =
+        \\value!!;
+        \\value!?.property;
+        \\value!?.();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_extra_non_null_assertion.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_extra_non_null_assertion.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-extra-non-null-assertion for useful assertions" {
+    const source =
+        \\value!;
+        \\value.property;
+        \\value?.property;
+        \\value?.();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_extra_non_null_assertion.id));
+}
+
+test "can disable @typescript-eslint/no-extra-non-null-assertion" {
+    const source =
+        \\value!!;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_extra_non_null_assertion = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_extra_non_null_assertion.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-extra-non-null-assertion
- report nested non-null assertions and extra non-null assertions before optional member/call chains
- wire the rule into CLI options, docs, traversal, and tests

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_no_extra_non_null_assertion.zig tests/all.zig tests/rules/typescript_eslint_no_extra_non_null_assertion.zig
- zig test -O ReleaseFast --test-filter no-extra-non-null-assertion --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- local @typescript-eslint plugin cross-check
- CLI smoke for default error and --typescript-eslint-no-extra-non-null-assertion=off