### PR TITLE
feat: port jsx-a11y aria-props

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
+    jsx_a11y_aria_props: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -195,6 +195,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-props=off")) {
+            options.jsx_a11y_aria_props = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-iframe-has-title=off")) {
             options.jsx_a11y_iframe_has_title = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-img-redundant-alt=off")) {
@@ -844,6 +846,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
+        \\  --jsx-a11y-aria-props=off Disable jsx-a11y/aria-props
         \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key

--- a/src/rules/jsx_a11y_aria_props.zig
+++ b/src/rules/jsx_a11y_aria_props.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/aria-props";
+
+const valid_aria_attributes = [_][]const u8{
+    "aria-activedescendant",
+    "aria-atomic",
+    "aria-autocomplete",
+    "aria-braillelabel",
+    "aria-brailleroledescription",
+    "aria-busy",
+    "aria-checked",
+    "aria-colcount",
+    "aria-colindex",
+    "aria-colspan",
+    "aria-controls",
+    "aria-current",
+    "aria-describedby",
+    "aria-description",
+    "aria-details",
+    "aria-disabled",
+    "aria-dropeffect",
+    "aria-errormessage",
+    "aria-expanded",
+    "aria-flowto",
+    "aria-grabbed",
+    "aria-haspopup",
+    "aria-hidden",
+    "aria-invalid",
+    "aria-keyshortcuts",
+    "aria-label",
+    "aria-labelledby",
+    "aria-level",
+    "aria-live",
+    "aria-modal",
+    "aria-multiline",
+    "aria-multiselectable",
+    "aria-orientation",
+    "aria-owns",
+    "aria-placeholder",
+    "aria-posinset",
+    "aria-pressed",
+    "aria-readonly",
+    "aria-relevant",
+    "aria-required",
+    "aria-roledescription",
+    "aria-rowcount",
+    "aria-rowindex",
+    "aria-rowspan",
+    "aria-selected",
+    "aria-setsize",
+    "aria-sort",
+    "aria-valuemax",
+    "aria-valuemin",
+    "aria-valuenow",
+    "aria-valuetext",
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = attributeName(tree, attribute.name) orelse return;
+    if (!std.mem.startsWith(u8, name, "aria-")) return;
+    if (isValidAriaAttribute(name)) return;
+
+    if (suggestion(name)) |suggested| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "{s}: This attribute is an invalid ARIA attribute. Did you mean to use {s}?",
+            .{ name, suggested },
+        );
+        return;
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "{s}: This attribute is an invalid ARIA attribute.",
+        .{name},
+    );
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isValidAriaAttribute(name: []const u8) bool {
+    for (valid_aria_attributes) |attribute| {
+        if (std.mem.eql(u8, name, attribute)) return true;
+    }
+    return false;
+}
+
+fn suggestion(name: []const u8) ?[]const u8 {
+    var best_distance: usize = 3;
+    var best: ?[]const u8 = null;
+
+    for (valid_aria_attributes) |attribute| {
+        const distance = damerauLevenshteinDistance(name, attribute, 2);
+        if (distance <= 2 and distance < best_distance) {
+            best_distance = distance;
+            best = attribute;
+        }
+    }
+
+    return best;
+}
+
+fn damerauLevenshteinDistance(a: []const u8, b: []const u8, max_distance: usize) usize {
+    var matrix: [64][64]usize = undefined;
+    const a_len = a.len;
+    const b_len = b.len;
+    if (a_len >= matrix.len or b_len >= matrix[0].len) return max_distance + 1;
+
+    for (0..a_len + 1) |i| matrix[i][0] = i;
+    for (0..b_len + 1) |j| matrix[0][j] = j;
+
+    for (1..a_len + 1) |i| {
+        var row_min: usize = max_distance + 1;
+        for (1..b_len + 1) |j| {
+            const cost: usize = if (std.ascii.toUpper(a[i - 1]) == std.ascii.toUpper(b[j - 1])) 0 else 1;
+            var value = @min(
+                @min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1),
+                matrix[i - 1][j - 1] + cost,
+            );
+
+            if (i > 1 and j > 1 and
+                std.ascii.toUpper(a[i - 1]) == std.ascii.toUpper(b[j - 2]) and
+                std.ascii.toUpper(a[i - 2]) == std.ascii.toUpper(b[j - 1]))
+            {
+                value = @min(value, matrix[i - 2][j - 2] + 1);
+            }
+
+            matrix[i][j] = value;
+            row_min = @min(row_min, value);
+        }
+        if (row_min > max_distance and i > max_distance) return max_distance + 1;
+    }
+
+    return matrix[a_len][b_len];
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
 pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
@@ -1744,6 +1745,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.jsx_a11y_aria_props) {
+            try jsx_a11y_aria_props.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+        }
         if (self.options.react_no_danger) {
             try react_no_danger.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_aria_props.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_iframe_has_title.zig");
 }
 

--- a/tests/rules/jsx_a11y_aria_props.zig
+++ b/tests/rules/jsx_a11y_aria_props.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports jsx-a11y/aria-props for invalid aria attributes" {
+    const source =
+        \\const one = <div aria-foo="x" />;
+        \\const two = <div aria-labeledby="x" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.jsx_a11y_aria_props.id));
+    try std.testing.expect(hasMessage(result, "aria-foo: This attribute is an invalid ARIA attribute."));
+    try std.testing.expect(hasMessage(result, "aria-labeledby: This attribute is an invalid ARIA attribute. Did you mean to use aria-labelledby?"));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/aria-props valid aria attributes and non aria props" {
+    const source =
+        \\const one = <div aria-label="Name" aria-labelledby="id" aria-activedescendant="item" />;
+        \\const two = <div ariaLabel="Name" aria="ignored" data-aria-foo="x" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_props.id));
+}
+
+test "can disable jsx-a11y/aria-props" {
+    const source =
+        \\const node = <div aria-foo="x" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_aria_props = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_props.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_aria_props.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/aria-props for fishlint's default warn configuration
- validate aria-* prop names against aria-query's ARIA attribute list
- include upstream-style typo suggestions and the CLI disable flag

## Tests
- zig build test --summary all -- 'jsx-a11y/aria-props'
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke for default warning and --jsx-a11y-aria-props=off