### PR TITLE
feat: port typescript-eslint no-loss-of-precision

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -176,6 +176,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
+| [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -189,6 +189,7 @@ pub const Options = struct {
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
+    typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_misused_new: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_require_imports: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -397,6 +397,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_extra_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {
             options.typescript_eslint_no_inferrable_types = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-loss-of-precision=off")) {
+            options.typescript_eslint_no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-misused-new=off")) {
             options.typescript_eslint_no_misused_new = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {

--- a/src/rules/no_loss_of_precision.zig
+++ b/src/rules/no_loss_of_precision.zig
@@ -17,7 +17,7 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     const raw = tree.string(literal.raw);
-    if (!losesPrecision(raw, literal.kind)) return;
+    if (!numericLiteralLosesPrecision(raw, literal.kind)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -29,7 +29,7 @@ pub fn check(
     );
 }
 
-fn losesPrecision(raw: []const u8, kind: ast.NumericLiteral.Kind) bool {
+pub fn numericLiteralLosesPrecision(raw: []const u8, kind: ast.NumericLiteral.Kind) bool {
     var buffer: [256]u8 = undefined;
     const clean = stripSeparators(raw, &buffer) orelse return false;
     if (clean.len == 0) return false;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -182,6 +182,7 @@ pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescrip
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
+pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no_loss_of_precision.zig");
 pub const typescript_eslint_no_misused_new = @import("typescript_eslint_no_misused_new.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
@@ -1107,8 +1108,11 @@ const BasicVisitor = struct {
         if (self.options.no_floating_decimal) {
             try no_floating_decimal.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
-        if (self.options.no_loss_of_precision) {
+        if (self.options.no_loss_of_precision and !self.options.typescript_eslint_no_loss_of_precision) {
             try no_loss_of_precision.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.typescript_eslint_no_loss_of_precision) {
+            try typescript_eslint_no_loss_of_precision.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_loss_of_precision.zig
+++ b/src/rules/typescript_eslint_no_loss_of_precision.zig
@@ -1,0 +1,28 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_loss_of_precision = @import("no_loss_of_precision.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-loss-of-precision";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.NumericLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const raw = tree.string(literal.raw);
+    if (!no_loss_of_precision.numericLiteralLosesPrecision(raw, literal.kind)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "This number literal will lose precision at runtime.",
+        tree.span(index),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -679,6 +679,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_loss_of_precision.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_misused_new.zig");
 }
 

--- a/tests/rules/no_loss_of_precision.zig
+++ b/tests/rules/no_loss_of_precision.zig
@@ -14,6 +14,7 @@ test "reports no-loss-of-precision for decimal literals with lost digits" {
         .no_floating_decimal = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_loss_of_precision = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -31,6 +32,7 @@ test "reports no-loss-of-precision for non-decimal literals with lost bits" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_loss_of_precision = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -53,6 +55,7 @@ test "does not report no-loss-of-precision for safe or documented literals" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_loss_of_precision = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -69,6 +72,7 @@ test "can disable no-loss-of-precision" {
         .no_loss_of_precision = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_loss_of_precision = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_loss_of_precision.zig
+++ b/tests/rules/typescript_eslint_no_loss_of_precision.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-loss-of-precision for imprecise number literals" {
+    const source =
+        \\const tooLarge = 9007199254740993;
+        \\const separated = 9_007_199_254_740_993;
+        \\const fractional = .1230000000000000000000000;
+        \\const hex = 0X20000000000001;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_floating_decimal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_no_loss_of_precision.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_loss_of_precision.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_loss_of_precision.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-loss-of-precision for safe literals or bigint" {
+    const source =
+        \\const small = 12345;
+        \\const exponent = 123e34;
+        \\const max = 9007199254740991;
+        \\const bigint = 9007199254740993n;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_loss_of_precision.id));
+}
+
+test "can disable @typescript-eslint/no-loss-of-precision and fall back to core rule" {
+    const source =
+        \\const tooLarge = 9007199254740993;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_loss_of_precision = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_loss_of_precision.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_loss_of_precision.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-loss-of-precision using the existing numeric precision detector with the TypeScript rule id/message/severity\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics, while preserving core no-loss-of-precision when the TS rule is disabled\n- add focused TS rule tests and update core tests to opt out of the TS replacement\n\n## Verification\n- zig test -O ReleaseFast --test-filter loss-of-precision --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-loss-of-precision=off\n