### PR TITLE
feat: port react no-find-dom-node

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -192,6 +192,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
+| [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 
 ## TypeScript ESLint rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -189,6 +189,7 @@ pub const Options = struct {
     react_jsx_no_comment_textnodes: bool = true,
     react_jsx_pascal_case: bool = true,
     react_no_danger: bool = true,
+    react_no_find_dom_node: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -391,6 +391,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_pascal_case = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-find-dom-node=off")) {
+            options.react_no_find_dom_node = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -892,6 +894,7 @@ fn printHelp() void {
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
         \\  --react-no-danger=off     Disable react/no-danger
+        \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_no_find_dom_node.zig
+++ b/src/rules/react_no_find_dom_node.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-find-dom-node";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (!isFindDomNodeCallee(tree, callee)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Do not use findDOMNode. It doesn't work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode",
+        tree.span(callee),
+    );
+}
+
+fn isFindDomNodeCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "findDOMNode"),
+        .member_expression => |member| {
+            const property = memberPropertyName(tree, member) orelse return false;
+            return std.mem.eql(u8, property, "findDOMNode");
+        },
+        else => false,
+    };
+}
+
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) return null;
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -180,6 +180,7 @@ pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.z
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
+pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -1475,6 +1476,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.react_no_find_dom_node) {
+            try react_no_find_dom_node.check(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_find_dom_node.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_boolean_value.zig");
 }
 

--- a/tests/rules/react_no_find_dom_node.zig
+++ b/tests/rules/react_no_find_dom_node.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-find-dom-node for direct and member calls" {
+    const source =
+        \\findDOMNode(node);
+        \\ReactDOM.findDOMNode(node);
+        \\React.findDOMNode(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_find_dom_node.id));
+    try std.testing.expectEqualStrings(
+        "Do not use findDOMNode. It doesn't work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode",
+        result.diagnostics[0].message,
+    );
+}
+
+test "ignores other calls and computed property access" {
+    const source =
+        \\findDomNode(node);
+        \\ReactDOM.render(node);
+        \\ReactDOM["findDOMNode"](node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_find_dom_node.id));
+}
+
+test "can disable react/no-find-dom-node" {
+    const source =
+        \\ReactDOM.findDOMNode(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_find_dom_node = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_find_dom_node.id));
+}


### PR DESCRIPTION
## Summary
- add react/no-find-dom-node rule for fishlint
- report direct findDOMNode calls and member calls like ReactDOM.findDOMNode
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --check
- git diff --cached --check
- zig test -O ReleaseFast --test-filter react_no_find_dom_node --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- zig test -O ReleaseFast --test-no-exec --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- CLI smoke for default report and --react-no-find-dom-node=off