### PR TITLE
feat: port typescript-eslint array-type

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -169,6 +169,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
+| [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) | Implemented for fishlint's `array-simple` configuration |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -185,6 +185,7 @@ pub const Options = struct {
     spaced_comment: bool = true,
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
+    typescript_eslint_array_type: bool = true,
     typescript_eslint_consistent_type_definitions: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -383,6 +383,8 @@ pub fn main(init: std.process.Init) !void {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
             options.typescript_eslint_adjacent_overload_signatures = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-array-type=off")) {
+            options.typescript_eslint_array_type = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-consistent-type-definitions=off")) {
             options.typescript_eslint_consistent_type_definitions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-dot-notation=off")) {
@@ -840,6 +842,7 @@ fn printHelp() void {
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
+        \\  --typescript-eslint-array-type=off Disable @typescript-eslint/array-type
         \\  --typescript-eslint-consistent-type-definitions=off Disable @typescript-eslint/consistent-type-definitions
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
+pub const typescript_eslint_array_type = @import("typescript_eslint_array_type.zig");
 pub const typescript_eslint_consistent_type_definitions = @import("typescript_eslint_consistent_type_definitions.zig");
 pub const typescript_eslint_dot_notation = @import("typescript_eslint_dot_notation.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
@@ -710,6 +711,18 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
+    pub fn enter_ts_array_type(
+        self: *BasicVisitor,
+        array_type: ast.TSArrayType,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_array_type) {
+            try typescript_eslint_array_type.checkArrayType(self.allocator, self.diagnostics, ctx.tree, array_type, index);
+        }
+        return .proceed;
+    }
+
     pub fn enter_variable_declarator(
         self: *BasicVisitor,
         declarator: ast.VariableDeclarator,
@@ -797,9 +810,12 @@ const BasicVisitor = struct {
     pub fn enter_ts_type_reference(
         self: *BasicVisitor,
         reference: ast.TSTypeReference,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_array_type) {
+            try typescript_eslint_array_type.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference, index);
+        }
         if (self.options.typescript_eslint_ban_types) {
             try typescript_eslint_ban_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
         }

--- a/src/rules/typescript_eslint_array_type.zig
+++ b/src/rules/typescript_eslint_array_type.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/array-type";
+
+pub fn checkTypeReference(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reference: ast.TSTypeReference,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = typeName(tree, reference.type_name) orelse return;
+    const readonly = std.mem.eql(u8, name, "ReadonlyArray");
+    if (!readonly and !std.mem.eql(u8, name, "Array")) return;
+
+    const element_type = singleTypeArgument(tree, reference.type_arguments) orelse return;
+    if (!isSimpleType(tree, element_type)) return;
+
+    const type_text = sourceText(tree, index);
+    const element_text = sourceText(tree, unwrapParenthesized(tree, element_type));
+
+    if (readonly) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Array type using '{s}' is forbidden for simple types. Use 'readonly {s}[]' instead.",
+            .{ type_text, element_text },
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Array type using '{s}' is forbidden for simple types. Use '{s}[]' instead.",
+            .{ type_text, element_text },
+        );
+    }
+}
+
+pub fn checkArrayType(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    array_type: ast.TSArrayType,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (isSimpleType(tree, array_type.element_type)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.",
+        tree.span(index),
+    );
+}
+
+fn singleTypeArgument(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .ts_type_parameter_instantiation => |instantiation| {
+            const params = tree.extra(instantiation.params);
+            if (params.len != 1) return null;
+            return params[0];
+        },
+        else => null,
+    };
+}
+
+fn isSimpleType(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapParenthesized(tree, index))) {
+        .ts_array_type => true,
+        .ts_any_keyword,
+        .ts_bigint_keyword,
+        .ts_boolean_keyword,
+        .ts_intrinsic_keyword,
+        .ts_never_keyword,
+        .ts_null_keyword,
+        .ts_number_keyword,
+        .ts_object_keyword,
+        .ts_string_keyword,
+        .ts_symbol_keyword,
+        .ts_this_type,
+        .ts_undefined_keyword,
+        .ts_unknown_keyword,
+        .ts_void_keyword,
+        => true,
+        .ts_type_reference => |reference| reference.type_arguments == .null,
+        else => false,
+    };
+}
+
+fn unwrapParenthesized(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .ts_parenthesized_type => |parenthesized| current = parenthesized.type_annotation,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn typeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn sourceText(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start > end or end > tree.source.len) return "Array<T>";
+    return tree.source[start..end];
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -651,6 +651,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_array_type.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_consistent_type_definitions.zig");
 }
 

--- a/tests/rules/typescript_eslint_array_type.zig
+++ b/tests/rules/typescript_eslint_array_type.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/array-type for simple generic array types" {
+    const source =
+        \\type Names = Array<string>;
+        \\type Values = ReadonlyArray<number>;
+        \\type Nested = Array<string[]>;
+        \\type Qualified = Array<Foo.Bar>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_array_type.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_array_type.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "reports @typescript-eslint/array-type for non-simple shorthand array types" {
+    const source =
+        \\type Union = (string | number)[];
+        \\type Callable = (() => void)[];
+        \\type ObjectLiteral = { name: string }[];
+        \\type Tuple = [string, number][];
+        \\type Keyed = Foo["bar"][];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_array_type.id));
+}
+
+test "allows @typescript-eslint/array-type compliant array-simple forms" {
+    const source =
+        \\type Names = string[];
+        \\type Nested = string[][];
+        \\type Union = Array<string | number>;
+        \\type Callable = Array<() => void>;
+        \\type Generic = Array<Promise<string>>;
+        \\type Readonly = readonly string[];
+        \\type Parenthesized = (string)[];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_array_type.id));
+}
+
+test "can disable @typescript-eslint/array-type" {
+    const source =
+        \\type Names = Array<string>;
+        \\type Union = (string | number)[];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_array_type = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_array_type.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/array-type for fishlint's `array-simple` configuration
- add CLI/config switch and visitor registration for array/reference type nodes
- document rule support and cover generic, shorthand, allowed, nested, readonly, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter array-type --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports two array-type warnings, `--typescript-eslint-array-type=off` reports 0 diagnostics