### PR TITLE
feat: port typescript-eslint explicit-member-accessibility

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
+| [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |
 | [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -191,6 +191,7 @@ pub const Options = struct {
     typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
+    typescript_eslint_explicit_member_accessibility: bool = true,
     typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -397,6 +397,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_ts_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-ban-tslint-comment=off")) {
             options.typescript_eslint_ban_tslint_comment = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-explicit-member-accessibility=off")) {
+            options.typescript_eslint_explicit_member_accessibility = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-method-signature-style=off")) {
             options.typescript_eslint_method_signature_style = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
@@ -851,6 +853,7 @@ fn printHelp() void {
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
+        \\  --typescript-eslint-explicit-member-accessibility=off Disable @typescript-eslint/explicit-member-accessibility
         \\  --typescript-eslint-method-signature-style=off Disable @typescript-eslint/method-signature-style
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-dupe-class-members=off Disable @typescript-eslint/no-dupe-class-members

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -184,6 +184,7 @@ pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no
 pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig");
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
+pub const typescript_eslint_explicit_member_accessibility = @import("typescript_eslint_explicit_member_accessibility.zig");
 pub const typescript_eslint_method_signature_style = @import("typescript_eslint_method_signature_style.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_dupe_class_members = @import("typescript_eslint_no_dupe_class_members.zig");
@@ -1551,6 +1552,9 @@ const BasicVisitor = struct {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
         }
+        if (self.options.typescript_eslint_explicit_member_accessibility) {
+            try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+        }
         return .proceed;
     }
 
@@ -1562,6 +1566,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
+        }
+        if (self.options.typescript_eslint_explicit_member_accessibility) {
+            try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);

--- a/src/rules/typescript_eslint_explicit_member_accessibility.zig
+++ b/src/rules/typescript_eslint_explicit_member_accessibility.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/explicit-member-accessibility";
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (method.accessibility != .public) return;
+
+    const member_name = methodName(tree, method);
+    const description = switch (method.kind) {
+        .get => "get property accessor",
+        .set => "set property accessor",
+        else => "method definition",
+    };
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Public accessibility modifier on {s} {s}.",
+        .{ description, member_name },
+    );
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (property.accessibility != .public) return;
+
+    const member_name = staticKeyName(tree, property.key, property.computed) orelse "member";
+    const description = if (property.accessor) "accessor property" else "class property";
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Public accessibility modifier on {s} {s}.",
+        .{ description, member_name },
+    );
+}
+
+fn methodName(tree: *const ast.Tree, method: ast.MethodDefinition) []const u8 {
+    if (method.kind == .constructor and !method.static) return "constructor";
+    return staticKeyName(tree, method.key, method.computed) orelse "member";
+}
+
+fn staticKeyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| if (computed) null else tree.string(identifier.name),
+        .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_explicit_member_accessibility.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_method_signature_style.zig");
 }
 

--- a/tests/rules/typescript_eslint_explicit_member_accessibility.zig
+++ b/tests/rules/typescript_eslint_explicit_member_accessibility.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/explicit-member-accessibility for public class members" {
+    const source =
+        \\class Service {
+        \\  public constructor() {}
+        \\  public start(): void {}
+        \\  public get size(): number {
+        \\    return 1;
+        \\  }
+        \\  public value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_explicit_member_accessibility.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/explicit-member-accessibility non-public and omitted accessibility" {
+    const source =
+        \\class Service {
+        \\  constructor(public readonly id: string) {}
+        \\  start(): void {}
+        \\  private stop(): void {}
+        \\  protected restart(): void {}
+        \\  value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
+}
+
+test "can disable @typescript-eslint/explicit-member-accessibility" {
+    const source =
+        \\class Service {
+        \\  public start(): void {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_explicit_member_accessibility = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/explicit-member-accessibility for fishlint's `no-public` configuration
- add CLI/config switch and class member checks for explicit `public`
- document rule support and cover public members, allowed non-public/omitted accessibility, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter explicit-member-accessibility --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports explicit-member-accessibility warning, `--typescript-eslint-explicit-member-accessibility=off` reports 0 diagnostics