### PR TITLE
feat: port jsx-a11y iframe-has-title

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
+    jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_no_access_key: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -195,6 +195,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-iframe-has-title=off")) {
+            options.jsx_a11y_iframe_has_title = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-access-key=off")) {
             options.jsx_a11y_no_access_key = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
@@ -840,6 +842,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
+        \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace

--- a/src/rules/jsx_a11y_iframe_has_title.zig
+++ b/src/rules/jsx_a11y_iframe_has_title.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/iframe-has-title";
+
+const message = "<iframe> elements must have a unique title property.";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isIframeElement(tree, opening.name)) return;
+    if (hasValidTitle(tree, opening)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn isIframeElement(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "iframe"),
+        else => false,
+    };
+}
+
+fn hasValidTitle(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (!std.mem.eql(u8, name, "title")) continue;
+        return titleValueIsValid(tree, attribute.value);
+    }
+    return false;
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn titleValueIsValid(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+    if (value_index == .null) return false;
+
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value).len > 0,
+        .jsx_expression_container => |container| expressionValueIsValid(tree, container.expression),
+        else => true,
+    };
+}
+
+fn expressionValueIsValid(tree: *const ast.Tree, expression_index: ast.NodeIndex) bool {
+    return switch (tree.data(expression_index)) {
+        .string_literal => |literal| tree.string(literal.value).len > 0,
+        .boolean_literal,
+        .null_literal,
+        .numeric_literal,
+        => false,
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        else => true,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
@@ -1798,6 +1799,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_no_access_key) {
             try jsx_a11y_no_access_key.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_iframe_has_title) {
+            try jsx_a11y_iframe_has_title.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_iframe_has_title.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_no_access_key.zig");
 }
 

--- a/tests/rules/jsx_a11y_iframe_has_title.zig
+++ b/tests/rules/jsx_a11y_iframe_has_title.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "<iframe> elements must have a unique title property.";
+
+test "reports jsx-a11y/iframe-has-title for iframe without valid title" {
+    const source =
+        \\const one = <iframe />;
+        \\const two = <iframe title />;
+        \\const three = <iframe title="" />;
+        \\const four = <iframe title={false} />;
+        \\const five = <iframe title={0} />;
+        \\const six = <iframe title={null} />;
+        \\const seven = <iframe title={undefined} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.jsx_a11y_iframe_has_title.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/iframe-has-title valid titles and non-iframes" {
+    const source =
+        \\const one = <iframe title="Account summary" />;
+        \\const two = <iframe title={label} />;
+        \\const three = <iframe title={`Embedded ${name}`} />;
+        \\const four = <Frame title="" />;
+        \\const five = <div />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_iframe_has_title.id));
+}
+
+test "can disable jsx-a11y/iframe-has-title" {
+    const source =
+        \\const node = <iframe />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_iframe_has_title = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_iframe_has_title.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_iframe_has_title.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/iframe-has-title for fishlint's default warn configuration
- require iframe titles to be present and statically non-empty, while allowing dynamic title expressions like upstream
- add the CLI disable flag and focused coverage for invalid, valid, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/iframe-has-title'
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default warning and --jsx-a11y-iframe-has-title=off