### PR TITLE
feat: port typescript-eslint consistent-type-definitions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -172,6 +172,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
+| [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -185,6 +185,7 @@ pub const Options = struct {
     spaced_comment: bool = true,
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
+    typescript_eslint_consistent_type_definitions: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -383,6 +383,8 @@ pub fn main(init: std.process.Init) !void {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
             options.typescript_eslint_adjacent_overload_signatures = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-consistent-type-definitions=off")) {
+            options.typescript_eslint_consistent_type_definitions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-dot-notation=off")) {
             options.typescript_eslint_dot_notation = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-array-constructor=off")) {
@@ -838,6 +840,7 @@ fn printHelp() void {
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
+        \\  --typescript-eslint-consistent-type-definitions=off Disable @typescript-eslint/consistent-type-definitions
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
+pub const typescript_eslint_consistent_type_definitions = @import("typescript_eslint_consistent_type_definitions.zig");
 pub const typescript_eslint_dot_notation = @import("typescript_eslint_dot_notation.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
 pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig");
@@ -750,6 +751,18 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkInterfaceDeclaration(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_type_alias_declaration(
+        self: *BasicVisitor,
+        declaration: ast.TSTypeAliasDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_consistent_type_definitions) {
+            try typescript_eslint_consistent_type_definitions.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_consistent_type_definitions.zig
+++ b/src/rules/typescript_eslint_consistent_type_definitions.zig
@@ -1,0 +1,28 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/consistent-type-definitions";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSTypeAliasDeclaration,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    _ = index;
+
+    if (tree.data(declaration.type_annotation) != .ts_type_literal) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use an interface instead of a type.",
+        tree.span(declaration.id),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -651,6 +651,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_consistent_type_definitions.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_dot_notation.zig");
 }
 

--- a/tests/rules/typescript_eslint_consistent_type_definitions.zig
+++ b/tests/rules/typescript_eslint_consistent_type_definitions.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/consistent-type-definitions for object type aliases" {
+    const source =
+        \\type User = {
+        \\  name: string;
+        \\};
+        \\type Callable = {
+        \\  (): void;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_consistent_type_definitions.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "does not report @typescript-eslint/consistent-type-definitions for non-object aliases or interfaces" {
+    const source =
+        \\type Id = string | number;
+        \\type Handler = () => void;
+        \\interface User {
+        \\  name: string;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
+}
+
+test "can disable @typescript-eslint/consistent-type-definitions" {
+    const source =
+        \\type User = {
+        \\  name: string;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_definitions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/consistent-type-definitions for fishlint's `interface` configuration
- add CLI/config switch and visitor registration
- document rule support and cover reporting, allowed cases, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter consistent-type-definitions --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports the warning, `--typescript-eslint-consistent-type-definitions=off` reports 0 diagnostics