### PR TITLE
feat: port typescript-eslint no-unused-expressions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -188,6 +188,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
+| [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -158,6 +158,7 @@ pub const Options = struct {
     no_useless_escape: bool = true,
     no_useless_rename: bool = true,
     no_unused_expressions: bool = true,
+    typescript_eslint_no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
     no_void: bool = true,
     no_with: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -421,6 +421,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
             options.typescript_eslint_no_useless_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unused-expressions=off")) {
+            options.typescript_eslint_no_unused_expressions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unused-vars=off")) {
             options.typescript_eslint_no_unused_vars = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-use-before-define=off")) {
@@ -846,6 +848,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
+        \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword

--- a/src/rules/no_unused_expressions.zig
+++ b/src/rules/no_unused_expressions.zig
@@ -7,6 +7,14 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-unused-expressions";
 
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    severity: core.Severity = .warning,
+    allow_short_circuit: bool = false,
+    allow_ternary: bool = false,
+    allow_tagged_templates: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,19 +22,30 @@ pub fn check(
     statement: ast.ExpressionStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (hasSideEffect(tree, statement.expression)) return;
+    try checkWithOptions(allocator, diagnostics, tree, statement, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ExpressionStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (hasSideEffect(tree, statement.expression, options)) return;
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
-        .warning,
-        id,
+        options.severity,
+        options.rule_id,
         "Expected an assignment or function call and instead saw an expression.",
         tree.span(index),
     );
 }
 
-fn hasSideEffect(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn hasSideEffect(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) bool {
     if (index == .null) return false;
 
     return switch (tree.data(index)) {
@@ -35,22 +54,28 @@ fn hasSideEffect(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .call_expression,
         .import_expression,
         .new_expression,
-        .tagged_template_expression,
         .update_expression,
         .yield_expression,
         => true,
 
-        .chain_expression => |chain| hasSideEffect(tree, chain.expression),
-        .parenthesized_expression => |parenthesized| hasSideEffect(tree, parenthesized.expression),
-        .sequence_expression => |sequence| hasLastExpressionSideEffect(tree, sequence),
+        .tagged_template_expression => options.allow_tagged_templates,
+
+        .chain_expression => |chain| hasSideEffect(tree, chain.expression, options),
+        .conditional_expression => |conditional| options.allow_ternary and
+            hasSideEffect(tree, conditional.consequent, options) and
+            hasSideEffect(tree, conditional.alternate, options),
+        .logical_expression => |logical| options.allow_short_circuit and
+            hasSideEffect(tree, logical.right, options),
+        .parenthesized_expression => |parenthesized| hasSideEffect(tree, parenthesized.expression, options),
+        .sequence_expression => |sequence| hasLastExpressionSideEffect(tree, sequence, options),
 
         else => false,
     };
 }
 
-fn hasLastExpressionSideEffect(tree: *const ast.Tree, sequence: ast.SequenceExpression) bool {
+fn hasLastExpressionSideEffect(tree: *const ast.Tree, sequence: ast.SequenceExpression, options: Options) bool {
     const expressions = tree.extra(sequence.expressions);
     if (expressions.len == 0) return false;
 
-    return hasSideEffect(tree, expressions[expressions.len - 1]);
+    return hasSideEffect(tree, expressions[expressions.len - 1], options);
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -196,6 +196,7 @@ pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_r
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
+pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_no_unused_expressions.zig");
 pub const typescript_eslint_no_unused_vars = @import("typescript_eslint_no_unused_vars.zig");
 pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no_use_before_define.zig");
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
@@ -674,8 +675,11 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.no_unused_expressions) {
+        if (self.options.no_unused_expressions and !self.options.typescript_eslint_no_unused_expressions) {
             try no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        if (self.options.typescript_eslint_no_unused_expressions) {
+            try typescript_eslint_no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_unused_expressions.zig
+++ b/src/rules/typescript_eslint_no_unused_expressions.zig
@@ -1,0 +1,23 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const no_unused_expressions = @import("no_unused_expressions.zig");
+
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-unused-expressions";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    statement: parser.ast.ExpressionStatement,
+    index: parser.ast.NodeIndex,
+) Allocator.Error!void {
+    try no_unused_expressions.checkWithOptions(allocator, diagnostics, tree, statement, index, .{
+        .rule_id = id,
+        .severity = .@"error",
+        .allow_short_circuit = true,
+        .allow_ternary = true,
+        .allow_tagged_templates = true,
+    });
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -727,6 +727,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_unused_expressions.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unused_vars.zig");
 }
 

--- a/tests/rules/block_scoped_var.zig
+++ b/tests/rules/block_scoped_var.zig
@@ -30,6 +30,7 @@ test "reports block-scoped-var references outside binding context" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });
@@ -62,6 +63,7 @@ test "does not report block-scoped-var references inside binding context" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });
@@ -82,6 +84,7 @@ test "can disable block-scoped-var" {
         .block_scoped_var = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -14,6 +14,7 @@ test "reports dot-notation for computed string properties that can use dot acces
         .eol_last = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,

--- a/tests/rules/no_loop_func.zig
+++ b/tests/rules/no_loop_func.zig
@@ -21,6 +21,7 @@ test "reports no-loop-func for functions with unsafe loop references" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -46,6 +47,7 @@ test "reports no-loop-func for for-in and for-of iteration variables" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -70,6 +72,7 @@ test "does not report no-loop-func for per-iteration bindings or stable values" 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -89,6 +92,7 @@ test "can disable no-loop-func" {
         .no_loop_func = false,
         .no_unused_vars = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/no_unused_expressions.zig
+++ b/tests/rules/no_unused_expressions.zig
@@ -17,6 +17,7 @@ test "reports no-unused-expressions for expressions without side effects" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_undef = false,
         .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -50,6 +51,7 @@ test "does not report no-unused-expressions for expressions with side effects" {
         .no_unused_vars = false,
         .no_plusplus = false,
         .no_sequences = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -65,6 +67,7 @@ test "can disable no-unused-expressions" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions = false,
         .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -18,6 +18,7 @@ test "reports no-use-before-define for references before declarations" {
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
@@ -41,6 +42,7 @@ test "does not report no-use-before-define for references after declarations" {
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
@@ -76,6 +78,7 @@ test "can disable no-use-before-define" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_use_before_define = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .typescript_eslint_no_use_before_define = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -15,6 +15,7 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
         .no_undef = false,
         .no_unused_vars = false,
         .typescript_eslint_dot_notation = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/require_atomic_updates.zig
+++ b/tests/rules/require_atomic_updates.zig
@@ -115,6 +115,7 @@ test "does not leak require-atomic-updates stale reads across exclusive branches
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_vars = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_dot_notation.zig
+++ b/tests/rules/typescript_eslint_dot_notation.zig
@@ -14,6 +14,7 @@ test "reports @typescript-eslint/dot-notation for computed string properties" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });
@@ -57,6 +58,7 @@ test "can disable @typescript-eslint/dot-notation and fall back to core rule" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .typescript_eslint_dot_notation = false,
         .parser_semantic_errors = false,

--- a/tests/rules/typescript_eslint_no_confusing_non_null_assertion.zig
+++ b/tests/rules/typescript_eslint_no_confusing_non_null_assertion.zig
@@ -13,6 +13,7 @@ test "reports @typescript-eslint/no-confusing-non-null-assertion for confusing e
         .eqeqeq = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -31,6 +32,7 @@ test "does not report @typescript-eslint/no-confusing-non-null-assertion for par
         .eqeqeq = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -47,6 +49,7 @@ test "can disable @typescript-eslint/no-confusing-non-null-assertion" {
         .eqeqeq = false,
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .typescript_eslint_no_confusing_non_null_assertion = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/typescript_eslint_no_extra_non_null_assertion.zig
+++ b/tests/rules/typescript_eslint_no_extra_non_null_assertion.zig
@@ -12,6 +12,7 @@ test "reports @typescript-eslint/no-extra-non-null-assertion for nested assertio
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -35,6 +36,7 @@ test "does not report @typescript-eslint/no-extra-non-null-assertion for useful 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -50,6 +52,7 @@ test "can disable @typescript-eslint/no-extra-non-null-assertion" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .typescript_eslint_no_extra_non_null_assertion = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
+++ b/tests/rules/typescript_eslint_no_non_null_asserted_optional_chain.zig
@@ -12,6 +12,7 @@ test "reports @typescript-eslint/no-non-null-asserted-optional-chain for asserte
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -33,6 +34,7 @@ test "does not report @typescript-eslint/no-non-null-asserted-optional-chain for
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -48,6 +50,7 @@ test "can disable @typescript-eslint/no-non-null-asserted-optional-chain" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_undef = false,
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .typescript_eslint_no_non_null_asserted_optional_chain = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/typescript_eslint_no_unused_expressions.zig
+++ b/tests/rules/typescript_eslint_no_unused_expressions.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-unused-expressions for expressions without side effects" {
+    const source =
+        \\foo;
+        \\1;
+        \\`text`;
+        \\foo + bar;
+        \\foo && bar();
+        \\foo ? bar() : baz();
+        \\obj.prop;
+        \\[foo];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_expressions.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_expressions.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_unused_expressions.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows fishlint short circuit ternary and tagged template expressions" {
+    const source =
+        \\foo && bar();
+        \\foo ? bar() : baz();
+        \\tag`template`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_expressions.id));
+}
+
+test "can disable @typescript-eslint/no-unused-expressions and fall back to core rule" {
+    const source =
+        \\foo && bar();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_expressions.id));
+    try std.testing.expect(helpers.hasRule(result, lint.rules.no_unused_expressions.id));
+}

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -16,6 +16,7 @@ test "reports @typescript-eslint/no-use-before-define for classes and variables 
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-unused-expressions for fishlint's short-circuit, ternary, and tagged-template configuration
- refactor the core no-unused-expressions checker to support rule id/severity and expression allowance switches
- use the TypeScript rule by default to avoid duplicate core/TS diagnostics and update focused tests

## Verification
- zig test -O ReleaseFast --test-filter no-unused-expressions --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter use-before-define --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter dot-notation --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for default and --typescript-eslint-no-unused-expressions=off
