### PR TITLE
feat: port typescript-eslint no-namespace

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -183,6 +183,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
+| [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for fishlint's `allowDeclarations: true, allowDefinitionFiles: true` configuration |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -198,6 +198,7 @@ pub const Options = struct {
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_misused_new: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
+    typescript_eslint_no_namespace: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -411,6 +411,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-misused-new=off")) {
             options.typescript_eslint_no_misused_new = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-namespace=off")) {
+            options.typescript_eslint_no_namespace = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-non-null-asserted-optional-chain=off")) {
             options.typescript_eslint_no_non_null_asserted_optional_chain = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-require-imports=off")) {
@@ -844,6 +846,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
         \\  --typescript-eslint-no-inferrable-types=off Disable @typescript-eslint/no-inferrable-types
+        \\  --typescript-eslint-no-namespace=off Disable @typescript-eslint/no-namespace
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias

--- a/src/root.zig
+++ b/src/root.zig
@@ -21,23 +21,28 @@ pub fn lintSource(
     var diagnostics: core.DiagnosticList = .empty;
     errdefer core.freeDiagnostics(allocator, &diagnostics);
 
+    var effective_options = options;
+    if (isDefinitionFile(path)) {
+        effective_options.typescript_eslint_no_namespace = false;
+    }
+
     var tree = try parser.parse(allocator, source, .{
         .source_type = ast.SourceType.fromPath(path),
         .lang = ast.Lang.fromPath(path),
     });
     defer tree.deinit();
 
-    const needs_semantic = options.parser_semantic_errors or options.block_scoped_var or options.no_array_constructor or options.no_alert or options.no_extra_boolean_cast or options.no_global_is_finite or options.no_global_is_nan or options.no_invalid_regexp or options.no_loop_func or options.no_misleading_character_class or options.no_new_func or options.no_new_object or options.no_new_symbol or options.no_new_wrappers or options.no_redeclare or options.no_shadow or options.no_unused_vars or options.no_use_before_define or options.no_undef or options.prefer_const or options.prefer_exponentiation_operator or options.prefer_regex_literals or options.radix or options.require_atomic_updates or options.symbol_description;
+    const needs_semantic = effective_options.parser_semantic_errors or effective_options.block_scoped_var or effective_options.no_array_constructor or effective_options.no_alert or effective_options.no_extra_boolean_cast or effective_options.no_global_is_finite or effective_options.no_global_is_nan or effective_options.no_invalid_regexp or effective_options.no_loop_func or effective_options.no_misleading_character_class or effective_options.no_new_func or effective_options.no_new_object or effective_options.no_new_symbol or effective_options.no_new_wrappers or effective_options.no_redeclare or effective_options.no_shadow or effective_options.no_unused_vars or effective_options.no_use_before_define or effective_options.no_undef or effective_options.prefer_const or effective_options.prefer_exponentiation_operator or effective_options.prefer_regex_literals or effective_options.radix or effective_options.require_atomic_updates or effective_options.symbol_description;
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
-        try rules.runBasic(allocator, &diagnostics, &tree, options);
-        try rules.runSemantic(allocator, &diagnostics, &tree, semantic_result, options);
+        try rules.runBasic(allocator, &diagnostics, &tree, effective_options);
+        try rules.runSemantic(allocator, &diagnostics, &tree, semantic_result, effective_options);
     } else {
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
-        try rules.runBasic(allocator, &diagnostics, &tree, options);
+        try rules.runBasic(allocator, &diagnostics, &tree, effective_options);
     }
 
     return .{
@@ -54,6 +59,12 @@ pub fn isLintablePath(path: []const u8) bool {
         std.mem.endsWith(u8, path, ".cjs") or
         std.mem.endsWith(u8, path, ".mts") or
         std.mem.endsWith(u8, path, ".cts");
+}
+
+fn isDefinitionFile(path: []const u8) bool {
+    return std.mem.endsWith(u8, path, ".d.ts") or
+        std.mem.endsWith(u8, path, ".d.mts") or
+        std.mem.endsWith(u8, path, ".d.cts");
 }
 
 pub fn offsetToLineColumn(source: []const u8, offset: u32) SourcePosition {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -191,6 +191,7 @@ pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_es
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
 pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no_loss_of_precision.zig");
 pub const typescript_eslint_no_misused_new = @import("typescript_eslint_no_misused_new.zig");
+pub const typescript_eslint_no_namespace = @import("typescript_eslint_no_namespace.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
@@ -836,6 +837,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_prefer_namespace_keyword) {
             try typescript_eslint_prefer_namespace_keyword.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        if (self.options.typescript_eslint_no_namespace) {
+            try typescript_eslint_no_namespace.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_namespace.zig
+++ b/src/rules/typescript_eslint_no_namespace.zig
@@ -1,0 +1,26 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-namespace";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSModuleDeclaration,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (declaration.declare) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "TypeScript namespaces are not allowed.",
+        tree.span(index),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -707,6 +707,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_namespace.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_non_null_asserted_optional_chain.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_namespace.zig
+++ b/tests/rules/typescript_eslint_no_namespace.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-namespace for non-declare namespaces and modules" {
+    const source =
+        \\namespace Internal {
+        \\  export const value = 1;
+        \\}
+        \\module Legacy {
+        \\  export const value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_namespace.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_namespace.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows declare namespaces and modules" {
+    const source =
+        \\declare namespace Internal {
+        \\  export const value: number;
+        \\}
+        \\declare module "external" {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}
+
+test "allows namespaces in definition files" {
+    const source =
+        \\namespace Internal {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.d.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}
+
+test "can disable @typescript-eslint/no-namespace" {
+    const source =
+        \\namespace Internal {
+        \\  export const value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_namespace = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-namespace for fishlint's allowDeclarations and allowDefinitionFiles configuration
- disable the rule automatically for TypeScript definition files while keeping non-declare namespaces disallowed in regular TS files
- add CLI, docs, and focused tests for regular, declare, definition-file, and disabled-rule cases

## Verification
- zig test -O ReleaseFast --test-filter no-namespace --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter namespace --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-filter prefer-namespace-keyword --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --check
- CLI smoke for regular .ts, .d.ts, and --typescript-eslint-no-namespace=off
