### PR TITLE
feat: port react no-danger

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -183,6 +183,12 @@ Each rule links to the corresponding ESLint rule reference.
 
 `parser-semantic-errors` reports parse diagnostics from Yuku, including semantic early errors by default. It is not an ESLint rule and therefore does not have a corresponding ESLint rule page.
 
+## React rules
+
+| Rule | Status |
+| --- | --- |
+| [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
+
 ## TypeScript ESLint rules
 
 | Rule | Status |

--- a/src/core.zig
+++ b/src/core.zig
@@ -184,6 +184,7 @@ pub const Options = struct {
     prefer_rest_params: bool = true,
     prefer_spread: bool = true,
     prefer_template: bool = true,
+    react_no_danger: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -381,6 +381,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-template=off")) {
             options.prefer_template = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
+            options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -877,6 +879,7 @@ fn printHelp() void {
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread
+        \\  --react-no-danger=off     Disable react/no-danger
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_no_danger.zig
+++ b/src/rules/react_no_danger.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-danger";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isDangerousAttribute(tree, attribute.name)) return;
+
+    const opening = switch (tree.data(parent_index orelse return)) {
+        .jsx_opening_element => |opening| opening,
+        else => return,
+    };
+    if (!isDomComponent(tree, opening.name)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Dangerous property '{s}' found",
+        .{"dangerouslySetInnerHTML"},
+    );
+}
+
+fn isDangerousAttribute(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "dangerouslySetInnerHTML"),
+        else => false,
+    };
+}
+
+fn isDomComponent(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    const root = jsxNameRoot(tree, name_index) orelse return false;
+    const name = switch (tree.data(root)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return name.len > 0 and name[0] >= 'a' and name[0] <= 'z';
+}
+
+fn jsxNameRoot(tree: *const ast.Tree, name_index: ast.NodeIndex) ?ast.NodeIndex {
+    var current = name_index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .jsx_identifier => return current,
+            .jsx_namespaced_name => |name| return name.namespace,
+            .jsx_member_expression => |member| current = member.object,
+            else => return null,
+        }
+    }
+    return null;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -175,6 +175,7 @@ pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
+pub const react_no_danger = @import("react_no_danger.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -1565,6 +1566,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_sparse_arrays) {
             try no_sparse_arrays.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_jsx_attribute(
+        self: *BasicVisitor,
+        attribute: ast.JSXAttribute,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.react_no_danger) {
+            try react_no_danger.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -651,6 +651,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_danger.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_no_danger.zig
+++ b/tests/rules/react_no_danger.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-danger on DOM JSX elements" {
+    const source =
+        \\const node = <div dangerouslySetInnerHTML={{ __html: html }} />;
+        \\const path = <svg:path dangerouslySetInnerHTML={{ __html: html }} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_danger.id));
+    try std.testing.expectEqualStrings("Dangerous property 'dangerouslySetInnerHTML' found", result.diagnostics[0].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "does not report react/no-danger on custom JSX components by default" {
+    const source =
+        \\const node = <Widget dangerouslySetInnerHTML={{ __html: html }} />;
+        \\const member = <Widget.Inner dangerouslySetInnerHTML={{ __html: html }} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_danger.id));
+}
+
+test "can disable react/no-danger" {
+    const source =
+        \\const node = <div dangerouslySetInnerHTML={{ __html: html }} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_no_danger = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_danger.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint-enabled react/no-danger for DOM JSX elements
- add a JSX attribute visitor hook and CLI disable flag
- document React rule coverage and add focused tests for DOM, custom component, and disabled cases

## Validation
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/react_no_danger.zig tests/all.zig tests/rules/react_no_danger.zig
- zig test -O ReleaseFast --test-filter react/no-danger --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --cached --check
- CLI smoke: default reports react/no-danger, --react-no-danger=off suppresses it