### PR TITLE
feat: port typescript-eslint no-inferrable-types

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -174,6 +174,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
+| [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
+    typescript_eslint_no_inferrable_types: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -393,6 +393,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_empty_interface = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-non-null-assertion=off")) {
             options.typescript_eslint_no_extra_non_null_assertion = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {
+            options.typescript_eslint_no_inferrable_types = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
             options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
@@ -813,6 +815,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
+        \\  --typescript-eslint-no-inferrable-types=off Disable @typescript-eslint/no-inferrable-types
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
+pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
@@ -662,6 +663,21 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_this_alias) {
             try typescript_eslint_no_this_alias.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        if (self.options.typescript_eslint_no_inferrable_types) {
+            try typescript_eslint_no_inferrable_types.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_assignment_pattern(
+        self: *BasicVisitor,
+        pattern: ast.AssignmentPattern,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_inferrable_types) {
+            try typescript_eslint_no_inferrable_types.checkAssignmentPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
         }
         return .proceed;
     }
@@ -1407,6 +1423,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+        }
+        if (self.options.typescript_eslint_no_inferrable_types) {
+            try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_inferrable_types.zig
+++ b/src/rules/typescript_eslint_no_inferrable_types.zig
@@ -1,0 +1,203 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-inferrable-types";
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    if (declarator.init == .null) return;
+    const type_annotation = bindingTypeAnnotation(tree, declarator.id);
+    try reportInferrableType(allocator, diagnostics, tree, type_annotation, declarator.init);
+}
+
+pub fn checkAssignmentPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.AssignmentPattern,
+) Allocator.Error!void {
+    const type_annotation = if (pattern.type_annotation != .null)
+        pattern.type_annotation
+    else
+        bindingTypeAnnotation(tree, pattern.left);
+
+    try reportInferrableType(allocator, diagnostics, tree, type_annotation, pattern.right);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+) Allocator.Error!void {
+    if (property.readonly or property.optional) return;
+    if (property.value == .null) return;
+    try reportInferrableType(allocator, diagnostics, tree, property.type_annotation, property.value);
+}
+
+fn reportInferrableType(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    type_annotation: ast.NodeIndex,
+    value: ast.NodeIndex,
+) Allocator.Error!void {
+    const type_node = annotationType(tree, type_annotation);
+    const type_name = inferrableType(tree, type_node, value) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(type_annotation),
+        "Type {s} trivially inferred from a {s} literal, remove type annotation.",
+        .{ type_name, type_name },
+    );
+}
+
+fn inferrableType(tree: *const ast.Tree, type_node: ast.NodeIndex, value: ast.NodeIndex) ?[]const u8 {
+    if (type_node == .null or value == .null) return null;
+
+    return switch (tree.data(type_node)) {
+        .ts_bigint_keyword => if (isBigIntValue(tree, value)) "bigint" else null,
+        .ts_boolean_keyword => if (isBooleanValue(tree, value)) "boolean" else null,
+        .ts_number_keyword => if (isNumberValue(tree, value)) "number" else null,
+        .ts_null_keyword => if (isNullValue(tree, value)) "null" else null,
+        .ts_string_keyword => if (isStringValue(tree, value)) "string" else null,
+        .ts_symbol_keyword => if (isCallNamed(tree, value, "Symbol")) "symbol" else null,
+        .ts_undefined_keyword => if (isUndefinedValue(tree, value)) "undefined" else null,
+        .ts_type_reference => |reference| if (isTypeReferenceNamed(tree, reference, "RegExp") and isRegExpValue(tree, value)) "RegExp" else null,
+        else => null,
+    };
+}
+
+fn isBigIntValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapUnary(tree, index, .negate);
+    return switch (tree.data(unwrapTransparent(tree, value))) {
+        .bigint_literal => true,
+        else => isCallNamed(tree, value, "BigInt"),
+    };
+}
+
+fn isBooleanValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .boolean_literal => true,
+        .unary_expression => |expression| expression.operator == .logical_not,
+        else => isCallNamed(tree, value, "Boolean"),
+    };
+}
+
+fn isNumberValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapUnary(tree, index, .positive);
+    const unwrapped = unwrapUnary(tree, value, .negate);
+    return switch (tree.data(unwrapTransparent(tree, unwrapped))) {
+        .numeric_literal => true,
+        .identifier_reference => |identifier| {
+            const name = tree.string(identifier.name);
+            return std.mem.eql(u8, name, "Infinity") or std.mem.eql(u8, name, "NaN");
+        },
+        else => isCallNamed(tree, unwrapped, "Number"),
+    };
+}
+
+fn isNullValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        else => false,
+    };
+}
+
+fn isStringValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .string_literal => true,
+        .template_literal => true,
+        else => isCallNamed(tree, value, "String"),
+    };
+}
+
+fn isUndefinedValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => |expression| expression.operator == .void,
+        else => false,
+    };
+}
+
+fn isRegExpValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .regexp_literal => true,
+        .new_expression => |expression| isIdentifierReferenceNamed(tree, expression.callee, "RegExp"),
+        else => isCallNamed(tree, value, "RegExp"),
+    };
+}
+
+fn isCallNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .call_expression => |expression| isIdentifierReferenceNamed(tree, expression.callee, name),
+        else => false,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isTypeReferenceNamed(tree: *const ast.Tree, reference: ast.TSTypeReference, name: []const u8) bool {
+    return isIdentifierReferenceNamed(tree, reference.type_name, name);
+}
+
+fn unwrapUnary(tree: *const ast.Tree, index: ast.NodeIndex, operator: ast.UnaryOperator) ast.NodeIndex {
+    const value = unwrapTransparent(tree, index);
+    return switch (tree.data(value)) {
+        .unary_expression => |expression| if (expression.operator == operator) expression.argument else value,
+        else => value,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn annotationType(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    if (index == .null) return .null;
+    return switch (tree.data(index)) {
+        .ts_type_annotation => |annotation| annotation.type_annotation,
+        else => .null,
+    };
+}
+
+fn bindingTypeAnnotation(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    if (index == .null) return .null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| identifier.type_annotation,
+        else => .null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -671,6 +671,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_inferrable_types.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_non_null_asserted_optional_chain.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_inferrable_types.zig
+++ b/tests/rules/typescript_eslint_no_inferrable_types.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-inferrable-types for literal variables and properties" {
+    const source =
+        \\const name: string = "Ada";
+        \\const count: number = -1;
+        \\const enabled: boolean = Boolean(false);
+        \\const missing: undefined = undefined;
+        \\const pattern: RegExp = /x/;
+        \\class Example {
+        \\  value: number = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_inferrable_types.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "reports @typescript-eslint/no-inferrable-types for defaulted parameters" {
+    const source =
+        \\function visit(name: string = "Ada", count: number = Number(1)) {
+        \\  return name + count;
+        \\}
+        \\const arrow = (enabled: boolean = true) => enabled;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
+}
+
+test "does not report @typescript-eslint/no-inferrable-types for non-inferrable annotations" {
+    const source =
+        \\const value: string | number = "Ada";
+        \\const count: number = getCount();
+        \\class Example {
+        \\  readonly value: number = 1;
+        \\  optional?: number = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
+}
+
+test "can disable @typescript-eslint/no-inferrable-types" {
+    const source =
+        \\const name: string = "Ada";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-inferrable-types for fishlint's default configuration
- report inferrable annotations on variables, defaulted parameters, and class properties
- wire the rule into CLI options, docs, traversal, and tests

## Verification
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/typescript_eslint_no_inferrable_types.zig tests/all.zig tests/rules/typescript_eslint_no_inferrable_types.zig
- zig test -O ReleaseFast --test-filter no-inferrable-types --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- local @typescript-eslint plugin cross-check
- CLI smoke for default error and --typescript-eslint-no-inferrable-types=off