### PR TITLE
feat: port typescript-eslint no-dupe-class-members

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
+| [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -55,6 +55,7 @@ pub const Options = struct {
     no_duplicate_case: bool = true,
     no_dupe_args: bool = true,
     no_dupe_class_members: bool = true,
+    typescript_eslint_no_dupe_class_members: bool = true,
     no_dupe_keys: bool = true,
     no_duplicate_imports: bool = true,
     no_delete_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,6 +395,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_tslint_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
             options.typescript_eslint_no_confusing_non_null_assertion = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-dupe-class-members=off")) {
+            options.typescript_eslint_no_dupe_class_members = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-function=off")) {
             options.typescript_eslint_no_empty_function = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-empty-interface=off")) {
@@ -836,6 +838,7 @@ fn printHelp() void {
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
+        \\  --typescript-eslint-no-dupe-class-members=off Disable @typescript-eslint/no-dupe-class-members
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
         \\  --typescript-eslint-no-inferrable-types=off Disable @typescript-eslint/no-inferrable-types

--- a/src/rules/no_dupe_class_members.zig
+++ b/src/rules/no_dupe_class_members.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-dupe-class-members";
 
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    severity: core.Severity = .warning,
+};
+
 const MemberKind = enum {
     constructor,
     method_or_field,
@@ -26,6 +31,16 @@ pub fn check(
     tree: *const ast.Tree,
     body: ast.ClassBody,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, body, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+    options: Options,
+) Allocator.Error!void {
     var members: std.ArrayList(Member) = .empty;
     defer members.deinit(allocator);
 
@@ -39,8 +54,8 @@ pub fn check(
         try core.addDiagnostic(
             allocator,
             diagnostics,
-            .warning,
-            id,
+            options.severity,
+            options.rule_id,
             "Duplicate class member.",
             tree.span(member_index),
         );

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -183,6 +183,7 @@ pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
+pub const typescript_eslint_no_dupe_class_members = @import("typescript_eslint_no_dupe_class_members.zig");
 pub const typescript_eslint_no_empty_function = @import("typescript_eslint_no_empty_function.zig");
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_semi = @import("typescript_eslint_no_extra_semi.zig");
@@ -1475,8 +1476,11 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.no_dupe_class_members) {
+        if (self.options.no_dupe_class_members and !self.options.typescript_eslint_no_dupe_class_members) {
             try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
+        }
+        if (self.options.typescript_eslint_no_dupe_class_members) {
+            try typescript_eslint_no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
         }
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);

--- a/src/rules/typescript_eslint_no_dupe_class_members.zig
+++ b/src/rules/typescript_eslint_no_dupe_class_members.zig
@@ -1,0 +1,19 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_dupe_class_members = @import("no_dupe_class_members.zig");
+
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-dupe-class-members";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    body: parser.ast.ClassBody,
+) Allocator.Error!void {
+    try no_dupe_class_members.checkWithOptions(allocator, diagnostics, tree, body, .{
+        .rule_id = id,
+        .severity = .@"error",
+    });
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -675,6 +675,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_dupe_class_members.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_empty_function.zig");
 }
 

--- a/tests/rules/no_dupe_class_members.zig
+++ b/tests/rules/no_dupe_class_members.zig
@@ -17,6 +17,7 @@ test "reports no-dupe-class-members for duplicate methods and fields" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_dupe_class_members = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -40,6 +41,7 @@ test "reports no-dupe-class-members for constructors and static members" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_dupe_class_members = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -64,6 +66,7 @@ test "does not report no-dupe-class-members for allowed combinations" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_dupe_class_members = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -85,6 +88,7 @@ test "can disable no-dupe-class-members" {
         .no_empty_function = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_dupe_class_members = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_dupe_class_members.zig
+++ b/tests/rules/typescript_eslint_no_dupe_class_members.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-dupe-class-members for duplicate members" {
+    const source =
+        \\class Example {
+        \\  value() {}
+        \\  value() {}
+        \\  field = 1;
+        \\  field = 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_class_members.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_dupe_class_members.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/no-dupe-class-members for getter setter pairs" {
+    const source =
+        \\class Example {
+        \\  get value() { return this.x; }
+        \\  set value(next) { this.x = next; }
+        \\  value2() {}
+        \\  static value2() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
+}
+
+test "can disable @typescript-eslint/no-dupe-class-members and fall back to core rule" {
+    const source =
+        \\class Example {
+        \\  value() {}
+        \\  value() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_dupe_class_members = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_dupe_class_members.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-dupe-class-members for fishlint's TypeScript rule set
- refactor the core no-dupe-class-members checker to support rule id and severity overrides
- use the TypeScript rule by default to avoid duplicate core/TS diagnostics and update focused tests

## Verification
- zig test -O ReleaseFast --test-filter no-dupe-class-members --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for default and --typescript-eslint-no-dupe-class-members=off
