### PR TITLE
feat: port typescript-eslint restrict-plus-operands

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -208,3 +208,4 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |
+| [`@typescript-eslint/restrict-plus-operands`](https://typescript-eslint.io/rules/restrict-plus-operands/) | Implemented for primitive literals and explicit primitive annotations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -221,6 +221,7 @@ pub const Options = struct {
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,
+    typescript_eslint_restrict_plus_operands: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     yoda: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -461,6 +461,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-namespace-keyword=off")) {
             options.typescript_eslint_prefer_namespace_keyword = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-restrict-plus-operands=off")) {
+            options.typescript_eslint_restrict_plus_operands = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -894,6 +896,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
+        \\  --typescript-eslint-restrict-plus-operands=off Disable @typescript-eslint/restrict-plus-operands
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -216,6 +216,7 @@ pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
+pub const typescript_eslint_restrict_plus_operands = @import("typescript_eslint_restrict_plus_operands.zig");
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
@@ -1332,6 +1333,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_bitwise) {
             try no_bitwise.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.typescript_eslint_restrict_plus_operands) {
+            try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_compare_neg_zero) {
             try no_compare_neg_zero.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/src/rules/typescript_eslint_restrict_plus_operands.zig
+++ b/src/rules/typescript_eslint_restrict_plus_operands.zig
@@ -1,0 +1,192 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/restrict-plus-operands";
+
+const ValueType = enum {
+    string,
+    number,
+    bigint,
+    boolean,
+    unknown,
+    invalid,
+    unknown_expression,
+
+    fn text(self: ValueType) []const u8 {
+        return switch (self) {
+            .string => "string",
+            .number => "number",
+            .bigint => "bigint",
+            .boolean => "boolean",
+            .unknown => "unknown",
+            .invalid => "invalid",
+            .unknown_expression => "unknown",
+        };
+    }
+};
+
+const TypeEnv = std.StringHashMapUnmanaged(ValueType);
+
+pub fn checkBinaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .add) return;
+
+    var env: TypeEnv = .empty;
+    defer env.deinit(allocator);
+
+    var visitor = TypeEnvVisitor{ .allocator = allocator, .env = &env };
+    try traverser.basic.traverse(TypeEnvVisitor, tree, &visitor);
+
+    const left = inferExpressionType(tree, env, expression.left);
+    const right = inferExpressionType(tree, env, expression.right);
+    if (left == .unknown_expression or right == .unknown_expression) return;
+    if (isAllowedPair(left, right)) return;
+
+    if (isAllowedOperand(left) and isAllowedOperand(right)) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Operands of '+' operations must be a number or string. Got `{s}` + `{s}`.",
+            .{ left.text(), right.text() },
+        );
+        return;
+    }
+
+    const invalid = if (!isAllowedOperand(left)) left else right;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Invalid operand for a '+' operation. Operands must each be a number or string. Got `{s}`.",
+        .{invalid.text()},
+    );
+}
+
+fn isAllowedPair(left: ValueType, right: ValueType) bool {
+    return (left == .number and right == .number) or
+        (left == .string and right == .string);
+}
+
+fn isAllowedOperand(value_type: ValueType) bool {
+    return value_type == .number or value_type == .string;
+}
+
+fn inferExpressionType(tree: *const ast.Tree, env: TypeEnv, index: ast.NodeIndex) ValueType {
+    if (index == .null) return .unknown_expression;
+
+    return switch (tree.data(index)) {
+        .numeric_literal => .number,
+        .string_literal, .template_literal => .string,
+        .bigint_literal => .bigint,
+        .boolean_literal => .boolean,
+        .null_literal, .array_expression, .object_expression => .invalid,
+        .identifier_reference => |identifier| env.get(tree.string(identifier.name)) orelse .unknown_expression,
+        .parenthesized_expression => |parenthesized| inferExpressionType(tree, env, parenthesized.expression),
+        .ts_as_expression => |expression| typeFromAnnotation(tree, expression.type_annotation) orelse inferExpressionType(tree, env, expression.expression),
+        .ts_type_assertion => |expression| typeFromAnnotation(tree, expression.type_annotation) orelse inferExpressionType(tree, env, expression.expression),
+        .ts_satisfies_expression => |expression| inferExpressionType(tree, env, expression.expression),
+        .ts_non_null_expression => |expression| inferExpressionType(tree, env, expression.expression),
+        .binary_expression => |binary| if (binary.operator == .add) inferBinaryResultType(tree, env, binary) else .unknown_expression,
+        else => .unknown_expression,
+    };
+}
+
+fn inferBinaryResultType(tree: *const ast.Tree, env: TypeEnv, expression: ast.BinaryExpression) ValueType {
+    const left = inferExpressionType(tree, env, expression.left);
+    const right = inferExpressionType(tree, env, expression.right);
+    if (left == .string and right == .string) return .string;
+    if (left == .number and right == .number) return .number;
+    return .unknown_expression;
+}
+
+fn typeFromAnnotation(tree: *const ast.Tree, index: ast.NodeIndex) ?ValueType {
+    if (index == .null) return null;
+    const type_index = switch (tree.data(index)) {
+        .ts_type_annotation => |annotation| annotation.type_annotation,
+        else => index,
+    };
+
+    return switch (tree.data(type_index)) {
+        .ts_string_keyword => .string,
+        .ts_number_keyword => .number,
+        .ts_bigint_keyword => .bigint,
+        .ts_boolean_keyword => .boolean,
+        .ts_unknown_keyword => .unknown,
+        .ts_any_keyword => null,
+        .ts_literal_type => |literal| literalType(tree, literal.literal),
+        else => null,
+    };
+}
+
+fn literalType(tree: *const ast.Tree, index: ast.NodeIndex) ?ValueType {
+    return switch (tree.data(index)) {
+        .numeric_literal => .number,
+        .string_literal, .template_literal => .string,
+        .bigint_literal => .bigint,
+        .boolean_literal => .boolean,
+        .null_literal => .invalid,
+        else => null,
+    };
+}
+
+const TypeEnvVisitor = struct {
+    allocator: Allocator,
+    env: *TypeEnv,
+
+    pub fn enter_variable_declarator(
+        self: *TypeEnvVisitor,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.collectBinding(ctx.tree, declarator.id);
+        return .proceed;
+    }
+
+    pub fn enter_formal_parameter(
+        self: *TypeEnvVisitor,
+        parameter: ast.FormalParameter,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.collectBinding(ctx.tree, parameter.pattern);
+        return .proceed;
+    }
+
+    fn collectBinding(self: *TypeEnvVisitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        if (index == .null) return;
+
+        switch (tree.data(index)) {
+            .binding_identifier => |identifier| {
+                const value_type = typeFromAnnotation(tree, identifier.type_annotation) orelse return;
+                try self.env.put(self.allocator, tree.string(identifier.name), value_type);
+            },
+            .assignment_pattern => |assignment| {
+                if (typeFromAnnotation(tree, assignment.type_annotation)) |value_type| {
+                    if (tree.data(assignment.left) == .binding_identifier) {
+                        const identifier = tree.data(assignment.left).binding_identifier;
+                        try self.env.put(self.allocator, tree.string(identifier.name), value_type);
+                        return;
+                    }
+                }
+                try self.collectBinding(tree, assignment.left);
+            },
+            else => {},
+        }
+    }
+};

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -807,6 +807,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_restrict_plus_operands.zig");
+}
+
+comptime {
     _ = @import("rules/unicode_bom.zig");
 }
 

