### PR TITLE
feat: port typescript-eslint no-misused-new

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
+| [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -188,6 +188,7 @@ pub const Options = struct {
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
+    typescript_eslint_no_misused_new: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,6 +395,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_extra_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {
             options.typescript_eslint_no_inferrable_types = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-misused-new=off")) {
+            options.typescript_eslint_no_misused_new = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
             options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -179,6 +179,7 @@ pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescrip
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
+pub const typescript_eslint_no_misused_new = @import("typescript_eslint_no_misused_new.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
@@ -482,6 +483,9 @@ const BasicVisitor = struct {
         if (self.options.no_useless_constructor) {
             try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
+        if (self.options.typescript_eslint_no_misused_new) {
+            try typescript_eslint_no_misused_new.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
         return .proceed;
     }
 
@@ -695,6 +699,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_empty_interface) {
             try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
         }
+        if (self.options.typescript_eslint_no_misused_new) {
+            try typescript_eslint_no_misused_new.checkInterfaceDeclaration(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
+        }
         return .proceed;
     }
 
@@ -718,6 +725,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, type_literal.members);
+        }
+        if (self.options.typescript_eslint_no_misused_new) {
+            try typescript_eslint_no_misused_new.checkTypeLiteral(self.allocator, self.diagnostics, ctx.tree, type_literal);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_misused_new.zig
+++ b/src/rules/typescript_eslint_no_misused_new.zig
@@ -1,0 +1,152 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-misused-new";
+
+pub fn checkInterfaceDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSInterfaceDeclaration,
+) Allocator.Error!void {
+    const name = bindingIdentifierName(tree, declaration.id) orelse return;
+    const body = switch (tree.data(declaration.body)) {
+        .ts_interface_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        switch (tree.data(member_index)) {
+            .ts_construct_signature_declaration => |signature| {
+                if (isMatchingTypeName(tree, signature.return_type, name)) {
+                    try reportInterface(allocator, diagnostics, tree, member_index);
+                }
+            },
+            .ts_method_signature => |signature| {
+                if (isConstructorMethodName(tree, signature.key, signature.computed)) {
+                    try reportInterface(allocator, diagnostics, tree, member_index);
+                }
+            },
+            else => {},
+        }
+    }
+}
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    const name = bindingIdentifierName(tree, class.id) orelse return;
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (!isNewMethodName(tree, method.key, method.computed)) continue;
+
+        const function = switch (tree.data(method.value)) {
+            .function => |function| function,
+            else => continue,
+        };
+        if (function.type != .ts_empty_body_function_expression) continue;
+        if (!isMatchingTypeName(tree, function.return_type, name)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Class cannot have method named `new`.",
+            tree.span(member_index),
+        );
+    }
+}
+
+pub fn checkTypeLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    type_literal: ast.TSTypeLiteral,
+) Allocator.Error!void {
+    for (tree.extra(type_literal.members)) |member_index| {
+        const signature = switch (tree.data(member_index)) {
+            .ts_method_signature => |signature| signature,
+            else => continue,
+        };
+        if (!isConstructorMethodName(tree, signature.key, signature.computed)) continue;
+
+        try reportInterface(allocator, diagnostics, tree, member_index);
+    }
+}
+
+fn reportInterface(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Interfaces cannot be constructed, only classes.",
+        tree.span(index),
+    );
+}
+
+fn isConstructorMethodName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) bool {
+    return keyNameEquals(tree, key, computed, "constructor");
+}
+
+fn isNewMethodName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) bool {
+    return keyNameEquals(tree, key, computed, "new");
+}
+
+fn keyNameEquals(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool, expected: []const u8) bool {
+    if (computed or key == .null) return false;
+
+    const actual = switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => return false,
+    };
+    return std.mem.eql(u8, actual, expected);
+}
+
+fn isMatchingTypeName(tree: *const ast.Tree, return_type: ast.NodeIndex, expected: []const u8) bool {
+    const actual = typeReferenceName(tree, return_type) orelse return false;
+    return std.mem.eql(u8, actual, expected);
+}
+
+fn typeReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .ts_type_annotation => |annotation| typeReferenceName(tree, annotation.type_annotation),
+        .ts_type_reference => |reference| typeReferenceName(tree, reference.type_name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -675,6 +675,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_misused_new.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_non_null_asserted_optional_chain.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_misused_new.zig
+++ b/tests/rules/typescript_eslint_no_misused_new.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-misused-new for construct signatures returning the interface" {
+    const source =
+        \\interface Widget {
+        \\  new (): Widget;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_misused_new.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_misused_new.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "reports @typescript-eslint/no-misused-new for constructor method signatures" {
+    const source =
+        \\interface Widget {
+        \\  constructor(): void;
+        \\}
+        \\type Shape = {
+        \\  constructor(): void;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_misused_new.id));
+}
+
+test "reports @typescript-eslint/no-misused-new for class new signatures returning the class" {
+    const source =
+        \\class Widget {
+        \\  new (): Widget;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_misused_new.id));
+}
+
+test "does not report @typescript-eslint/no-misused-new for non-self construct signatures" {
+    const source =
+        \\interface Widget {
+        \\  new (): Other;
+        \\}
+        \\class Factory {
+        \\  new (): Other;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_misused_new.id));
+}
+
+test "can disable @typescript-eslint/no-misused-new" {
+    const source =
+        \\interface Widget {
+        \\  constructor(): void;
+        \\  new (): Widget;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_misused_new = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_misused_new.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-misused-new coverage for interface construct signatures, constructor method signatures, and class new signatures\n- wire the rule into default options, CLI disabling, docs, and test registration\n- add focused tests and verify behavior against the local fishlint @typescript-eslint plugin\n\n## Verification\n- zig test -O ReleaseFast --test-filter no-misused-new --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-misused-new=off\n