### PR TITLE
feat: port typescript-eslint no-use-before-define

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -186,6 +186,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
+| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -199,6 +199,7 @@ pub const Options = struct {
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
+    typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -417,6 +417,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
             options.typescript_eslint_no_useless_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-use-before-define=off")) {
+            options.typescript_eslint_no_use_before_define = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-var-requires=off")) {
             options.typescript_eslint_no_var_requires = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -11,6 +11,13 @@ pub const id = "no-use-before-define";
 const SymbolId = traverser.semantic.SymbolId;
 const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
 
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    severity: core.Severity = .warning,
+    check_functions: bool = true,
+    check_classes: bool = true,
+};
+
 const InitRange = struct {
     symbol_id: SymbolId,
     span: ast.Span,
@@ -22,12 +29,22 @@ pub fn run(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var decl_symbols = DeclSymbolMap.init(allocator);
     defer decl_symbols.deinit();
 
     var symbol_iter = symbol_table.iterSymbols();
     while (symbol_iter.next()) |entry| {
-        if (!isLintableSymbol(entry.symbol.flags)) continue;
+        if (!isLintableSymbol(entry.symbol.flags, options)) continue;
         for (symbol_table.symbolDecls(entry.id)) |decl| {
             try decl_symbols.put(decl, entry.id);
         }
@@ -53,7 +70,7 @@ pub fn run(
         if (symbol_id == .none) continue;
 
         const symbol = symbol_table.getSymbol(symbol_id);
-        if (!isLintableSymbol(symbol.flags)) continue;
+        if (!isLintableSymbol(symbol.flags, options)) continue;
 
         const decls = symbol_table.symbolDecls(symbol_id);
         if (decls.len == 0) continue;
@@ -67,8 +84,8 @@ pub fn run(
         try core.addDiagnosticFmt(
             allocator,
             diagnostics,
-            .warning,
-            id,
+            options.severity,
+            options.rule_id,
             reference_span,
             "'{s}' was used before it was defined.",
             .{tree.string(reference.name)},
@@ -166,8 +183,10 @@ fn spanInside(span: ast.Span, container: ast.Span) bool {
     return span.start >= container.start and span.end <= container.end;
 }
 
-fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
     if (flags.ambient) return false;
     if (flags.type_import or flags.interface or flags.type_alias or flags.type_parameter) return false;
+    if (!options.check_functions and flags.function) return false;
+    if (!options.check_classes and flags.class) return false;
     return flags.inValueSpace() or flags.import;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -193,6 +193,7 @@ pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_r
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
+pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no_use_before_define.zig");
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
@@ -430,8 +431,12 @@ pub fn runSemantic(
         try no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_use_before_define) {
+    if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {
         try no_use_before_define.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.typescript_eslint_no_use_before_define) {
+        try typescript_eslint_no_use_before_define.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_undef) {

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -1,0 +1,22 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_use_before_define = @import("no_use_before_define.zig");
+
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-use-before-define";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    try no_use_before_define.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+        .rule_id = id,
+        .severity = .@"error",
+        .check_functions = false,
+        .check_classes = true,
+    });
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -719,6 +719,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_use_before_define.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_var_requires.zig");
 }
 

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -19,6 +19,7 @@ test "reports no-use-before-define for references before declarations" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -41,6 +42,7 @@ test "does not report no-use-before-define for references after declarations" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -57,6 +59,7 @@ test "reports no-use-before-define for repeated initializer self references" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_redeclare = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -73,6 +76,7 @@ test "can disable no-use-before-define" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_use_before_define = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-use-before-define for classes and variables but not functions" {
+    const source =
+        \\f();
+        \\function f() {}
+        \\
+        \\new C();
+        \\class C {}
+        \\
+        \\a;
+        \\let a = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_use_before_define.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_use_before_define.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-use-before-define for type references" {
+    const source =
+        \\let value: Later;
+        \\type Later = string;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+}
+
+test "can disable @typescript-eslint/no-use-before-define and fall back to core rule" {
+    const source =
+        \\f();
+        \\function f() {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_use_before_define = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_use_before_define.id));
+}


### PR DESCRIPTION
## Summary\n- add @typescript-eslint/no-use-before-define for fishlint's functions:false/classes:true configuration\n- refactor the core no-use-before-define runner to support rule id/severity and function/class switches\n- use the TypeScript rule by default to avoid duplicate core/TS diagnostics and update focused tests\n\n## Verification\n- zig test -O ReleaseFast --test-filter use-before-define --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig\n- zig build test -Doptimize=ReleaseFast -j1\n- zig build -Doptimize=ReleaseFast -j1\n- git diff --check\n- CLI smoke for default and --typescript-eslint-no-use-before-define=off\n