### PR TITLE
feat: port react jsx-no-comment-textnodes

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -188,6 +188,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
+| [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -186,6 +186,7 @@ pub const Options = struct {
     prefer_template: bool = true,
     react_jsx_boolean_value: bool = true,
     react_jsx_no_duplicate_props: bool = true,
+    react_jsx_no_comment_textnodes: bool = true,
     react_no_danger: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -385,6 +385,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_boolean_value = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-duplicate-props=off")) {
             options.react_jsx_no_duplicate_props = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-no-comment-textnodes=off")) {
+            options.react_jsx_no_comment_textnodes = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
@@ -885,6 +887,7 @@ fn printHelp() void {
         \\  --prefer-spread=off       Disable prefer-spread
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
+        \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates

--- a/src/rules/react_jsx_no_comment_textnodes.zig
+++ b/src/rules/react_jsx_no_comment_textnodes.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-no-comment-textnodes";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    text: ast.JSXText,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!startsWithCommentToken(tree.string(text.value))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Comments inside children section of tag should be placed inside braces",
+        tree.span(index),
+    );
+}
+
+fn startsWithCommentToken(value: []const u8) bool {
+    var line_start: usize = 0;
+    while (line_start <= value.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, value, line_start, '\n') orelse value.len;
+        var index = line_start;
+        while (index < line_end and isWhitespace(value[index])) : (index += 1) {}
+        if (index + 1 < line_end and value[index] == '/' and (value[index + 1] == '/' or value[index + 1] == '*')) {
+            return true;
+        }
+        if (line_end == value.len) break;
+        line_start = line_end + 1;
+    }
+    return false;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\r' or byte == '\n';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -177,6 +177,7 @@ pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
+pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -1595,6 +1596,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
             try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_jsx_text(
+        self: *BasicVisitor,
+        text: ast.JSXText,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.react_jsx_no_comment_textnodes) {
+            try react_jsx_no_comment_textnodes.check(self.allocator, self.diagnostics, ctx.tree, text, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_no_comment_textnodes.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_jsx_no_comment_textnodes.zig
+++ b/tests/rules/react_jsx_no_comment_textnodes.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-no-comment-textnodes for text comments in JSX children" {
+    const source =
+        \\const node = <div>
+        \\  // text comment
+        \\  /* block text comment */
+        \\</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_comment_textnodes.id));
+    try std.testing.expectEqualStrings("Comments inside children section of tag should be placed inside braces", result.diagnostics[0].message);
+}
+
+test "allows JSX expression comments and ordinary JSX text" {
+    const source =
+        \\const node = <div>
+        \\  {/* real comment */}
+        \\  / not a comment
+        \\  text
+        \\</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_comment_textnodes.id));
+}
+
+test "can disable react/jsx-no-comment-textnodes" {
+    const source =
+        \\const node = <div>// text comment</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_no_comment_textnodes = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_comment_textnodes.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint-enabled react/jsx-no-comment-textnodes
- report JSX text children that start with // or /* comment syntax
- document React coverage and add focused report, allowed, and disabled tests

## Validation
- zig fmt src/core.zig src/main.zig src/rules/root.zig src/rules/react_jsx_no_comment_textnodes.zig tests/all.zig tests/rules/react_jsx_no_comment_textnodes.zig
- zig test -O ReleaseFast --test-filter JSX --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- git diff --cached --check
- CLI smoke: default reports react/jsx-no-comment-textnodes, --react-jsx-no-comment-textnodes=off suppresses it