### PR TITLE
feat: port react jsx-boolean-value

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -187,6 +187,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 
 ## TypeScript ESLint rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -184,6 +184,7 @@ pub const Options = struct {
     prefer_rest_params: bool = true,
     prefer_spread: bool = true,
     prefer_template: bool = true,
+    react_jsx_boolean_value: bool = true,
     react_no_danger: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -381,6 +381,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-template=off")) {
             options.prefer_template = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-boolean-value=off")) {
+            options.react_jsx_boolean_value = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
@@ -879,6 +881,7 @@ fn printHelp() void {
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread
+        \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates

--- a/src/rules/react_jsx_boolean_value.zig
+++ b/src/rules/react_jsx_boolean_value.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-boolean-value";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = attributeName(tree, attribute.name) orelse return;
+    if (!isExplicitTrue(tree, attribute.value)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Value must be omitted for boolean attribute `{s}`",
+        .{name},
+    );
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isExplicitTrue(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+    if (value_index == .null) return false;
+
+    const container = switch (tree.data(value_index)) {
+        .jsx_expression_container => |container| container,
+        else => return false,
+    };
+
+    return switch (tree.data(container.expression)) {
+        .boolean_literal => |literal| literal.value,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -175,6 +175,7 @@ pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
+pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -1578,6 +1579,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_no_danger) {
             try react_no_danger.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));
+        }
+        if (self.options.react_jsx_boolean_value) {
+            try react_jsx_boolean_value.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_boolean_value.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_jsx_boolean_value.zig
+++ b/tests/rules/react_jsx_boolean_value.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-boolean-value for explicit true boolean attributes" {
+    const source =
+        \\const node = <Widget disabled={true} required={true} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_boolean_value.id));
+    try std.testing.expectEqualStrings("Value must be omitted for boolean attribute `disabled`", result.diagnostics[0].message);
+}
+
+test "allows omitted false and non-boolean JSX attribute values" {
+    const source =
+        \\const node = <Widget disabled checked={false} label="ok" count={1} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_boolean_value.id));
+}
+
+test "can disable react/jsx-boolean-value" {
+    const source =
+        \\const node = <Widget disabled={true} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_boolean_value = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_boolean_value.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint-enabled react/jsx-boolean-value for the configured never mode
- report explicit {true} JSX boolean attributes and support the disable flag
- document React coverage and add focused tests for explicit true, omitted/false/non-boolean values, and disabled behavior

## Validation
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/react_jsx_boolean_value.zig tests/all.zig tests/rules/react_jsx_boolean_value.zig
- zig test -O ReleaseFast --test-filter boolean --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --cached --check
- CLI smoke: default reports react/jsx-boolean-value, --react-jsx-boolean-value=off suppresses it