### PR TITLE
feat: port react jsx-no-bind

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -187,6 +187,7 @@ pub const Options = struct {
     react_jsx_boolean_value: bool = true,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
+    react_jsx_no_bind: bool = true,
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_no_duplicate_props = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-comment-textnodes=off")) {
             options.react_jsx_no_comment_textnodes = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-no-bind=off")) {
+            options.react_jsx_no_bind = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-target-blank=off")) {
             options.react_jsx_no_target_blank = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-undef=off")) {
@@ -922,6 +924,7 @@ fn printHelp() void {
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
+        \\  --react-jsx-no-bind=off Disable react/jsx-no-bind
         \\  --react-jsx-no-target-blank=off Disable react/jsx-no-target-blank
         \\  --react-jsx-no-undef=off Disable react/jsx-no-undef
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case

--- a/src/rules/react_jsx_no_bind.zig
+++ b/src/rules/react_jsx_no_bind.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-no-bind";
+
+const Violation = enum {
+    bind_call,
+    arrow_func,
+    func,
+
+    fn message(self: Violation) []const u8 {
+        return switch (self) {
+            .bind_call => "JSX props should not use .bind()",
+            .arrow_func => "JSX props should not use arrow functions",
+            .func => "JSX props should not use functions",
+        };
+    }
+};
+
+const Binding = struct {
+    name: []const u8,
+    violation: Violation,
+};
+
+const Scope = struct {
+    bindings: std.ArrayList(Binding) = .empty,
+
+    fn deinit(self: *Scope, allocator: Allocator) void {
+        self.bindings.deinit(allocator);
+    }
+};
+
+pub const State = struct {
+    scopes: std.ArrayList(Scope) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        for (self.scopes.items) |*scope| {
+            scope.deinit(allocator);
+        }
+        self.scopes.deinit(allocator);
+    }
+};
+
+pub fn enterBlock(allocator: Allocator, state: *State) Allocator.Error!void {
+    try state.scopes.append(allocator, .{});
+}
+
+pub fn exitBlock(allocator: Allocator, state: *State) void {
+    if (state.scopes.pop()) |scope_value| {
+        var scope = scope_value;
+        scope.deinit(allocator);
+    }
+}
+
+pub fn checkFunctionDeclaration(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    state: *State,
+) Allocator.Error!void {
+    if (function.type != .function_declaration) return;
+    if (state.scopes.items.len == 0) return;
+    const name = bindingIdentifierName(tree, function.id) orelse return;
+    try addBinding(allocator, state, name, .func);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    parent_index: ?ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (declarator.init == .null) return;
+    if (state.scopes.items.len == 0) return;
+
+    const parent = parent_index orelse return;
+    const declaration = switch (tree.data(parent)) {
+        .variable_declaration => |declaration| declaration,
+        else => return,
+    };
+    if (declaration.kind != .@"const") return;
+
+    const violation = nodeViolationType(tree, declarator.init) orelse return;
+    const name = bindingIdentifierName(tree, declarator.id) orelse return;
+    try addBinding(allocator, state, name, violation);
+}
+
+pub fn checkJSXAttribute(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+    state: State,
+) Allocator.Error!void {
+    if (attribute.value == .null) return;
+    const container = switch (tree.data(attribute.value)) {
+        .jsx_expression_container => |container| container,
+        else => return,
+    };
+
+    if (container.expression == .null) return;
+    const expression = unwrapTransparent(tree, container.expression);
+    if (identifierReferenceName(tree, expression)) |name| {
+        if (findBinding(state, name)) |violation| {
+            try report(allocator, diagnostics, tree, index, violation);
+        }
+        return;
+    }
+
+    const violation = nodeViolationType(tree, expression) orelse return;
+    try report(allocator, diagnostics, tree, index, violation);
+}
+
+fn addBinding(
+    allocator: Allocator,
+    state: *State,
+    name: []const u8,
+    violation: Violation,
+) Allocator.Error!void {
+    const scope = &state.scopes.items[state.scopes.items.len - 1];
+    try scope.bindings.append(allocator, .{ .name = name, .violation = violation });
+}
+
+fn findBinding(state: State, name: []const u8) ?Violation {
+    var scope_index = state.scopes.items.len;
+    while (scope_index > 0) {
+        scope_index -= 1;
+        const scope = state.scopes.items[scope_index];
+        var binding_index = scope.bindings.items.len;
+        while (binding_index > 0) {
+            binding_index -= 1;
+            const binding = scope.bindings.items[binding_index];
+            if (std.mem.eql(u8, binding.name, name)) return binding.violation;
+        }
+    }
+    return null;
+}
+
+fn nodeViolationType(tree: *const ast.Tree, index: ast.NodeIndex) ?Violation {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .call_expression => |call| if (isBindCall(tree, call)) .bind_call else null,
+        .conditional_expression => |conditional| nodeViolationType(tree, conditional.@"test") orelse
+            nodeViolationType(tree, conditional.consequent) orelse
+            nodeViolationType(tree, conditional.alternate),
+        .arrow_function_expression => .arrow_func,
+        .function => |function| switch (function.type) {
+            .function_declaration,
+            .function_expression,
+            => .func,
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn isBindCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, property, "bind");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed or member.property == .null) return null;
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    violation: Violation,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        violation.message(),
+        tree.span(index),
+    );
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -178,6 +178,7 @@ pub const prefer_template = @import("prefer_template.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
+pub const react_jsx_no_bind = @import("react_jsx_no_bind.zig");
 pub const react_jsx_no_target_blank = @import("react_jsx_no_target_blank.zig");
 pub const react_jsx_no_undef = @import("react_jsx_no_undef.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
@@ -311,6 +312,7 @@ pub fn runBasic(
         .options = options,
     };
     defer visitor.react_no_array_index_key_state.deinit(allocator);
+    defer visitor.react_jsx_no_bind_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -538,6 +540,7 @@ const BasicVisitor = struct {
     react_no_danger_with_children_bindings: react_no_danger_with_children.ObjectBindings = .{},
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
     react_no_array_index_key_state: react_no_array_index_key.State = .{},
+    react_jsx_no_bind_state: react_jsx_no_bind.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
@@ -606,6 +609,9 @@ const BasicVisitor = struct {
         }
         if (self.options.prefer_rest_params) {
             try prefer_rest_params.check(self.allocator, self.diagnostics, ctx.tree, function, index);
+        }
+        if (self.options.react_jsx_no_bind) {
+            try react_jsx_no_bind.checkFunctionDeclaration(self.allocator, ctx.tree, function, &self.react_jsx_no_bind_state);
         }
         return .proceed;
     }
@@ -858,6 +864,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_void_dom_elements_no_children) {
             react_void_dom_elements_no_children.checkVariableDeclarator(ctx.tree, declarator, &self.react_void_dom_elements_no_children_bindings);
+        }
+        if (self.options.react_jsx_no_bind) {
+            try react_jsx_no_bind.checkVariableDeclarator(self.allocator, ctx.tree, declarator, ctx.path.ancestor(1), &self.react_jsx_no_bind_state);
         }
         return .proceed;
     }
