### PR TITLE
feat: add focused rule selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Rule toggles:
 utoo-lint --no-console=off --no-unused-vars=off src
 ```
 
+Run only a focused rule set:
+
+```bash
+utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
+```
+
 ## Architecture
 
 - `src/root.zig` owns parsing, rule execution, and public API exports.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,8 @@
 # utoo-lint benchmark
 
 This directory benchmarks the current local `@utoo/lint` binary against Oxlint,
-Biome, and ESLint on the same generated TypeScript corpus.
+Biome, and ESLint on the same generated TypeScript corpus and the same shared
+lint rule set.
 
 ## Setup
 
@@ -15,7 +16,8 @@ npm run generate
 npm run bench
 ```
 
-The benchmark runner writes machine-readable output to `results/latest.json`.
+The benchmark runner writes machine-readable output to `results/latest.json`,
+including the target file count and the shared rule list used for that run.
 
 ## Commands
 
@@ -42,7 +44,13 @@ npm run bench -- --skip-eslint
 - The generated corpus is designed to be valid TypeScript with no intentional
   diagnostics. This keeps benchmark time focused on traversal and rule
   execution instead of terminal output.
-- The tools do not have identical rule sets. Treat the result as practical CLI
-  throughput, not proof that all tools performed identical semantic work.
+- The runner keeps tool comparisons aligned by applying the same target path to
+  every tool and enabling only the shared rules defined in
+  `scripts/shared-rules.mjs`.
+- The current shared rule set is: `no-const-assign`,
+  `no-empty-character-class`, `no-empty-pattern`, `no-unsafe-finally`,
+  `use-isnan`, `valid-typeof`, `no-debugger`, `no-duplicate-case`,
+  `no-fallthrough`, `no-global-assign`, `no-import-assign`, and
+  `no-unsafe-negation`.
 - The runner measures wall-clock time for fresh CLI processes. Editor daemon
   behavior, caches, and type-aware ESLint rules are intentionally out of scope.

--- a/benchmarks/biome.json
+++ b/benchmarks/biome.json
@@ -1,12 +1,33 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": false,
+    "useIgnoreFile": false
+  },
   "files": {
-    "includes": ["fixtures/src/**/*.ts"]
+    "includes": ["fixtures/**/*.ts"],
+    "maxSize": 67108864
   },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": false,
+      "correctness": {
+        "noConstAssign": "error",
+        "noEmptyCharacterClassInRegex": "error",
+        "noEmptyPattern": "error",
+        "noUnsafeFinally": "error",
+        "useIsNan": "error",
+        "useValidTypeof": "error"
+      },
+      "suspicious": {
+        "noDebugger": "error",
+        "noDuplicateCase": "error",
+        "noFallthroughSwitchClause": "error",
+        "noGlobalAssign": "error",
+        "noImportAssign": "error",
+        "noUnsafeNegation": "error"
+      }
     }
   }
 }

