### PR TITLE
feat: port react void dom children rule

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -195,6 +195,7 @@ pub const Options = struct {
     react_no_is_mounted: bool = true,
     react_no_render_return_value: bool = true,
     react_no_unescaped_entities: bool = true,
+    react_void_dom_elements_no_children: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -403,6 +403,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_render_return_value = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
             options.react_no_unescaped_entities = false;
+        } else if (std.mem.eql(u8, arg, "--react-void-dom-elements-no-children=off")) {
+            options.react_void_dom_elements_no_children = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -910,6 +912,7 @@ fn printHelp() void {
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
+        \\  --react-void-dom-elements-no-children=off Disable react/void-dom-elements-no-children
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_void_dom_elements_no_children.zig
+++ b/src/rules/react_void_dom_elements_no_children.zig
@@ -1,0 +1,394 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/void-dom-elements-no-children";
+
+pub const ReactBindings = struct {
+    pragma: []const u8 = "React",
+    has_bare_create_element: bool = false,
+};
+
+pub fn bindingsFromProgram(tree: *const ast.Tree, program: ast.Program) ReactBindings {
+    var bindings = ReactBindings{
+        .pragma = pragmaFromComments(tree) orelse "React",
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| scanImportDeclaration(tree, declaration, &bindings),
+            .variable_declaration => |declaration| scanVariableDeclaration(tree, declaration, bindings.pragma, &bindings),
+            else => {},
+        }
+    }
+
+    return bindings;
+}
+
+pub fn checkVariableDeclarator(tree: *const ast.Tree, declarator: ast.VariableDeclarator, bindings: *ReactBindings) void {
+    if (declarator.init == .null) return;
+    if (isBareCreateElementDeclarator(tree, declarator, bindings.pragma)) {
+        bindings.has_bare_create_element = true;
+    }
+}
+
+pub fn checkJSXElement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return,
+    };
+    const element_name = jsxIdentifierName(tree, opening.name) orelse return;
+    if (!isVoidDomElement(element_name)) return;
+
+    if (tree.extra(element.children).len > 0) {
+        try addDiagnostic(allocator, diagnostics, tree, index, element_name);
+    }
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = jsxIdentifierName(tree, attribute.name) orelse continue;
+        if (isForbiddenProp(name)) {
+            try addDiagnostic(allocator, diagnostics, tree, index, element_name);
+            return;
+        }
+    }
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    bindings: ReactBindings,
+) Allocator.Error!void {
+    if (!isCreateElementCall(tree, call, bindings)) return;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 1) return;
+
+    const element_name = stringLiteralValue(tree, arguments[0]) orelse return;
+    if (!isVoidDomElement(element_name)) return;
+
+    if (arguments.len < 2) return;
+    const props = switch (tree.data(arguments[1])) {
+        .object_expression => |object| tree.extra(object.properties),
+        else => return,
+    };
+
+    if (arguments.len >= 3) {
+        try addDiagnostic(allocator, diagnostics, tree, index, element_name);
+    }
+
+    for (props) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const key = objectPropertyKeyName(tree, property) orelse continue;
+        if (isForbiddenProp(key)) {
+            try addDiagnostic(allocator, diagnostics, tree, index, element_name);
+            return;
+        }
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    element_name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Void DOM element <{s} /> cannot receive children.",
+        .{element_name},
+    );
+}
+
+fn scanImportDeclaration(tree: *const ast.Tree, declaration: ast.ImportDeclaration, bindings: *ReactBindings) void {
+    if (declaration.import_kind == .type) return;
+
+    const source = stringLiteralValue(tree, declaration.source) orelse return;
+    if (!sourceEqualsLowercasePragma(source, bindings.pragma)) return;
+
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .import_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.import_kind == .type) continue;
+
+        const imported = propertyName(tree, specifier.imported) orelse continue;
+        const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+        if (std.mem.eql(u8, imported, "createElement") and std.mem.eql(u8, local, "createElement")) {
+            bindings.has_bare_create_element = true;
+        }
+    }
+}
+
+fn scanVariableDeclaration(
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    pragma: []const u8,
+    bindings: *ReactBindings,
+) void {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+        if (declarator.init == .null) continue;
+
+        if (isBareCreateElementDeclarator(tree, declarator, pragma)) {
+            bindings.has_bare_create_element = true;
+        }
+    }
+}
+
+fn isBareCreateElementDeclarator(tree: *const ast.Tree, declarator: ast.VariableDeclarator, pragma: []const u8) bool {
+    if (bindingIdentifierName(tree, declarator.id)) |name| {
+        if (!std.mem.eql(u8, name, "createElement")) return false;
+        return isPragmaCreateElementMember(tree, declarator.init, pragma) or isRequireReactCreateElementMember(tree, declarator.init, pragma);
+    }
+
+    const pattern = switch (tree.data(declarator.id)) {
+        .object_pattern => |pattern| pattern,
+        else => return false,
+    };
+    if (!isPragmaIdentifier(tree, declarator.init, pragma) and !isRequireReactCall(tree, declarator.init, pragma)) return false;
+
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        if (property.computed) continue;
+
+        const key = propertyName(tree, property.key) orelse continue;
+        if (!std.mem.eql(u8, key, "createElement")) continue;
+
+        const value = unwrapAssignmentPattern(tree, property.value);
+        const local = bindingIdentifierName(tree, value) orelse continue;
+        if (std.mem.eql(u8, local, "createElement")) return true;
+    }
+
+    return false;
+}
+
+fn isCreateElementCall(tree: *const ast.Tree, call: ast.CallExpression, bindings: ReactBindings) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+
+    if (calleeIdentifierName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createElement") and bindings.has_bare_create_element;
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    const property = propertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "createElement") and isPragmaIdentifier(tree, member.object, bindings.pragma);
+}
+
+fn isPragmaCreateElementMember(tree: *const ast.Tree, index: ast.NodeIndex, pragma: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    const property = propertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "createElement") and isPragmaIdentifier(tree, member.object, pragma);
+}
+
+fn isRequireReactCreateElementMember(tree: *const ast.Tree, index: ast.NodeIndex, pragma: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    const property = propertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "createElement") and isRequireReactCall(tree, member.object, pragma);
+}
+
+fn isRequireReactCall(tree: *const ast.Tree, index: ast.NodeIndex, pragma: []const u8) bool {
+    const call = switch (tree.data(unwrapTransparent(tree, index))) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const callee = calleeIdentifierName(tree, unwrapTransparent(tree, call.callee)) orelse return false;
+    if (!std.mem.eql(u8, callee, "require")) return false;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len != 1) return false;
+    const source = stringLiteralValue(tree, arguments[0]) orelse return false;
+    return sourceEqualsLowercasePragma(source, pragma);
+}
+
+fn isPragmaIdentifier(tree: *const ast.Tree, index: ast.NodeIndex, pragma: []const u8) bool {
+    const name = calleeIdentifierName(tree, unwrapTransparent(tree, index)) orelse return false;
+    return std.mem.eql(u8, name, pragma);
+}
+
+fn pragmaFromComments(tree: *const ast.Tree) ?[]const u8 {
+    for (tree.comments) |comment| {
+        const value = tree.string(comment.value);
+        const marker_index = std.mem.indexOf(u8, value, "@jsx") orelse continue;
+        var cursor = marker_index + "@jsx".len;
+
+        if (cursor >= value.len or !isWhitespace(value[cursor])) continue;
+        while (cursor < value.len and isWhitespace(value[cursor])) : (cursor += 1) {}
+
+        const start = cursor;
+        while (cursor < value.len and !isWhitespace(value[cursor])) : (cursor += 1) {}
+        var pragma = value[start..cursor];
+        if (std.mem.indexOfScalar(u8, pragma, '.')) |dot_index| {
+            pragma = pragma[0..dot_index];
+        }
+        if (isIdentifier(pragma)) return pragma;
+    }
+    return null;
+}
+
+fn sourceEqualsLowercasePragma(source: []const u8, pragma: []const u8) bool {
+    if (source.len != pragma.len) return false;
+    for (source, pragma) |source_byte, pragma_byte| {
+        if (source_byte != std.ascii.toLower(pragma_byte)) return false;
+    }
+    return true;
+}
+
+fn isVoidDomElement(name: []const u8) bool {
+    const elements = [_][]const u8{
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "keygen",
+        "link",
+        "menuitem",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    };
+
+    for (elements) |element| {
+        if (std.mem.eql(u8, name, element)) return true;
+    }
+    return false;
+}
+
+fn isForbiddenProp(name: []const u8) bool {
+    return std.mem.eql(u8, name, "children") or std.mem.eql(u8, name, "dangerouslySetInnerHTML");
+}
+
+fn objectPropertyKeyName(tree: *const ast.Tree, property: ast.ObjectProperty) ?[]const u8 {
+    if (property.computed) return null;
+    return switch (tree.data(property.key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn calleeIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapAssignmentPattern(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    return switch (tree.data(index)) {
+        .assignment_pattern => |pattern| pattern.left,
+        else => index,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn isIdentifier(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (!isIdentifierStart(value[0])) return false;
+    for (value[1..]) |byte| {
+        if (!isIdentifierPart(byte)) return false;
+    }
+    return true;
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_' or byte == '$';
+}
+
+fn isIdentifierPart(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\r' or byte == '\n';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -186,6 +186,7 @@ pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
 pub const react_no_unescaped_entities = @import("react_no_unescaped_entities.zig");
+pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -511,6 +512,7 @@ const BasicVisitor = struct {
     file_path: []const u8,
     options: core.Options,
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
+    react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
     pub fn enter_program(
         self: *BasicVisitor,
@@ -532,6 +534,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_children_prop) {
             self.react_no_children_prop_bindings = react_no_children_prop.bindingsFromProgram(ctx.tree, program);
+        }
+        if (self.options.react_void_dom_elements_no_children) {
+            self.react_void_dom_elements_no_children_bindings = react_void_dom_elements_no_children.bindingsFromProgram(ctx.tree, program);
         }
         if (self.options.no_duplicate_imports and !self.options.import_no_duplicates) {
             try no_duplicate_imports.check(self.allocator, self.diagnostics, ctx.tree, program);
@@ -811,6 +816,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
+        }
+        if (self.options.react_void_dom_elements_no_children) {
+            react_void_dom_elements_no_children.checkVariableDeclarator(ctx.tree, declarator, &self.react_void_dom_elements_no_children_bindings);
         }
         return .proceed;
     }
@@ -1501,6 +1509,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_children_prop) {
             try react_no_children_prop.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_no_children_prop_bindings);
         }
+        if (self.options.react_void_dom_elements_no_children) {
+            try react_void_dom_elements_no_children.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_void_dom_elements_no_children_bindings);
+        }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -1625,6 +1636,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_no_children_prop) {
             try react_no_children_prop.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+        }
+        if (self.options.react_void_dom_elements_no_children) {
+            try react_void_dom_elements_no_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -695,6 +695,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_void_dom_elements_no_children.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_void_dom_elements_no_children.zig
+++ b/tests/rules/react_void_dom_elements_no_children.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/void-dom-elements-no-children for JSX children and props" {
+    const source =
+        \\const textChild = <br>text</br>;
+        \\const childProp = <img children="alt" />;
+        \\const danger = <input dangerouslySetInnerHTML={{ __html: html }} />;
+        \\const both = <hr children="x">text</hr>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_children_prop = false,
+        .react_no_danger = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.react_void_dom_elements_no_children.id));
+    try std.testing.expectEqualStrings(
+        "Void DOM element <br /> cannot receive children.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Void DOM element <hr /> cannot receive children.",
+        result.diagnostics[4].message,
+    );
+}
+
+test "reports react/void-dom-elements-no-children for createElement children and props" {
+    const source =
+        \\import { createElement } from "react";
+        \\const argChild = React.createElement("br", {}, "text");
+        \\const propChild = createElement("img", { children: "alt" });
+        \\const propDanger = createElement("input", { dangerouslySetInnerHTML: { __html: html } });
+        \\const both = createElement("hr", { children: "x" }, "text");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .react_no_children_prop = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.react_void_dom_elements_no_children.id));
+    try std.testing.expectEqualStrings(
+        "Void DOM element <br /> cannot receive children.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Void DOM element <hr /> cannot receive children.",
+        result.diagnostics[4].message,
+    );
+}
+
+test "detects destructured and require createElement bindings" {
+    const source =
+        \\{
+        \\  const { createElement } = React;
+        \\  const a = createElement("br", { children: text });
+        \\}
+        \\{
+        \\  const createElement = require("react").createElement;
+        \\  const b = createElement("img", { children: text });
+        \\}
+        \\{
+        \\  const { createElement } = require("react");
+        \\  const c = createElement("input", { dangerouslySetInnerHTML: { __html: html } });
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_children_prop = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_void_dom_elements_no_children.id));
+}
+
+test "allows non-void JSX elements non-react calls and unsupported prop shapes" {
+    const source =
+        \\const div = <div children="ok">text</div>;
+        \\const custom = <Img children="ok" />;
+        \\const spread = <br {...props} />;
+        \\const local = createElement("br", { children: text });
+        \\const nullPropsChild = React.createElement("br", null, "text");
+        \\const stringKey = React.createElement("br", { "children": text });
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_children_prop = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_void_dom_elements_no_children.id));
+}
+
+test "ignores type-only createElement imports" {
+    const source =
+        \\import type { createElement } from "react";
+        \\const local = createElement("br", { children: text });
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .react_no_children_prop = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_void_dom_elements_no_children.id));
+}
+
+test "can disable react/void-dom-elements-no-children" {
+    const source =
+        \\const child = <br>text</br>;
+        \\const call = React.createElement("br", { children: text });
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_void_dom_elements_no_children = false,
+        .react_no_children_prop = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_void_dom_elements_no_children.id));
+}


### PR DESCRIPTION
## Summary\n- add react/void-dom-elements-no-children for JSX void DOM tags\n- detect React.createElement void tags with child args or forbidden props\n- support default pragma imports, destructuring, require bindings, and the disable flag\n\n## Tests\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1