### PR TITLE
perf: combine symbol checks traversal

### DIFF
--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 
 const global_is_checks = @import("global_is_checks.zig");
 const object_constructor_checks = @import("object_constructor_checks.zig");
+const symbol_checks = @import("symbol_checks.zig");
 
 pub const curly = @import("curly.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
@@ -364,8 +365,15 @@ pub fn runSemantic(
         try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_new_symbol) {
-        try no_new_symbol.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    if (options.no_new_symbol or options.symbol_description) {
+        try symbol_checks.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.no_new_symbol,
+            options.symbol_description,
+        );
     }
 
     if (options.no_new_wrappers) {
@@ -394,10 +402,6 @@ pub fn runSemantic(
 
     if (options.require_atomic_updates) {
         try require_atomic_updates.run(allocator, diagnostics, tree, semantic_result.symbol_table);
-    }
-
-    if (options.symbol_description) {
-        try symbol_description.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_unused_vars) {

--- a/src/rules/symbol_checks.zig
+++ b/src/rules/symbol_checks.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_new_symbol = @import("no_new_symbol.zig");
+const symbol_description = @import("symbol_description.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    check_no_new_symbol: bool,
+    check_symbol_description: bool,
+) Allocator.Error!void {
+    if (!check_no_new_symbol and !check_symbol_description) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .check_no_new_symbol = check_no_new_symbol,
+        .check_symbol_description = check_symbol_description,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    check_no_new_symbol: bool,
+    check_symbol_description: bool,
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.check_no_new_symbol and isGlobalSymbolReference(ctx.tree, self.symbol_table, expression.callee)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .@"error",
+                no_new_symbol.id,
+                "`Symbol` cannot be called as a constructor.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.check_symbol_description and
+            call.arguments.len == 0 and
+            isGlobalSymbolReference(ctx.tree, self.symbol_table, call.callee))
+        {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                symbol_description.id,
+                "Expected Symbol to have a description.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isGlobalSymbolReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+
+    return std.mem.eql(u8, name, "Symbol") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
## Summary
- Run `no-new-symbol` and `symbol-description` in one shared traversal
- Keep both rule options and diagnostic rule ids independent

## Performance
- 1000 generated TS files: base 39.139 ms median, current 38.695 ms median, ~1.1% faster
- 50k generated TS files: base 1881.094 ms median, current 1865.834 ms median, ~0.8% faster

## Verification
- `zig build -Doptimize=ReleaseFast -j1`
- `zig build test --summary all` (576/576 passed)
- `npm run codspeed -- --target=fixtures/perf-next --time=100 --warmup-time=0`
