### PR TITLE
feat: port typescript-eslint dot-notation

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -172,6 +172,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
+| [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -22,6 +22,7 @@ pub const Options = struct {
     constructor_super: bool = true,
     curly: bool = true,
     dot_notation: bool = true,
+    typescript_eslint_dot_notation: bool = true,
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -383,6 +383,8 @@ pub fn main(init: std.process.Init) !void {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
             options.typescript_eslint_adjacent_overload_signatures = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-dot-notation=off")) {
+            options.typescript_eslint_dot_notation = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-array-constructor=off")) {
             options.typescript_eslint_no_array_constructor = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-types=off")) {
@@ -830,6 +832,7 @@ fn printHelp() void {
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
+        \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion

--- a/src/rules/dot_notation.zig
+++ b/src/rules/dot_notation.zig
@@ -7,12 +7,28 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "dot-notation";
 
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    severity: core.Severity = .warning,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     member: ast.MemberExpression,
     index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, member, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (!member.computed or member.property == .null) return;
 
@@ -25,8 +41,8 @@ pub fn check(
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
-        .warning,
-        id,
+        options.severity,
+        options.rule_id,
         tree.span(index),
         "['{s}'] is better written in dot notation.",
         .{property_name},

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
+pub const typescript_eslint_dot_notation = @import("typescript_eslint_dot_notation.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
 pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
@@ -1387,8 +1388,11 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.dot_notation) {
+        if (self.options.dot_notation and !self.options.typescript_eslint_dot_notation) {
             try dot_notation.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.typescript_eslint_dot_notation) {
+            try typescript_eslint_dot_notation.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
         if (self.options.no_caller) {
             try no_caller.check(self.allocator, self.diagnostics, ctx.tree, member, index);

--- a/src/rules/typescript_eslint_dot_notation.zig
+++ b/src/rules/typescript_eslint_dot_notation.zig
@@ -1,0 +1,20 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const dot_notation = @import("dot_notation.zig");
+
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/dot-notation";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    member: parser.ast.MemberExpression,
+    index: parser.ast.NodeIndex,
+) Allocator.Error!void {
+    try dot_notation.checkWithOptions(allocator, diagnostics, tree, member, index, .{
+        .rule_id = id,
+        .severity = .@"error",
+    });
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -651,6 +651,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_dot_notation.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_array_constructor.zig");
 }
 

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -15,6 +15,7 @@ test "reports dot-notation for computed string properties that can use dot acces
         .no_undef = false,
         .no_unused_expressions = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -39,6 +40,7 @@ test "does not report dot-notation when bracket access is required" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -56,6 +58,7 @@ test "can disable dot-notation" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -15,6 +15,7 @@ test "reports no-extend-native for native prototype assignments" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
@@ -39,6 +40,7 @@ test "reports no-extend-native for Object defineProperty calls" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
@@ -66,6 +68,7 @@ test "does not report no-extend-native for shadowed constructors or ordinary obj
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });
@@ -87,6 +90,7 @@ test "can disable no-extend-native" {
         .no_extend_native = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .typescript_eslint_no_empty_function = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -12,6 +12,7 @@ test "reports prefer-destructuring for object property variable declarators" {
         .dot_notation = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -14,6 +14,7 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_dot_notation.zig
+++ b/tests/rules/typescript_eslint_dot_notation.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/dot-notation for computed string properties" {
+    const source =
+        \\object["property"];
+        \\object["_private"];
+        \\object["$value"];
+        \\object["property1"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_dot_notation.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/dot-notation when bracket access is required" {
+    const source =
+        \\object["not-valid"];
+        \\object["123"];
+        \\object[""];
+        \\object[property];
+        \\object[call()];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_dot_notation.id));
+}
+
+test "can disable @typescript-eslint/dot-notation and fall back to core rule" {
+    const source =
+        \\object["property"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_dot_notation.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.dot_notation.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/dot-notation for fishlint's TypeScript rule set
- refactor the core dot-notation checker to support rule id and severity overrides
- use the TypeScript rule by default to avoid duplicate core/TS diagnostics and update focused tests

## Verification
- zig test -O ReleaseFast --test-filter dot-notation --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter prefer-exponentiation-operator --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter no-extend-native --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for default and --typescript-eslint-dot-notation=off
