### PR TITLE
feat: port typescript-eslint no-extra-semi

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
+| [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -188,6 +188,7 @@ pub const Options = struct {
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,
     typescript_eslint_no_empty_interface: bool = true,
+    typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,6 +395,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_empty_function = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
             options.typescript_eslint_no_empty_interface = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-semi=off")) {
+            options.typescript_eslint_no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-non-null-assertion=off")) {
             options.typescript_eslint_no_extra_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {

--- a/src/rules/no_extra_semi.zig
+++ b/src/rules/no_extra_semi.zig
@@ -26,7 +26,7 @@ pub fn check(
     );
 }
 
-fn isStatementBody(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+pub fn isStatementBody(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
     const parent = ctx.path.ancestor(1) orelse return false;
 
     return switch (tree.data(parent)) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -181,6 +181,7 @@ pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_empty_function = @import("typescript_eslint_no_empty_function.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
+pub const typescript_eslint_no_extra_semi = @import("typescript_eslint_no_extra_semi.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
 pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no_loss_of_precision.zig");
@@ -640,8 +641,11 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.no_extra_semi) {
+        if (self.options.no_extra_semi and !self.options.typescript_eslint_no_extra_semi) {
             try no_extra_semi.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
+        }
+        if (self.options.typescript_eslint_no_extra_semi) {
+            try typescript_eslint_no_extra_semi.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_extra_semi.zig
+++ b/src/rules/typescript_eslint_no_extra_semi.zig
@@ -1,0 +1,28 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_extra_semi = @import("no_extra_semi.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-extra-semi";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (no_extra_semi.isStatementBody(tree, index, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Unnecessary semicolon.",
+        tree.span(index),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -675,6 +675,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_extra_semi.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_extra_non_null_assertion.zig");
 }
 

--- a/tests/rules/no_extra_semi.zig
+++ b/tests/rules/no_extra_semi.zig
@@ -12,6 +12,7 @@ test "reports no-extra-semi for unnecessary empty statements" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -32,6 +33,7 @@ test "does not report no-extra-semi for empty statement bodies" {
         .no_constant_condition = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -48,6 +50,7 @@ test "can disable no-extra-semi" {
         .no_extra_semi = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_extra_semi.zig
+++ b/tests/rules/typescript_eslint_no_extra_semi.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-extra-semi for unnecessary empty statements" {
+    const source =
+        \\const value = 1;;
+        \\function run() {}
+        \\;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_function = false,
+        .typescript_eslint_no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_extra_semi.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_semi.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_extra_semi.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-extra-semi for empty statement bodies" {
+    const source =
+        \\while (ready);
+        \\for (; ready; );
+        \\if (ready); else ;
+        \\label: ;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_labels = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_extra_semi.id));
+}
+
+test "can disable @typescript-eslint/no-extra-semi and fall back to core rule" {
+    const source =
+        \\const value = 1;;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_extra_semi.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_extra_semi.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-extra-semi using the existing empty-statement context detector with the TypeScript rule id/severity\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics, while preserving core no-extra-semi when the TS rule is disabled\n- add focused TS rule tests and update core tests to opt out of the TS replacement\n\n## Verification\n- zig test -O ReleaseFast --test-filter extra-semi --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-extra-semi=off\n