### PR TITLE
feat: add js api

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,23 @@ Run only a focused rule set:
 utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
 ```
 
+Machine-readable output:
+
+```bash
+utoo-lint --format=json src
+```
+
+JavaScript API:
+
+```js
+import { lintFiles } from "@utoo/lint";
+
+const report = lintFiles(["src"], {
+  config: "utoo.json",
+  rules: ["no-debugger"]
+});
+```
+
 ## Architecture
 
 - `src/root.zig` owns parsing, rule execution, and public API exports.

--- a/npm/README.md
+++ b/npm/README.md
@@ -5,6 +5,26 @@ This directory contains the npm CLI wrapper for `@utoo/lint` and the native plat
 - `@utoo/lint` is the JavaScript CLI package.
 - `@utoo/lint-darwin-arm64` contains the native Zig binary for macOS arm64.
 
+The CLI package also exposes a small ESM API:
+
+```js
+import { lintFiles, resolveBinary, run } from "@utoo/lint";
+
+const report = lintFiles(["src", "test"], {
+  config: "utoo.json",
+  rules: ["no-debugger", "@typescript-eslint/no-unused-vars"]
+});
+
+console.log(report.diagnostics);
+console.log(resolveBinary());
+console.log(run(["--help"]).stdout);
+```
+
+`lintFiles()` returns `{ files, diagnostics, exitCode }`. Each diagnostic includes
+`filePath`, `line`, `column`, `severity`, `message`, and `ruleId`. Set
+`UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
+specific native binary during local development.
+
 Build and stage the local native package:
 
 ```bash

--- a/npm/utoo-lint/bin/utoo-lint.js
+++ b/npm/utoo-lint/bin/utoo-lint.js
@@ -1,45 +1,13 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
 
-const require = createRequire(import.meta.url);
-const here = dirname(fileURLToPath(import.meta.url));
+import { resolveBinary } from "../lib/binary.js";
 
-const packages = {
-  "darwin-arm64": "@utoo/lint-darwin-arm64"
-};
-
-const platformKey = `${process.platform}-${process.arch}`;
-const packageName = packages[platformKey];
-
-if (!packageName) {
-  console.error(`utoo-lint: unsupported platform ${platformKey}`);
-  process.exit(1);
-}
-
-const candidates = [
-  () => require.resolve(`${packageName}/bin/utoo-lint`),
-  () => join(here, "..", "..", packageName, "bin", "utoo-lint"),
-  () => join(here, "..", "..", "..", "zig-out", "bin", "utoo-lint")
-];
-
-let binary = null;
-for (const candidate of candidates) {
-  try {
-    const resolved = candidate();
-    if (existsSync(resolved)) {
-      binary = resolved;
-      break;
-    }
-  } catch {}
-}
-
-if (!binary) {
-  console.error(`utoo-lint: missing native package ${packageName}`);
-  console.error("Run `./scripts/package-npm.sh` from the repository root, or install the matching optional dependency.");
+let binary;
+try {
+  binary = resolveBinary();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+
+import { resolveBinary } from "./lib/binary.js";
+
+export { platformPackageName, resolveBinary } from "./lib/binary.js";
+
+export function run(args = [], options = {}) {
+  const cliArgs = normalizeStringArray(args, "args");
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  const binary = options.binary ?? resolveBinary({ env });
+
+  return spawnSync(binary, cliArgs, {
+    cwd: options.cwd,
+    env,
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio
+  });
+}
+
+export function lintFiles(paths = ["."], options = {}) {
+  const cliArgs = buildLintArgs(paths, options);
+  const result = run(cliArgs, { ...options, stdio: undefined, encoding: "utf8" });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const status = result.status ?? 1;
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+
+  if (status !== 0 && status !== 1) {
+    throw new Error(stderr.trim() || `utoo-lint exited with status ${status}`);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`utoo-lint returned invalid JSON: ${error.message}`);
+  }
+
+  report.exitCode = status;
+  if (stderr) {
+    Object.defineProperty(report, "stderr", {
+      value: stderr,
+      enumerable: false
+    });
+  }
+
+  return report;
+}
+
+function buildLintArgs(paths, options) {
+  const cliArgs = [];
+
+  if (options.config) {
+    cliArgs.push(`--config=${options.config}`);
+  }
+  if (options.noConfig) {
+    cliArgs.push("--no-config");
+  }
+  if (options.rules) {
+    const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
+    cliArgs.push(`--rules=${rules}`);
+  }
+  if (options.threads != null) {
+    cliArgs.push(`--threads=${options.threads}`);
+  }
+
+  cliArgs.push("--format=json");
+
+  if (options.extraArgs) {
+    cliArgs.push(...normalizeStringArray(options.extraArgs, "extraArgs"));
+  }
+
+  cliArgs.push(...normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths"));
+  return cliArgs;
+}
+
+function normalizeStringArray(values, name) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${name} must be an array of strings`);
+  }
+  for (const value of values) {
+    if (typeof value !== "string") {
+      throw new TypeError(`${name} must be an array of strings`);
+    }
+  }
+  return values;
+}

