### PR TITLE
feat: port react self-closing-comp

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -198,6 +198,7 @@ pub const Options = struct {
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
     react_prefer_es6_class: bool = true,
+    react_self_closing_comp: bool = true,
     react_style_prop_object: bool = true,
     react_void_dom_elements_no_children: bool = true,
     radix: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -409,6 +409,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_unescaped_entities = false;
         } else if (std.mem.eql(u8, arg, "--react-prefer-es6-class=off")) {
             options.react_prefer_es6_class = false;
+        } else if (std.mem.eql(u8, arg, "--react-self-closing-comp=off")) {
+            options.react_self_closing_comp = false;
         } else if (std.mem.eql(u8, arg, "--react-style-prop-object=off")) {
             options.react_style_prop_object = false;
         } else if (std.mem.eql(u8, arg, "--react-void-dom-elements-no-children=off")) {
@@ -923,6 +925,7 @@ fn printHelp() void {
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --react-prefer-es6-class=off Disable react/prefer-es6-class
+        \\  --react-self-closing-comp=off Disable react/self-closing-comp
         \\  --react-style-prop-object=off Disable react/style-prop-object
         \\  --react-void-dom-elements-no-children=off Disable react/void-dom-elements-no-children
         \\  --radix=off               Disable radix

--- a/src/rules/react_self_closing_comp.zig
+++ b/src/rules/react_self_closing_comp.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/self-closing-comp";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+) Allocator.Error!void {
+    if (opening.self_closing) return;
+    if (!isConfiguredElementName(tree, opening.name)) return;
+
+    const element = switch (tree.data(parent orelse return)) {
+        .jsx_element => |element| element,
+        else => return,
+    };
+    if (!childrenAreEmpty(tree, element.children)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Empty components are self-closing",
+        tree.span(index),
+    );
+}
+
+fn isConfiguredElementName(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .jsx_identifier => true,
+        .jsx_member_expression => true,
+        else => false,
+    };
+}
+
+fn childrenAreEmpty(tree: *const ast.Tree, children_range: ast.IndexRange) bool {
+    const children = tree.extra(children_range);
+    if (children.len == 0) return true;
+    if (children.len != 1) return false;
+
+    const value = switch (tree.data(children[0])) {
+        .jsx_text => |text| tree.string(text.value),
+        else => return false,
+    };
+    if (!containsLineBreak(value)) return false;
+    return isMultilineWhitespace(value);
+}
+
+fn containsLineBreak(value: []const u8) bool {
+    return std.mem.indexOfScalar(u8, value, '\n') != null or
+        std.mem.indexOfScalar(u8, value, '\r') != null;
+}
+
+fn isMultilineWhitespace(value: []const u8) bool {
+    for (value) |byte| {
+        if (byte == 0xc2 or byte == 0xa0) return false;
+        if (!isWhitespace(byte)) return false;
+    }
+    return true;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\r' or byte == '\n';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -190,6 +190,7 @@ pub const react_no_string_refs = @import("react_no_string_refs.zig");
 pub const react_no_unescaped_entities = @import("react_no_unescaped_entities.zig");
 pub const react_prefer_es6_class = @import("react_prefer_es6_class.zig");
 pub const react_style_prop_object = @import("react_style_prop_object.zig");
+pub const react_self_closing_comp = @import("react_self_closing_comp.zig");
 pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -1687,6 +1688,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_jsx_pascal_case) {
             try react_jsx_pascal_case.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.react_self_closing_comp) {
+            try react_self_closing_comp.check(self.allocator, self.diagnostics, ctx.tree, opening, index, ctx.path.ancestor(1));
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -707,6 +707,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_self_closing_comp.zig");
+}
+
+comptime {
     _ = @import("rules/react_style_prop_object.zig");
 }
 

--- a/tests/rules/react_self_closing_comp.zig
+++ b/tests/rules/react_self_closing_comp.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/self-closing-comp for empty JSX elements" {
+    const source =
+        \\const html = <div></div>;
+        \\const component = <Widget></Widget>;
+        \\const member = <UI.Widget></UI.Widget>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_void_dom_elements_no_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_self_closing_comp.id));
+    try std.testing.expectEqualStrings(
+        "Empty components are self-closing",
+        result.diagnostics[0].message,
+    );
+}
+
+test "reports react/self-closing-comp for multiline whitespace children" {
+    const source =
+        \\const html = <div>
+        \\</div>;
+        \\const component = <Widget>
+        \\  </Widget>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_void_dom_elements_no_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_self_closing_comp.id));
+}
+
+test "allows react/self-closing-comp when elements have children or are already self closing" {
+    const source =
+        \\const selfClosing = <div />;
+        \\const text = <div>text</div>;
+        \\const expression = <Widget>{child}</Widget>;
+        \\const namespaced = <svg:path></svg:path>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_void_dom_elements_no_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_self_closing_comp.id));
+}
+
+test "can disable react/self-closing-comp" {
+    const source =
+        \\const html = <div></div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .react_self_closing_comp = false,
+        .react_void_dom_elements_no_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_self_closing_comp.id));
+}


### PR DESCRIPTION
## Summary
- add react/self-closing-comp default behavior for empty JSX elements
- detect empty and multiline-whitespace children for DOM and component tags
- add the CLI disable flag and focused tests

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1