### PR TITLE
feat: port react no-string-refs

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -195,6 +195,7 @@ pub const Options = struct {
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
     react_no_render_return_value: bool = true,
+    react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
     react_prefer_es6_class: bool = true,
     react_style_prop_object: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -403,6 +403,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_is_mounted = false;
         } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
             options.react_no_render_return_value = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
+            options.react_no_string_refs = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
             options.react_no_unescaped_entities = false;
         } else if (std.mem.eql(u8, arg, "--react-prefer-es6-class=off")) {
@@ -918,6 +920,7 @@ fn printHelp() void {
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
+        \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --react-prefer-es6-class=off Disable react/prefer-es6-class
         \\  --react-style-prop-object=off Disable react/style-prop-object

--- a/src/rules/react_no_string_refs.zig
+++ b/src/rules/react_no_string_refs.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-string-refs";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = jsxIdentifierName(tree, attribute.name) orelse return;
+    if (!std.mem.eql(u8, name, "ref")) return;
+    if (!containsStringLiteral(tree, attribute.value)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Using string literals in ref attributes is deprecated.",
+        tree.span(index),
+    );
+}
+
+fn containsStringLiteral(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+    if (value_index == .null) return false;
+
+    return switch (tree.data(value_index)) {
+        .string_literal => true,
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .string_literal => true,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -186,6 +186,7 @@ pub const react_no_children_prop = @import("react_no_children_prop.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
+pub const react_no_string_refs = @import("react_no_string_refs.zig");
 pub const react_no_unescaped_entities = @import("react_no_unescaped_entities.zig");
 pub const react_prefer_es6_class = @import("react_prefer_es6_class.zig");
 pub const react_style_prop_object = @import("react_style_prop_object.zig");
@@ -1647,6 +1648,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_children_prop) {
             try react_no_children_prop.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+        }
+        if (self.options.react_no_string_refs) {
+            try react_no_string_refs.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -675,6 +675,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_string_refs.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_unescaped_entities.zig");
 }
 

--- a/tests/rules/react_no_string_refs.zig
+++ b/tests/rules/react_no_string_refs.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-string-refs for string ref attributes" {
+    const source =
+        \\const direct = <div ref="root" />;
+        \\const expression = <div ref={"root"} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_string_refs.id));
+    try std.testing.expectEqualStrings(
+        "Using string literals in ref attributes is deprecated.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "allows non-string refs and default template literals" {
+    const source =
+        \\const callback = <div ref={(node) => node} />;
+        \\const objectRef = <div ref={ref} />;
+        \\const template = <div ref={`root`} />;
+        \\const other = <div data-ref="root" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_string_refs.id));
+}
+
+test "can disable react/no-string-refs" {
+    const source =
+        \\const direct = <div ref="root" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_no_string_refs = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_string_refs.id));
+}


### PR DESCRIPTION
## Summary\n- add react/no-string-refs for string literal JSX ref attributes\n- preserve default behavior for template literals and latest React this.refs handling\n- wire the CLI disable flag and tests\n\n## Tests\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1