### PR TITLE
feat: port typescript-eslint method-signature-style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
+| [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -191,6 +191,7 @@ pub const Options = struct {
     typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,
     typescript_eslint_no_empty_interface: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -397,6 +397,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-method-signature-style=off")) {
+            options.typescript_eslint_method_signature_style = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
             options.typescript_eslint_no_confusing_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-dupe-class-members=off")) {
@@ -847,6 +849,7 @@ fn printHelp() void {
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-method-signature-style=off Disable @typescript-eslint/method-signature-style
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-dupe-class-members=off Disable @typescript-eslint/no-dupe-class-members
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -184,6 +184,7 @@ pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no
 pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_method_signature_style = @import("typescript_eslint_method_signature_style.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_dupe_class_members = @import("typescript_eslint_no_dupe_class_members.zig");
 pub const typescript_eslint_no_empty_function = @import("typescript_eslint_no_empty_function.zig");
@@ -788,6 +789,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_method_signature(
+        self: *BasicVisitor,
+        signature: ast.TSMethodSignature,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_method_signature_style) {
+            try typescript_eslint_method_signature_style.check(self.allocator, self.diagnostics, ctx.tree, signature, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_method_signature_style.zig
+++ b/src/rules/typescript_eslint_method_signature_style.zig
@@ -1,0 +1,26 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/method-signature-style";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    signature: ast.TSMethodSignature,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (signature.kind != .method) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Shorthand method signature is forbidden. Use a function property instead.",
+        tree.span(index),
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_method_signature_style.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_array_constructor.zig");
 }
 

--- a/tests/rules/typescript_eslint_method_signature_style.zig
+++ b/tests/rules/typescript_eslint_method_signature_style.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/method-signature-style for shorthand method signatures" {
+    const source =
+        \\interface Service {
+        \\  start(): void;
+        \\  optional?<T>(value: T): T;
+        \\}
+        \\type Handler = {
+        \\  run(input: string): void;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_method_signature_style.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_method_signature_style.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/method-signature-style property and non-method signatures" {
+    const source =
+        \\interface Service {
+        \\  start: () => void;
+        \\  (): void;
+        \\  new (): Service;
+        \\  get size(): number;
+        \\}
+        \\type Handler = {
+        \\  run: (input: string) => void;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_method_signature_style.id));
+}
+
+test "can disable @typescript-eslint/method-signature-style" {
+    const source =
+        \\interface Service {
+        \\  start(): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_method_signature_style = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_method_signature_style.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/method-signature-style for fishlint's `property` configuration
- add CLI/config switch and visitor registration for TS method signatures
- document rule support and cover reporting, allowed signatures, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter method-signature-style --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports method-signature-style warning, `--typescript-eslint-method-signature-style=off` reports 0 diagnostics