### PR TITLE
feat: port typescript-eslint triple-slash-reference

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -190,6 +190,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
+| [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -204,6 +204,7 @@ pub const Options = struct {
     typescript_eslint_no_namespace: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
+    typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_unused_vars: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -425,6 +425,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_require_imports = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-this-alias=off")) {
             options.typescript_eslint_no_this_alias = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-triple-slash-reference=off")) {
+            options.typescript_eslint_triple_slash_reference = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
@@ -859,6 +861,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
+        \\  --typescript-eslint-triple-slash-reference=off Disable @typescript-eslint/triple-slash-reference
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -198,6 +198,7 @@ pub const typescript_eslint_no_namespace = @import("typescript_eslint_no_namespa
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
+pub const typescript_eslint_triple_slash_reference = @import("typescript_eslint_triple_slash_reference.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
 pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_no_unused_expressions.zig");
@@ -258,6 +259,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_ban_tslint_comment) {
         try typescript_eslint_ban_tslint_comment.run(allocator, diagnostics, tree);
+    }
+    if (options.typescript_eslint_triple_slash_reference) {
+        try typescript_eslint_triple_slash_reference.run(allocator, diagnostics, tree);
     }
     if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);

--- a/src/rules/typescript_eslint_triple_slash_reference.zig
+++ b/src/rules/typescript_eslint_triple_slash_reference.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/triple-slash-reference";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    for (tree.comments) |comment| {
+        if (comment.type != .line) continue;
+
+        const path = referencePath(tree.string(comment.value)) orelse continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            .{ .start = comment.start, .end = comment.end },
+            "Do not use a triple slash reference for {s}, use `import` style instead.",
+            .{path},
+        );
+    }
+}
+
+fn referencePath(value: []const u8) ?[]const u8 {
+    if (value.len == 0 or value[0] != '/') return null;
+
+    const body = trimLeftWhitespace(value[1..]);
+    if (!std.mem.startsWith(u8, body, "<reference")) return null;
+
+    const path_index = std.mem.indexOf(u8, body, "path=") orelse return null;
+    var rest = body[path_index + "path=".len ..];
+    rest = trimLeftWhitespace(rest);
+    if (rest.len < 2) return null;
+
+    const quote = rest[0];
+    if (quote != '"' and quote != '\'') return null;
+    const end = std.mem.indexOfScalar(u8, rest[1..], quote) orelse return null;
+    return rest[1..][0..end];
+}
+
+fn trimLeftWhitespace(value: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index < value.len and (value[index] == ' ' or value[index] == '\t')) : (index += 1) {}
+    return value[index..];
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -735,6 +735,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_triple_slash_reference.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unnecessary_type_constraint.zig");
 }
 

--- a/tests/rules/typescript_eslint_triple_slash_reference.zig
+++ b/tests/rules/typescript_eslint_triple_slash_reference.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/triple-slash-reference for path references" {
+    const source =
+        \\/// <reference path="./foo.d.ts" />
+        \\/// <reference path='./bar.d.ts' />
+        \\export const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_triple_slash_reference.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/triple-slash-reference types and lib references" {
+    const source =
+        \\/// <reference types="node" />
+        \\/// <reference lib="dom" />
+        \\//// <reference path="./not-a-directive.d.ts" />
+        \\export const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
+}
+
+test "can disable @typescript-eslint/triple-slash-reference" {
+    const source =
+        \\/// <reference path="./foo.d.ts" />
+        \\export const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_triple_slash_reference = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/triple-slash-reference for fishlint's `path: never, types: always, lib: always` configuration
- add CLI/config switch and comment scanning for path triple-slash directives
- document rule support and cover path reporting, allowed types/lib directives, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter triple-slash-reference --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports triple-slash path error, `--typescript-eslint-triple-slash-reference=off` reports 0 diagnostics