### PR TITLE
perf: combine native object checks traversal

### DIFF
--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_new_native_nonconstructor = @import("no_new_native_nonconstructor.zig");
+const no_obj_calls = @import("no_obj_calls.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    check_no_new_native_nonconstructor: bool,
+    check_no_obj_calls: bool,
+) Allocator.Error!void {
+    if (!check_no_new_native_nonconstructor and !check_no_obj_calls) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .check_no_new_native_nonconstructor = check_no_new_native_nonconstructor,
+        .check_no_obj_calls = check_no_obj_calls,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    check_no_new_native_nonconstructor: bool,
+    check_no_obj_calls: bool,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.check_no_obj_calls) {
+            if (globalObjectName(ctx.tree, self.symbol_table, call.callee)) |name| {
+                try self.reportNoObjCalls(ctx.tree, index, name);
+            }
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const callee = unwrapTransparent(ctx.tree, expression.callee);
+        const name = identifierReferenceName(ctx.tree, callee) orelse return .proceed;
+
+        if (self.check_no_new_native_nonconstructor and isNativeNonconstructorName(name)) {
+            if (isUnresolvedReference(self.symbol_table, callee)) {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .@"error",
+                    no_new_native_nonconstructor.id,
+                    ctx.tree.span(index),
+                    "`{s}` cannot be called as a constructor.",
+                    .{name},
+                );
+            }
+        }
+
+        if (self.check_no_obj_calls and isForbiddenObject(name)) {
+            if (isUnresolvedReference(self.symbol_table, callee)) {
+                try self.reportNoObjCalls(ctx.tree, index, name);
+            }
+        }
+
+        return .proceed;
+    }
+
+    fn reportNoObjCalls(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) Allocator.Error!void {
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            no_obj_calls.id,
+            tree.span(index),
+            "'{s}' is not a function.",
+            .{name},
+        );
+    }
+};
+
+fn globalObjectName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, callee);
+    const name = identifierReferenceName(tree, unwrapped) orelse return null;
+    if (!isForbiddenObject(name)) return null;
+    if (!isUnresolvedReference(symbol_table, unwrapped)) return null;
+    return name;
+}
+
+fn isNativeNonconstructorName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Symbol") or
+        std.mem.eql(u8, name, "BigInt");
+}
+
+fn isForbiddenObject(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Math") or
+        std.mem.eql(u8, name, "JSON") or
+        std.mem.eql(u8, name, "Reflect") or
+        std.mem.eql(u8, name, "Atomics") or
+        std.mem.eql(u8, name, "Intl") or
+        std.mem.eql(u8, name, "Temporal");
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -7,6 +7,7 @@ const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 const global_is_checks = @import("global_is_checks.zig");
+const native_object_checks = @import("native_object_checks.zig");
 const object_constructor_checks = @import("object_constructor_checks.zig");
 const promise_checks = @import("promise_checks.zig");
 const symbol_checks = @import("symbol_checks.zig");
@@ -349,12 +350,15 @@ pub fn runSemantic(
         try no_new_func.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_new_native_nonconstructor) {
-        try no_new_native_nonconstructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
-    }
-
-    if (options.no_obj_calls) {
-        try no_obj_calls.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    if (options.no_new_native_nonconstructor or options.no_obj_calls) {
+        try native_object_checks.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.no_new_native_nonconstructor,
+            options.no_obj_calls,
+        );
     }
 
     if (options.no_new_object or options.no_object_constructor) {


### PR DESCRIPTION
## Summary
- run `no-new-native-nonconstructor` and `no-obj-calls` in one shared traversal
- keep both rule flags independent and preserve each rule's original id/message
- avoid duplicate outer AST walks and duplicate global callee/reference lookup for native object checks

## Performance
Local A/B against `origin/main@0261623`:

- 1000 generated TS files, 30 statement blocks/file, `--time=100 --warmup-time=0`
  - base median: 36.534 ms
  - current median: 35.236 ms
  - ~3.6% faster
- 50000 generated TS files, 30 statement blocks/file, `--time=100 --warmup-time=0`
  - base median: 3389.117 ms
  - current median: 3320.336 ms
  - ~2.0% faster

## Verification
- `zig build test --summary all` (594/594)
- `zig build -Doptimize=ReleaseFast -j1`
- `npm run codspeed -- --target=fixtures/perf-next --time=100 --warmup-time=0`
- `npm run codspeed -- --target=fixtures/perf-profile --time=100 --warmup-time=0`
