### PR TITLE
feat: port typescript-eslint class-literal-property-style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -173,6 +173,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
+| [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for fishlint's `fields` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -186,6 +186,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
+    typescript_eslint_class_literal_property_style: bool = true,
     typescript_eslint_consistent_type_definitions: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_adjacent_overload_signatures = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-array-type=off")) {
             options.typescript_eslint_array_type = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-class-literal-property-style=off")) {
+            options.typescript_eslint_class_literal_property_style = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-consistent-type-definitions=off")) {
             options.typescript_eslint_consistent_type_definitions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-dot-notation=off")) {
@@ -849,6 +851,7 @@ fn printHelp() void {
         \\  --require-yield=off       Disable require-yield
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
         \\  --typescript-eslint-array-type=off Disable @typescript-eslint/array-type
+        \\  --typescript-eslint-class-literal-property-style=off Disable @typescript-eslint/class-literal-property-style
         \\  --typescript-eslint-consistent-type-definitions=off Disable @typescript-eslint/consistent-type-definitions
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -178,6 +178,7 @@ pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
 pub const typescript_eslint_array_type = @import("typescript_eslint_array_type.zig");
+pub const typescript_eslint_class_literal_property_style = @import("typescript_eslint_class_literal_property_style.zig");
 pub const typescript_eslint_consistent_type_definitions = @import("typescript_eslint_consistent_type_definitions.zig");
 pub const typescript_eslint_dot_notation = @import("typescript_eslint_dot_notation.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
@@ -1554,6 +1555,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+        }
+        if (self.options.typescript_eslint_class_literal_property_style) {
+            try typescript_eslint_class_literal_property_style.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_class_literal_property_style.zig
+++ b/src/rules/typescript_eslint_class_literal_property_style.zig
@@ -1,0 +1,78 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/class-literal-property-style";
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (method.kind != .get) return;
+    if (!getterReturnsSingleLiteral(tree, method)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Literals should be exposed using readonly fields.",
+        tree.span(index),
+    );
+}
+
+fn getterReturnsSingleLiteral(tree: *const ast.Tree, method: ast.MethodDefinition) bool {
+    const function = switch (tree.data(method.value)) {
+        .function => |function| function,
+        else => return false,
+    };
+    if (function.body == .null) return false;
+
+    const body = switch (tree.data(function.body)) {
+        .function_body => |body| body,
+        else => return false,
+    };
+
+    const statements = tree.extra(body.body);
+    if (statements.len != 1) return false;
+
+    const statement = switch (tree.data(statements[0])) {
+        .return_statement => |statement| statement,
+        else => return false,
+    };
+
+    return isLiteral(tree, statement.argument);
+}
+
+fn isLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .regexp_literal,
+        => true,
+        .template_literal => |literal| literal.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            .chain_expression => |chain| current = chain.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_class_literal_property_style.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_consistent_type_definitions.zig");
 }
 

--- a/tests/rules/typescript_eslint_class_literal_property_style.zig
+++ b/tests/rules/typescript_eslint_class_literal_property_style.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/class-literal-property-style for literal getters" {
+    const source =
+        \\class Example {
+        \\  get name() {
+        \\    return "fish";
+        \\  }
+        \\  static get count() {
+        \\    return 1;
+        \\  }
+        \\  get enabled() {
+        \\    return true;
+        \\  }
+        \\  get pattern() {
+        \\    return /fish/;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_class_literal_property_style.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/class-literal-property-style non-literal and non-single-return getters" {
+    const source =
+        \\declare function compute(): string;
+        \\class Example {
+        \\  get name() {
+        \\    return compute();
+        \\  }
+        \\  get object() {
+        \\    return {};
+        \\  }
+        \\  get multiple() {
+        \\    const value = "fish";
+        \\    return value;
+        \\  }
+        \\  value() {
+        \\    return "fish";
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
+}
+
+test "can disable @typescript-eslint/class-literal-property-style" {
+    const source =
+        \\class Example {
+        \\  get name() {
+        \\    return "fish";
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_class_literal_property_style = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/class-literal-property-style for fishlint's `fields` configuration
- add CLI/config switch and getter literal checks
- document rule support and cover literal getters, allowed cases, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter class-literal-property-style --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports class-literal-property-style warning, `--typescript-eslint-class-literal-property-style=off` reports 0 diagnostics