@@ -1221,7 +1230,16 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, block.body);
         }
+        if (self.options.react_jsx_no_bind) {
+            try react_jsx_no_bind.enterBlock(self.allocator, &self.react_jsx_no_bind_state);
+        }
         return .proceed;
+    }
+
+    pub fn exit_block_statement(self: *BasicVisitor, _: ast.BlockStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        if (self.options.react_jsx_no_bind) {
+            react_jsx_no_bind.exitBlock(self.allocator, &self.react_jsx_no_bind_state);
+        }
     }
 
     pub fn enter_function_body(
@@ -1230,6 +1248,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.react_jsx_no_bind) {
+            try react_jsx_no_bind.enterBlock(self.allocator, &self.react_jsx_no_bind_state);
+        }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index);
         }
@@ -1246,6 +1267,12 @@ const BasicVisitor = struct {
             try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);
         }
         return .proceed;
+    }
+
+    pub fn exit_function_body(self: *BasicVisitor, _: ast.FunctionBody, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        if (self.options.react_jsx_no_bind) {
+            react_jsx_no_bind.exitBlock(self.allocator, &self.react_jsx_no_bind_state);
+        }
     }
 
     pub fn enter_static_block(
@@ -1692,6 +1719,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_array_index_key) {
             try react_no_array_index_key.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, self.react_no_array_index_key_state);
+        }
+        if (self.options.react_jsx_no_bind) {
+            try react_jsx_no_bind.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, self.react_jsx_no_bind_state);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -707,6 +707,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_no_bind.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_pascal_case.zig");
 }
 

--- a/tests/rules/react_jsx_no_bind.zig
+++ b/tests/rules/react_jsx_no_bind.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const test_options = lint.Options{
+    .no_undef = false,
+    .no_unused_vars = false,
+    .typescript_eslint_no_unused_vars = false,
+    .react_jsx_no_undef = false,
+};
+
+test "reports inline function values in JSX props" {
+    const source =
+        \\const one = <Button onClick={() => action()} />;
+        \\const two = <Button onClick={function () { action(); }} />;
+        \\const three = <Button onClick={this.handle.bind(this)} />;
+        \\const four = <Button onClick={condition ? () => a() : handler} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.react_jsx_no_bind.id));
+}
+
+test "reports const and function aliases from enclosing blocks" {
+    const source =
+        \\function Demo() {
+        \\  const onClick = () => action();
+        \\  const onFocus = this.handle.bind(this);
+        \\  function onBlur() {}
+        \\  return <Button onClick={onClick} onFocus={onFocus} onBlur={onBlur} />;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_jsx_no_bind.id));
+}
+
+test "does not report safe prop references" {
+    const source =
+        \\const handler = () => action();
+        \\function Demo(props) {
+        \\  const onClick = props.onClick;
+        \\  return <Button onClick={onClick} onFocus={handler} />;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_bind.id));
+}
+
+test "can disable react jsx no bind" {
+    const source = "const node = <Button onClick={() => action()} />;";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .react_jsx_no_undef = false,
+        .react_jsx_no_bind = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_bind.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-no-bind default checks for arrow functions, function expressions, and .bind() in JSX props
- track block/function-body const and function aliases used as JSX prop values
- add the CLI disable flag and focused coverage

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default warning and --react-jsx-no-bind=off