### PR TITLE
feat: port react no-array-index-key

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -193,6 +193,7 @@ pub const Options = struct {
     react_jsx_uses_react: bool = true,
     react_no_danger: bool = true,
     react_no_danger_with_children: bool = true,
+    react_no_array_index_key: bool = true,
     react_no_children_prop: bool = true,
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -399,6 +399,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger-with-children=off")) {
             options.react_no_danger_with_children = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-array-index-key=off")) {
+            options.react_no_array_index_key = false;
         } else if (std.mem.eql(u8, arg, "--react-no-children-prop=off")) {
             options.react_no_children_prop = false;
         } else if (std.mem.eql(u8, arg, "--react-no-find-dom-node=off")) {
@@ -924,6 +926,7 @@ fn printHelp() void {
         \\  --react-jsx-uses-react=off Disable react/jsx-uses-react
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-danger-with-children=off Disable react/no-danger-with-children
+        \\  --react-no-array-index-key=off Disable react/no-array-index-key
         \\  --react-no-children-prop=off Disable react/no-children-prop
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted

--- a/src/rules/react_no_array_index_key.zig
+++ b/src/rules/react_no_array_index_key.zig
@@ -1,0 +1,406 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-array-index-key";
+
+const iterator_functions = [_]struct { name: []const u8, index_param_position: usize }{
+    .{ .name = "every", .index_param_position = 1 },
+    .{ .name = "filter", .index_param_position = 1 },
+    .{ .name = "find", .index_param_position = 1 },
+    .{ .name = "findIndex", .index_param_position = 1 },
+    .{ .name = "flatMap", .index_param_position = 1 },
+    .{ .name = "forEach", .index_param_position = 1 },
+    .{ .name = "map", .index_param_position = 1 },
+    .{ .name = "reduce", .index_param_position = 2 },
+    .{ .name = "reduceRight", .index_param_position = 2 },
+    .{ .name = "some", .index_param_position = 1 },
+};
+
+pub const State = struct {
+    index_param_names: std.ArrayList([]const u8) = .empty,
+    create_clone_names: std.ArrayList([]const u8) = .empty,
+    pragma: []const u8 = "React",
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.index_param_names.deinit(allocator);
+        self.create_clone_names.deinit(allocator);
+    }
+};
+
+pub fn collectProgram(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    state: *State,
+) Allocator.Error!void {
+    state.pragma = pragmaFromComments(tree) orelse "React";
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        const source = stringLiteralValue(tree, declaration.source) orelse continue;
+        if (!std.mem.eql(u8, source, "react")) continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .import_specifier => |specifier| specifier,
+                else => continue,
+            };
+            const imported = staticName(tree, specifier.imported) orelse continue;
+            if (!std.mem.eql(u8, imported, "createElement") and !std.mem.eql(u8, imported, "cloneElement")) continue;
+            const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+            try state.create_clone_names.append(allocator, local);
+        }
+    }
+}
+
+pub fn enterCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (isCreateCloneElementCall(tree, call, state.*)) {
+        if (state.index_param_names.items.len == 0) return;
+        try checkCreateElementProps(allocator, diagnostics, tree, call, index, state.*);
+        return;
+    }
+
+    const index_param_name = mapIndexParamName(tree, call, state.*) orelse return;
+    try state.index_param_names.append(allocator, index_param_name);
+}
+
+pub fn exitCallExpression(tree: *const ast.Tree, call: ast.CallExpression, state: *State) void {
+    if (mapIndexParamName(tree, call, state.*) == null) return;
+    _ = state.index_param_names.pop();
+}
+
+pub fn checkJSXAttribute(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    state: State,
+) Allocator.Error!void {
+    if (state.index_param_names.items.len == 0) return;
+    const name = jsxIdentifierName(tree, attribute.name) orelse return;
+    if (!std.mem.eql(u8, name, "key")) return;
+
+    const container = switch (tree.data(attribute.value)) {
+        .jsx_expression_container => |container| container,
+        else => return,
+    };
+    try checkPropValue(allocator, diagnostics, tree, container.expression, state);
+}
+
+fn checkCreateElementProps(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    state: State,
+) Allocator.Error!void {
+    _ = index;
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len <= 1) return;
+
+    const props = switch (tree.data(unwrapTransparent(tree, arguments[1]))) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(props.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const key = objectPropertyKeyName(tree, property) orelse continue;
+        if (!std.mem.eql(u8, key, "key")) continue;
+        try checkPropValue(allocator, diagnostics, tree, property.value, state);
+    }
+}
+
+fn checkPropValue(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: State,
+) Allocator.Error!void {
+    const current = unwrapTransparent(tree, index);
+    switch (tree.data(current)) {
+        .identifier_reference => |identifier| {
+            if (isArrayIndexName(tree.string(identifier.name), state)) {
+                try report(allocator, diagnostics, tree, current);
+            }
+        },
+        .template_literal => |literal| {
+            for (tree.extra(literal.expressions)) |expression| {
+                if (isArrayIndexReference(tree, expression, state)) {
+                    try report(allocator, diagnostics, tree, current);
+                }
+            }
+        },
+        .binary_expression => {
+            const count = countArrayIndexReferences(tree, current, state);
+            var i: usize = 0;
+            while (i < count) : (i += 1) {
+                try report(allocator, diagnostics, tree, current);
+            }
+        },
+        .call_expression => |call| {
+            if (isIndexToStringCall(tree, call, state)) {
+                try report(allocator, diagnostics, tree, current);
+                return;
+            }
+            if (isStringIndexCall(tree, call, state)) |argument| {
+                try report(allocator, diagnostics, tree, argument);
+            }
+        },
+        else => {},
+    }
+}
+
+fn mapIndexParamName(tree: *const ast.Tree, call: ast.CallExpression, state: State) ?[]const u8 {
+    const callee = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    const method = propertyName(tree, callee) orelse return null;
+    const position = iteratorIndexParamPosition(method) orelse return null;
+
+    const arguments = tree.extra(call.arguments);
+    const callback_index: usize = if (isReactChildrenIterator(tree, callee, state)) 1 else 0;
+    if (arguments.len <= callback_index) return null;
+
+    const callback = unwrapTransparent(tree, arguments[callback_index]);
+    const params_index = switch (tree.data(callback)) {
+        .arrow_function_expression => |function| function.params,
+        .function => |function| switch (function.type) {
+            .function_expression => function.params,
+            else => return null,
+        },
+        else => return null,
+    };
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return null,
+    };
+    const items = tree.extra(params.items);
+    if (items.len <= position) return null;
+
+    const parameter = switch (tree.data(items[position])) {
+        .formal_parameter => |parameter| parameter,
+        else => return null,
+    };
+    return bindingIdentifierName(tree, parameter.pattern);
+}
+
+fn iteratorIndexParamPosition(method: []const u8) ?usize {
+    for (iterator_functions) |entry| {
+        if (std.mem.eql(u8, method, entry.name)) return entry.index_param_position;
+    }
+    return null;
+}
+
+fn isReactChildrenIterator(tree: *const ast.Tree, callee: ast.MemberExpression, state: State) bool {
+    const method = propertyName(tree, callee) orelse return false;
+    if (!std.mem.eql(u8, method, "map") and !std.mem.eql(u8, method, "forEach")) return false;
+
+    const object = unwrapTransparent(tree, callee.object);
+    if (identifierReferenceName(tree, object)) |name| {
+        return std.mem.eql(u8, name, "Children");
+    }
+    const member = switch (tree.data(object)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    const root = identifierReferenceName(tree, unwrapTransparent(tree, member.object)) orelse return false;
+    return std.mem.eql(u8, property, "Children") and std.mem.eql(u8, root, state.pragma);
+}
+
+fn isCreateCloneElementCall(tree: *const ast.Tree, call: ast.CallExpression, state: State) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        for (state.create_clone_names.items) |local| {
+            if (std.mem.eql(u8, name, local)) return true;
+        }
+        return false;
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "createElement") and !std.mem.eql(u8, property, "cloneElement")) return false;
+    const object = identifierReferenceName(tree, unwrapTransparent(tree, member.object)) orelse return false;
+    return std.mem.eql(u8, object, state.pragma);
+}
+
+fn isArrayIndexReference(tree: *const ast.Tree, index: ast.NodeIndex, state: State) bool {
+    const name = identifierReferenceName(tree, unwrapTransparent(tree, index)) orelse return false;
+    return isArrayIndexName(name, state);
+}
+
+fn isArrayIndexName(name: []const u8, state: State) bool {
+    for (state.index_param_names.items) |index_name| {
+        if (std.mem.eql(u8, name, index_name)) return true;
+    }
+    return false;
+}
+
+fn countArrayIndexReferences(tree: *const ast.Tree, index: ast.NodeIndex, state: State) usize {
+    const current = unwrapTransparent(tree, index);
+    if (isArrayIndexReference(tree, current, state)) return 1;
+    const binary = switch (tree.data(current)) {
+        .binary_expression => |binary| binary,
+        else => return 0,
+    };
+    return countArrayIndexReferences(tree, binary.left, state) +
+        countArrayIndexReferences(tree, binary.right, state);
+}
+
+fn isIndexToStringCall(tree: *const ast.Tree, call: ast.CallExpression, state: State) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, property, "toString") and isArrayIndexReference(tree, member.object, state);
+}
+
+fn isStringIndexCall(tree: *const ast.Tree, call: ast.CallExpression, state: State) ?ast.NodeIndex {
+    const callee = identifierReferenceName(tree, unwrapTransparent(tree, call.callee)) orelse return null;
+    if (!std.mem.eql(u8, callee, "String")) return null;
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return null;
+    return if (isArrayIndexReference(tree, arguments[0], state)) arguments[0] else null;
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Do not use Array index in keys",
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+    if (member.computed) return null;
+    return staticName(tree, member.property);
+}
+
+fn objectPropertyKeyName(tree: *const ast.Tree, property: ast.ObjectProperty) ?[]const u8 {
+    if (property.computed) return null;
+    return staticName(tree, property.key);
+}
+
+fn staticName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn pragmaFromComments(tree: *const ast.Tree) ?[]const u8 {
+    for (tree.comments) |comment| {
+        const value = tree.string(comment.value);
+        const marker_index = std.mem.indexOf(u8, value, "@jsx") orelse continue;
+        var cursor = marker_index + "@jsx".len;
+
+        if (cursor >= value.len or !isWhitespace(value[cursor])) continue;
+        while (cursor < value.len and isWhitespace(value[cursor])) : (cursor += 1) {}
+
+        const start = cursor;
+        while (cursor < value.len and !isWhitespace(value[cursor])) : (cursor += 1) {}
+        var pragma = value[start..cursor];
+        if (std.mem.indexOfScalar(u8, pragma, '.')) |dot_index| {
+            pragma = pragma[0..dot_index];
+        }
+        if (isIdentifier(pragma)) return pragma;
+    }
+    return null;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\n' or byte == '\r';
+}
+
+fn isIdentifier(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (!isIdentifierStart(value[0])) return false;
+    for (value[1..]) |byte| {
+        if (!isIdentifierContinue(byte)) return false;
+    }
+    return true;
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_' or byte == '$';
+}
+
+fn isIdentifierContinue(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -185,6 +185,7 @@ pub const react_jsx_uses_react = @import("react_jsx_uses_react.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_danger_with_children = @import("react_no_danger_with_children.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
+pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
@@ -308,6 +309,7 @@ pub fn runBasic(
         .file_path = file_path,
         .options = options,
     };
+    defer visitor.react_no_array_index_key_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -526,6 +528,7 @@ const BasicVisitor = struct {
     options: core.Options,
     react_no_danger_with_children_bindings: react_no_danger_with_children.ObjectBindings = .{},
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
+    react_no_array_index_key_state: react_no_array_index_key.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
@@ -549,6 +552,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_children_prop) {
             self.react_no_children_prop_bindings = react_no_children_prop.bindingsFromProgram(ctx.tree, program);
+        }
+        if (self.options.react_no_array_index_key) {
+            try react_no_array_index_key.collectProgram(self.allocator, ctx.tree, program, &self.react_no_array_index_key_state);
         }
         if (self.options.react_void_dom_elements_no_children) {
             self.react_void_dom_elements_no_children_bindings = react_void_dom_elements_no_children.bindingsFromProgram(ctx.tree, program);
@@ -1542,6 +1548,9 @@ const BasicVisitor = struct {
         if (self.options.react_void_dom_elements_no_children) {
             try react_void_dom_elements_no_children.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_void_dom_elements_no_children_bindings);
         }
+        if (self.options.react_no_array_index_key) {
+            try react_no_array_index_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, &self.react_no_array_index_key_state);
+        }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -1558,6 +1567,17 @@ const BasicVisitor = struct {
             try typescript_eslint_no_array_constructor.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         return .proceed;
+    }
+
+    pub fn exit_call_expression(
+        self: *BasicVisitor,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_array_index_key) {
+            react_no_array_index_key.exitCallExpression(ctx.tree, call, &self.react_no_array_index_key_state);
+        }
     }
 
     pub fn enter_new_expression(
@@ -1660,6 +1680,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_string_refs) {
             try react_no_string_refs.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+        }
+        if (self.options.react_no_array_index_key) {
+            try react_no_array_index_key.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, self.react_no_array_index_key_state);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -663,6 +663,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_array_index_key.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_find_dom_node.zig");
 }
 

