### PR TITLE
feat: port jsx-a11y scope

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -95,6 +95,7 @@ pub const Options = struct {
     jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,
     jsx_a11y_no_distracting_elements: bool = true,
+    jsx_a11y_scope: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -227,6 +227,8 @@ pub fn main(init: std.process.Init) !void {
             options.jsx_a11y_no_access_key = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-distracting-elements=off")) {
             options.jsx_a11y_no_distracting_elements = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-scope=off")) {
+            options.jsx_a11y_scope = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
             options.no_invalid_regexp = false;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
@@ -993,6 +995,7 @@ fn printHelp() void {
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
         \\  --jsx-a11y-no-distracting-elements=off Disable jsx-a11y/no-distracting-elements
+        \\  --jsx-a11y-scope=off      Disable jsx-a11y/scope
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments

--- a/src/rules/jsx_a11y_scope.zig
+++ b/src/rules/jsx_a11y_scope.zig
@@ -1,0 +1,197 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/scope";
+
+const message = "The scope prop can only be used on <th> elements.";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!isDomElement(tag_name)) return;
+    if (std.ascii.eqlIgnoreCase(tag_name, "th")) return;
+    if (!hasScopeAttribute(tree, opening)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn hasScopeAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (std.ascii.eqlIgnoreCase(name, "scope")) return true;
+    }
+    return false;
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isDomElement(name: []const u8) bool {
+    for (dom_elements) |element| {
+        if (std.ascii.eqlIgnoreCase(name, element)) return true;
+    }
+    return false;
+}
+
+const dom_elements = [_][]const u8{
+    "a",
+    "abbr",
+    "acronym",
+    "address",
+    "applet",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "base",
+    "bdi",
+    "bdo",
+    "big",
+    "blink",
+    "blockquote",
+    "body",
+    "br",
+    "button",
+    "canvas",
+    "caption",
+    "center",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "content",
+    "data",
+    "datalist",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "embed",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "font",
+    "footer",
+    "form",
+    "frame",
+    "frameset",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "hr",
+    "html",
+    "i",
+    "iframe",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "keygen",
+    "label",
+    "legend",
+    "li",
+    "link",
+    "main",
+    "map",
+    "mark",
+    "marquee",
+    "menu",
+    "menuitem",
+    "meta",
+    "meter",
+    "nav",
+    "noembed",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "param",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "rtc",
+    "ruby",
+    "s",
+    "samp",
+    "script",
+    "section",
+    "select",
+    "small",
+    "source",
+    "spacer",
+    "span",
+    "strike",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "title",
+    "tr",
+    "track",
+    "tt",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
+    "xmp",
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
 pub const jsx_a11y_no_distracting_elements = @import("jsx_a11y_no_distracting_elements.zig");
+pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -1814,6 +1815,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_no_distracting_elements) {
             try jsx_a11y_no_distracting_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_scope) {
+            try jsx_a11y_scope.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -83,6 +83,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_scope.zig");
+}
+
+comptime {
     _ = @import("rules/linebreak_style.zig");
 }
 

--- a/tests/rules/jsx_a11y_scope.zig
+++ b/tests/rules/jsx_a11y_scope.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "The scope prop can only be used on <th> elements.";
+
+test "reports jsx-a11y/scope for scope on non-th dom elements" {
+    const source =
+        \\const one = <div scope="row" />;
+        \\const two = <td scope="col" />;
+        \\const three = <span SCOPE />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.jsx_a11y_scope.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/scope on th and custom components" {
+    const source =
+        \\const one = <th scope="row" />;
+        \\const two = <Th scope="row" />;
+        \\const three = <Custom scope="row" />;
+        \\const four = <foo scope="row" />;
+        \\const five = <td />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_scope.id));
+}
+
+test "can disable jsx-a11y/scope" {
+    const source =
+        \\const node = <div scope="row" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_scope = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_scope.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_scope.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/scope for fishlint's default warn configuration
- report scope attributes on DOM elements other than <th> using the upstream diagnostic text
- add the CLI disable flag and focused coverage for invalid, valid, custom-component, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/scope'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-scope=off, and --rules=jsx-a11y/scope