### PR TITLE
feat: port typescript-eslint typedef

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -193,6 +193,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
+| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -207,6 +207,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
+    typescript_eslint_typedef: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_unused_vars: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -431,6 +431,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_this_alias = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-triple-slash-reference=off")) {
             options.typescript_eslint_triple_slash_reference = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-typedef=off")) {
+            options.typescript_eslint_typedef = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
@@ -868,6 +870,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-triple-slash-reference=off Disable @typescript-eslint/triple-slash-reference
+        \\  --typescript-eslint-typedef=off Disable @typescript-eslint/typedef
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -201,6 +201,7 @@ pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("types
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_triple_slash_reference = @import("typescript_eslint_triple_slash_reference.zig");
+pub const typescript_eslint_typedef = @import("typescript_eslint_typedef.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
 pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_no_unused_expressions.zig");
@@ -822,6 +823,18 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkTypeLiteral(self.allocator, self.diagnostics, ctx.tree, type_literal);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_property_signature(
+        self: *BasicVisitor,
+        signature: ast.TSPropertySignature,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_typedef) {
+            try typescript_eslint_typedef.checkPropertySignature(self.allocator, self.diagnostics, ctx.tree, signature, index);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_typedef.zig
+++ b/src/rules/typescript_eslint_typedef.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/typedef";
+
+pub fn checkPropertySignature(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    signature: ast.TSPropertySignature,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (signature.type_annotation != .null) return;
+
+    if (propertyName(tree, signature.key)) |name| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            "Expected {s} to have a type annotation.",
+            .{name},
+        );
+        return;
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Expected a type annotation.",
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -747,6 +747,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_typedef.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unnecessary_type_constraint.zig");
 }
 

--- a/tests/rules/typescript_eslint_typedef.zig
+++ b/tests/rules/typescript_eslint_typedef.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/typedef for unannotated type properties" {
+    const source =
+        \\declare const key: unique symbol;
+        \\interface InterfaceShape {
+        \\  value;
+        \\  optional?;
+        \\  readonly readonlyValue;
+        \\  [key];
+        \\  "literal";
+        \\}
+        \\type TypeShape = {
+        \\  value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_typedef.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/typedef annotated properties and non-property declarations" {
+    const source =
+        \\interface InterfaceShape {
+        \\  value: string;
+        \\  method(): void;
+        \\}
+        \\type TypeShape = {
+        \\  value: number;
+        \\};
+        \\class Example {
+        \\  value = 1;
+        \\}
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_typedef.id));
+}
+
+test "can disable @typescript-eslint/typedef" {
+    const source =
+        \\interface InterfaceShape {
+        \\  value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_typedef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_typedef.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/typedef for fishlint's `propertyDeclaration: true` configuration
- add CLI/config switch and TS property signature checks
- document rule support and cover unannotated type properties, allowed cases, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter typedef --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports typedef error, `--typescript-eslint-typedef=off` reports 0 diagnostics