### PR TITLE
feat: port jsx-a11y aria-unsupported-elements

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -91,6 +91,7 @@ pub const Options = struct {
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_aria_props: bool = true,
+    jsx_a11y_aria_unsupported_elements: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-props=off")) {
             options.jsx_a11y_aria_props = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-unsupported-elements=off")) {
+            options.jsx_a11y_aria_unsupported_elements = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-iframe-has-title=off")) {
             options.jsx_a11y_iframe_has_title = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-img-redundant-alt=off")) {
@@ -1153,6 +1155,7 @@ fn printHelp() void {
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-aria-props=off Disable jsx-a11y/aria-props
+        \\  --jsx-a11y-aria-unsupported-elements=off Disable jsx-a11y/aria-unsupported-elements
         \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key

--- a/src/rules/jsx_a11y_aria_props.zig
+++ b/src/rules/jsx_a11y_aria_props.zig
@@ -7,7 +7,7 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "jsx-a11y/aria-props";
 
-const valid_aria_attributes = [_][]const u8{
+pub const valid_aria_attributes = [_][]const u8{
     "aria-activedescendant",
     "aria-atomic",
     "aria-autocomplete",
@@ -103,7 +103,7 @@ fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
     };
 }
 
-fn isValidAriaAttribute(name: []const u8) bool {
+pub fn isValidAriaAttribute(name: []const u8) bool {
     for (valid_aria_attributes) |attribute| {
         if (std.mem.eql(u8, name, attribute)) return true;
     }

--- a/src/rules/jsx_a11y_aria_unsupported_elements.zig
+++ b/src/rules/jsx_a11y_aria_unsupported_elements.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/aria-unsupported-elements";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!isReservedDomElement(tag_name)) return;
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        var lower_buffer: [64]u8 = undefined;
+        const lower_name = lowerAttributeName(name, &lower_buffer) orelse continue;
+        if (!isUnsupportedAttribute(lower_name)) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "This element does not support ARIA roles, states and properties. Try removing the prop '{s}'.",
+            .{lower_name},
+        );
+    }
+}
+
+fn isUnsupportedAttribute(name: []const u8) bool {
+    if (std.ascii.eqlIgnoreCase(name, "role")) return true;
+    return jsx_a11y_aria_props.isValidAriaAttribute(name);
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn lowerAttributeName(name: []const u8, buffer: *[64]u8) ?[]const u8 {
+    if (name.len > buffer.len) return null;
+    for (name, 0..) |char, index| {
+        buffer[index] = std.ascii.toLower(char);
+    }
+    return buffer[0..name.len];
+}
+
+fn isReservedDomElement(name: []const u8) bool {
+    for (reserved_dom_elements) |element| {
+        if (std.mem.eql(u8, name, element)) return true;
+    }
+    return false;
+}
+
+const reserved_dom_elements = [_][]const u8{
+    "base",
+    "col",
+    "colgroup",
+    "head",
+    "html",
+    "link",
+    "meta",
+    "noembed",
+    "noscript",
+    "param",
+    "picture",
+    "script",
+    "source",
+    "style",
+    "title",
+    "track",
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
+pub const jsx_a11y_aria_unsupported_elements = @import("jsx_a11y_aria_unsupported_elements.zig");
 pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
@@ -1815,6 +1816,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_no_distracting_elements) {
             try jsx_a11y_no_distracting_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_aria_unsupported_elements) {
+            try jsx_a11y_aria_unsupported_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.jsx_a11y_scope) {
             try jsx_a11y_scope.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -67,6 +67,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_aria_unsupported_elements.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_iframe_has_title.zig");
 }
 

--- a/tests/rules/jsx_a11y_aria_unsupported_elements.zig
+++ b/tests/rules/jsx_a11y_aria_unsupported_elements.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports jsx-a11y/aria-unsupported-elements for aria and role on reserved elements" {
+    const source =
+        \\const one = <meta aria-hidden="true" />;
+        \\const two = <script role="button" />;
+        \\const three = <style ARIA-LABEL="theme" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.jsx_a11y_aria_unsupported_elements.id));
+    try std.testing.expect(hasMessage(result, "This element does not support ARIA roles, states and properties. Try removing the prop 'aria-hidden'."));
+    try std.testing.expect(hasMessage(result, "This element does not support ARIA roles, states and properties. Try removing the prop 'role'."));
+    try std.testing.expect(hasMessage(result, "This element does not support ARIA roles, states and properties. Try removing the prop 'aria-label'."));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/aria-unsupported-elements supported and invalid aria props" {
+    const source =
+        \\const one = <div aria-hidden="true" role="button" />;
+        \\const two = <Meta aria-hidden="true" />;
+        \\const three = <meta aria-foo="bar" />;
+        \\const four = <meta data-id="bar" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_aria_props = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_unsupported_elements.id));
+}
+
+test "can disable jsx-a11y/aria-unsupported-elements" {
+    const source =
+        \\const node = <meta aria-hidden="true" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_aria_unsupported_elements = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_unsupported_elements.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_aria_unsupported_elements.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/aria-unsupported-elements for fishlint's default warn configuration
- reject role and valid aria-* attributes on aria-query reserved DOM elements with upstream diagnostic text
- reuse the aria-props valid attribute list and add CLI disable plus focused coverage

## Tests
- zig build test --summary all -- 'jsx-a11y/aria-unsupported-elements'\n- zig build test --summary all -- 'jsx-a11y/aria-props'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-aria-unsupported-elements=off, and --rules=jsx-a11y/aria-unsupported-elements