--- a/npm/utoo-lint/lib/binary.js
+++ b/npm/utoo-lint/lib/binary.js
@@ -1,0 +1,53 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+const packages = {
+  "darwin-arm64": "@utoo/lint-darwin-arm64"
+};
+
+export function platformPackageName(platform = process.platform, arch = process.arch) {
+  return packages[`${platform}-${arch}`] ?? null;
+}
+
+export function resolveBinary(options = {}) {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+
+  if (env.UTOO_LINT_BIN) {
+    if (existsSync(env.UTOO_LINT_BIN)) {
+      return env.UTOO_LINT_BIN;
+    }
+    throw new Error(`utoo-lint: UTOO_LINT_BIN does not exist: ${env.UTOO_LINT_BIN}`);
+  }
+
+  const packageName = platformPackageName(platform, arch);
+  if (!packageName) {
+    throw new Error(`utoo-lint: unsupported platform ${platform}-${arch}`);
+  }
+
+  const candidates = [
+    () => require.resolve(`${packageName}/bin/utoo-lint`),
+    () => join(here, "..", "..", packageName, "bin", "utoo-lint"),
+    () => join(here, "..", "..", "..", "zig-out", "bin", "utoo-lint")
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const resolved = candidate();
+      if (existsSync(resolved)) {
+        return resolved;
+      }
+    } catch {}
+  }
+
+  throw new Error(
+    `utoo-lint: missing native package ${packageName}. ` +
+      "Run `./scripts/package-npm.sh` from the repository root, or install the matching optional dependency."
+  );
+}

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -12,11 +12,18 @@
   },
   "homepage": "https://github.com/fireairforce/utoo-lint#readme",
   "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./binary": "./lib/binary.js",
+    "./package.json": "./package.json"
+  },
   "bin": {
     "utoo-lint": "./bin/utoo-lint.js"
   },
   "files": [
-    "bin"
+    "bin",
+    "index.js",
+    "lib"
   ],
   "optionalDependencies": {
     "@utoo/lint-darwin-arm64": "0.1.0"

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,6 +16,27 @@ const Stats = struct {
     }
 };
 
