### PR TITLE
feat: port typescript-eslint unified-signatures

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -196,6 +196,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |
+| [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -210,6 +210,7 @@ pub const Options = struct {
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_typedef: bool = true,
+    typescript_eslint_unified_signatures: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_unused_vars: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -437,6 +437,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_triple_slash_reference = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-typedef=off")) {
             options.typescript_eslint_typedef = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-unified-signatures=off")) {
+            options.typescript_eslint_unified_signatures = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
@@ -877,6 +879,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
         \\  --typescript-eslint-triple-slash-reference=off Disable @typescript-eslint/triple-slash-reference
         \\  --typescript-eslint-typedef=off Disable @typescript-eslint/typedef
+        \\  --typescript-eslint-unified-signatures=off Disable @typescript-eslint/unified-signatures
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -204,6 +204,7 @@ pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_r
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
 pub const typescript_eslint_triple_slash_reference = @import("typescript_eslint_triple_slash_reference.zig");
 pub const typescript_eslint_typedef = @import("typescript_eslint_typedef.zig");
+pub const typescript_eslint_unified_signatures = @import("typescript_eslint_unified_signatures.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
 pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_no_unused_expressions.zig");
@@ -486,6 +487,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, program.body);
+        }
+        if (self.options.typescript_eslint_unified_signatures) {
+            try typescript_eslint_unified_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, program.body);
         }
         return .proceed;
     }
@@ -805,6 +809,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
         }
+        if (self.options.typescript_eslint_unified_signatures) {
+            try typescript_eslint_unified_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
+        }
         return .proceed;
     }
 
