### PR TITLE
feat: port react no-is-mounted

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -193,6 +193,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
+| [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 
 ## TypeScript ESLint rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -190,6 +190,7 @@ pub const Options = struct {
     react_jsx_pascal_case: bool = true,
     react_no_danger: bool = true,
     react_no_find_dom_node: bool = true,
+    react_no_is_mounted: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -393,6 +393,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--react-no-find-dom-node=off")) {
             options.react_no_find_dom_node = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-is-mounted=off")) {
+            options.react_no_is_mounted = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -895,6 +897,7 @@ fn printHelp() void {
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
+        \\  --react-no-is-mounted=off Disable react/no-is-mounted
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_no_is_mounted.zig
+++ b/src/rules/react_no_is_mounted.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-is-mounted";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (!isThisIsMountedCall(tree, callee)) return;
+    if (!hasMethodLikeAncestor(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Do not use isMounted",
+        tree.span(callee),
+    );
+}
+
+fn isThisIsMountedCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    if (member.computed) return false;
+    if (tree.data(unwrapTransparent(tree, member.object)) != .this_expression) return false;
+
+    const property = switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, property, "isMounted");
+}
+
+fn hasMethodLikeAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .object_property,
+            .method_definition,
+            => return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -181,6 +181,7 @@ pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnod
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
+pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -1479,6 +1480,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_find_dom_node) {
             try react_no_find_dom_node.check(self.allocator, self.diagnostics, ctx.tree, call);
+        }
+        if (self.options.react_no_is_mounted) {
+            try react_no_is_mounted.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
         }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -659,6 +659,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_is_mounted.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_boolean_value.zig");
 }
 

--- a/tests/rules/react_no_is_mounted.zig
+++ b/tests/rules/react_no_is_mounted.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-is-mounted inside class and object methods" {
+    const source =
+        \\class Component {
+        \\  render() {
+        \\    return this.isMounted();
+        \\  }
+        \\}
+        \\const objectComponent = {
+        \\  render() {
+        \\    return this.isMounted();
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_is_mounted.id));
+    try std.testing.expectEqualStrings("Do not use isMounted", result.diagnostics[0].message);
+}
+
+test "ignores isMounted outside methods and non-this calls" {
+    const source =
+        \\function check() {
+        \\  this.isMounted();
+        \\  component.isMounted();
+        \\  this["isMounted"]();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_is_mounted.id));
+}
+
+test "can disable react/no-is-mounted" {
+    const source =
+        \\class Component {
+        \\  render() {
+        \\    return this.isMounted();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .react_no_is_mounted = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_is_mounted.id));
+}


### PR DESCRIPTION
## Summary
- add react/no-is-mounted rule for fishlint
- report this.isMounted() calls inside object properties or class methods
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --check
- git diff --cached --check
- zig test -O ReleaseFast --test-filter react_no_is_mounted --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default report and --react-no-is-mounted=off