### PR TITLE
feat: port typescript-eslint no-var-requires

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -180,5 +180,6 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
+| [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -193,6 +193,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
+    typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,
     parser_semantic_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -405,6 +405,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_this_alias = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-var-requires=off")) {
+            options.typescript_eslint_no_var_requires = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
             options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-namespace-keyword=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -185,6 +185,7 @@ pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("types
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
+pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
@@ -364,6 +365,10 @@ pub fn runSemantic(
 
     if (options.typescript_eslint_no_require_imports) {
         try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.typescript_eslint_no_var_requires) {
+        try typescript_eslint_no_var_requires.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_new_symbol or options.symbol_description) {

--- a/src/rules/typescript_eslint_no_var_requires.zig
+++ b/src/rules/typescript_eslint_no_var_requires.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-var-requires";
+
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    if (std.mem.indexOf(u8, tree.source, "require") == null) return;
+
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .reference_lookup = &reference_lookup,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    reference_lookup: *const ReferenceLookup,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.isGlobalRequireReference(ctx.tree, call.callee)) return .proceed;
+        if (!hasDisallowedParent(ctx.tree, index, ctx)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .@"error",
+            id,
+            "Require statement not part of import statement.",
+            ctx.tree.span(index),
+        );
+        return .proceed;
+    }
+
+    fn isGlobalRequireReference(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        const name = identifierReferenceName(tree, index) orelse return false;
+        if (!std.mem.eql(u8, name, "require")) return false;
+
+        return (self.reference_lookup.get(index) orelse .none) == .none;
+    }
+};
+
+fn hasDisallowedParent(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child_index = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent_index| : (depth += 1) {
+        const parent = tree.data(parent_index);
+        switch (parent) {
+            .chain_expression => |chain| {
+                if (chain.expression != child_index) return false;
+                child_index = parent_index;
+                continue;
+            },
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child_index) return false;
+                child_index = parent_index;
+                continue;
+            },
+            .call_expression,
+            .member_expression,
+            .new_expression,
+            .ts_as_expression,
+            .ts_type_assertion,
+            .variable_declarator,
+            => return true,
+            else => return false,
+        }
+    }
+
+    return false;
+}
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -695,6 +695,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_var_requires.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_prefer_as_const.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_var_requires.zig
+++ b/tests/rules/typescript_eslint_no_var_requires.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-var-requires for require in disallowed expression contexts" {
+    const source =
+        \\const fs = require("fs");
+        \\const joined = require("path").join;
+        \\const typed = require("module") as unknown;
+        \\const value = <unknown>require("value");
+        \\const instance = new (require("factory"))();
+        \\require("runner")();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_new = false,
+        .no_new_require = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_no_var_requires.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_var_requires.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-var-requires for import statements or bare require calls" {
+    const source =
+        \\import fs = require("fs");
+        \\require("side-effect");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_var_requires.id));
+}
+
+test "does not report @typescript-eslint/no-var-requires for local require functions" {
+    const source =
+        \\function require(name: string) {
+        \\  return name;
+        \\}
+        \\const fs = require("fs");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_var_requires.id));
+}
+
+test "can disable @typescript-eslint/no-var-requires" {
+    const source =
+        \\const fs = require("fs");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_var_requires = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_var_requires.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-var-requires with global require detection and upstream-compatible parent context filtering\n- wire the rule into default options, CLI disabling, docs, and test registration\n- cover import-equals, bare require calls, local require shadowing, and disabled-rule behavior\n\n## Verification\n- zig test -O ReleaseFast --test-filter no-var-requires --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-var-requires=off\n