### PR TITLE
feat: port react jsx-pascal-case

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -190,6 +190,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
+| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 
 ## TypeScript ESLint rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     react_jsx_boolean_value: bool = true,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
+    react_jsx_pascal_case: bool = true,
     react_no_danger: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_no_duplicate_props = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-comment-textnodes=off")) {
             options.react_jsx_no_comment_textnodes = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-pascal-case=off")) {
+            options.react_jsx_pascal_case = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
@@ -888,6 +890,7 @@ fn printHelp() void {
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
+        \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates

--- a/src/rules/react_jsx_pascal_case.zig
+++ b/src/rules/react_jsx_pascal_case.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-pascal-case";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (isDomComponent(tree, opening.name)) return;
+
+    const invalid_name = invalidNamePart(tree, opening.name) orelse return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Imported JSX component {s} must be in PascalCase or SCREAMING_SNAKE_CASE",
+        .{invalid_name},
+    );
+}
+
+fn isDomComponent(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    const first = firstNamePart(tree, name_index) orelse return false;
+    return first.len > 0 and first[0] >= 'a' and first[0] <= 'z';
+}
+
+fn firstNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        .jsx_namespaced_name => |name| firstNamePart(tree, name.namespace),
+        .jsx_member_expression => |member| firstNamePart(tree, member.object),
+        else => null,
+    };
+}
+
+fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| {
+            const name = tree.string(identifier.name);
+            if (name.len == 1) return null;
+            return if (isPascalCase(name) or isAllCaps(name)) null else name;
+        },
+        .jsx_namespaced_name => |name| {
+            if (invalidNamePart(tree, name.namespace)) |invalid| return invalid;
+            return invalidNamePart(tree, name.name);
+        },
+        .jsx_member_expression => |member| {
+            if (invalidNamePart(tree, member.object)) |invalid| return invalid;
+            return invalidNamePart(tree, member.property);
+        },
+        else => return null,
+    }
+}
+
+fn isPascalCase(name: []const u8) bool {
+    if (name.len == 0 or !isUpper(name[0])) return false;
+
+    var has_lower_or_digit = false;
+    for (name[1..]) |byte| {
+        if (isLower(byte) or isDigit(byte)) {
+            has_lower_or_digit = true;
+        } else if (!isUpper(byte)) {
+            return false;
+        }
+    }
+    return has_lower_or_digit;
+}
+
+fn isAllCaps(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (!isUpper(name[0]) and !isDigit(name[0])) return false;
+    if (name.len == 1) return true;
+
+    for (name[1 .. name.len - 1]) |byte| {
+        if (!isUpper(byte) and !isDigit(byte) and byte != '_') return false;
+    }
+
+    const last = name[name.len - 1];
+    return isUpper(last) or isDigit(last);
+}
+
+fn isUpper(byte: u8) bool {
+    return byte >= 'A' and byte <= 'Z';
+}
+
+fn isLower(byte: u8) bool {
+    return byte >= 'a' and byte <= 'z';
+}
+
+fn isDigit(byte: u8) bool {
+    return byte >= '0' and byte <= '9';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -178,6 +178,7 @@ pub const prefer_template = @import("prefer_template.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
+pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -1591,11 +1592,14 @@ const BasicVisitor = struct {
     pub fn enter_jsx_opening_element(
         self: *BasicVisitor,
         opening: ast.JSXOpeningElement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
             try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        if (self.options.react_jsx_pascal_case) {
+            try react_jsx_pascal_case.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -667,6 +667,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_pascal_case.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_jsx_pascal_case.zig
+++ b/tests/rules/react_jsx_pascal_case.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-pascal-case for non-pascal custom components" {
+    const source =
+        \\const first = <fooBar />;
+        \\const second = <Foo.bar />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
+    try std.testing.expectEqualStrings("Imported JSX component bar must be in PascalCase or SCREAMING_SNAKE_CASE", result.diagnostics[0].message);
+}
+
+test "allows DOM tags pascal case and screaming snake case components" {
+    const source =
+        \\const dom = <div><span /></div>;
+        \\const pascal = <FooBar><Foo.Bar /></FooBar>;
+        \\const caps = <FOO_BAR><FOO.BAR /></FOO_BAR>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_pascal_case.id));
+}
+
+test "can disable react/jsx-pascal-case" {
+    const source =
+        \\const node = <Foo.bar />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_pascal_case = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_pascal_case.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-pascal-case for fishlint's allowAllCaps: true and ignore: [] config
- validate JSX identifiers, namespace parts, and member expression parts while skipping DOM-compatible lowercase tags
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --cached --check
- zig test -O ReleaseFast --test-filter pascal --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1