### PR TITLE
feat: port react jsx-no-duplicate-props

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -188,6 +188,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
+| [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 
 ## TypeScript ESLint rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -185,6 +185,7 @@ pub const Options = struct {
     prefer_spread: bool = true,
     prefer_template: bool = true,
     react_jsx_boolean_value: bool = true,
+    react_jsx_no_duplicate_props: bool = true,
     react_no_danger: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -383,6 +383,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-boolean-value=off")) {
             options.react_jsx_boolean_value = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-no-duplicate-props=off")) {
+            options.react_jsx_no_duplicate_props = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
@@ -882,6 +884,7 @@ fn printHelp() void {
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
+        \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates

--- a/src/rules/react_jsx_no_duplicate_props.zig
+++ b/src/rules/react_jsx_no_duplicate_props.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-no-duplicate-props";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+) Allocator.Error!void {
+    var seen: std.ArrayList([]const u8) = .empty;
+    defer seen.deinit(allocator);
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+
+        if (containsIgnoreCase(seen.items, name)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                "No duplicate props allowed",
+                tree.span(attribute_index),
+            );
+            continue;
+        }
+
+        try seen.append(allocator, name);
+    }
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn containsIgnoreCase(items: []const []const u8, name: []const u8) bool {
+    for (items) |item| {
+        if (std.ascii.eqlIgnoreCase(item, name)) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -176,6 +176,7 @@ pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
+pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -1582,6 +1583,18 @@ const BasicVisitor = struct {
         }
         if (self.options.react_jsx_boolean_value) {
             try react_jsx_boolean_value.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_jsx_opening_element(
+        self: *BasicVisitor,
+        opening: ast.JSXOpeningElement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.react_jsx_no_duplicate_props) {
+            try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -659,6 +659,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_no_duplicate_props.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_jsx_no_duplicate_props.zig
+++ b/tests/rules/react_jsx_no_duplicate_props.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-no-duplicate-props for repeated JSX props" {
+    const source =
+        \\const node = <Widget name="a" Name="b" enabled enabled={true} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_boolean_value = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_no_duplicate_props.id));
+    try std.testing.expectEqualStrings("No duplicate props allowed", result.diagnostics[0].message);
+}
+
+test "ignores spread attributes and distinct JSX props" {
+    const source =
+        \\const node = <Widget {...props} name="a" label="b" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_duplicate_props.id));
+}
+
+test "can disable react/jsx-no-duplicate-props" {
+    const source =
+        \\const node = <Widget name="a" name="b" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_no_duplicate_props = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_duplicate_props.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint-enabled react/jsx-no-duplicate-props for ignoreCase: true
- scan JSX opening elements for repeated explicit props while ignoring spreads
- document React coverage and add focused duplicate, allowed, and disabled tests

## Validation
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/react_jsx_no_duplicate_props.zig tests/all.zig tests/rules/react_jsx_no_duplicate_props.zig
- zig test -O ReleaseFast --test-filter duplicate --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --cached --check
- CLI smoke: default reports react/jsx-no-duplicate-props, --react-jsx-no-duplicate-props=off suppresses it