### PR TITLE
feat: port react jsx-uses-vars

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -191,6 +191,7 @@ pub const Options = struct {
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_uses_react: bool = true,
+    react_jsx_uses_vars: bool = true,
     react_no_danger: bool = true,
     react_no_danger_with_children: bool = true,
     react_no_array_index_key: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,6 +395,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_pascal_case = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-uses-react=off")) {
             options.react_jsx_uses_react = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-uses-vars=off")) {
+            options.react_jsx_uses_vars = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger=off")) {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger-with-children=off")) {
@@ -924,6 +926,7 @@ fn printHelp() void {
         \\  --react-jsx-no-undef=off Disable react/jsx-no-undef
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case
         \\  --react-jsx-uses-react=off Disable react/jsx-uses-react
+        \\  --react-jsx-uses-vars=off Disable react/jsx-uses-vars
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-danger-with-children=off Disable react/no-danger-with-children
         \\  --react-no-array-index-key=off Disable react/no-array-index-key

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -19,6 +19,7 @@ pub const Options = struct {
     ignore_rest_siblings: bool = false,
     check_type_parameters: bool = false,
     react_jsx_uses_react: bool = false,
+    react_jsx_uses_vars: bool = true,
 };
 
 const JSXReactUsage = struct {
@@ -84,7 +85,7 @@ pub fn runWithOptions(
     defer parameters.deinit(allocator);
 
     if (options.check_parameters and options.args_after_used) {
-        try collectParameters(allocator, tree, symbol_table, &parameters);
+        try collectParameters(allocator, tree, symbol_table, options, &parameters);
         std.mem.sort(Parameter, parameters.items, {}, lessThanParameter);
     }
 
@@ -111,7 +112,7 @@ pub fn runWithOptions(
             if (!options.check_parameters) continue;
             if (options.args_after_used and !shouldCheckParameter(entry.id, symbol.scope, parameters.items)) continue;
         }
-        if (symbol_table.isReferenced(entry.id)) continue;
+        if (isReferenced(tree, symbol_table, entry.id, options)) continue;
 
         const name = tree.string(symbol.name);
         if (std.mem.startsWith(u8, name, "_")) continue;
@@ -142,10 +143,26 @@ fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bo
         (options.check_type_parameters and flags.type_parameter);
 }
 
+fn isReferenced(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    symbol_id: SymbolId,
+    options: Options,
+) bool {
+    if (options.react_jsx_uses_vars) return symbol_table.isReferenced(symbol_id);
+
+    var iter = symbol_table.symbolUses(symbol_id);
+    while (iter.next()) |use_node| {
+        if (tree.data(use_node) != .jsx_identifier) return true;
+    }
+    return false;
+}
+
 fn collectParameters(
     allocator: Allocator,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
     parameters: *std.ArrayList(Parameter),
 ) Allocator.Error!void {
     var iter = symbol_table.iterSymbols();
@@ -160,7 +177,7 @@ fn collectParameters(
             .symbol_id = entry.id,
             .scope = symbol.scope,
             .start = tree.span(decls[0]).start,
-            .used = symbol_table.isReferenced(entry.id),
+            .used = isReferenced(tree, symbol_table, entry.id, options),
         });
     }
 }

--- a/src/rules/react_jsx_uses_vars.zig
+++ b/src/rules/react_jsx_uses_vars.zig
@@ -1,0 +1,1 @@
+pub const id = "react/jsx-uses-vars";

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -182,6 +182,7 @@ pub const react_jsx_no_target_blank = @import("react_jsx_no_target_blank.zig");
 pub const react_jsx_no_undef = @import("react_jsx_no_undef.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
 pub const react_jsx_uses_react = @import("react_jsx_uses_react.zig");
+pub const react_jsx_uses_vars = @import("react_jsx_uses_vars.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_danger_with_children = @import("react_no_danger_with_children.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
@@ -493,11 +494,19 @@ pub fn runSemantic(
     if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {
         try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .react_jsx_uses_react = options.react_jsx_uses_react,
+            .react_jsx_uses_vars = options.react_jsx_uses_vars,
         });
     }
 
     if (options.typescript_eslint_no_unused_vars) {
-        try typescript_eslint_no_unused_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table, options.react_jsx_uses_react);
+        try typescript_eslint_no_unused_vars.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.react_jsx_uses_react,
+            options.react_jsx_uses_vars,
+        );
     }
 
     if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -13,6 +13,7 @@ pub fn run(
     tree: *const parser.ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
     react_jsx_uses_react: bool,
+    react_jsx_uses_vars: bool,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
@@ -22,5 +23,6 @@ pub fn run(
         .ignore_rest_siblings = true,
         .check_type_parameters = true,
         .react_jsx_uses_react = react_jsx_uses_react,
+        .react_jsx_uses_vars = react_jsx_uses_vars,
     });
 }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -715,6 +715,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_uses_vars.zig");
+}
+
+comptime {
     _ = @import("rules/react_prefer_es6_class.zig");
 }
 

--- a/tests/rules/react_jsx_uses_vars.zig
+++ b/tests/rules/react_jsx_uses_vars.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "marks JSX component variables as used" {
+    const source =
+        \\const Component = () => null;
+        \\export const node = <Component />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "can disable react jsx uses vars" {
+    const source =
+        \\const Component = () => null;
+        \\export const node = <Component />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+        .react_jsx_uses_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "does not treat lowercase DOM JSX as variable usage" {
+    const source =
+        \\const div = 1;
+        \\export const node = <div />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-uses-vars as an option and exported rule id
- make no-unused-vars ignore JSX-only references only when the React rule is disabled
- add CLI flag and focused coverage for component and lowercase DOM JSX names

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1