### PR TITLE
feat: port react jsx-key

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -188,6 +188,7 @@ pub const Options = struct {
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
     react_jsx_no_bind: bool = true,
+    react_jsx_key: bool = true,
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -389,6 +389,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_jsx_no_comment_textnodes = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-bind=off")) {
             options.react_jsx_no_bind = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-key=off")) {
+            options.react_jsx_key = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-target-blank=off")) {
             options.react_jsx_no_target_blank = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-undef=off")) {
@@ -925,6 +927,7 @@ fn printHelp() void {
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
         \\  --react-jsx-no-bind=off Disable react/jsx-no-bind
+        \\  --react-jsx-key=off Disable react/jsx-key
         \\  --react-jsx-no-target-blank=off Disable react/jsx-no-target-blank
         \\  --react-jsx-no-undef=off Disable react/jsx-no-undef
         \\  --react-jsx-pascal-case=off Disable react/jsx-pascal-case

--- a/src/rules/react_jsx_key.zig
+++ b/src/rules/react_jsx_key.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-key";
+
+const missing_array_key_message = "Missing \"key\" prop for element in array";
+const missing_iter_key_message = "Missing \"key\" prop for element in iterator";
+
+pub const State = struct {
+    pragma: []const u8 = "React",
+    children_to_array_depth: usize = 0,
+};
+
+pub fn collectProgram(tree: *const ast.Tree, state: *State) void {
+    state.pragma = pragmaFromComments(tree) orelse "React";
+}
+
+pub fn enterCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    state: *State,
+) Allocator.Error!void {
+    if (isChildrenToArrayCall(tree, call, state.*)) {
+        state.children_to_array_depth += 1;
+        return;
+    }
+    if (state.children_to_array_depth > 0) return;
+
+    const callback = iteratorCallback(tree, call) orelse return;
+    try checkIteratorCallback(allocator, diagnostics, tree, callback);
+}
+
+pub fn exitCallExpression(tree: *const ast.Tree, call: ast.CallExpression, state: *State) void {
+    if (!isChildrenToArrayCall(tree, call, state.*)) return;
+    if (state.children_to_array_depth > 0) {
+        state.children_to_array_depth -= 1;
+    }
+}
+
+pub fn checkArrayExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrayExpression,
+) Allocator.Error!void {
+    for (tree.extra(expression.elements)) |element_index| {
+        if (element_index == .null) continue;
+        const element = switch (tree.data(unwrapTransparent(tree, element_index))) {
+            .jsx_element => |element| element,
+            else => continue,
+        };
+        if (hasKeyProp(tree, element)) continue;
+        try report(allocator, diagnostics, tree, element_index, missing_array_key_message);
+    }
+}
+
+fn checkIteratorCallback(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    callback_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const current = unwrapTransparent(tree, callback_index);
+    switch (tree.data(current)) {
+        .arrow_function_expression => |function| {
+            if (function.expression) {
+                try checkIteratorExpression(allocator, diagnostics, tree, function.body);
+            } else {
+                try checkFunctionBody(allocator, diagnostics, tree, function.body);
+            }
+        },
+        .function => |function| {
+            if (function.type != .function_expression or function.body == .null) return;
+            try checkFunctionBody(allocator, diagnostics, tree, function.body);
+        },
+        else => {},
+    }
+}
+
+fn checkIteratorExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const current = unwrapTransparent(tree, index);
+    switch (tree.data(current)) {
+        .jsx_element => |element| try checkIteratorElement(allocator, diagnostics, tree, element, current),
+        .conditional_expression => |conditional| {
+            try checkIteratorExpression(allocator, diagnostics, tree, conditional.consequent);
+            try checkIteratorExpression(allocator, diagnostics, tree, conditional.alternate);
+        },
+        .logical_expression => |logical| try checkIteratorExpression(allocator, diagnostics, tree, logical.right),
+        else => {},
+    }
+}
+
+fn checkFunctionBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const body = switch (tree.data(index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return,
+    };
+    try checkReturnStatements(allocator, diagnostics, tree, body);
+}
+
+fn checkReturnStatements(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+) Allocator.Error!void {
+    for (tree.extra(range)) |statement_index| {
+        try checkReturnStatement(allocator, diagnostics, tree, statement_index);
+    }
+}
+
+fn checkReturnStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    switch (tree.data(index)) {
+        .return_statement => |statement| {
+            if (statement.argument != .null) {
+                try checkIteratorExpression(allocator, diagnostics, tree, statement.argument);
+            }
+        },
+        .if_statement => |statement| {
+            try checkReturnStatement(allocator, diagnostics, tree, statement.consequent);
+            if (statement.alternate != .null) {
+                try checkReturnStatement(allocator, diagnostics, tree, statement.alternate);
+            }
+        },
+        .block_statement => |block| try checkReturnStatements(allocator, diagnostics, tree, block.body),
+        else => {},
+    }
+}
+
+fn checkIteratorElement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (hasKeyProp(tree, element)) return;
+    try report(allocator, diagnostics, tree, index, missing_iter_key_message);
+}
+
+fn iteratorCallback(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+    const callee = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const method = propertyName(tree, callee.property) orelse return null;
+    const arguments = tree.extra(call.arguments);
+    if (std.mem.eql(u8, method, "map")) {
+        if (arguments.len == 0) return null;
+        return arguments[0];
+    }
+
+    if (!std.mem.eql(u8, method, "from")) return null;
+    if (!isIdentifierReference(tree, callee.object, "Array")) return null;
+    if (arguments.len <= 1) return null;
+    return arguments[1];
+}
+
+fn hasKeyProp(tree: *const ast.Tree, element: ast.JSXElement) bool {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return false,
+    };
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = jsxIdentifierName(tree, attribute.name) orelse continue;
+        if (std.mem.eql(u8, name, "key")) return true;
+    }
+    return false;
+}
+
+fn isChildrenToArrayCall(tree: *const ast.Tree, call: ast.CallExpression, state: State) bool {
+    const callee = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const method = propertyName(tree, callee.property) orelse return false;
+    if (!std.mem.eql(u8, method, "toArray")) return false;
+
+    const object = unwrapTransparent(tree, callee.object);
+    if (isIdentifierReference(tree, object, "Children")) return true;
+
+    const member = switch (tree.data(object)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property) orelse return false;
+    if (!std.mem.eql(u8, property, "Children")) return false;
+    return isIdentifierReference(tree, member.object, state.pragma);
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    message: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const current = unwrapTransparent(tree, index);
+    const name = switch (tree.data(current)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, expected);
+}
+
+fn pragmaFromComments(tree: *const ast.Tree) ?[]const u8 {
+    for (tree.comments) |comment| {
+        const value = tree.string(comment.value);
+        const marker_index = std.mem.indexOf(u8, value, "@jsx") orelse continue;
+        var cursor = marker_index + "@jsx".len;
+
+        if (cursor >= value.len or !isWhitespace(value[cursor])) continue;
+        while (cursor < value.len and isWhitespace(value[cursor])) : (cursor += 1) {}
+
+        const start = cursor;
+        while (cursor < value.len and !isWhitespace(value[cursor])) : (cursor += 1) {}
+        var pragma = value[start..cursor];
+        if (std.mem.indexOfScalar(u8, pragma, '.')) |dot_index| {
+            pragma = pragma[0..dot_index];
+        }
+        if (isIdentifier(pragma)) return pragma;
+    }
+    return null;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t' or byte == '\n' or byte == '\r';
+}
+
+fn isIdentifier(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (!isIdentifierStart(value[0])) return false;
+    for (value[1..]) |byte| {
+        if (!isIdentifierContinue(byte)) return false;
+    }
+    return true;
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_' or byte == '$';
+}
+
+fn isIdentifierContinue(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -179,6 +179,7 @@ pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
 pub const react_jsx_no_bind = @import("react_jsx_no_bind.zig");
+pub const react_jsx_key = @import("react_jsx_key.zig");
 pub const react_jsx_no_target_blank = @import("react_jsx_no_target_blank.zig");
 pub const react_jsx_no_undef = @import("react_jsx_no_undef.zig");
 pub const react_jsx_pascal_case = @import("react_jsx_pascal_case.zig");
@@ -541,6 +542,7 @@ const BasicVisitor = struct {
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
     react_no_array_index_key_state: react_no_array_index_key.State = .{},
     react_jsx_no_bind_state: react_jsx_no_bind.State = .{},
+    react_jsx_key_state: react_jsx_key.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
@@ -567,6 +569,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_array_index_key) {
             try react_no_array_index_key.collectProgram(self.allocator, ctx.tree, program, &self.react_no_array_index_key_state);
+        }
+        if (self.options.react_jsx_key) {
+            react_jsx_key.collectProgram(ctx.tree, &self.react_jsx_key_state);
         }
         if (self.options.react_void_dom_elements_no_children) {
             self.react_void_dom_elements_no_children_bindings = react_void_dom_elements_no_children.bindingsFromProgram(ctx.tree, program);
@@ -1587,6 +1592,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_array_index_key) {
             try react_no_array_index_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, &self.react_no_array_index_key_state);
         }