+const OutputFormat = enum {
+    text,
+    json,
+};
+
+const JsonDiagnostic = struct {
+    @"filePath": []const u8,
+    line: usize,
+    column: usize,
+    severity: []const u8,
+    message: []const u8,
+    @"ruleId": []const u8,
+};
+
+const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
+
+const JsonReport = struct {
+    files: usize,
+    diagnostics: []const JsonDiagnostic,
+};
+
 const WorkQueue = struct {
     io: std.Io,
     files: []const []const u8,
@@ -50,6 +71,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     var thread_count_override: ?usize = null;
+    var output_format: OutputFormat = .text;
     var targets: std.ArrayList([]const u8) = .empty;
     defer targets.deinit(allocator);
 
@@ -72,6 +94,14 @@ pub fn main(init: std.process.Init) !void {
                 std.process.exit(2);
             }
             thread_count_override = parsed;
+        } else if (std.mem.eql(u8, arg, "--json")) {
+            output_format = .json;
+        } else if (std.mem.startsWith(u8, arg, "--format=")) {
+            const value = arg["--format=".len..];
+            output_format = parseOutputFormat(value) orelse {
+                std.debug.print("utoo-lint: invalid --format value: {s}\n", .{value});
+                std.process.exit(2);
+            };
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
             options = lint.Options.allDisabled();
             parseEnabledRules(arg["--rules=".len..], &options);
@@ -580,17 +610,26 @@ pub fn main(init: std.process.Init) !void {
         files.deinit(allocator);
     }
 
+    var json_diagnostics: JsonDiagnosticList = .empty;
+    defer freeJsonDiagnostics(allocator, &json_diagnostics);
+    const json_diagnostics_ptr: ?*JsonDiagnosticList = if (output_format == .json) &json_diagnostics else null;
+
     var stats = Stats{};
     for (targets.items) |target| {
-        try collectLintablePaths(allocator, io, target, &files, &stats);
+        try collectLintablePaths(allocator, io, target, &files, &stats, json_diagnostics_ptr);
     }
 
-    try lintFiles(allocator, io, files.items, options, thread_count_override, &stats);
+    if (output_format == .json) {
+        try lintFilesJson(allocator, io, files.items, options, &stats, &json_diagnostics);
+        try writeJsonReport(io, stats, json_diagnostics.items);
+    } else {
+        try lintFiles(allocator, io, files.items, options, thread_count_override, &stats);
 
-    std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{
-        stats.files,
-        stats.diagnostics,
-    });
+        std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{
+            stats.files,
+            stats.diagnostics,
+        });
+    }
 
     if (stats.errors > 0 or stats.diagnostics > 0) {
         std.process.exit(1);
@@ -638,6 +677,12 @@ fn findDefaultConfig(io: std.Io) ?[]const u8 {
         const stat = cwd.statFile(io, path, .{}) catch continue;
         if (stat.kind == .file) return path;
     }
+    return null;
+}
+
+fn parseOutputFormat(value: []const u8) ?OutputFormat {
+    if (std.mem.eql(u8, value, "text")) return .text;
+    if (std.mem.eql(u8, value, "json")) return .json;
     return null;
 }
 
@@ -698,10 +743,17 @@ fn collectLintablePaths(
     path: []const u8,
     files: *std.ArrayList([]const u8),
     stats: *Stats,
+    json_diagnostics: ?*JsonDiagnosticList,
 ) !void {
     const cwd = std.Io.Dir.cwd();
     const stat = cwd.statFile(io, path, .{}) catch |err| {
-        std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
+        if (json_diagnostics) |diagnostics| {
+            const message = try std.fmt.allocPrint(allocator, "unable to stat path: {s}", .{@errorName(err)});
+            defer allocator.free(message);
+            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io");
+        } else {
+            std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
+        }
         stats.errors += 1;
         stats.diagnostics += 1;
         return;
@@ -713,7 +765,7 @@ fn collectLintablePaths(
                 try files.append(allocator, try allocator.dupe(u8, path));
             }
         },
-        .directory => try collectLintableDirectory(allocator, io, path, files, stats),
+        .directory => try collectLintableDirectory(allocator, io, path, files, stats, json_diagnostics),
         else => {},
     }
 }
@@ -744,6 +796,7 @@ fn collectLintableDirectory(
     path: []const u8,
     files: *std.ArrayList([]const u8),
     stats: *Stats,
+    json_diagnostics: ?*JsonDiagnosticList,
 ) !void {
     var dir = try std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true });
     defer dir.close(io);
@@ -761,7 +814,7 @@ fn collectLintableDirectory(
                     try files.append(allocator, try allocator.dupe(u8, child_path));
                 }
             },
-            .directory => try collectLintableDirectory(allocator, io, child_path, files, stats),
+            .directory => try collectLintableDirectory(allocator, io, child_path, files, stats, json_diagnostics),
             else => {},
         }
     }
@@ -829,6 +882,19 @@ fn lintFiles(
     }
 }
 
+fn lintFilesJson(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    files: []const []const u8,
+    options: lint.Options,
+    stats: *Stats,
+    json_diagnostics: *JsonDiagnosticList,
+) !void {
+    for (files) |file| {
+        try lintFileJson(allocator, io, file, options, stats, json_diagnostics);
+    }
+}
+
 fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
     while (true) {
         const index = queue.next_index.fetchAdd(1, .monotonic);
@@ -845,6 +911,49 @@ fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
             result.err = err;
             return;
         };