--- a/benchmarks/eslint.config.js
+++ b/benchmarks/eslint.config.js
@@ -1,22 +1,19 @@
-import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { eslintRuleConfig } from "./scripts/shared-rules.mjs";
 
 export default [
   {
     ignores: ["node_modules/**", "results/**"]
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
   {
-    files: ["fixtures/src/**/*.ts"],
+    files: ["fixtures/**/*.ts"],
     languageOptions: {
+      parser: tseslint.parser,
       parserOptions: {
         ecmaVersion: "latest",
         sourceType: "module"
       }
     },
-    rules: {
-      "no-undef": "off"
-    }
+    rules: eslintRuleConfig("error")
   }
 ];

--- a/benchmarks/scripts/run-benchmark.mjs
+++ b/benchmarks/scripts/run-benchmark.mjs
@@ -1,8 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { benchmarkRuleNames, oxlintRuleArgs, utooRuleArgs } from "./shared-rules.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 const runs = positiveInt(args.runs, 8, "runs");
@@ -17,25 +18,25 @@ const benchmarks = [
   {
     name: "utoo-lint",
     command: utooBin,
-    args: [target],
+    args: [...utooRuleArgs(), target],
     requiredPath: utooBin
   },
   {
     name: "oxlint",
     command: bin("oxlint"),
-    args: [target],
+    args: [...oxlintRuleArgs(), "--no-ignore", "--silent", target],
     requiredPath: bin("oxlint")
   },
   {
     name: "biome",
     command: bin("biome"),
-    args: ["lint", "--max-diagnostics=0", target],
+    args: ["lint", "--config-path=biome.json", "--max-diagnostics=0", target],
     requiredPath: bin("biome")
   },
   {
     name: "eslint",
     command: bin("eslint"),
-    args: [target],
+    args: ["--max-warnings=0", "--no-warn-ignored", target],
     requiredPath: bin("eslint"),
     optional: skipEslint
   }
@@ -50,6 +51,7 @@ for (const benchmark of benchmarks) {
 }
 
 const results = [];
+const targetFiles = await countFiles(target);
 
 for (const benchmark of benchmarks) {
   for (let i = 0; i < warmups; i += 1) {
@@ -81,6 +83,8 @@ const printable = results.map((result) => ({
   relative: `${(result.summary.medianMs / fastest).toFixed(2)}x`
 }));
 
+console.log(`Rules: ${benchmarkRuleNames().join(", ")}`);
+console.log(`Target: ${target} (${targetFiles} file(s))`);
 console.table(printable);
 
 await mkdir("results", { recursive: true });
@@ -93,6 +97,8 @@ await writeFile(
       platform: process.platform,
       arch: process.arch,
       target,
+      targetFiles,
+      rules: benchmarkRuleNames(),
       results
     },
     null,
@@ -160,6 +166,27 @@ function formatMs(value) {
 function bin(name) {
   const suffix = process.platform === "win32" ? ".cmd" : "";
   return join(localBin, `${name}${suffix}`);
+}
+
+async function countFiles(path) {
+  const pathStat = await stat(path);
+  if (pathStat.isFile()) {
+    return 1;
+  }
+  if (!pathStat.isDirectory()) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) {
+      count += await countFiles(child);
+    } else if (entry.isFile() && /\.(?:[cm]?[jt]sx?)$/.test(entry.name)) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function parseArgs(argv) {

--- a/benchmarks/scripts/run-codspeed.mjs
+++ b/benchmarks/scripts/run-codspeed.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { Bench } from "tinybench";
 import { withCodSpeed } from "@codspeed/tinybench-plugin";
+import { benchmarkRuleNames, utooRuleArgs } from "./shared-rules.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 const target = args.target ?? "fixtures/codspeed";
@@ -30,11 +31,13 @@ bench.add(`utoo-lint/${target}`, () => {
   runUtooLint(target);
 });
 
+console.log(`Rules: ${benchmarkRuleNames().join(", ")}`);
+
 await bench.run();
 console.table(bench.table());
 
 function runUtooLint(targetPath) {
-  const result = spawnSync(utooBin, [targetPath], {
+  const result = spawnSync(utooBin, [...utooRuleArgs(), targetPath], {
     cwd: process.cwd(),
     env: {
       ...process.env,

--- a/benchmarks/scripts/shared-rules.mjs
+++ b/benchmarks/scripts/shared-rules.mjs
@@ -1,0 +1,114 @@
+export const sharedRules = [
+  {
+    name: "no-const-assign",
+    utooOption: "no_const_assign",
+    eslint: "no-const-assign",
+    oxlint: "no-const-assign",
+    biomeGroup: "correctness",
+    biome: "noConstAssign"
+  },
+  {
+    name: "no-empty-character-class",
+    utooOption: "no_empty_character_class",
+    eslint: "no-empty-character-class",
+    oxlint: "no-empty-character-class",
+    biomeGroup: "correctness",
+    biome: "noEmptyCharacterClassInRegex"
+  },
+  {
+    name: "no-empty-pattern",
+    utooOption: "no_empty_pattern",
+    eslint: "no-empty-pattern",
+    oxlint: "no-empty-pattern",
+    biomeGroup: "correctness",
+    biome: "noEmptyPattern"
+  },
+  {
+    name: "no-unsafe-finally",
+    utooOption: "no_unsafe_finally",
+    eslint: "no-unsafe-finally",
+    oxlint: "no-unsafe-finally",
+    biomeGroup: "correctness",
+    biome: "noUnsafeFinally"
+  },
+  {
+    name: "use-isnan",
+    utooOption: "use_isnan",
+    eslint: "use-isnan",
+    oxlint: "use-isnan",
+    biomeGroup: "correctness",
+    biome: "useIsNan"
+  },
+  {
+    name: "valid-typeof",
+    utooOption: "valid_typeof",
+    eslint: "valid-typeof",
+    oxlint: "valid-typeof",
+    biomeGroup: "correctness",
+    biome: "useValidTypeof"
+  },
+  {
+    name: "no-debugger",
+    utooOption: "no_debugger",
+    eslint: "no-debugger",
+    oxlint: "no-debugger",
+    biomeGroup: "suspicious",
+    biome: "noDebugger"
+  },
+  {
+    name: "no-duplicate-case",
+    utooOption: "no_duplicate_case",
+    eslint: "no-duplicate-case",
+    oxlint: "no-duplicate-case",
+    biomeGroup: "suspicious",
+    biome: "noDuplicateCase"
+  },
+  {
+    name: "no-fallthrough",
+    utooOption: "no_fallthrough",
+    eslint: "no-fallthrough",
+    oxlint: "no-fallthrough",
+    biomeGroup: "suspicious",
+    biome: "noFallthroughSwitchClause"
+  },
+  {
+    name: "no-global-assign",
+    utooOption: "no_global_assign",
+    eslint: "no-global-assign",
+    oxlint: "no-global-assign",
+    biomeGroup: "suspicious",
+    biome: "noGlobalAssign"
+  },
+  {
+    name: "no-import-assign",
+    utooOption: "no_import_assign",
+    eslint: "no-import-assign",
+    oxlint: "no-import-assign",
+    biomeGroup: "suspicious",
+    biome: "noImportAssign"
+  },
+  {
+    name: "no-unsafe-negation",
+    utooOption: "no_unsafe_negation",
+    eslint: "no-unsafe-negation",
+    oxlint: "no-unsafe-negation",
+    biomeGroup: "suspicious",
+    biome: "noUnsafeNegation"
+  }
+];
+
+export function eslintRuleConfig(severity = "error") {
+  return Object.fromEntries(sharedRules.map((rule) => [rule.eslint, severity]));
+}
+
+export function oxlintRuleArgs(severity = "-D") {
+  return ["-A", "all", ...sharedRules.flatMap((rule) => [severity, rule.oxlint])];
+}
+
+export function utooRuleArgs() {
+  return [`--rules=${sharedRules.map((rule) => rule.name).join(",")}`];
+}
+
+export function benchmarkRuleNames() {
+  return sharedRules.map((rule) => rule.name);
+}

--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -179,6 +179,15 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
+## JSX a11y rules
+
+| Rule | Status |
+| --- | --- |
+| [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
+| [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
+| [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Implemented |
+| [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |
+
 ## Parser diagnostics
 
 `parser-semantic-errors` reports parse diagnostics from Yuku, including semantic early errors by default. It is not an ESLint rule and therefore does not have a corresponding ESLint rule page.

--- a/src/core.zig
+++ b/src/core.zig
@@ -260,6 +260,96 @@ pub const Options = struct {
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     yoda: bool = true,
+
+    pub fn allDisabled() Options {
+        var options = Options{};
+        inline for (@typeInfo(Options).@"struct".fields) |field| {
+            if (field.type == bool) {
+                @field(options, field.name) = false;
+            }
+        }
+        return options;
+    }
+
+    pub fn setByCliName(self: *Options, cli_name: []const u8, value: bool) bool {
+        @setEvalBranchQuota(10000);
+
+        if (std.mem.eql(u8, cli_name, "semantic-errors")) {
+            self.parser_semantic_errors = value;
+            return true;
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "@typescript-eslint/")) {
+            const typescript_rule_name = cli_name["@typescript-eslint/".len..];
+            inline for (@typeInfo(Options).@"struct".fields) |field| {
+                if (field.type == bool) {
+                    if (comptime fieldNameStartsWith(field.name, "typescript_eslint_")) {
+                        if (cliNameMatchesFieldName(field.name["typescript_eslint_".len..], typescript_rule_name)) {
+                            @field(self, field.name) = value;
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "import/")) {
+            return self.setByPrefixedRuleName("import_", cli_name["import/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "jsx-a11y/")) {
+            return self.setByPrefixedRuleName("jsx_a11y_", cli_name["jsx-a11y/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "react/")) {
+            return self.setByPrefixedRuleName("react_", cli_name["react/".len..], value);
+        }
+
+        inline for (@typeInfo(Options).@"struct".fields) |field| {
+            if (field.type == bool and cliNameMatchesFieldName(field.name, cli_name)) {
+                @field(self, field.name) = value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
+        inline for (@typeInfo(Options).@"struct".fields) |field| {
+            if (field.type == bool) {
+                if (comptime fieldNameStartsWith(field.name, field_prefix)) {
+                    if (cliNameMatchesFieldName(field.name[field_prefix.len..], rule_name)) {
+                        @field(self, field.name) = value;
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    fn cliNameMatchesFieldName(comptime field_name: []const u8, cli_name: []const u8) bool {
+        if (cli_name.len != field_name.len) return false;
+
+        comptime var index: usize = 0;
+        inline while (index < field_name.len) : (index += 1) {
+            const expected = if (field_name[index] == '_') '-' else field_name[index];
+            if (cli_name[index] != expected) return false;
+        }
+        return true;
+    }
+
+    fn fieldNameStartsWith(comptime field_name: []const u8, comptime prefix: []const u8) bool {
+        @setEvalBranchQuota(10_000);
+        if (field_name.len < prefix.len) return false;
+
+        comptime var index: usize = 0;
+        inline while (index < prefix.len) : (index += 1) {
+            if (field_name[index] != prefix[index]) return false;
+        }
+        return true;
+    }
 };
 
 pub const Diagnostic = struct {
@@ -402,4 +492,31 @@ pub fn isKnownGlobal(name: []const u8) bool {
     }
 
     return false;
+}
+
+test "Options can enable rules by CLI name" {
+    var options = Options.allDisabled();
+
+    try std.testing.expect(!options.no_debugger);
+    try std.testing.expect(options.setByCliName("no-debugger", true));
+    try std.testing.expect(options.no_debugger);
+
+    try std.testing.expect(!options.typescript_eslint_no_unused_vars);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-unused-vars", true));
+    try std.testing.expect(options.typescript_eslint_no_unused_vars);
+    try std.testing.expect(!options.no_unused_vars);
+
+    try std.testing.expect(!options.jsx_a11y_aria_props);
+    try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));
+    try std.testing.expect(options.jsx_a11y_aria_props);
+
+    try std.testing.expect(!options.react_jsx_no_target_blank);
+    try std.testing.expect(options.setByCliName("react/jsx-no-target-blank", true));
+    try std.testing.expect(options.react_jsx_no_target_blank);
+
+    try std.testing.expect(!options.import_no_duplicates);
+    try std.testing.expect(options.setByCliName("import/no-duplicates", true));
+    try std.testing.expect(options.import_no_duplicates);
+
+    try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,6 +53,9 @@ pub fn main(init: std.process.Init) !void {
                 std.process.exit(2);
             }
             thread_count_override = parsed;
+        } else if (std.mem.startsWith(u8, arg, "--rules=")) {
+            options = lint.Options.allDisabled();
+            parseEnabledRules(arg["--rules=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
             options.constructor_super = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
@@ -599,6 +602,26 @@ fn collectLintablePaths(
     }
 }
 
+fn parseEnabledRules(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --rules requires a comma-separated rule list\n", .{});
+        std.process.exit(2);
+    }
+
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_rule| {
+        const rule = std.mem.trim(u8, raw_rule, " \t\r\n");
+        if (rule.len == 0) {
+            std.debug.print("utoo-lint: --rules contains an empty rule name\n", .{});
+            std.process.exit(2);
+        }
+        if (!options.setByCliName(rule, true)) {
+            std.debug.print("utoo-lint: unknown rule in --rules: {s}\n", .{rule});
+            std.process.exit(2);
+        }
+    }
+}
+
 fn collectLintableDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -776,6 +799,7 @@ fn printHelp() void {
         \\
         \\Options:
         \\  --threads=N              Number of worker threads to use
+        \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --array-callback-return=off Disable array-callback-return
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --constructor-super=off  Disable constructor-super

--- a/src/root.zig
+++ b/src/root.zig
@@ -32,7 +32,7 @@ pub fn lintSource(
     });
     defer tree.deinit();
 
-    const needs_semantic = effective_options.parser_semantic_errors or effective_options.block_scoped_var or effective_options.no_array_constructor or effective_options.no_alert or effective_options.no_extra_boolean_cast or effective_options.no_global_is_finite or effective_options.no_global_is_nan or effective_options.no_invalid_regexp or effective_options.no_loop_func or effective_options.typescript_eslint_no_loop_func or effective_options.no_misleading_character_class or effective_options.no_new_func or effective_options.no_new_object or effective_options.no_new_symbol or effective_options.no_new_wrappers or effective_options.no_redeclare or effective_options.typescript_eslint_no_redeclare or effective_options.no_shadow or effective_options.typescript_eslint_no_shadow or effective_options.no_unused_vars or effective_options.no_use_before_define or effective_options.no_undef or effective_options.react_jsx_no_undef or effective_options.prefer_const or effective_options.prefer_exponentiation_operator or effective_options.prefer_regex_literals or effective_options.radix or effective_options.require_atomic_updates or effective_options.symbol_description;
+    const needs_semantic = hasSemanticRules(effective_options);
 
     if (needs_semantic) {
         var semantic_result = try parser.semantic.analyze(&tree);
@@ -65,6 +65,59 @@ fn isDefinitionFile(path: []const u8) bool {
     return std.mem.endsWith(u8, path, ".d.ts") or
         std.mem.endsWith(u8, path, ".d.mts") or
         std.mem.endsWith(u8, path, ".d.cts");
+}
+
+fn hasSemanticRules(options: Options) bool {
+    return options.parser_semantic_errors or
+        options.block_scoped_var or
+        options.no_array_constructor or
+        options.no_alert or
+        options.no_async_promise_executor or
+        options.no_buffer_constructor or
+        options.no_class_assign or
+        options.no_const_assign or
+        options.no_eval or
+        options.no_ex_assign or
+        options.no_extend_native or
+        options.no_extra_boolean_cast or
+        options.no_func_assign or
+        options.no_global_assign or
+        options.no_global_is_finite or
+        options.no_global_is_nan or
+        options.no_implied_eval or
+        options.no_import_assign or
+        options.no_invalid_regexp or
+        options.no_label_var or
+        options.no_loop_func or
+        options.no_misleading_character_class or
+        options.no_new_func or
+        options.no_new_native_nonconstructor or
+        options.no_new_object or
+        options.no_new_symbol or
+        options.no_new_wrappers or
+        options.no_obj_calls or
+        options.no_object_constructor or
+        options.no_promise_executor_return or
+        options.no_redeclare or
+        options.no_shadow or
+        options.no_undef or
+        options.react_jsx_no_undef or
+        options.no_unused_vars or
+        options.no_use_before_define or
+        options.prefer_const or
+        options.prefer_exponentiation_operator or
+        options.prefer_promise_reject_errors or
+        options.prefer_regex_literals or
+        options.radix or
+        options.require_atomic_updates or
+        options.symbol_description or
+        options.typescript_eslint_no_redeclare or
+        options.typescript_eslint_no_require_imports or
+        options.typescript_eslint_no_loop_func or
+        options.typescript_eslint_no_shadow or
+        options.typescript_eslint_no_unused_vars or
+        options.typescript_eslint_no_use_before_define or
+        options.typescript_eslint_no_var_requires;
 }
 
 pub fn offsetToLineColumn(source: []const u8, offset: u32) SourcePosition {


### PR DESCRIPTION
## Summary
- add a shared Options mapper for CLI rule names, including plugin rules
- add --rules to run a focused comma-separated rule set
- align benchmark tools around a shared rule list and record target/rule metadata
- document the focused rule flag and JSX a11y rule status

## Tests
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast
- ./zig-out/bin/utoo-lint --rules=no-debugger test/fixtures/bad.ts
- ./zig-out/bin/utoo-lint --rules=jsx-a11y/aria-props /tmp/utoo-aria-props.tsx
- node scripts/run-benchmark.mjs --target=fixtures/one/000/module-00000.ts --runs=1 --warmups=0 --skip-eslint