+        if (self.options.react_jsx_key) {
+            try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state);
+        }
         if (self.options.new_cap) {
             try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -1613,6 +1621,9 @@ const BasicVisitor = struct {
     ) void {
         if (self.options.react_no_array_index_key) {
             react_no_array_index_key.exitCallExpression(ctx.tree, call, &self.react_no_array_index_key_state);
+        }
+        if (self.options.react_jsx_key) {
+            react_jsx_key.exitCallExpression(ctx.tree, call, &self.react_jsx_key_state);
         }
     }
 
@@ -1692,6 +1703,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_sparse_arrays) {
             try no_sparse_arrays.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.react_jsx_key and self.react_jsx_key_state.children_to_array_depth == 0) {
+            try react_jsx_key.checkArrayExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -711,6 +711,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_key.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_pascal_case.zig");
 }
 

--- a/tests/rules/react_jsx_key.zig
+++ b/tests/rules/react_jsx_key.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const test_options = lint.Options{
+    .no_undef = false,
+    .no_unused_vars = false,
+    .typescript_eslint_no_unused_vars = false,
+    .react_jsx_no_undef = false,
+};
+
+test "reports JSX elements without keys in arrays" {
+    const source =
+        \\const nodes = [
+        \\  <Item />,
+        \\  <Item key="stable" />,
+        \\  <Item {...props} />,
+        \\];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
+test "reports JSX elements without keys in map callbacks" {
+    const source =
+        \\items.map((item) => <Item value={item} />);
+        \\items.map((item) => condition ? <Item value={item} /> : <Other key={item.id} />);
+        \\items.map((item) => condition && <Item value={item} />);
+        \\items.map((item) => <Item key={item.id} value={item} />);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
+test "reports JSX elements without keys in block callback returns" {
+    const source =
+        \\items.map(function (item) {
+        \\  if (item.visible) {
+        \\    return <Item value={item} />;
+        \\  }
+        \\  return <Fallback key={item.id} />;
+        \\});
+        \\items.map((item) => {
+        \\  if (item.ready) return <Ready value={item} />;
+        \\  return null;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
+test "reports Array.from mapper results and ignores Children.toArray" {
+    const source =
+        \\Array.from(items, (item) => <Item value={item} />);
+        \\React.Children.toArray([<Item />, <Item />]);
+        \\Children.toArray(items.map((item) => <Item value={item} />));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
+test "can disable react jsx key" {
+    const source = "const nodes = [<Item />];";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .react_jsx_no_undef = false,
+        .react_jsx_key = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_key.id));
+}


### PR DESCRIPTION
## Summary
- add react/jsx-key default checks for JSX elements missing key props in arrays
- check map and Array.from callbacks that return JSX elements without keys
- skip React.Children.toArray scopes and add the CLI disable flag

## Tests
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default error and --react-jsx-key=off