### PR TITLE
feat: port typescript-eslint ban-types

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -171,6 +171,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
+| [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
+    typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_adjacent_overload_signatures = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-array-constructor=off")) {
             options.typescript_eslint_no_array_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-types=off")) {
+            options.typescript_eslint_ban_types = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-ts-comment=off")) {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
+pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
@@ -758,6 +759,18 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkTypeLiteral(self.allocator, self.diagnostics, ctx.tree, type_literal);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_type_reference(
+        self: *BasicVisitor,
+        reference: ast.TSTypeReference,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_ban_types) {
+            try typescript_eslint_ban_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_ban_types.zig
+++ b/src/rules/typescript_eslint_ban_types.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/ban-types";
+
+const BannedType = struct {
+    name: []const u8,
+    message: []const u8,
+};
+
+pub fn checkTypeReference(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reference: ast.TSTypeReference,
+) Allocator.Error!void {
+    const name = typeName(tree, reference.type_name) orelse return;
+    const banned = bannedType(name) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(reference.type_name),
+        "Don't use `{s}` as a type. {s}",
+        .{ banned.name, banned.message },
+    );
+}
+
+fn bannedType(name: []const u8) ?BannedType {
+    if (std.mem.eql(u8, name, "String")) return .{
+        .name = "String",
+        .message = "Use string instead",
+    };
+    if (std.mem.eql(u8, name, "Boolean")) return .{
+        .name = "Boolean",
+        .message = "Use boolean instead",
+    };
+    if (std.mem.eql(u8, name, "Number")) return .{
+        .name = "Number",
+        .message = "Use number instead",
+    };
+    if (std.mem.eql(u8, name, "Symbol")) return .{
+        .name = "Symbol",
+        .message = "Use symbol instead",
+    };
+    if (std.mem.eql(u8, name, "BigInt")) return .{
+        .name = "BigInt",
+        .message = "Use bigint instead",
+    };
+    if (std.mem.eql(u8, name, "Function")) return .{
+        .name = "Function",
+        .message = "The `Function` type accepts any function-like value.\n" ++
+            "It provides no type safety when calling the function, which can be a common source of bugs.\n" ++
+            "It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.\n" ++
+            "If you are expecting the function to accept certain arguments, you should explicitly define the function shape.",
+    };
+    if (std.mem.eql(u8, name, "Object")) return .{
+        .name = "Object",
+        .message = "The `Object` type actually means \"any non-nullish value\", so it is marginally better than `unknown`.\n" ++
+            "- If you want a type meaning \"any object\", you probably want `object` instead.\n" ++
+            "- If you want a type meaning \"any value\", you probably want `unknown` instead.\n" ++
+            "- If you really want a type meaning \"any non-nullish value\", you probably want `NonNullable<unknown>` instead.",
+    };
+
+    return null;
+}
+
+fn typeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_ban_types.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_ban_ts_comment.zig");
 }
 

--- a/tests/rules/typescript_eslint_ban_types.zig
+++ b/tests/rules/typescript_eslint_ban_types.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/ban-types for fishlint banned default types" {
+    const source =
+        \\let text: String;
+        \\let flag: Boolean;
+        \\let count: Number;
+        \\let sym: Symbol;
+        \\let big: BigInt;
+        \\let fn: Function;
+        \\let value: Object;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.typescript_eslint_ban_types.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_ban_types.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/ban-types for fishlint allowed object forms" {
+    const source =
+        \\let value: object;
+        \\let empty: {};
+        \\let text: string;
+        \\let count: number;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_types.id));
+}
+
+test "can disable @typescript-eslint/ban-types" {
+    const source =
+        \\let text: String;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_ban_types = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_types.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/ban-types for fishlint's configured defaults\n- reports default banned wrapper/broad types while respecting fishlint's disabled {} and object entries\n- wire default options, CLI disabling, docs, and focused tests\n\n## Verification\n- zig test -O ReleaseFast --test-filter ban-types --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-ban-types=off\n