### PR TITLE
feat: port typescript-eslint no-useless-constructor

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -182,6 +182,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
+| [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -195,6 +195,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
+    typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -409,6 +409,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_this_alias = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
+            options.typescript_eslint_no_useless_constructor = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-var-requires=off")) {
             options.typescript_eslint_no_var_requires = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {

--- a/src/rules/no_useless_constructor.zig
+++ b/src/rules/no_useless_constructor.zig
@@ -36,7 +36,7 @@ pub fn checkClass(
     }
 }
 
-fn isUselessConstructor(tree: *const ast.Tree, class: ast.Class, method: ast.MethodDefinition) bool {
+pub fn isUselessConstructor(tree: *const ast.Tree, class: ast.Class, method: ast.MethodDefinition) bool {
     if (method.kind != .constructor) return false;
     if (method.static) return false;
     if (method.decorators.len != 0) return false;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -188,6 +188,7 @@ pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("types
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
+pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
@@ -497,8 +498,11 @@ const BasicVisitor = struct {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
         }
-        if (self.options.no_useless_constructor) {
+        if (self.options.no_useless_constructor and !self.options.typescript_eslint_no_useless_constructor) {
             try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
+        if (self.options.typescript_eslint_no_useless_constructor) {
+            try typescript_eslint_no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkClass(self.allocator, self.diagnostics, ctx.tree, class);

--- a/src/rules/typescript_eslint_no_useless_constructor.zig
+++ b/src/rules/typescript_eslint_no_useless_constructor.zig
@@ -1,0 +1,37 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_useless_constructor = @import("no_useless_constructor.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-useless-constructor";
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (!no_useless_constructor.isUselessConstructor(tree, class, method)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Useless constructor.",
+            tree.span(member_index),
+        );
+    }
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -703,6 +703,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_useless_constructor.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_var_requires.zig");
 }
 

--- a/tests/rules/no_useless_constructor.zig
+++ b/tests/rules/no_useless_constructor.zig
@@ -17,6 +17,7 @@ test "reports no-useless-constructor for empty constructors without superclasses
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_useless_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -48,6 +49,7 @@ test "reports no-useless-constructor for pass-through super calls" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_useless_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -78,6 +80,7 @@ test "does not report no-useless-constructor for useful constructors" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_useless_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -98,6 +101,7 @@ test "can disable no-useless-constructor" {
         .no_undef = false,
         .no_unused_vars = false,
         .no_useless_constructor = false,
+        .typescript_eslint_no_useless_constructor = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_useless_constructor.zig
+++ b/tests/rules/typescript_eslint_no_useless_constructor.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-useless-constructor for empty and pass-through constructors" {
+    const source =
+        \\class Empty {
+        \\  constructor() {}
+        \\}
+        \\class Derived extends Base {
+        \\  constructor(...args: unknown[]) {
+        \\    super(...args);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_useless_constructor.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_constructor.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_useless_constructor.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-useless-constructor for useful TypeScript constructors" {
+    const source =
+        \\class ParameterProperty {
+        \\  constructor(public value: string) {}
+        \\}
+        \\class ProtectedConstructor {
+        \\  protected constructor() {}
+        \\}
+        \\class PublicDerived extends Base {
+        \\  public constructor() {
+        \\    super();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_useless_constructor.id));
+}
+
+test "can disable @typescript-eslint/no-useless-constructor and fall back to core rule" {
+    const source =
+        \\class Empty {
+        \\  constructor() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_useless_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_useless_constructor.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_useless_constructor.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-useless-constructor using the existing constructor usefulness detector with the TypeScript rule id/severity\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics, while preserving core no-useless-constructor when the TS rule is disabled\n- add focused TS rule tests and update core tests to opt out of the TS replacement\n\n## Verification\n- zig test -O ReleaseFast --test-filter useless-constructor --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-useless-constructor=off\n