### PR TITLE
feat: port jsx-a11y no-access-key

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
+    jsx_a11y_no_access_key: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -195,6 +195,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-access-key=off")) {
+            options.jsx_a11y_no_access_key = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
             options.no_invalid_regexp = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
@@ -838,6 +840,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
+        \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments

--- a/src/rules/jsx_a11y_no_access_key.zig
+++ b/src/rules/jsx_a11y_no_access_key.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/no-access-key";
+
+const message = "No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications.";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (!std.ascii.eqlIgnoreCase(name, "accesskey")) continue;
+        if (!attributeValueIsTruthy(tree, attribute.value)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+        );
+        return;
+    }
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeValueIsTruthy(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+    if (value_index == .null) return true;
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value).len > 0,
+        .jsx_expression_container => |container| expressionValueIsTruthy(tree, container.expression),
+        else => true,
+    };
+}
+
+fn expressionValueIsTruthy(tree: *const ast.Tree, expression_index: ast.NodeIndex) bool {
+    return switch (tree.data(expression_index)) {
+        .boolean_literal => |literal| literal.value,
+        .null_literal => false,
+        .numeric_literal => |literal| !numericLiteralIsZero(tree.string(literal.raw)),
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        else => true,
+    };
+}
+
+fn numericLiteralIsZero(raw: []const u8) bool {
+    for (raw) |byte| {
+        if (byte == '0' or byte == '_' or byte == '.') continue;
+        return false;
+    }
+    return true;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -1794,6 +1795,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
             try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        if (self.options.jsx_a11y_no_access_key) {
+            try jsx_a11y_no_access_key.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_no_access_key.zig");
+}
+
+comptime {
     _ = @import("rules/linebreak_style.zig");
 }
 

--- a/tests/rules/jsx_a11y_no_access_key.zig
+++ b/tests/rules/jsx_a11y_no_access_key.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications.";
+
+test "reports jsx-a11y/no-access-key for truthy accessKey attributes" {
+    const source =
+        \\const one = <div accessKey="n" />;
+        \\const two = <Button accesskey />;
+        \\const three = <span accessKey={1} />;
+        \\const four = <span accessKey={shortcut} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.jsx_a11y_no_access_key.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/no-access-key falsy or absent values" {
+    const source =
+        \\const one = <div />;
+        \\const two = <div accessKey="" />;
+        \\const three = <div accessKey={false} />;
+        \\const four = <div accessKey={0} />;
+        \\const five = <div accessKey={null} />;
+        \\const six = <div accessKey={undefined} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_no_access_key.id));
+}
+
+test "can disable jsx-a11y/no-access-key" {
+    const source =
+        \\const node = <div accessKey="n" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_no_access_key = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_no_access_key.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_no_access_key.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/no-access-key for fishlint's default warn configuration
- report truthy accessKey/accesskey JSX attributes using the upstream diagnostic text
- add the CLI disable flag and focused coverage for truthy, falsy, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/no-access-key'
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default warning and --jsx-a11y-no-access-key=off