--- a/tests/rules/typescript_eslint_restrict_plus_operands.zig
+++ b/tests/rules/typescript_eslint_restrict_plus_operands.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/restrict-plus-operands for mixed and invalid primitive operands" {
+    const source =
+        \\const count: number = 1;
+        \\const label: string = "items";
+        \\const enabled: boolean = true;
+        \\const mystery: unknown = 1;
+        \\count + label;
+        \\enabled + count;
+        \\mystery + count;
+        \\1 + "x";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_restrict_plus_operands.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_restrict_plus_operands.id)) {
+            try std.testing.expectEqual(lint.Severity.warning, diagnostic.severity);
+        }
+    }
+}
+
+test "allows @typescript-eslint/restrict-plus-operands compatible primitive operands" {
+    const source =
+        \\const left: number = 1;
+        \\const right: number = 2;
+        \\const first: string = "a";
+        \\const second: string = "b";
+        \\left + right;
+        \\first + second;
+        \\(1 as number) + <number>2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_restrict_plus_operands.id));
+}
+
+test "can disable @typescript-eslint/restrict-plus-operands" {
+    const source =
+        \\const count: number = 1;
+        \\const label: string = "items";
+        \\count + label;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_restrict_plus_operands = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_restrict_plus_operands.id));
+}


### PR DESCRIPTION
## Summary
- port @typescript-eslint/restrict-plus-operands for primitive literals and explicit primitive annotations
- warn on mixed number/string operands and invalid primitive operands such as boolean or unknown
- add CLI disable flag, docs status, and focused tests

## Validation
- zig test -O ReleaseFast --test-filter restrict-plus-operands --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke test for default and --typescript-eslint-restrict-plus-operands=off
- git diff --check