--- a/tests/rules/react_no_array_index_key.zig
+++ b/tests/rules/react_no_array_index_key.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const test_options = lint.Options{
+    .no_undef = false,
+    .no_unused_vars = false,
+    .typescript_eslint_no_unused_vars = false,
+    .react_jsx_no_undef = false,
+};
+
+test "reports JSX key using array index parameter" {
+    const source =
+        \\items.map((item, index) => <Item key={index} value={item} />);
+        \\items.filter((item, index) => <Item key={`item-${index}`} value={item} />);
+        \\items.reduce((acc, item, index) => <Item key={"item-" + index} value={item} />, null);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_array_index_key.id));
+}
+
+test "reports String and toString index keys" {
+    const source =
+        \\items.map((item, index) => <Item key={index.toString()} value={item} />);
+        \\items.map((item, index) => <Item key={String(index)} value={item} />);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_array_index_key.id));
+}
+
+test "reports createElement and cloneElement index keys" {
+    const source =
+        \\import { createElement, cloneElement as clone } from "react";
+        \\
+        \\items.map((item, index) => createElement(Item, { key: index, value: item }));
+        \\items.map((item, index) => React.cloneElement(item, { key: index }));
+        \\items.map((item, index) => clone(item, { key: index }));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_array_index_key.id));
+}
+
+test "reports React Children index keys" {
+    const source =
+        \\React.Children.map(children, (child, index) => <Item key={index}>{child}</Item>);
+        \\Children.forEach(children, (child, index) => <Item key={index}>{child}</Item>);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_array_index_key.id));
+}
+
+test "does not report non-index key values" {
+    const source =
+        \\items.map((item, index) => <Item key={item.id} value={index} />);
+        \\items.map((item) => <Item key={item.id} />);
+        \\items.map((item, index) => <Item key="static" value={index} />);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_array_index_key.id));
+}
+
+test "can disable react no array index key" {
+    const source = "items.map((item, index) => <Item key={index} value={item} />);";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .react_jsx_no_undef = false,
+        .react_no_array_index_key = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_array_index_key.id));
+}


### PR DESCRIPTION
## Summary
- add react/no-array-index-key for JSX key props and React createElement/cloneElement props
- track array iterator and React.Children callback index parameters
- add the CLI disable flag and focused coverage for template, binary, String, and toString keys

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1