### PR TITLE
feat: port typescript-eslint no-invalid-void-type

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -187,6 +187,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
+| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Implemented |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for fishlint's `allowDeclarations: true, allowDefinitionFiles: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -201,6 +201,7 @@ pub const Options = struct {
     typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
+    typescript_eslint_no_invalid_void_type: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_misused_new: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -419,6 +419,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_extra_non_null_assertion = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {
             options.typescript_eslint_no_inferrable_types = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-invalid-void-type=off")) {
+            options.typescript_eslint_no_invalid_void_type = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-loss-of-precision=off")) {
             options.typescript_eslint_no_loss_of_precision = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-misused-new=off")) {
@@ -868,6 +870,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
         \\  --typescript-eslint-no-inferrable-types=off Disable @typescript-eslint/no-inferrable-types
+        \\  --typescript-eslint-no-invalid-void-type=off Disable @typescript-eslint/no-invalid-void-type
         \\  --typescript-eslint-no-namespace=off Disable @typescript-eslint/no-namespace
         \\  --typescript-eslint-no-non-null-asserted-optional-chain=off Disable @typescript-eslint/no-non-null-asserted-optional-chain
         \\  --typescript-eslint-no-require-imports=off Disable @typescript-eslint/no-require-imports

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -195,6 +195,7 @@ pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_e
 pub const typescript_eslint_no_extra_semi = @import("typescript_eslint_no_extra_semi.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
+pub const typescript_eslint_no_invalid_void_type = @import("typescript_eslint_no_invalid_void_type.zig");
 pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no_loss_of_precision.zig");
 pub const typescript_eslint_no_misused_new = @import("typescript_eslint_no_misused_new.zig");
 pub const typescript_eslint_no_namespace = @import("typescript_eslint_no_namespace.zig");
@@ -893,6 +894,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_unnecessary_type_constraint) {
             try typescript_eslint_no_unnecessary_type_constraint.check(self.allocator, self.diagnostics, ctx.tree, parameter, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_void_keyword(
+        self: *BasicVisitor,
+        _: ast.TSVoidKeyword,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_invalid_void_type) {
+            try typescript_eslint_no_invalid_void_type.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/src/rules/typescript_eslint_no_invalid_void_type.zig
@@ -1,0 +1,77 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-invalid-void-type";
+
+const Ancestor = struct {
+    index: ast.NodeIndex,
+    depth: usize,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const parent = nearestNonParenthesizedAncestor(tree, ctx, 1) orelse return;
+
+    switch (tree.data(parent.index)) {
+        .ts_union_type => {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                "void is not valid as a constituent in a union type",
+                tree.span(index),
+            );
+            return;
+        },
+        .ts_type_parameter_instantiation => return,
+        .ts_type_annotation => {
+            if (isReturnTypeAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
+        },
+        else => {},
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "void is only valid as a return type or generic type argument.",
+        tree.span(index),
+    );
+}
+
+fn nearestNonParenthesizedAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, start_depth: usize) ?Ancestor {
+    var depth = start_depth;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .ts_parenthesized_type => {},
+            else => return .{ .index = ancestor, .depth = depth },
+        }
+    }
+    return null;
+}
+
+fn isReturnTypeAnnotation(tree: *const ast.Tree, annotation_index: ast.NodeIndex, owner_index: ?ast.NodeIndex) bool {
+    const owner = owner_index orelse return false;
+
+    return switch (tree.data(owner)) {
+        .function => |function| function.return_type == annotation_index,
+        .arrow_function_expression => |arrow| arrow.return_type == annotation_index,
+        .ts_function_type => |function_type| function_type.return_type == annotation_index,
+        .ts_constructor_type => |constructor_type| constructor_type.return_type == annotation_index,
+        .ts_method_signature => |signature| signature.return_type == annotation_index,
+        .ts_call_signature_declaration => |signature| signature.return_type == annotation_index,
+        .ts_construct_signature_declaration => |signature| signature.return_type == annotation_index,
+        else => false,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -723,6 +723,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_invalid_void_type.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_loss_of_precision.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/tests/rules/typescript_eslint_no_invalid_void_type.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-invalid-void-type for invalid void positions" {
+    const source =
+        \\type Alias = void;
+        \\type ArrayVoid = void[];
+        \\type UnionVoid = string | void;
+        \\interface Shape {
+        \\  value: void;
+        \\}
+        \\function takesVoid(value: void) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_invalid_void_type.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/no-invalid-void-type valid void positions" {
+    const source =
+        \\function returnsVoid(): void {}
+        \\const arrow = (): void => {};
+        \\type FunctionType = () => void;
+        \\type ConstructorType = new () => void;
+        \\type PromiseVoid = Promise<void>;
+        \\interface Callable {
+        \\  value(): void;
+        \\  prop: () => void;
+        \\  (): void;
+        \\  new (): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}
+
+test "reports @typescript-eslint/no-invalid-void-type for void in unions inside type arguments" {
+    const source =
+        \\type PromiseUnion = Promise<string | void>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}
+
+test "can disable @typescript-eslint/no-invalid-void-type" {
+    const source =
+        \\type Alias = void;
+        \\type UnionVoid = string | void;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_no_invalid_void_type = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/no-invalid-void-type for fishlint
- add CLI/config switch and syntax context checks for `void`
- document rule support and cover invalid positions, valid return/generic positions, union-specific diagnostics, and disable behavior

## Validation
- `zig test -O ReleaseFast --test-filter no-invalid-void-type --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `git diff --check`
- CLI smoke: default reports no-invalid-void-type errors, `--typescript-eslint-no-invalid-void-type=off` reports 0 diagnostics with unused-vars disabled