### PR TITLE
feat: port typescript-eslint member-ordering

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -178,6 +178,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |
+| [`@typescript-eslint/member-ordering`](https://typescript-eslint.io/rules/member-ordering/) | Implemented for fishlint's default class member ordering |
 | [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -194,6 +194,7 @@ pub const Options = struct {
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_explicit_member_accessibility: bool = true,
+    typescript_eslint_member_ordering: bool = true,
     typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -403,6 +403,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_ban_tslint_comment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-explicit-member-accessibility=off")) {
             options.typescript_eslint_explicit_member_accessibility = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-member-ordering=off")) {
+            options.typescript_eslint_member_ordering = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-method-signature-style=off")) {
             options.typescript_eslint_method_signature_style = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-confusing-non-null-assertion=off")) {
@@ -870,6 +872,7 @@ fn printHelp() void {
         \\  --typescript-eslint-ban-ts-comment=off Disable @typescript-eslint/ban-ts-comment
         \\  --typescript-eslint-ban-tslint-comment=off Disable @typescript-eslint/ban-tslint-comment
         \\  --typescript-eslint-explicit-member-accessibility=off Disable @typescript-eslint/explicit-member-accessibility
+        \\  --typescript-eslint-member-ordering=off Disable @typescript-eslint/member-ordering
         \\  --typescript-eslint-method-signature-style=off Disable @typescript-eslint/method-signature-style
         \\  --typescript-eslint-no-confusing-non-null-assertion=off Disable @typescript-eslint/no-confusing-non-null-assertion
         \\  --typescript-eslint-no-dupe-class-members=off Disable @typescript-eslint/no-dupe-class-members

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -187,6 +187,7 @@ pub const typescript_eslint_ban_types = @import("typescript_eslint_ban_types.zig
 pub const typescript_eslint_ban_ts_comment = @import("typescript_eslint_ban_ts_comment.zig");
 pub const typescript_eslint_ban_tslint_comment = @import("typescript_eslint_ban_tslint_comment.zig");
 pub const typescript_eslint_explicit_member_accessibility = @import("typescript_eslint_explicit_member_accessibility.zig");
+pub const typescript_eslint_member_ordering = @import("typescript_eslint_member_ordering.zig");
 pub const typescript_eslint_method_signature_style = @import("typescript_eslint_method_signature_style.zig");
 pub const typescript_eslint_no_confusing_non_null_assertion = @import("typescript_eslint_no_confusing_non_null_assertion.zig");
 pub const typescript_eslint_no_dupe_class_members = @import("typescript_eslint_no_dupe_class_members.zig");
@@ -1597,6 +1598,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_dupe_class_members) {
             try typescript_eslint_no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
+        }
+        if (self.options.typescript_eslint_member_ordering) {
+            try typescript_eslint_member_ordering.check(self.allocator, self.diagnostics, ctx.tree, body);
         }
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);

--- a/src/rules/typescript_eslint_member_ordering.zig
+++ b/src/rules/typescript_eslint_member_ordering.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/member-ordering";
+
+const MemberKind = enum {
+    field,
+    method,
+    constructor,
+};
+
+const MemberInfo = struct {
+    name: []const u8,
+    rank: u8,
+    phrase: []const u8,
+    span: ast.Span,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+) Allocator.Error!void {
+    var latest: ?MemberInfo = null;
+
+    for (tree.extra(body.body)) |member_index| {
+        const current = memberInfo(tree, member_index) orelse continue;
+        if (latest) |previous| {
+            if (current.rank < previous.rank) {
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    current.span,
+                    "Member {s} should be declared before all {s}.",
+                    .{ current.name, previous.phrase },
+                );
+            }
+        }
+
+        if (latest == null or current.rank > latest.?.rank) {
+            latest = current;
+        }
+    }
+}
+
+fn memberInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?MemberInfo {
+    return switch (tree.data(index)) {
+        .property_definition => |property| memberInfoFromParts(
+            tree,
+            property.key,
+            property.computed,
+            property.static,
+            property.accessibility,
+            .field,
+        ),
+        .method_definition => |method| memberInfoFromParts(
+            tree,
+            method.key,
+            method.computed,
+            method.static,
+            method.accessibility,
+            if (method.kind == .constructor) .constructor else .method,
+        ),
+        else => null,
+    };
+}
+
+fn memberInfoFromParts(
+    tree: *const ast.Tree,
+    key: ast.NodeIndex,
+    computed: bool,
+    is_static: bool,
+    accessibility: ast.Accessibility,
+    kind: MemberKind,
+) ?MemberInfo {
+    if (computed) return null;
+    const name = if (kind == .constructor) "constructor" else keyName(tree, key) orelse return null;
+    const access = if (accessibility == .none) .public else accessibility;
+    return .{
+        .name = name,
+        .rank = memberRank(access, is_static, kind),
+        .phrase = memberPhrase(access, is_static, kind),
+        .span = tree.span(key),
+    };
+}
+
+fn memberRank(accessibility: ast.Accessibility, is_static: bool, kind: MemberKind) u8 {
+    if (kind == .constructor) return 16;
+
+    if (is_static) {
+        return switch (kind) {
+            .field => switch (accessibility) {
+                .public, .none => 0,
+                .protected => 1,
+                .private => 2,
+            },
+            .method => switch (accessibility) {
+                .public, .none => 4,
+                .protected => 5,
+                .private => 6,
+            },
+            .constructor => unreachable,
+        };
+    }
+
+    return switch (kind) {
+        .field => switch (accessibility) {
+            .public, .none => 8,
+            .protected => 9,
+            .private => 10,
+        },
+        .method => switch (accessibility) {
+            .public, .none => 17,
+            .protected => 18,
+            .private => 19,
+        },
+        .constructor => unreachable,
+    };
+}
+
+fn memberPhrase(accessibility: ast.Accessibility, is_static: bool, kind: MemberKind) []const u8 {
+    if (kind == .constructor) return "constructor definitions";
+
+    return switch (accessibility) {
+        .public, .none => if (is_static)
+            if (kind == .field) "public static field definitions" else "public static method definitions"
+        else if (kind == .field) "public instance field definitions" else "public instance method definitions",
+        .protected => if (is_static)
+            if (kind == .field) "protected static field definitions" else "protected static method definitions"
+        else if (kind == .field) "protected instance field definitions" else "protected instance method definitions",
+        .private => if (is_static)
+            if (kind == .field) "private static field definitions" else "private static method definitions"
+        else if (kind == .field) "private instance field definitions" else "private instance method definitions",
+    };
+}
+
+fn keyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -695,6 +695,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_member_ordering.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_confusing_non_null_assertion.zig");
 }
 

--- a/tests/rules/typescript_eslint_member_ordering.zig
+++ b/tests/rules/typescript_eslint_member_ordering.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/member-ordering for fishlint class member order" {
+    const source =
+        \\class Example {
+        \\  method() {}
+        \\  field = 1;
+        \\  private static privateValue = 1;
+        \\  public static publicValue = 1;
+        \\  constructor() {}
+        \\  lateField = 2;
+        \\  protected protectedMethod() {}
+        \\  public publicMethod() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_block_statements = false,
+        .typescript_eslint_explicit_member_accessibility = false,
+        .typescript_eslint_no_empty_function = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_member_ordering.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_member_ordering.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/member-ordering correct fishlint order" {
+    const source =
+        \\class Example {
+        \\  public static publicValue = 1;
+        \\  protected static protectedValue = 1;
+        \\  private static privateValue = 1;
+        \\  public static publicMethod() {}
+        \\  field = 1;
+        \\  constructor() {}
+        \\  public method() {}
+        \\  protected protectedMethod() {}
+        \\  private privateMethod() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_empty_block_statements = false,
+        .typescript_eslint_explicit_member_accessibility = false,
+        .typescript_eslint_no_empty_function = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_member_ordering.id));
+}
+
+test "can disable @typescript-eslint/member-ordering" {
+    const source =
+        \\class Example {
+        \\  method() {}
+        \\  field = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_member_ordering = false,
+        .no_empty_block_statements = false,
+        .typescript_eslint_explicit_member_accessibility = false,
+        .typescript_eslint_no_empty_function = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_member_ordering.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/member-ordering for fishlint default class member order
- add class member rank checks for fields, methods, constructors, static members, and accessibility groups
- add CLI disable flag, docs status, and focused tests

## Validation
- zig test -O ReleaseFast --test-filter member-ordering --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke test for default and --typescript-eslint-member-ordering=off
- git diff --check