### PR TITLE
feat: port typescript-eslint no-array-constructor

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -171,6 +171,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -182,6 +182,7 @@ pub const Options = struct {
     spaced_comment: bool = true,
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
+    typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -383,6 +383,8 @@ pub fn main(init: std.process.Init) !void {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
             options.typescript_eslint_adjacent_overload_signatures = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-array-constructor=off")) {
+            options.typescript_eslint_no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-ts-comment=off")) {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -174,6 +174,7 @@ pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
+pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
@@ -269,7 +270,7 @@ pub fn runSemantic(
         try no_async_promise_executor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_array_constructor) {
+    if (options.no_array_constructor and !options.typescript_eslint_no_array_constructor) {
         try no_array_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
@@ -1286,6 +1287,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_extra_non_null_assertion) {
             try typescript_eslint_no_extra_non_null_assertion.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
+        if (self.options.typescript_eslint_no_array_constructor) {
+            try typescript_eslint_no_array_constructor.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
         return .proceed;
     }
 
@@ -1308,6 +1312,9 @@ const BasicVisitor = struct {
         }
         if (self.options.new_parens) {
             try new_parens.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.typescript_eslint_no_array_constructor) {
+            try typescript_eslint_no_array_constructor.checkNewExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_array_constructor.zig
+++ b/src/rules/typescript_eslint_no_array_constructor.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-array-constructor";
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (call.arguments.len == 1) return;
+    if (call.type_arguments != .null) return;
+    if (call.optional) return;
+    if (!isArrayIdentifier(tree, call.callee)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkNewExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NewExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.arguments.len == 1) return;
+    if (expression.type_arguments != .null) return;
+    if (!isArrayIdentifier(tree, expression.callee)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "The array literal notation [] is preferable.",
+        tree.span(index),
+    );
+}
+
+fn isArrayIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    const name = switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, "Array");
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -651,6 +651,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_array_constructor.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_ban_ts_comment.zig");
 }
 

--- a/tests/rules/no_array_constructor.zig
+++ b/tests/rules/no_array_constructor.zig
@@ -15,6 +15,7 @@ test "reports no-array-constructor for disallowed Array constructor usage" {
         .no_console = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -36,6 +37,7 @@ test "does not report no-array-constructor for single non-spread argument or sha
         .no_console = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -52,6 +54,7 @@ test "can disable no-array-constructor" {
         .no_array_constructor = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_array_constructor.zig
+++ b/tests/rules/typescript_eslint_no_array_constructor.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-array-constructor for generic Array constructors" {
+    const source =
+        \\const a = Array();
+        \\const b = new Array();
+        \\const c = Array(1, 2);
+        \\const d = new Array("a", "b");
+        \\function local(Array: (...args: unknown[]) => unknown) {
+        \\  const e = Array();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_array_constructor.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_array_constructor.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-array-constructor for single arguments or type arguments" {
+    const source =
+        \\const a = Array(length);
+        \\const b = new Array(10);
+        \\const c = Array(...items);
+        \\const d = Array<string>();
+        \\const e = new Array<string>();
+        \\const f = Array?.();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
+}
+
+test "can disable @typescript-eslint/no-array-constructor and fall back to core rule" {
+    const source =
+        \\const a = Array();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_array_constructor.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-array-constructor with upstream-compatible AST behavior\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics, while preserving core no-array-constructor when the TS rule is disabled\n- add focused TS rule tests and update core rule tests to opt out of the TS replacement\n\n## Verification\n- zig test -O ReleaseFast --test-filter array-constructor --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-array-constructor=off\n