@@ -828,6 +835,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, type_literal.members);
+        }
+        if (self.options.typescript_eslint_unified_signatures) {
+            try typescript_eslint_unified_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, type_literal.members);
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkTypeLiteral(self.allocator, self.diagnostics, ctx.tree, type_literal);
@@ -870,6 +880,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
+        }
+        if (self.options.typescript_eslint_unified_signatures) {
+            try typescript_eslint_unified_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_unified_signatures.zig
+++ b/src/rules/typescript_eslint_unified_signatures.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/unified-signatures";
+
+const Signature = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+    params: ast.NodeIndex,
+    return_type: ast.NodeIndex,
+};
+
+const Param = struct {
+    node: ast.NodeIndex,
+    type_text: []const u8,
+    optional: bool,
+};
+
+pub fn checkRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    members: ast.IndexRange,
+) Allocator.Error!void {
+    var seen: std.ArrayList(Signature) = .empty;
+    defer seen.deinit(allocator);
+
+    for (tree.extra(members)) |member_index| {
+        const current = signatureInfo(tree, member_index) orelse continue;
+        for (seen.items) |previous| {
+            if (!std.mem.eql(u8, previous.name, current.name)) continue;
+            try compareSignatures(allocator, diagnostics, tree, previous, current);
+        }
+        try seen.append(allocator, current);
+    }
+}
+
+fn compareSignatures(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    previous: Signature,
+    current: Signature,
+) Allocator.Error!void {
+    if (!sameReturnType(tree, previous.return_type, current.return_type)) return;
+
+    const previous_params = params(tree, previous.params) orelse return;
+    const current_params = params(tree, current.params) orelse return;
+    if (previous_params.rest != .null or current_params.rest != .null) return;
+
+    const previous_items = tree.extra(previous_params.items);
+    const current_items = tree.extra(current_params.items);
+
+    if (previous_items.len == current_items.len) {
+        try compareSameLength(allocator, diagnostics, tree, previous_items, current_items);
+        return;
+    }
+
+    if (previous_items.len + 1 == current_items.len and paramsPrefixMatches(tree, previous_items, current_items[0..previous_items.len])) {
+        try addOptionalDiagnostic(allocator, diagnostics, tree, current_items[previous_items.len]);
+        return;
+    }
+
+    if (current_items.len + 1 == previous_items.len and paramsPrefixMatches(tree, current_items, previous_items[0..current_items.len])) {
+        try addOptionalDiagnostic(allocator, diagnostics, tree, previous_items[current_items.len]);
+    }
+}
+
+fn compareSameLength(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    previous_items: []const ast.NodeIndex,
+    current_items: []const ast.NodeIndex,
+) Allocator.Error!void {
+    var mismatch_count: usize = 0;
+    var mismatch_param: ast.NodeIndex = .null;
+    var first_type: []const u8 = "";
+    var second_type: []const u8 = "";
+
+    for (previous_items, current_items) |previous_item, current_item| {
+        const previous_param = paramInfo(tree, previous_item) orelse return;
+        const current_param = paramInfo(tree, current_item) orelse return;
+        if (previous_param.optional != current_param.optional) return;
+
+        if (!std.mem.eql(u8, previous_param.type_text, current_param.type_text)) {
+            mismatch_count += 1;
+            mismatch_param = current_param.node;
+            first_type = previous_param.type_text;
+            second_type = current_param.type_text;
+        }
+    }
+
+    if (mismatch_count == 1) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(mismatch_param),
+            "These overloads can be combined into one signature taking `{s} | {s}`.",
+            .{ first_type, second_type },
+        );
+    }
+}
+
+fn paramsPrefixMatches(tree: *const ast.Tree, previous_items: []const ast.NodeIndex, current_items: []const ast.NodeIndex) bool {
+    for (previous_items, current_items) |previous_item, current_item| {
+        const previous_param = paramInfo(tree, previous_item) orelse return false;
+        const current_param = paramInfo(tree, current_item) orelse return false;
+        if (previous_param.optional != current_param.optional) return false;
+        if (!std.mem.eql(u8, previous_param.type_text, current_param.type_text)) return false;
+    }
+    return true;
+}
+
+fn addOptionalDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    param_index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "These overloads can be combined into one signature with an optional parameter.",
+        tree.span(param_index),
+    );
+}
+
+fn signatureInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?Signature {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .export_named_declaration => |declaration| signatureInfo(tree, declaration.declaration),
+        .export_default_declaration => |declaration| signatureInfo(tree, declaration.declaration),
+        .function => |function| functionSignature(tree, function, index),
+        .ts_method_signature => |signature| methodSignature(tree, signature, index),
+        else => null,
+    };
+}
+
+fn functionSignature(tree: *const ast.Tree, function: ast.Function, index: ast.NodeIndex) ?Signature {
+    switch (function.type) {
+        .function_declaration,
+        .ts_declare_function,
+        => {},
+        else => return null,
+    }
+    if (function.body != .null) return null;
+
+    const name = bindingIdentifierName(tree, function.id) orelse return null;
+    return .{ .name = name, .node = index, .params = function.params, .return_type = function.return_type };
+}
+
+fn methodSignature(tree: *const ast.Tree, signature: ast.TSMethodSignature, index: ast.NodeIndex) ?Signature {
+    if (signature.kind != .method) return null;
+    const name = keyName(tree, signature.key, signature.computed) orelse return null;
+    return .{ .name = name, .node = index, .params = signature.params, .return_type = signature.return_type };
+}
+
+fn params(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.FormalParameters {
+    return switch (tree.data(index)) {
+        .formal_parameters => |parameters| parameters,
+        else => null,
+    };
+}
+
+fn paramInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?Param {
+    return switch (tree.data(index)) {
+        .formal_parameter => |parameter| patternParamInfo(tree, parameter.pattern, index),
+        else => null,
+    };
+}
+
+fn patternParamInfo(tree: *const ast.Tree, pattern: ast.NodeIndex, param_index: ast.NodeIndex) ?Param {
+    return switch (tree.data(pattern)) {
+        .binding_identifier => |identifier| typedParam(tree, identifier.type_annotation, identifier.optional, param_index),
+        .assignment_pattern => |assignment| typedParam(tree, assignment.type_annotation, true, param_index),
+        else => null,
+    };
+}
+
+fn typedParam(tree: *const ast.Tree, type_annotation: ast.NodeIndex, optional: bool, param_index: ast.NodeIndex) ?Param {
+    const type_text = typeAnnotationText(tree, type_annotation) orelse return null;
+    return .{ .node = param_index, .type_text = type_text, .optional = optional };
+}
+
+fn sameReturnType(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_text = typeAnnotationText(tree, left) orelse "";
+    const right_text = typeAnnotationText(tree, right) orelse "";
+    return std.mem.eql(u8, left_text, right_text);
+}
+
+fn typeAnnotationText(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    const type_index = switch (tree.data(index)) {
+        .ts_type_annotation => |annotation| annotation.type_annotation,
+        else => index,
+    };
+    return sourceText(tree, type_index);
+}
+
+fn sourceText(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return null;
+    return std.mem.trim(u8, tree.source[start..end], " \t\r\n");
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn keyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed or index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -759,6 +759,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_unified_signatures.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unnecessary_type_constraint.zig");
 }
 

--- a/tests/rules/typescript_eslint_unified_signatures.zig
+++ b/tests/rules/typescript_eslint_unified_signatures.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/unified-signatures for unionable overloads" {
+    const source =
+        \\function f(value: string): void;
+        \\function f(value: number): void;
+        \\interface Shape {
+        \\  method(value: "a"): void;
+        \\  method(value: "b"): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_unified_signatures.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_unified_signatures.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "reports @typescript-eslint/unified-signatures for optional trailing parameters" {
+    const source =
+        \\interface Shape {
+        \\  method(value: string): void;
+        \\  method(value: string, extra: number): void;
+        \\}
+        \\interface ReverseShape {
+        \\  method(value: string, extra: number): void;
+        \\  method(value: string): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_unified_signatures.id));
+}
+
+test "allows @typescript-eslint/unified-signatures non-equivalent overloads" {
+    const source =
+        \\function f(value: string): string;
+        \\function f(value: number): number;
+        \\interface Shape {
+        \\  method(value: string): void;
+        \\  method(value: string, extra: number, other: boolean): void;
+        \\  rest(value: string): void;
+        \\  rest(...value: string[]): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_unified_signatures.id));
+}
+
+test "can disable @typescript-eslint/unified-signatures" {
+    const source =
+        \\interface Shape {
+        \\  method(value: string): void;
+        \\  method(value: number): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_unified_signatures = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_unified_signatures.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/unified-signatures as a fishlint-enabled warning
- detect combinable overloads with one differing parameter type or one optional trailing parameter
- add CLI disable flag, docs status, and focused rule tests

## Validation
- zig test -O ReleaseFast --test-filter unified-signatures --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke test for default and --typescript-eslint-unified-signatures=off
- git diff --check