### PR TITLE
feat: port jsx-a11y no-distracting-elements

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -94,6 +94,7 @@ pub const Options = struct {
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,
+    jsx_a11y_no_distracting_elements: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -206,6 +206,8 @@ pub fn main(init: std.process.Init) !void {
             options.jsx_a11y_img_redundant_alt = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-access-key=off")) {
             options.jsx_a11y_no_access_key = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-distracting-elements=off")) {
+            options.jsx_a11y_no_distracting_elements = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
             options.no_invalid_regexp = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
@@ -874,6 +876,7 @@ fn printHelp() void {
         \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
+        \\  --jsx-a11y-no-distracting-elements=off Disable jsx-a11y/no-distracting-elements
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments

--- a/src/rules/jsx_a11y_no_distracting_elements.zig
+++ b/src/rules/jsx_a11y_no_distracting_elements.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/no-distracting-elements";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const element = distractingElement(tree, opening.name) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Do not use <{s}> elements as they can create visual accessibility issues and are deprecated.",
+        .{element},
+    );
+}
+
+fn distractingElement(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    const name = switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => return null,
+    };
+
+    if (std.mem.eql(u8, name, "marquee") or std.mem.eql(u8, name, "blink")) return name;
+    return null;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -33,6 +33,7 @@ pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
 pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
+pub const jsx_a11y_no_distracting_elements = @import("jsx_a11y_no_distracting_elements.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -1810,6 +1811,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_img_redundant_alt) {
             try jsx_a11y_img_redundant_alt.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_no_distracting_elements) {
+            try jsx_a11y_no_distracting_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -79,6 +79,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_no_distracting_elements.zig");
+}
+
+comptime {
     _ = @import("rules/linebreak_style.zig");
 }
 

--- a/tests/rules/jsx_a11y_no_distracting_elements.zig
+++ b/tests/rules/jsx_a11y_no_distracting_elements.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports jsx-a11y/no-distracting-elements for marquee and blink" {
+    const source =
+        \\const one = <marquee />;
+        \\const two = <blink />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.jsx_a11y_no_distracting_elements.id));
+    try std.testing.expect(hasMessage(result, "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated."));
+    try std.testing.expect(hasMessage(result, "Do not use <blink> elements as they can create visual accessibility issues and are deprecated."));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/no-distracting-elements non distracting and custom components" {
+    const source =
+        \\const one = <div />;
+        \\const two = <Marquee />;
+        \\const three = <Blink />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_no_distracting_elements.id));
+}
+
+test "can disable jsx-a11y/no-distracting-elements" {
+    const source =
+        \\const node = <marquee />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_no_distracting_elements = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_no_distracting_elements.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_no_distracting_elements.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/no-distracting-elements for fishlint's default warn configuration
- flag deprecated <marquee> and <blink> JSX elements with upstream diagnostic text
- add the CLI disable flag and focused coverage for invalid, valid, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/no-distracting-elements'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-no-distracting-elements=off, and --rules=jsx-a11y/no-distracting-elements