### PR TITLE
feat: port typescript-eslint adjacent-overload-signatures

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -168,6 +168,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -181,6 +181,7 @@ pub const Options = struct {
     require_yield: bool = true,
     spaced_comment: bool = true,
     symbol_description: bool = true,
+    typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -381,6 +381,8 @@ pub fn main(init: std.process.Init) !void {
             options.spaced_comment = false;
         } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {
             options.symbol_description = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
+            options.typescript_eslint_adjacent_overload_signatures = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-ts-comment=off")) {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
@@ -805,6 +807,7 @@ fn printHelp() void {
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
+        \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -171,6 +171,7 @@ const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
+pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
@@ -425,6 +426,9 @@ const BasicVisitor = struct {
         if (self.options.no_duplicate_imports) {
             try no_duplicate_imports.check(self.allocator, self.diagnostics, ctx.tree, program);
         }
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, program.body);
+        }
         return .proceed;
     }
 
@@ -674,6 +678,42 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
+    pub fn enter_ts_interface_body(
+        self: *BasicVisitor,
+        body: ast.TSInterfaceBody,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_type_literal(
+        self: *BasicVisitor,
+        type_literal: ast.TSTypeLiteral,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, type_literal.members);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_module_block(
+        self: *BasicVisitor,
+        block: ast.TSModuleBlock,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
+        }
+        return .proceed;
+    }
+
     pub fn enter_ts_non_null_expression(
         self: *BasicVisitor,
         expression: ast.TSNonNullExpression,
@@ -888,6 +928,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable) {
             try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
+        }
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
         }
         return .proceed;
     }
@@ -1334,6 +1377,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_class_members) {
             try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
+        }
+        if (self.options.typescript_eslint_adjacent_overload_signatures) {
+            try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_adjacent_overload_signatures.zig
+++ b/src/rules/typescript_eslint_adjacent_overload_signatures.zig
@@ -1,0 +1,138 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/adjacent-overload-signatures";
+
+const Member = struct {
+    name: []const u8,
+    static: bool = false,
+    call_signature: bool = false,
+};
+
+pub fn checkRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    members: ast.IndexRange,
+) Allocator.Error!void {
+    var seen: std.ArrayList(Member) = .empty;
+    defer seen.deinit(allocator);
+
+    var last: ?Member = null;
+
+    for (tree.extra(members)) |member_index| {
+        const member = memberInfo(tree, member_index) orelse {
+            last = null;
+            continue;
+        };
+
+        if (seenIndex(seen.items, member)) |index| {
+            if (!isSameMember(member, last)) {
+                try addDiagnostic(allocator, diagnostics, tree, member_index, member);
+            }
+            _ = index;
+        } else {
+            try seen.append(allocator, member);
+        }
+
+        last = member;
+    }
+}
+
+fn seenIndex(seen: []const Member, candidate: Member) ?usize {
+    for (seen, 0..) |member, index| {
+        if (isSameMember(candidate, member)) return index;
+    }
+    return null;
+}
+
+fn isSameMember(candidate: Member, existing: ?Member) bool {
+    const member = existing orelse return false;
+    return candidate.static == member.static and
+        candidate.call_signature == member.call_signature and
+        std.mem.eql(u8, candidate.name, member.name);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    member: Member,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "All {s}{s} signatures should be adjacent.",
+        .{ if (member.static) "static " else "", member.name },
+    );
+}
+
+fn memberInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?Member {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .export_named_declaration => |declaration| memberInfo(tree, declaration.declaration),
+        .export_default_declaration => |declaration| memberInfo(tree, declaration.declaration),
+        .function => |function| functionInfo(tree, function),
+        .method_definition => |method| methodDefinitionInfo(tree, method),
+        .ts_method_signature => |signature| methodSignatureInfo(tree, signature),
+        .ts_call_signature_declaration => .{ .name = "call", .call_signature = true },
+        .ts_construct_signature_declaration => .{ .name = "new" },
+        else => null,
+    };
+}
+
+fn functionInfo(tree: *const ast.Tree, function: ast.Function) ?Member {
+    switch (function.type) {
+        .function_declaration,
+        .ts_declare_function,
+        => {},
+        else => return null,
+    }
+
+    const name = bindingIdentifierName(tree, function.id) orelse return null;
+    return .{ .name = name };
+}
+
+fn methodDefinitionInfo(tree: *const ast.Tree, method: ast.MethodDefinition) ?Member {
+    const name = if (method.kind == .constructor and !method.static)
+        "constructor"
+    else
+        keyName(tree, method.key, method.computed) orelse return null;
+
+    return .{ .name = name, .static = method.static };
+}
+
+fn methodSignatureInfo(tree: *const ast.Tree, signature: ast.TSMethodSignature) ?Member {
+    const name = keyName(tree, signature.key, signature.computed) orelse return null;
+    return .{ .name = name };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn keyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed or index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -647,6 +647,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_adjacent_overload_signatures.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_ban_ts_comment.zig");
 }
 

--- a/tests/rules/typescript_eslint_adjacent_overload_signatures.zig
+++ b/tests/rules/typescript_eslint_adjacent_overload_signatures.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/adjacent-overload-signatures for separated function overloads" {
+    const source =
+        \\function parse(value: string): string;
+        \\function other(value: string): string;
+        \\function parse(value: number): number;
+        \\function parse(value: string | number): string | number {
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_adjacent_overload_signatures.id));
+}
+
+test "reports @typescript-eslint/adjacent-overload-signatures for separated class and interface members" {
+    const source =
+        \\class Example {
+        \\  method(value: string): string;
+        \\  other(): void {}
+        \\  method(value: number): number;
+        \\  method(value: string | number): string | number {
+        \\    return value;
+        \\  }
+        \\}
+        \\interface Contract {
+        \\  call(value: string): string;
+        \\  other(): void;
+        \\  call(value: number): number;
+        \\}
+        \\type Callable = {
+        \\  (value: string): string;
+        \\  value: string;
+        \\  (value: number): number;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_adjacent_overload_signatures.id));
+}
+
+test "does not report @typescript-eslint/adjacent-overload-signatures for adjacent overloads" {
+    const source =
+        \\function parse(value: string): string;
+        \\function parse(value: number): number;
+        \\function parse(value: string | number): string | number {
+        \\  return value;
+        \\}
+        \\class Example {
+        \\  method(value: string): string;
+        \\  method(value: number): number;
+        \\  method(value: string | number): string | number {
+        \\    return value;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_adjacent_overload_signatures.id));
+}
+
+test "can disable @typescript-eslint/adjacent-overload-signatures" {
+    const source =
+        \\function parse(value: string): string;
+        \\function other(value: string): string;
+        \\function parse(value: number): number;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_adjacent_overload_signatures = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_adjacent_overload_signatures.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/adjacent-overload-signatures
- scan program/block/module/class/interface/type-literal bodies for separated overload signatures
- wire the rule into CLI options, docs, traversal, and tests

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_adjacent_overload_signatures.zig tests/all.zig tests/rules/typescript_eslint_adjacent_overload_signatures.zig
- zig test -O ReleaseFast --test-filter adjacent-overload-signatures --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- local @typescript-eslint plugin cross-check
- CLI smoke for default error and --typescript-eslint-adjacent-overload-signatures=off