### PR TITLE
feat: port import no-self-import

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -177,6 +177,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
+| [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## Parser diagnostics
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -89,6 +89,7 @@ pub const Options = struct {
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
+    import_no_self_import: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -193,6 +193,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_amd = false;
         } else if (std.mem.eql(u8, arg, "--import-no-duplicates=off")) {
             options.import_no_duplicates = false;
+        } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
+            options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
             options.no_invalid_regexp = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
@@ -783,6 +785,7 @@ fn printHelp() void {
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
+        \\  --import-no-self-import=off Disable import/no-self-import
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments

--- a/src/root.zig
+++ b/src/root.zig
@@ -38,11 +38,11 @@ pub fn lintSource(
         var semantic_result = try parser.semantic.analyze(&tree);
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
-        try rules.runBasic(allocator, &diagnostics, &tree, effective_options);
+        try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
         try rules.runSemantic(allocator, &diagnostics, &tree, semantic_result, effective_options);
     } else {
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
-        try rules.runBasic(allocator, &diagnostics, &tree, effective_options);
+        try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
     }
 
     return .{

--- a/src/rules/import_no_self_import.zig
+++ b/src/rules/import_no_self_import.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/no-self-import";
+
+const extensions = [_][]const u8{
+    ".ts",
+    ".cts",
+    ".mts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const current_path = try std.fs.path.resolve(allocator, &.{file_path});
+    defer allocator.free(current_path);
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        const source = importSource(tree, declaration) orelse continue;
+        if (!isRelativeImport(source)) continue;
+
+        if (try resolvesToCurrentFile(allocator, file_path, source, current_path)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                "Module imports itself.",
+                tree.span(statement_index),
+            );
+        }
+    }
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn isRelativeImport(source: []const u8) bool {
+    return std.mem.startsWith(u8, source, "./") or
+        std.mem.startsWith(u8, source, "../") or
+        std.mem.eql(u8, source, ".") or
+        std.mem.eql(u8, source, "..");
+}
+
+fn resolvesToCurrentFile(
+    allocator: Allocator,
+    file_path: []const u8,
+    source: []const u8,
+    current_path: []const u8,
+) Allocator.Error!bool {
+    const directory = std.fs.path.dirname(file_path) orelse ".";
+    const imported_path = try std.fs.path.resolve(allocator, &.{ directory, source });
+    defer allocator.free(imported_path);
+
+    if (std.mem.eql(u8, imported_path, current_path)) return true;
+
+    for (extensions) |extension| {
+        const with_extension = try std.mem.concat(allocator, u8, &.{ imported_path, extension });
+        defer allocator.free(with_extension);
+        if (std.mem.eql(u8, with_extension, current_path)) return true;
+
+        const index_name = try std.mem.concat(allocator, u8, &.{ "index", extension });
+        defer allocator.free(index_name);
+        const index_path = try std.fs.path.join(allocator, &.{ imported_path, index_name });
+        defer allocator.free(index_path);
+        if (std.mem.eql(u8, index_path, current_path)) return true;
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -28,6 +28,7 @@ pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
+pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -230,6 +231,7 @@ pub fn runBasic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    file_path: []const u8,
     options: core.Options,
 ) Allocator.Error!void {
     if (options.no_warning_comments) {
@@ -284,6 +286,7 @@ pub fn runBasic(
     var visitor = BasicVisitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .file_path = file_path,
         .options = options,
     };
 
@@ -494,6 +497,7 @@ pub fn runSemantic(
 const BasicVisitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    file_path: []const u8,
     options: core.Options,
 
     pub fn enter_program(
@@ -510,6 +514,9 @@ const BasicVisitor = struct {
         }
         if (self.options.import_no_duplicates) {
             try import_no_duplicates.check(self.allocator, self.diagnostics, ctx.tree, program);
+        }
+        if (self.options.import_no_self_import) {
+            try import_no_self_import.check(self.allocator, self.diagnostics, ctx.tree, program, self.file_path);
         }
         if (self.options.no_duplicate_imports and !self.options.import_no_duplicates) {
             try no_duplicate_imports.check(self.allocator, self.diagnostics, ctx.tree, program);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_no_self_import.zig");
+}
+
+comptime {
     _ = @import("rules/linebreak_style.zig");
 }
 

--- a/tests/rules/import_no_self_import.zig
+++ b/tests/rules/import_no_self_import.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/no-self-import for relative imports that resolve to the current file" {
+    const source =
+        \\import first from "./button";
+        \\import second from "../components/button.ts";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/components/button.ts", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_self_import.id));
+    try std.testing.expectEqualStrings("Module imports itself.", result.diagnostics[0].message);
+}
+
+test "reports import/no-self-import for index module imports" {
+    const source =
+        \\import first from "./";
+        \\import second from "./index";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/components/index.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_self_import.id));
+}
+
+test "does not report import/no-self-import for other modules or packages" {
+    const source =
+        \\import other from "./other";
+        \\import react from "react";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/components/button.ts", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_self_import.id));
+}
+
+test "can disable import/no-self-import" {
+    const source =
+        \\import button from "./button";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/components/button.ts", .{
+        .eol_last = false,
+        .import_no_self_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_self_import.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint-enabled import/no-self-import for relative module imports
- pass the linted file path into basic rules so self-import resolution can compare against the current file
- support fishlint's configured JS/TS extensions and index module imports

## Validation
- zig fmt src/core.zig src/main.zig src/root.zig src/rules/root.zig src/rules/import_no_self_import.zig tests/all.zig tests/rules/import_no_self_import.zig
- zig test -O ReleaseFast --test-filter import/no-self-import --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --cached --check
- CLI smoke: default reports import/no-self-import, --import-no-self-import=off suppresses it