### PR TITLE
feat: port react jsx-uses-react

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -190,6 +190,7 @@ pub const Options = struct {
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
+    react_jsx_uses_react: bool = true,
     react_no_danger: bool = true,
     react_no_danger_with_children: bool = true,
     react_no_children_prop: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -393,6 +393,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_no_undef = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-pascal-case=off")) {
             options.react_jsx_pascal_case = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-uses-react=off")) {
+            options.react_jsx_uses_react = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger-with-children=off")) {
@@ -919,6 +921,7 @@ fn printHelp() void {
         \\  --react-jsx-no-target-blank=off Disable react/jsx-no-target-blank
         \\  --react-jsx-no-undef=off Disable react/jsx-no-undef
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
+        \\  --react-jsx-uses-react=off Disable react/jsx-uses-react
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-danger-with-children=off Disable react/no-danger-with-children
         \\  --react-no-children-prop=off Disable react/no-children-prop

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -18,6 +18,43 @@ pub const Options = struct {
     args_after_used: bool = false,
     ignore_rest_siblings: bool = false,
     check_type_parameters: bool = false,
+    react_jsx_uses_react: bool = false,
+};
+
+const JSXReactUsage = struct {
+    pragma: []const u8 = "React",
+    has_jsx: bool = false,
+    has_fragment: bool = false,
+
+    pub fn enter_jsx_opening_element(
+        usage: *JSXReactUsage,
+        _: ast.JSXOpeningElement,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        usage.has_jsx = true;
+        return .proceed;
+    }
+
+    pub fn enter_jsx_opening_fragment(
+        usage: *JSXReactUsage,
+        _: ast.JSXOpeningFragment,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        usage.has_jsx = true;
+        return .proceed;
+    }
+
+    pub fn enter_jsx_fragment(
+        usage: *JSXReactUsage,
+        _: ast.JSXFragment,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        usage.has_fragment = true;
+        return .proceed;
+    }
 };
 
 const Parameter = struct {
@@ -59,6 +96,8 @@ pub fn runWithOptions(
         try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
     }
 
+    const jsx_react_usage = if (options.react_jsx_uses_react) collectJSXReactUsage(tree) else JSXReactUsage{};
+
     var iter = symbol_table.iterSymbols();
 
     while (iter.next()) |entry| {
@@ -76,6 +115,7 @@ pub fn runWithOptions(
 
         const name = tree.string(symbol.name);
         if (std.mem.startsWith(u8, name, "_")) continue;
+        if (isUsedByReactJSX(name, jsx_react_usage)) continue;
 
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
@@ -198,3 +238,57 @@ const RestSiblingVisitor = struct {
         }
     }
 };
+
+fn collectJSXReactUsage(tree: *const ast.Tree) JSXReactUsage {
+    var usage = JSXReactUsage{
+        .pragma = pragmaFromComments(tree) orelse "React",
+    };
+    traverser.basic.traverse(JSXReactUsage, tree, &usage) catch unreachable;
+    return usage;
+}
+
+fn isUsedByReactJSX(name: []const u8, usage: JSXReactUsage) bool {
+    return (usage.has_jsx and std.mem.eql(u8, name, usage.pragma)) or
+        (usage.has_fragment and std.mem.eql(u8, name, "Fragment"));
+}
+
+fn pragmaFromComments(tree: *const ast.Tree) ?[]const u8 {
+    for (tree.comments) |comment| {
+        const value = tree.string(comment.value);
+        const marker_index = std.mem.indexOf(u8, value, "@jsx") orelse continue;
+        var cursor = marker_index + "@jsx".len;
+
+        if (cursor >= value.len or !isWhitespace(value[cursor])) continue;
+        while (cursor < value.len and isWhitespace(value[cursor])) : (cursor += 1) {}
+
+        const start = cursor;
+        while (cursor < value.len and !isWhitespace(value[cursor])) : (cursor += 1) {}
+        var pragma = value[start..cursor];
+        if (std.mem.indexOfScalar(u8, pragma, '.')) |dot_index| {
+            pragma = pragma[0..dot_index];
+        }
+        if (isIdentifier(pragma)) return pragma;
+    }
+    return null;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\n' or byte == '\r';
+}
+
+fn isIdentifier(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (!isIdentifierStart(value[0])) return false;
+    for (value[1..]) |byte| {
+        if (!isIdentifierContinue(byte)) return false;
+    }
+    return true;
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_' or byte == '$';
+}
+
+fn isIdentifierContinue(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}

--- a/src/rules/react_jsx_uses_react.zig
+++ b/src/rules/react_jsx_uses_react.zig
@@ -1,0 +1,1 @@
+pub const id = "react/jsx-uses-react";

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -181,6 +181,7 @@ pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnod
 pub const react_jsx_no_target_blank = @import("react_jsx_no_target_blank.zig");
 pub const react_jsx_no_undef = @import("react_jsx_no_undef.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
+pub const react_jsx_uses_react = @import("react_jsx_uses_react.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_danger_with_children = @import("react_no_danger_with_children.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
@@ -488,11 +489,13 @@ pub fn runSemantic(
     }
 
     if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {
-        try no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .react_jsx_uses_react = options.react_jsx_uses_react,
+        });
     }
 
     if (options.typescript_eslint_no_unused_vars) {
-        try typescript_eslint_no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try typescript_eslint_no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table, options.react_jsx_uses_react);
     }
 
     if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -12,6 +12,7 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    react_jsx_uses_react: bool,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
@@ -20,5 +21,6 @@ pub fn run(
         .args_after_used = true,
         .ignore_rest_siblings = true,
         .check_type_parameters = true,
+        .react_jsx_uses_react = react_jsx_uses_react,
     });
 }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -707,6 +707,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_uses_react.zig");
+}
+
+comptime {
     _ = @import("rules/react_prefer_es6_class.zig");
 }
 

--- a/tests/rules/react_jsx_uses_react.zig
+++ b/tests/rules/react_jsx_uses_react.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "marks React as used when JSX is present" {
+    const source =
+        \\import React from "react";
+        \\
+        \\const node = <div />;
+        \\console.log(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "can disable react jsx uses react" {
+    const source =
+        \\import React from "react";
+        \\
+        \\const node = <div />;
+        \\console.log(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+        .react_jsx_uses_react = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "marks custom jsx pragma as used" {
+    const source =
+        \\/** @jsx h */
+        \\import h from "preact";
+        \\
+        \\const node = <div />;
+        \\console.log(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "marks React and Fragment as used for JSX fragments" {
+    const source =
+        \\import React, { Fragment } from "react";
+        \\
+        \\const node = <>text</>;
+        \\console.log(node);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-uses-react as a no-unused-vars usage marker
- mark React, custom @jsx pragmas, and Fragment as used when JSX requires them
- add the CLI disable flag and focused unused-var coverage

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1