### PR TITLE
feat: port react no-render-return-value

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -194,6 +194,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
+| [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 
 ## TypeScript ESLint rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -191,6 +191,7 @@ pub const Options = struct {
     react_no_danger: bool = true,
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
+    react_no_render_return_value: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,6 +395,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_find_dom_node = false;
         } else if (std.mem.eql(u8, arg, "--react-no-is-mounted=off")) {
             options.react_no_is_mounted = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
+            options.react_no_render_return_value = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -898,6 +900,7 @@ fn printHelp() void {
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
+        \\  --react-no-render-return-value=off Disable react/no-render-return-value
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_no_render_return_value.zig
+++ b/src/rules/react_no_render_return_value.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-render-return-value";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (!isReactDomRenderCallee(tree, callee)) return;
+    if (!usesReturnValue(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Do not depend on the return value from ReactDOM.render",
+        tree.span(callee),
+    );
+}
+
+fn isReactDomRenderCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    if (member.computed) return false;
+    if (!isIdentifierReferenceNamed(tree, unwrapTransparent(tree, member.object), "ReactDOM")) return false;
+
+    const property = switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, property, "render");
+}
+
+fn usesReturnValue(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .parenthesized_expression => continue,
+            .variable_declarator,
+            .object_property,
+            .return_statement,
+            .arrow_function_expression,
+            .assignment_expression,
+            => return true,
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -182,6 +182,7 @@ pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
+pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -1483,6 +1484,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_is_mounted) {
             try react_no_is_mounted.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
+        }
+        if (self.options.react_no_render_return_value) {
+            try react_no_render_return_value.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
         }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_render_return_value.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_boolean_value.zig");
 }
 

--- a/tests/rules/react_no_render_return_value.zig
+++ b/tests/rules/react_no_render_return_value.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-render-return-value when ReactDOM.render result is used" {
+    const source =
+        \\const mount = ReactDOM.render(node, container);
+        \\target = ReactDOM.render(node, container);
+        \\function mountNode() {
+        \\  return ReactDOM.render(node, container);
+        \\}
+        \\const mountArrow = () => ReactDOM.render(node, container);
+        \\const object = { mount: ReactDOM.render(node, container) };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.react_no_render_return_value.id));
+    try std.testing.expectEqualStrings(
+        "Do not depend on the return value from ReactDOM.render",
+        result.diagnostics[0].message,
+    );
+}
+
+test "ignores standalone render calls and non-ReactDOM render calls" {
+    const source =
+        \\ReactDOM.render(node, container);
+        \\React.render(node, container);
+        \\Renderer.render(node, container);
+        \\use(ReactDOM.render(node, container));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_render_return_value.id));
+}
+
+test "can disable react/no-render-return-value" {
+    const source =
+        \\const mount = ReactDOM.render(node, container);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_render_return_value = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_render_return_value.id));
+}


### PR DESCRIPTION
## Summary
- add react/no-render-return-value for eslint-plugin-react's default/latest React behavior
- report ReactDOM.render return values used by declarations, assignments, returns, object properties, and expression-bodied arrows
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --check
- git diff --cached --check
- zig test -O ReleaseFast --test-filter react_no_render_return_value --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default report and --react-no-render-return-value=off