### PR TITLE
feat: port jsx-a11y img-redundant-alt

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -91,6 +91,7 @@ pub const Options = struct {
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
+    jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -197,6 +197,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-iframe-has-title=off")) {
             options.jsx_a11y_iframe_has_title = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-img-redundant-alt=off")) {
+            options.jsx_a11y_img_redundant_alt = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-access-key=off")) {
             options.jsx_a11y_no_access_key = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
@@ -843,6 +845,7 @@ fn printHelp() void {
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
+        \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace

--- a/src/rules/jsx_a11y_img_redundant_alt.zig
+++ b/src/rules/jsx_a11y_img_redundant_alt.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/img-redundant-alt";
+
+const message = "Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isImgElement(tree, opening.name)) return;
+    if (isAriaHidden(tree, opening)) return;
+
+    const alt = attributeNamed(tree, opening, "alt") orelse return;
+    const value = stringValue(tree, alt.value) orelse return;
+    if (!containsRedundantWord(value)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn isImgElement(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "img"),
+        else => false,
+    };
+}
+
+fn attributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, name: []const u8) ?ast.JSXAttribute {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const attribute_name = attributeName(tree, attribute.name) orelse continue;
+        if (std.mem.eql(u8, attribute_name, name)) return attribute;
+    }
+    return null;
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isAriaHidden(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+    const attribute = attributeNamed(tree, opening, "aria-hidden") orelse return false;
+    if (attribute.value == .null) return true;
+    return switch (tree.data(attribute.value)) {
+        .string_literal => |literal| std.ascii.eqlIgnoreCase(tree.string(literal.value), "true"),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .boolean_literal => |literal| literal.value,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn stringValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?[]const u8 {
+    if (value_index == .null) return null;
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| firstTemplateQuasi(tree, literal),
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn firstTemplateQuasi(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn containsRedundantWord(value: []const u8) bool {
+    var words = std.mem.tokenizeAny(u8, value, " \t\r\n");
+    while (words.next()) |word| {
+        if (equalsRedundantWord(word)) return true;
+    }
+    return false;
+}
+
+fn equalsRedundantWord(word: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(word, "image") or
+        std.ascii.eqlIgnoreCase(word, "photo") or
+        std.ascii.eqlIgnoreCase(word, "picture");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
+pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
@@ -1802,6 +1803,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_iframe_has_title) {
             try jsx_a11y_iframe_has_title.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_img_redundant_alt) {
+            try jsx_a11y_img_redundant_alt.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -67,6 +67,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_img_redundant_alt.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_no_access_key.zig");
 }
 

--- a/tests/rules/jsx_a11y_img_redundant_alt.zig
+++ b/tests/rules/jsx_a11y_img_redundant_alt.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.";
+
+test "reports jsx-a11y/img-redundant-alt for redundant img alt text" {
+    const source =
+        \\const one = <img alt="photo of user" />;
+        \\const two = <img alt={"IMAGE"} />;
+        \\const three = <img alt={`picture`} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.jsx_a11y_img_redundant_alt.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/img-redundant-alt non-redundant hidden or dynamic alt text" {
+    const source =
+        \\const one = <img alt="portrait of user" />;
+        \\const two = <img alt="" />;
+        \\const three = <img alt={label} />;
+        \\const four = <img aria-hidden="true" alt="image" />;
+        \\const five = <img aria-hidden={true} alt="photo" />;
+        \\const six = <area alt="picture map" />;
+        \\const seven = <input type="image" alt="image button" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_img_redundant_alt.id));
+}
+
+test "can disable jsx-a11y/img-redundant-alt" {
+    const source =
+        \\const node = <img alt="image" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_img_redundant_alt = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_img_redundant_alt.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_img_redundant_alt.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/img-redundant-alt for fishlint's default warn configuration
- flag redundant literal img alt text for image/photo/picture while respecting aria-hidden and dynamic alt values
- add the CLI disable flag and focused coverage for invalid, valid, hidden, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/img-redundant-alt'
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default warning and --jsx-a11y-img-redundant-alt=off