+    }
+}
+
+fn lintFileJson(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    options: lint.Options,
+    stats: *Stats,
+    json_diagnostics: *JsonDiagnosticList,
+) !void {
+    const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
+        const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
+        defer allocator.free(message);
+        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io");
+        stats.errors += 1;
+        stats.diagnostics += 1;
+        return;
+    };
+    defer allocator.free(source);
+
+    var result = try lint.lintSource(allocator, source, path, options);
+    defer result.deinit(allocator);
+
+    stats.files += 1;
+
+    for (result.diagnostics) |diagnostic| {
+        const position = lint.offsetToLineColumn(source, diagnostic.span.start);
+        try appendJsonDiagnostic(
+            allocator,
+            json_diagnostics,
+            path,
+            position.line,
+            position.column,
+            diagnostic.severity.toString(),
+            diagnostic.message,
+            diagnostic.rule_id,
+        );
+
+        stats.diagnostics += 1;
+        if (diagnostic.severity == .@"error") {
+            stats.errors += 1;
+        }
     }
 }
 
@@ -887,6 +996,57 @@ fn lintFile(
     }
 }
 
+fn appendJsonDiagnostic(
+    allocator: std.mem.Allocator,
+    diagnostics: *JsonDiagnosticList,
+    path: []const u8,
+    line: usize,
+    column: usize,
+    severity: []const u8,
+    message: []const u8,
+    rule_id: []const u8,
+) !void {
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+
+    const owned_message = try allocator.dupe(u8, message);
+    errdefer allocator.free(owned_message);
+
+    const owned_rule_id = try allocator.dupe(u8, rule_id);
+    errdefer allocator.free(owned_rule_id);
+
+    try diagnostics.append(allocator, .{
+        .@"filePath" = owned_path,
+        .line = line,
+        .column = column,
+        .severity = severity,
+        .message = owned_message,
+        .@"ruleId" = owned_rule_id,
+    });
+}
+
+fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosticList) void {
+    for (diagnostics.items) |diagnostic| {
+        allocator.free(diagnostic.@"filePath");
+        allocator.free(diagnostic.message);
+        allocator.free(diagnostic.@"ruleId");
+    }
+    diagnostics.deinit(allocator);
+}
+
+fn writeJsonReport(io: std.Io, stats: Stats, diagnostics: []const JsonDiagnostic) !void {
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
+    try std.json.Stringify.value(JsonReport{
+        .files = stats.files,
+        .diagnostics = diagnostics,
+    }, .{}, stdout);
+    try stdout.writeByte('\n');
+    try stdout.flush();
+}
+
 fn printLocked(
     io: std.Io,
     mutex: ?*std.Io.Mutex,
@@ -916,6 +1076,8 @@ fn printHelp() void {
         \\Options:
         \\  --config=PATH            Read configuration from PATH
         \\  --no-config              Do not read utoo.json or utoo-lint.json
+        \\  --format=text|json       Select diagnostic output format
+        \\  --json                   Alias for --format=json
         \\  --threads=N              Number of worker threads to use
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --array-callback-return=off Disable array-callback-return


### PR DESCRIPTION
## Summary
- add machine-readable JSON output for utoo-lint diagnostics
- expose @utoo/lint ESM APIs: lintFiles, run, resolveBinary, platformPackageName
- share native binary resolution between the CLI wrapper and JS API, with UTOO_LINT_BIN override
- document JSON output and JS API usage

## Testing
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast
- ./zig-out/bin/utoo-lint --format=json --rules=no-debugger test/fixtures/bad.ts
- ./zig-out/bin/utoo-lint --json --rules=no-debugger /tmp/utoo-missing-file.ts
- UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node npm/utoo-lint/bin/utoo-lint.js --format=json --rules=no-debugger test/fixtures/bad.ts
- UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node --input-type=module -e 'import { lintFiles, resolveBinary, run } from "./npm/utoo-lint/index.js"; const report = lintFiles(["test/fixtures/bad.ts"], { rules: ["no-debugger"] }); console.log(JSON.stringify({ bin: resolveBinary(), files: report.files, count: report.diagnostics.length, first: report.diagnostics[0], exitCode: report.exitCode })); console.log(run(["--help"]).status);'\n- npm pack --dry-run ./npm/utoo-lint