### PR TITLE
feat: port typescript-eslint no-empty-function

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -173,6 +173,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
+| [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -186,6 +186,7 @@ pub const Options = struct {
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
+    typescript_eslint_no_empty_function: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -391,6 +391,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_tslint_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
             options.typescript_eslint_no_confusing_non_null_assertion = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-function=off")) {
+            options.typescript_eslint_no_empty_function = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
             options.typescript_eslint_no_empty_interface = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-non-null-assertion=off")) {

--- a/src/rules/no_empty_function.zig
+++ b/src/rules/no_empty_function.zig
@@ -27,7 +27,7 @@ pub fn check(
     );
 }
 
-fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+pub fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const span = tree.span(index);
     const start: usize = @intCast(span.start);
     const end: usize = @intCast(span.end);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -179,6 +179,7 @@ pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
+pub const typescript_eslint_no_empty_function = @import("typescript_eslint_no_empty_function.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
@@ -995,8 +996,11 @@ const BasicVisitor = struct {
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index);
         }
-        if (self.options.no_empty_function) {
+        if (self.options.no_empty_function and !self.options.typescript_eslint_no_empty_function) {
             try no_empty_function.check(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
+        if (self.options.typescript_eslint_no_empty_function) {
+            try typescript_eslint_no_empty_function.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);
         }
         if (self.options.getter_return) {
             try getter_return.check(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);

--- a/src/rules/typescript_eslint_no_empty_function.zig
+++ b/src/rules/typescript_eslint_no_empty_function.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_empty_function = @import("no_empty_function.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-empty-function";
+
+pub fn checkFunctionBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (body.body.len != 0) return;
+    if (no_empty_function.hasCommentInsideBraces(tree, index)) return;
+    if (hasParameterPropertyConstructor(tree, ctx)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Unexpected empty {s}.",
+        .{functionDescription(tree, ctx)},
+    );
+}
+
+fn hasParameterPropertyConstructor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const function = parentFunction(tree, ctx) orelse return false;
+    const method = parentMethod(tree, ctx) orelse return false;
+    if (method.kind != .constructor) return false;
+
+    const params = switch (tree.data(function.params)) {
+        .formal_parameters => |params| params,
+        else => return false,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        if (tree.data(item_index) == .ts_parameter_property) return true;
+    }
+    return false;
+}
+
+fn functionDescription(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) []const u8 {
+    if (parentMethod(tree, ctx)) |method| {
+        return switch (method.kind) {
+            .constructor => "constructor",
+            .method => methodDescription(tree, method, "method"),
+            .get => methodDescription(tree, method, "getter"),
+            .set => methodDescription(tree, method, "setter"),
+        };
+    }
+
+    const parent_index = ctx.path.parent() orelse return "function";
+    const function_index = ctx.path.ancestor(1) orelse parent_index;
+    _ = function_index;
+
+    return switch (tree.data(parent_index)) {
+        .function => |function| switch (function.type) {
+            .function_declaration => namedFunctionDescription(tree, function.id),
+            else => "function",
+        },
+        .arrow_function_expression => "arrow function",
+        else => "function",
+    };
+}
+
+fn methodDescription(tree: *const ast.Tree, method: ast.MethodDefinition, kind: []const u8) []const u8 {
+    const name = keyName(tree, method.key, method.computed) orelse return kind;
+    if (std.mem.eql(u8, kind, "method")) {
+        if (std.mem.eql(u8, name, "")) return kind;
+        return "method";
+    }
+    return kind;
+}
+
+fn namedFunctionDescription(tree: *const ast.Tree, id_index: ast.NodeIndex) []const u8 {
+    const name = bindingIdentifierName(tree, id_index) orelse return "function";
+    if (name.len == 0) return "function";
+    return "function";
+}
+
+fn parentFunction(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.Function {
+    const parent_index = ctx.path.parent() orelse return null;
+    return switch (tree.data(parent_index)) {
+        .function => |function| function,
+        else => null,
+    };
+}
+
+fn parentMethod(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.MethodDefinition {
+    const grandparent_index = ctx.path.ancestor(2) orelse return null;
+    return switch (tree.data(grandparent_index)) {
+        .method_definition => |method| method,
+        else => null,
+    };
+}
+
+fn keyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed or key == .null) return null;
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -667,6 +667,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_empty_function.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_empty_interface.zig");
 }
 

--- a/tests/rules/no_empty_function.zig
+++ b/tests/rules/no_empty_function.zig
@@ -15,6 +15,7 @@ test "reports no-empty-function for empty function bodies" {
         .no_empty_block_statements = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -39,6 +40,7 @@ test "does not report no-empty-function for non-empty or commented bodies" {
         .no_empty_block_statements = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -57,6 +59,7 @@ test "can disable no-empty-function" {
         .no_empty_block_statements = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -15,6 +15,7 @@ test "reports no-extend-native for native prototype assignments" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -38,6 +39,7 @@ test "reports no-extend-native for Object defineProperty calls" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -64,6 +66,7 @@ test "does not report no-extend-native for shadowed constructors or ordinary obj
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -84,6 +87,7 @@ test "can disable no-extend-native" {
         .no_extend_native = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_empty_function.zig
+++ b/tests/rules/typescript_eslint_no_empty_function.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-empty-function for empty function bodies" {
+    const source =
+        \\function empty() {}
+        \\const arrow = () => {};
+        \\class Example {
+        \\  method() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_function.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_function.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_empty_function.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-empty-function for comments or parameter properties" {
+    const source =
+        \\const documented = () => {
+        \\  // intentionally empty
+        \\};
+        \\class Example {
+        \\  constructor(public value: string) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_function.id));
+}
+
+test "can disable @typescript-eslint/no-empty-function and fall back to core rule" {
+    const source =
+        \\function empty() {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_function.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_empty_function.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-empty-function with TypeScript parameter-property constructor allowance\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics, while preserving core no-empty-function when the TS rule is disabled\n- add focused TS rule tests and update affected core tests to opt out of the TS replacement\n\n## Verification\n- zig test -O ReleaseFast --test-filter empty-function --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-empty-function=off\n