### PR TITLE
feat: add utoo config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github
 This repo is a working scaffold, not a production linter yet.
 
 See [Rule status](docs/rule-status.md) for the current rule list and the corresponding ESLint documentation links.
+See [Migrating from ESLint](docs/eslint-migration.md) for the current migration path.
 
 ## Prerequisites
 
@@ -98,6 +99,20 @@ utoo-lint [options] [file-or-directory ...]
 ```
 
 If no target is provided, `utoo-lint` scans the current directory. It skips `.git`, `.zig-cache`, `node_modules`, `vendor`, and `zig-out`.
+
+Configuration files:
+
+```json
+{
+  "rules": {
+    "no-console": "off",
+    "no-debugger": "error",
+    "@typescript-eslint/no-unused-vars": ["warn"]
+  }
+}
+```
+
+By default, `utoo-lint` reads `utoo.json` or `utoo-lint.json` from the current directory. Use `--config=path/to/utoo.json` for an explicit file or `--no-config` to ignore local config. Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an ESLint-style array whose first item is the severity.
 
 Rule toggles:
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -1,0 +1,89 @@
+# Migrating from ESLint
+
+This guide covers the current migration path from ESLint to `utoo-lint`.
+
+`utoo-lint` is still experimental. Migrate incrementally: start with a small shared rule set, compare diagnostics in CI, then expand coverage as matching rules land.
+
+## Install and Run
+
+```bash
+npm install --save-dev @utoo/lint
+npx utoo-lint src test
+```
+
+For a focused first pass, run only rules that already exist in both projects:
+
+```bash
+npx utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
+```
+
+## Add a Config File
+
+Create `utoo.json` in the project root:
+
+```json
+{
+  "rules": {
+    "no-debugger": "error",
+    "no-console": "off",
+    "no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn"],
+    "react/jsx-no-target-blank": "error",
+    "jsx-a11y/aria-props": "error"
+  }
+}
+```
+
+`utoo-lint` also reads `utoo-lint.json`. Use `--config=path/to/file.json` to select a file explicitly, or `--no-config` to ignore local config.
+
+Rule values support the common ESLint forms:
+
+- `"off"`, `0`, or `false` disable a rule.
+- `"warn"`, `"error"`, `1`, `2`, or `true` enable a rule.
+- Arrays such as `["error", { ...options }]` use the first item as severity. Rule-specific options are not interpreted yet.
+
+CLI flags are applied after config files, so command-line toggles override config:
+
+```bash
+npx utoo-lint --config=utoo.json --no-console=off src
+```
+
+## Translate ESLint Rules
+
+Move rules from `eslint.config.js` or `.eslintrc` into `utoo.json` by keeping the same canonical rule names:
+
+```js
+// eslint.config.js
+export default [
+  {
+    rules: {
+      "no-debugger": "error",
+      "@typescript-eslint/no-unused-vars": ["warn"],
+      "react/jsx-no-target-blank": "error"
+    }
+  }
+];
+```
+
+```json
+{
+  "rules": {
+    "no-debugger": "error",
+    "@typescript-eslint/no-unused-vars": ["warn"],
+    "react/jsx-no-target-blank": "error"
+  }
+}
+```
+
+Use [Rule status](rule-status.md) to confirm which ESLint, TypeScript ESLint, React, import, and JSX a11y rules are currently implemented.
+
+## Compare in CI
+
+Run ESLint and `utoo-lint` side by side until the selected rule set is stable:
+
+```bash
+npx eslint src test
+npx utoo-lint --config=utoo.json src test
+```
+
+Once diagnostics match your expectations, replace the ESLint job for that rule set or keep both while expanding rule coverage.

--- a/src/core.zig
+++ b/src/core.zig
@@ -315,6 +315,48 @@ pub const Options = struct {
         return false;
     }
 
+    pub fn setByRuleConfigValue(self: *Options, cli_name: []const u8, value: std.json.Value) RuleConfigError!void {
+        const enabled = try ruleConfigValueToBool(value);
+        if (!self.setByCliName(cli_name, enabled)) return error.UnknownRule;
+    }
+
+    pub const RuleConfigError = error{
+        EmptyRuleConfigArray,
+        UnknownRule,
+        UnsupportedRuleConfigValue,
+    };
+
+    fn ruleConfigValueToBool(value: std.json.Value) RuleConfigError!bool {
+        return switch (value) {
+            .bool => |enabled| enabled,
+            .integer => |severity| switch (severity) {
+                0 => false,
+                1, 2 => true,
+                else => error.UnsupportedRuleConfigValue,
+            },
+            .string => |severity| ruleSeverityStringToBool(severity) orelse error.UnsupportedRuleConfigValue,
+            .array => |items| {
+                if (items.items.len == 0) return error.EmptyRuleConfigArray;
+                return ruleConfigValueToBool(items.items[0]);
+            },
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn ruleSeverityStringToBool(severity: []const u8) ?bool {
+        if (std.ascii.eqlIgnoreCase(severity, "off") or std.mem.eql(u8, severity, "0")) return false;
+        if (std.ascii.eqlIgnoreCase(severity, "warn") or
+            std.ascii.eqlIgnoreCase(severity, "warning") or
+            std.ascii.eqlIgnoreCase(severity, "error") or
+            std.ascii.eqlIgnoreCase(severity, "on") or
+            std.mem.eql(u8, severity, "1") or
+            std.mem.eql(u8, severity, "2"))
+        {
+            return true;
+        }
+        return null;
+    }
+
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
         inline for (@typeInfo(Options).@"struct".fields) |field| {
             if (field.type == bool) {
@@ -519,4 +561,29 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.import_no_duplicates);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
+}
+
+test "Options can apply ESLint-style rule config values" {
+    var options = Options{};
+
+    try options.setByRuleConfigValue("no-debugger", .{ .string = "off" });
+    try std.testing.expect(!options.no_debugger);
+
+    try options.setByRuleConfigValue("no-debugger", .{ .integer = 2 });
+    try std.testing.expect(options.no_debugger);
+
+    var array = std.json.Array.init(std.testing.allocator);
+    defer array.deinit();
+    try array.append(.{ .string = "warn" });
+    try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
+    try std.testing.expect(options.jsx_a11y_aria_props);
+
+    try std.testing.expectError(
+        Options.RuleConfigError.UnsupportedRuleConfigValue,
+        options.setByRuleConfigValue("no-debugger", .{ .string = "sometimes" }),
+    );
+    try std.testing.expectError(
+        Options.RuleConfigError.UnknownRule,
+        options.setByRuleConfigValue("unknown-rule", .{ .string = "off" }),
+    );
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 
 const max_file_size = 64 * 1024 * 1024;
+const max_config_file_size = 1024 * 1024;
 
 const Stats = struct {
     files: usize = 0,
@@ -33,7 +34,21 @@ pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
+    if (hasHelpArg(args[1..])) {
+        printHelp();
+        return;
+    }
+
     var options = lint.Options{};
+    const config = parseConfigArgs(args[1..]);
+    if (config.enabled) {
+        if (config.path) |path| {
+            try loadConfigFile(allocator, io, path, true, &options);
+        } else if (findDefaultConfig(io)) |path| {
+            try loadConfigFile(allocator, io, path, false, &options);
+        }
+    }
+
     var thread_count_override: ?usize = null;
     var targets: std.ArrayList([]const u8) = .empty;
     defer targets.deinit(allocator);
@@ -42,6 +57,10 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
+        } else if (std.mem.eql(u8, arg, "--no-config")) {
+            continue;
+        } else if (std.mem.startsWith(u8, arg, "--config=")) {
+            continue;
         } else if (std.mem.startsWith(u8, arg, "--threads=")) {
             const value = arg["--threads=".len..];
             const parsed = std.fmt.parseInt(usize, value, 10) catch {
@@ -576,6 +595,101 @@ pub fn main(init: std.process.Init) !void {
     }
 }
 
+fn hasHelpArg(args: []const []const u8) bool {
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) return true;
+    }
+    return false;
+}
+
+const ConfigArgs = struct {
+    enabled: bool = true,
+    path: ?[]const u8 = null,
+};
+
+fn parseConfigArgs(args: []const []const u8) ConfigArgs {
+    var config = ConfigArgs{};
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--no-config")) {
+            config.enabled = false;
+            config.path = null;
+        } else if (std.mem.startsWith(u8, arg, "--config=")) {
+            config.enabled = true;
+            config.path = arg["--config=".len..];
+            if (config.path.?.len == 0) {
+                std.debug.print("utoo-lint: --config requires a path\n", .{});
+                std.process.exit(2);
+            }
+        }
+    }
+    return config;
+}
+
+fn findDefaultConfig(io: std.Io) ?[]const u8 {
+    const cwd = std.Io.Dir.cwd();
+    const candidates = [_][]const u8{
+        "utoo.json",
+        "utoo-lint.json",
+    };
+
+    for (candidates) |path| {
+        const stat = cwd.statFile(io, path, .{}) catch continue;
+        if (stat.kind == .file) return path;
+    }
+    return null;
+}
+
+fn loadConfigFile(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    explicit: bool,
+    options: *lint.Options,
+) !void {
+    const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_config_file_size)) catch |err| {
+        if (explicit) {
+            std.debug.print("utoo-lint: unable to read config {s}: {s}\n", .{ path, @errorName(err) });
+            std.process.exit(2);
+        }
+        return;
+    };
+    defer allocator.free(source);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch |err| {
+        std.debug.print("utoo-lint: invalid config {s}: {s}\n", .{ path, @errorName(err) });
+        std.process.exit(2);
+    };
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => {
+            std.debug.print("utoo-lint: config {s} must be a JSON object\n", .{path});
+            std.process.exit(2);
+        },
+    };
+
+    const rules_value = root.get("rules") orelse return;
+    const rules = switch (rules_value) {
+        .object => |object| object,
+        else => {
+            std.debug.print("utoo-lint: config {s} field \"rules\" must be an object\n", .{path});
+            std.process.exit(2);
+        },
+    };
+
+    var iter = rules.iterator();
+    while (iter.next()) |entry| {
+        options.setByRuleConfigValue(entry.key_ptr.*, entry.value_ptr.*) catch |err| {
+            std.debug.print(
+                "utoo-lint: invalid config {s} rule {s}: {s}\n",
+                .{ path, entry.key_ptr.*, @errorName(err) },
+            );
+            std.process.exit(2);
+        };
+    }
+}
+
 fn collectLintablePaths(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -798,6 +912,8 @@ fn printHelp() void {
         \\  utoo-lint [options] [file-or-directory ...]
         \\
         \\Options:
+        \\  --config=PATH            Read configuration from PATH
+        \\  --no-config              Do not read utoo.json or utoo-lint.json
         \\  --threads=N              Number of worker threads to use
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --array-callback-return=off Disable array-callback-return


### PR DESCRIPTION
## Summary
- load utoo.json or utoo-lint.json by default, with --config and --no-config controls
- support ESLint-style rule severities in config values
- document config usage and add an ESLint migration guide

## Tests
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast
- /Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint input.js (default utoo.json disables no-debugger)
- /Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint --no-config input.js
- /Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint --config=custom.json input.js
- /Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint --help in a directory with invalid config
- /Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint input.js in a directory with unknown-rule config