### PR TITLE
feat: port typescript-eslint consistent-type-assertions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -174,6 +174,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for fishlint's `fields` configuration |
+| [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Implemented for fishlint's `assertionStyle: as, objectLiteralTypeAssertions: never` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
     typescript_eslint_class_literal_property_style: bool = true,
+    typescript_eslint_consistent_type_assertions: bool = true,
     typescript_eslint_consistent_type_definitions: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_array_type = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-class-literal-property-style=off")) {
             options.typescript_eslint_class_literal_property_style = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-consistent-type-assertions=off")) {
+            options.typescript_eslint_consistent_type_assertions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-consistent-type-definitions=off")) {
             options.typescript_eslint_consistent_type_definitions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-dot-notation=off")) {
@@ -854,6 +856,7 @@ fn printHelp() void {
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
         \\  --typescript-eslint-array-type=off Disable @typescript-eslint/array-type
         \\  --typescript-eslint-class-literal-property-style=off Disable @typescript-eslint/class-literal-property-style
+        \\  --typescript-eslint-consistent-type-assertions=off Disable @typescript-eslint/consistent-type-assertions
         \\  --typescript-eslint-consistent-type-definitions=off Disable @typescript-eslint/consistent-type-definitions
         \\  --typescript-eslint-dot-notation=off Disable @typescript-eslint/dot-notation
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -179,6 +179,7 @@ pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
 pub const typescript_eslint_array_type = @import("typescript_eslint_array_type.zig");
 pub const typescript_eslint_class_literal_property_style = @import("typescript_eslint_class_literal_property_style.zig");
+pub const typescript_eslint_consistent_type_assertions = @import("typescript_eslint_consistent_type_assertions.zig");
 pub const typescript_eslint_consistent_type_definitions = @import("typescript_eslint_consistent_type_definitions.zig");
 pub const typescript_eslint_dot_notation = @import("typescript_eslint_dot_notation.zig");
 pub const typescript_eslint_no_array_constructor = @import("typescript_eslint_no_array_constructor.zig");
@@ -698,9 +699,12 @@ const BasicVisitor = struct {
     pub fn enter_ts_as_expression(
         self: *BasicVisitor,
         expression: ast.TSAsExpression,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_consistent_type_assertions) {
+            try typescript_eslint_consistent_type_assertions.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
@@ -710,9 +714,12 @@ const BasicVisitor = struct {
     pub fn enter_ts_type_assertion(
         self: *BasicVisitor,
         assertion: ast.TSTypeAssertion,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_consistent_type_assertions) {
+            try typescript_eslint_consistent_type_assertions.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion, index);
+        }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion);
         }

--- a/src/rules/typescript_eslint_consistent_type_assertions.zig
+++ b/src/rules/typescript_eslint_consistent_type_assertions.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/consistent-type-assertions";
+
+pub fn checkAsExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.TSAsExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (isConstType(tree, expression.type_annotation)) return;
+    if (!isObjectExpression(tree, expression.expression)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Always prefer const x: T = { ... }.",
+        tree.span(index),
+    );
+}
+
+pub fn checkTypeAssertion(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    assertion: ast.TSTypeAssertion,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const type_text = sourceText(tree, assertion.type_annotation);
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Use 'as {s}' instead of '<{s}>'.",
+        .{ type_text, type_text },
+    );
+}
+
+fn isObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .object_expression => true,
+        else => false,
+    };
+}
+
+fn isConstType(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .ts_type_reference => |reference| blk: {
+            const name = typeName(tree, reference.type_name) orelse break :blk false;
+            break :blk std.mem.eql(u8, name, "const");
+        },
+        else => false,
+    };
+}
+
+fn typeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            .chain_expression => |chain| current = chain.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn sourceText(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start > end or end > tree.source.len) return "T";
+    return tree.source[start..end];
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -659,6 +659,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_consistent_type_assertions.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_consistent_type_definitions.zig");
 }
 

--- a/tests/rules/typescript_eslint_consistent_type_assertions.zig
+++ b/tests/rules/typescript_eslint_consistent_type_assertions.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/consistent-type-assertions for angle bracket assertions" {
+    const source =
+        \\declare const input: unknown;
+        \\const value = <string>input;
+        \\const objectValue = <Foo>{ x: 1 };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_consistent_type_assertions.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "reports @typescript-eslint/consistent-type-assertions for object literal as assertions" {
+    const source =
+        \\const value = { x: 1 } as Foo;
+        \\const nested = ({ x: 1 }) as Foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+}
+
+test "allows @typescript-eslint/consistent-type-assertions compliant assertions" {
+    const source =
+        \\declare const input: unknown;
+        \\const value = input as string;
+        \\const objectValue = { x: 1 } as const;
+        \\const arrayValue = [1] as Foo;
+        \\const functionValue = (() => 1) as Foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+}
+
+test "can disable @typescript-eslint/consistent-type-assertions" {
+    const source =
+        \\declare const input: unknown;
+        \\const value = <string>input;
+        \\const objectValue = { x: 1 } as Foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_assertions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/consistent-type-assertions for fishlint's `assertionStyle: as` and `objectLiteralTypeAssertions: never` configuration
- add CLI/config switch and checks for angle-bracket assertions plus object literal `as` assertions
- document rule support and cover angle assertions, object literal assertions, allowed assertions, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter consistent-type-assertions --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports consistent-type-assertions errors, `--typescript-eslint-consistent-type-assertions=off` reports 0 diagnostics with unused-vars disabled