### PR TITLE
feat: port typescript-eslint no-unused-vars

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -186,6 +186,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
+| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -199,6 +199,7 @@ pub const Options = struct {
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
+    typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_prefer_as_const: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -417,6 +417,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
             options.typescript_eslint_no_useless_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unused-vars=off")) {
+            options.typescript_eslint_no_unused_vars = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-use-before-define=off")) {
             options.typescript_eslint_no_use_before_define = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-var-requires=off")) {
@@ -838,6 +840,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
+        \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
         \\  --semantic-errors=off     Disable parser semantic errors

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -8,21 +8,70 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-unused-vars";
 
+const SymbolId = traverser.semantic.SymbolId;
+const IgnoredDecls = std.AutoHashMap(ast.NodeIndex, void);
+
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    severity: core.Severity = .warning,
+    check_parameters: bool = false,
+    args_after_used: bool = false,
+    ignore_rest_siblings: bool = false,
+    check_type_parameters: bool = false,
+};
+
+const Parameter = struct {
+    symbol_id: SymbolId,
+    scope: traverser.semantic.ScopeId,
+    start: u32,
+    used: bool,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
+    var parameters: std.ArrayList(Parameter) = .empty;
+    defer parameters.deinit(allocator);
+
+    if (options.check_parameters and options.args_after_used) {
+        try collectParameters(allocator, tree, symbol_table, &parameters);
+        std.mem.sort(Parameter, parameters.items, {}, lessThanParameter);
+    }
+
+    var ignored_decls = IgnoredDecls.init(allocator);
+    defer ignored_decls.deinit();
+
+    if (options.ignore_rest_siblings) {
+        var visitor = RestSiblingVisitor{ .ignored_decls = &ignored_decls };
+        try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
+    }
+
     var iter = symbol_table.iterSymbols();
 
     while (iter.next()) |entry| {
         const symbol = entry.symbol;
         const flags = symbol.flags;
 
-        if (!isLintableSymbol(flags)) continue;
+        if (!isLintableSymbol(flags, options)) continue;
         if (flags.exported or flags.ambient) continue;
-        if (flags.parameter or flags.catch_var) continue;
+        if (flags.catch_var) continue;
+        if (flags.parameter) {
+            if (!options.check_parameters) continue;
+            if (options.args_after_used and !shouldCheckParameter(entry.id, symbol.scope, parameters.items)) continue;
+        }
         if (symbol_table.isReferenced(entry.id)) continue;
 
         const name = tree.string(symbol.name);
@@ -30,12 +79,13 @@ pub fn run(
 
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
+        if (ignored_decls.contains(decls[0])) continue;
 
         try core.addDiagnosticFmt(
             allocator,
             diagnostics,
-            .warning,
-            id,
+            options.severity,
+            options.rule_id,
             tree.span(decls[0]),
             "'{s}' is declared but never used.",
             .{name},
@@ -43,11 +93,108 @@ pub fn run(
     }
 }
 
-fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
     return flags.inValueSpace() or
         flags.import or
         flags.type_import or
         flags.interface or
-        flags.type_alias;
+        flags.type_alias or
+        (options.check_type_parameters and flags.type_parameter);
 }
 
+fn collectParameters(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    parameters: *std.ArrayList(Parameter),
+) Allocator.Error!void {
+    var iter = symbol_table.iterSymbols();
+    while (iter.next()) |entry| {
+        const symbol = entry.symbol;
+        if (!symbol.flags.parameter) continue;
+
+        const decls = symbol_table.symbolDecls(entry.id);
+        if (decls.len == 0) continue;
+
+        try parameters.append(allocator, .{
+            .symbol_id = entry.id,
+            .scope = symbol.scope,
+            .start = tree.span(decls[0]).start,
+            .used = symbol_table.isReferenced(entry.id),
+        });
+    }
+}
+
+fn lessThanParameter(_: void, a: Parameter, b: Parameter) bool {
+    const a_scope = @intFromEnum(a.scope);
+    const b_scope = @intFromEnum(b.scope);
+    if (a_scope != b_scope) return a_scope < b_scope;
+    return a.start < b.start;
+}
+
+fn shouldCheckParameter(
+    symbol_id: SymbolId,
+    scope: traverser.semantic.ScopeId,
+    parameters: []const Parameter,
+) bool {
+    var index: ?usize = null;
+    var last_used: ?usize = null;
+
+    for (parameters, 0..) |parameter, i| {
+        if (parameter.scope != scope) continue;
+        if (parameter.symbol_id == symbol_id) index = i;
+        if (parameter.used) last_used = i;
+    }
+
+    const current = index orelse return true;
+    const last = last_used orelse return true;
+    return current > last;
+}
+
+const RestSiblingVisitor = struct {
+    ignored_decls: *IgnoredDecls,
+
+    pub fn enter_object_pattern(
+        self: *RestSiblingVisitor,
+        pattern: ast.ObjectPattern,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (pattern.rest == .null) return .proceed;
+
+        for (ctx.tree.extra(pattern.properties)) |property_index| {
+            const property = ctx.tree.data(property_index).binding_property;
+            try self.collectBinding(property.value, ctx);
+        }
+
+        return .proceed;
+    }
+
+    fn collectBinding(
+        self: *RestSiblingVisitor,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!void {
+        if (index == .null) return;
+
+        switch (ctx.tree.data(index)) {
+            .binding_identifier => try self.ignored_decls.put(index, {}),
+            .assignment_pattern => |assignment| try self.collectBinding(assignment.left, ctx),
+            .binding_rest_element => |rest| try self.collectBinding(rest.argument, ctx),
+            .array_pattern => |array| {
+                for (ctx.tree.extra(array.elements)) |element| {
+                    try self.collectBinding(element, ctx);
+                }
+                try self.collectBinding(array.rest, ctx);
+            },
+            .object_pattern => |object| {
+                for (ctx.tree.extra(object.properties)) |property_index| {
+                    const property = ctx.tree.data(property_index).binding_property;
+                    try self.collectBinding(property.value, ctx);
+                }
+                try self.collectBinding(object.rest, ctx);
+            },
+            else => {},
+        }
+    }
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -194,6 +194,7 @@ pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_r
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
+pub const typescript_eslint_no_unused_vars = @import("typescript_eslint_no_unused_vars.zig");
 pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no_use_before_define.zig");
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
@@ -428,8 +429,12 @@ pub fn runSemantic(
         try require_atomic_updates.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
-    if (options.no_unused_vars) {
+    if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {
         try no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.typescript_eslint_no_unused_vars) {
+        try typescript_eslint_no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -1,0 +1,24 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_unused_vars = @import("no_unused_vars.zig");
+
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-unused-vars";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+        .rule_id = id,
+        .severity = .@"error",
+        .check_parameters = true,
+        .args_after_used = true,
+        .ignore_rest_siblings = true,
+        .check_type_parameters = true,
+    });
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -719,6 +719,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_unused_vars.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_use_before_define.zig");
 }
 

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -9,7 +9,9 @@ test "reports no-unused-vars for unused declarations" {
         \\console.log(used);
     ;
 
-    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{});
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_unused_vars = false,
+    });
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_unused_vars.id));

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-unused-vars for unused variables and after-used parameters" {
+    const source =
+        \\const unused = 1;
+        \\const used = 2;
+        \\console.log(used);
+        \\
+        \\function demo(before: string, usedParam: string, after: string) {
+        \\  console.log(usedParam);
+        \\}
+        \\demo("before", "used", "after");
+        \\
+        \\type UnusedType = string;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_unused_vars.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "ignores rest siblings for object destructuring" {
+    const source =
+        \\const data = { a: 1, b: 2 };
+        \\const { a, ...rest } = data;
+        \\console.log(rest);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "can disable @typescript-eslint/no-unused-vars and fall back to core rule" {
+    const source =
+        \\const unused = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_unused_vars.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-unused-vars for fishlint's args: after-used and ignoreRestSiblings configuration
- refactor the core no-unused-vars runner to support rule id/severity, parameter checking, rest sibling ignores, and TS type parameters
- use the TypeScript rule by default to avoid duplicate core/TS diagnostics and update focused tests

## Verification
- zig test -O ReleaseFast --test-filter unused-vars --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter "rest siblings" --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for default and --typescript-eslint-no-unused-vars=off
