### PR TITLE
feat: port react jsx-no-target-blank

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -190,6 +190,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
+| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Implemented for eslint-plugin-react's default link configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     react_jsx_boolean_value: bool = true,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
+    react_jsx_no_target_blank: bool = true,
     react_jsx_pascal_case: bool = true,
     react_no_danger: bool = true,
     react_no_find_dom_node: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_no_duplicate_props = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-comment-textnodes=off")) {
             options.react_jsx_no_comment_textnodes = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-no-target-blank=off")) {
+            options.react_jsx_no_target_blank = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-pascal-case=off")) {
             options.react_jsx_pascal_case = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
@@ -898,6 +900,7 @@ fn printHelp() void {
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
+        \\  --react-jsx-no-target-blank=off Disable react/jsx-no-target-blank
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node

--- a/src/rules/react_jsx_no_target_blank.zig
+++ b/src/rules/react_jsx_no_target_blank.zig
@@ -1,0 +1,211 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-no-target-blank";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isAnchorElement(tree, opening.name)) return;
+
+    const target = lastAttributeNamed(tree, opening, "target") orelse return;
+    if (!attributeValuePossiblyBlank(tree, target.attribute)) return;
+    if (!hasDangerousHref(tree, opening)) return;
+    if (hasSecureRel(tree, opening, target.attribute.value)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Using target=\"_blank\" without rel=\"noreferrer\" (which implies rel=\"noopener\") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations",
+        tree.span(index),
+    );
+}
+
+const AttributeMatch = struct {
+    attribute: ast.JSXAttribute,
+};
+
+fn isAnchorElement(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "a"),
+        else => false,
+    };
+}
+
+fn lastAttributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, name: []const u8) ?AttributeMatch {
+    const attributes = tree.extra(opening.attributes);
+    var cursor = attributes.len;
+    while (cursor > 0) {
+        cursor -= 1;
+        const attribute = switch (tree.data(attributes[cursor])) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        if (attributeName(tree, attribute.name)) |attribute_name| {
+            if (std.mem.eql(u8, attribute_name, name)) return .{ .attribute = attribute };
+        }
+    }
+    return null;
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeValuePossiblyBlank(tree: *const ast.Tree, attribute: ast.JSXAttribute) bool {
+    if (attribute.value == .null) return false;
+    if (stringValue(tree, attribute.value)) |value| return std.ascii.eqlIgnoreCase(value, "_blank");
+
+    const container = switch (tree.data(attribute.value)) {
+        .jsx_expression_container => |container| container,
+        else => return false,
+    };
+    const conditional = switch (tree.data(container.expression)) {
+        .conditional_expression => |conditional| conditional,
+        else => return false,
+    };
+    return isStringLiteralIgnoreCase(tree, conditional.consequent, "_blank") or
+        isStringLiteralIgnoreCase(tree, conditional.alternate, "_blank");
+}
+
+fn hasDangerousHref(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+    const href = lastAttributeNamed(tree, opening, "href") orelse return false;
+    if (href.attribute.value == .null) return false;
+    if (stringValue(tree, href.attribute.value)) |value| return isExternalHref(value);
+    return tree.data(href.attribute.value) == .jsx_expression_container;
+}
+
+fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_value: ast.NodeIndex) bool {
+    const rel = lastAttributeNamed(tree, opening, "rel") orelse return false;
+    if (rel.attribute.value == .null) return false;
+
+    var values: [2]?[]const u8 = .{ null, null };
+    const count = relValues(tree, rel.attribute.value, target_value, &values);
+    if (count == 0) return false;
+
+    for (values[0..count]) |value| {
+        if (!valueHasNoreferrer(value orelse return false)) return false;
+    }
+    return true;
+}
+
+fn relValues(tree: *const ast.Tree, rel_value: ast.NodeIndex, target_value: ast.NodeIndex, values: *[2]?[]const u8) usize {
+    if (stringValue(tree, rel_value)) |value| {
+        values[0] = value;
+        return 1;
+    }
+
+    const rel_container = switch (tree.data(rel_value)) {
+        .jsx_expression_container => |container| container,
+        else => return 0,
+    };
+    const rel_conditional = switch (tree.data(rel_container.expression)) {
+        .conditional_expression => |conditional| conditional,
+        else => return 0,
+    };
+
+    if (matchingTargetBlankBranch(tree, target_value, rel_conditional)) |branch| {
+        values[0] = switch (branch) {
+            .consequent => stringValue(tree, rel_conditional.consequent),
+            .alternate => stringValue(tree, rel_conditional.alternate),
+        };
+        return 1;
+    }
+
+    values[0] = stringValue(tree, rel_conditional.consequent);
+    values[1] = stringValue(tree, rel_conditional.alternate);
+    return 2;
+}
+
+const Branch = enum { consequent, alternate };
+
+fn matchingTargetBlankBranch(tree: *const ast.Tree, target_value: ast.NodeIndex, rel_conditional: ast.ConditionalExpression) ?Branch {
+    const target_container = switch (tree.data(target_value)) {
+        .jsx_expression_container => |container| container,
+        else => return null,
+    };
+    const target_conditional = switch (tree.data(target_container.expression)) {
+        .conditional_expression => |conditional| conditional,
+        else => return null,
+    };
+    if (!sameIdentifierReference(tree, target_conditional.@"test", rel_conditional.@"test")) return null;
+    if (isStringLiteral(tree, target_conditional.consequent, "_blank")) return .consequent;
+    if (isStringLiteral(tree, target_conditional.alternate, "_blank")) return .alternate;
+    return null;
+}
+
+fn stringValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| firstTemplateQuasi(tree, literal),
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn firstTemplateQuasi(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn isExternalHref(value: []const u8) bool {
+    if (std.mem.startsWith(u8, value, "//")) return true;
+    const colon_index = std.mem.indexOfScalar(u8, value, ':') orelse return false;
+    if (colon_index == 0) return false;
+
+    for (value[0..colon_index]) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and byte != '_') return false;
+    }
+    return true;
+}
+
+fn valueHasNoreferrer(value: []const u8) bool {
+    var iter = std.mem.tokenizeScalar(u8, value, ' ');
+    while (iter.next()) |token| {
+        if (std.ascii.eqlIgnoreCase(token, "noreferrer")) return true;
+    }
+    return false;
+}
+
+fn isStringLiteralIgnoreCase(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const value = stringValue(tree, index) orelse return false;
+    return std.ascii.eqlIgnoreCase(value, expected);
+}
+
+fn isStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const value = stringValue(tree, index) orelse return false;
+    return std.mem.eql(u8, value, expected);
+}
+
+fn sameIdentifierReference(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_name = identifierReferenceName(tree, left) orelse return false;
+    const right_name = identifierReferenceName(tree, right) orelse return false;
+    return std.mem.eql(u8, left_name, right_name);
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -178,6 +178,7 @@ pub const prefer_template = @import("prefer_template.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
+pub const react_jsx_no_target_blank = @import("react_jsx_no_target_blank.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
@@ -1610,6 +1611,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
             try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        if (self.options.react_jsx_no_target_blank) {
+            try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_pascal_case) {
             try react_jsx_pascal_case.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -679,6 +679,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_no_target_blank.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_no_comment_textnodes.zig");
 }
 

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-no-target-blank for external and dynamic links without noreferrer" {
+    const source =
+        \\const external = <a href="https://example.com" target="_blank" />;
+        \\const protocolRelative = <a href="//example.com" target="_blank" rel="noopener" />;
+        \\const dynamic = <a href={url} target="_blank" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
+    try std.testing.expectEqualStrings(
+        "Using target=\"_blank\" without rel=\"noreferrer\" (which implies rel=\"noopener\") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations",
+        result.diagnostics[0].message,
+    );
+}
+
+test "allows secure rel non-external links and non-anchor elements" {
+    const source =
+        \\const secure = <a href="https://example.com" target="_blank" rel="noopener noreferrer" />;
+        \\const relative = <a href="/docs" target="_blank" />;
+        \\const button = <button href="https://example.com" target="_blank" />;
+        \\const conditional = <a href={url} target={open ? "_blank" : "_self"} rel={open ? "noreferrer" : ""} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_target_blank.id));
+}
+
+test "can disable react/jsx-no-target-blank" {
+    const source =
+        \\const link = <a href="https://example.com" target="_blank" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_jsx_no_target_blank = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_target_blank.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-no-target-blank for eslint-plugin-react's default link configuration
- report external and dynamic <a href> links using target=_blank without rel=noreferrer
- add CLI disable flag, docs row, and focused rule tests

## Validation
- git diff --check
- git diff --cached --check
- zig test -O ReleaseFast --test-filter react_jsx_no_target_blank --dep utoo_lint -Mroot=tests/all.zig --dep parser -Mutoo_lint=src/root.zig --dep util -Mparser=vendor/yuku/src/parser/root.zig -Mutil=vendor/yuku/src/util/root.zig
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default report and --react-jsx-no-target-blank=off