### PR TITLE
feat: port react no-unescaped-entities

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -195,6 +195,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
+| [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
 
 ## TypeScript ESLint rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -192,6 +192,7 @@ pub const Options = struct {
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
     react_no_render_return_value: bool = true,
+    react_no_unescaped_entities: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -397,6 +397,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_is_mounted = false;
         } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
             options.react_no_render_return_value = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
+            options.react_no_unescaped_entities = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -901,6 +903,7 @@ fn printHelp() void {
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
+        \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_no_unescaped_entities.zig
+++ b/src/rules/react_no_unescaped_entities.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-unescaped-entities";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const span = tree.span(index);
+    const source = sourceSlice(tree, span) orelse return;
+
+    for (source, 0..) |byte, offset| {
+        const alternatives = alternativesFor(byte) orelse continue;
+        const start: u32 = span.start + @as(u32, @intCast(offset));
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            .{ .start = start, .end = start + 1 },
+            "`{c}` can be escaped with {s}.",
+            .{ byte, alternatives },
+        );
+    }
+}
+
+fn alternativesFor(byte: u8) ?[]const u8 {
+    return switch (byte) {
+        '>' => "`&gt;`",
+        '"' => "`&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`",
+        '\'' => "`&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`",
+        '}' => "`&#125;`",
+        else => null,
+    };
+}
+
+fn sourceSlice(tree: *const ast.Tree, span: ast.Span) ?[]const u8 {
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start > end or end > tree.source.len) return null;
+    return tree.source[start..end];
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -183,6 +183,7 @@ pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
+pub const react_no_unescaped_entities = @import("react_no_unescaped_entities.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -1624,6 +1625,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_comment_textnodes) {
             try react_jsx_no_comment_textnodes.check(self.allocator, self.diagnostics, ctx.tree, text, index);
+        }
+        if (self.options.react_no_unescaped_entities) {
+            try react_no_unescaped_entities.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -667,6 +667,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_unescaped_entities.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_boolean_value.zig");
 }
 

--- a/tests/rules/react_no_unescaped_entities.zig
+++ b/tests/rules/react_no_unescaped_entities.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-unescaped-entities for default JSX text entities" {
+    const source =
+        \\const node = <div>Tom's "quote" > brace }</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.react_no_unescaped_entities.id));
+    try std.testing.expectEqualStrings("`'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("`\"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`.", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("`>` can be escaped with `&gt;`.", result.diagnostics[3].message);
+    try std.testing.expectEqualStrings("`}` can be escaped with `&#125;`.", result.diagnostics[4].message);
+}
+
+test "allows escaped entities and JavaScript expression strings" {
+    const source =
+        \\const text = "Tom's > brace }";
+        \\const node = <div>Tom&apos;s &quot;quote&quot; &gt; brace &#125; {"}"}</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unescaped_entities.id));
+}
+
+test "can disable react/no-unescaped-entities" {
+    const source =
+        \\const node = <div>Tom's ></div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_unescaped_entities = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unescaped_entities.id));
+}


### PR DESCRIPTION
## Summary
- add react/no-unescaped-entities for eslint-plugin-react's default entity set
- report raw JSX text occurrences of >, double quote, apostrophe, and } with matching escape suggestions
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --check
- git diff --cached --check
- zig test -O ReleaseFast --test-filter react_no_unescaped_entities --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default report and --react-no-unescaped-entities=off