### PR TITLE
fix: align jsx-a11y scope component matching

### DIFF
--- a/src/rules/jsx_a11y_scope.zig
+++ b/src/rules/jsx_a11y_scope.zig
@@ -18,7 +18,7 @@ pub fn check(
 ) Allocator.Error!void {
     const tag_name = elementName(tree, opening.name) orelse return;
     if (!isDomElement(tag_name)) return;
-    if (std.ascii.eqlIgnoreCase(tag_name, "th")) return;
+    if (std.mem.eql(u8, tag_name, "th")) return;
     if (!hasScopeAttribute(tree, opening)) return;
 
     try core.addDiagnostic(
@@ -59,7 +59,7 @@ fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
 
 fn isDomElement(name: []const u8) bool {
     for (dom_elements) |element| {
-        if (std.ascii.eqlIgnoreCase(name, element)) return true;
+        if (std.mem.eql(u8, name, element)) return true;
     }
     return false;
 }

--- a/tests/rules/jsx_a11y_scope.zig
+++ b/tests/rules/jsx_a11y_scope.zig
@@ -31,6 +31,8 @@ test "allows jsx-a11y/scope on th and custom components" {
         \\const three = <Custom scope="row" />;
         \\const four = <foo scope="row" />;
         \\const five = <td />;
+        \\const six = <Div scope="row" />;
+        \\const seven = <TD scope="row" />;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{


### PR DESCRIPTION
## Summary
- make jsx-a11y/scope element matching case-sensitive like upstream getElementType/dom lookup
- avoid reporting custom components such as <Div scope> or <TD scope>
- add focused regression coverage for uppercase component names

## Tests
- zig build test --summary all -- 'jsx-a11y/scope'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for --rules=jsx-a11y/scope with <td> and <Div>