### PR TITLE
feat: port jsx-a11y aria-role

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -91,6 +91,7 @@ pub const Options = struct {
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_aria_props: bool = true,
+    jsx_a11y_aria_role: bool = true,
     jsx_a11y_aria_unsupported_elements: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-props=off")) {
             options.jsx_a11y_aria_props = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-role=off")) {
+            options.jsx_a11y_aria_role = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-unsupported-elements=off")) {
             options.jsx_a11y_aria_unsupported_elements = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-iframe-has-title=off")) {
@@ -1155,6 +1157,7 @@ fn printHelp() void {
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-aria-props=off Disable jsx-a11y/aria-props
+        \\  --jsx-a11y-aria-role=off Disable jsx-a11y/aria-role
         \\  --jsx-a11y-aria-unsupported-elements=off Disable jsx-a11y/aria-unsupported-elements
         \\  --jsx-a11y-iframe-has-title=off Disable jsx-a11y/iframe-has-title
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt

--- a/src/rules/jsx_a11y_aria_role.zig
+++ b/src/rules/jsx_a11y_aria_role.zig
@@ -1,0 +1,395 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/aria-role";
+
+const message = "Elements with ARIA roles must use a valid, non-abstract ARIA role.";
+
+const RoleValueStatus = enum {
+    valid,
+    invalid,
+    ignored,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+) Allocator.Error!void {
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!isDomElement(tag_name)) return;
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (!std.ascii.eqlIgnoreCase(name, "role")) continue;
+
+        switch (roleValueStatus(tree, attribute.value)) {
+            .valid, .ignored => {},
+            .invalid => try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                message,
+                tree.span(attribute_index),
+            ),
+        }
+    }
+}
+
+fn roleValueStatus(tree: *const ast.Tree, value_index: ast.NodeIndex) RoleValueStatus {
+    if (value_index == .null) return .invalid;
+
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| validateRoleList(tree.string(literal.value)),
+        .jsx_expression_container => |container| roleExpressionStatus(tree, container.expression),
+        else => .ignored,
+    };
+}
+
+fn roleExpressionStatus(tree: *const ast.Tree, expression_index: ast.NodeIndex) RoleValueStatus {
+    return switch (tree.data(expression_index)) {
+        .string_literal => |literal| validateRoleList(tree.string(literal.value)),
+        .template_literal => |literal| templateRoleStatus(tree, literal),
+        .identifier_reference => |identifier| identifierRoleStatus(tree.string(identifier.name)),
+        .boolean_literal,
+        .null_literal,
+        .numeric_literal,
+        => .invalid,
+        else => .ignored,
+    };
+}
+
+fn templateRoleStatus(tree: *const ast.Tree, literal: ast.TemplateLiteral) RoleValueStatus {
+    if (literal.expressions.len != 0) return .invalid;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return validateRoleList("");
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| validateRoleList(tree.string(element.cooked)),
+        else => .ignored,
+    };
+}
+
+fn identifierRoleStatus(name: []const u8) RoleValueStatus {
+    if (std.mem.eql(u8, name, "undefined")) return .ignored;
+    if (std.mem.eql(u8, name, "Array") or
+        std.mem.eql(u8, name, "Date") or
+        std.mem.eql(u8, name, "Infinity") or
+        std.mem.eql(u8, name, "Math") or
+        std.mem.eql(u8, name, "Number") or
+        std.mem.eql(u8, name, "Object") or
+        std.mem.eql(u8, name, "String"))
+    {
+        return .invalid;
+    }
+    return .ignored;
+}
+
+fn validateRoleList(value: []const u8) RoleValueStatus {
+    var values = std.mem.splitScalar(u8, value, ' ');
+    while (values.next()) |role| {
+        if (!isValidRole(role)) return .invalid;
+    }
+    return .valid;
+}
+
+fn isValidRole(role: []const u8) bool {
+    for (valid_roles) |valid_role| {
+        if (std.mem.eql(u8, role, valid_role)) return true;
+    }
+    return false;
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isDomElement(name: []const u8) bool {
+    for (dom_elements) |element| {
+        if (std.mem.eql(u8, name, element)) return true;
+    }
+    return false;
+}
+
+const valid_roles = [_][]const u8{
+    "alert",
+    "alertdialog",
+    "application",
+    "article",
+    "banner",
+    "blockquote",
+    "button",
+    "caption",
+    "cell",
+    "checkbox",
+    "code",
+    "columnheader",
+    "combobox",
+    "complementary",
+    "contentinfo",
+    "definition",
+    "deletion",
+    "dialog",
+    "directory",
+    "doc-abstract",
+    "doc-acknowledgments",
+    "doc-afterword",
+    "doc-appendix",
+    "doc-backlink",
+    "doc-biblioentry",
+    "doc-bibliography",
+    "doc-biblioref",
+    "doc-chapter",
+    "doc-colophon",
+    "doc-conclusion",
+    "doc-cover",
+    "doc-credit",
+    "doc-credits",
+    "doc-dedication",
+    "doc-endnote",
+    "doc-endnotes",
+    "doc-epigraph",
+    "doc-epilogue",
+    "doc-errata",
+    "doc-example",
+    "doc-footnote",
+    "doc-foreword",
+    "doc-glossary",
+    "doc-glossref",
+    "doc-index",
+    "doc-introduction",
+    "doc-noteref",
+    "doc-notice",
+    "doc-pagebreak",
+    "doc-pagefooter",
+    "doc-pageheader",
+    "doc-pagelist",
+    "doc-part",
+    "doc-preface",
+    "doc-prologue",
+    "doc-pullquote",
+    "doc-qna",
+    "doc-subtitle",
+    "doc-tip",
+    "doc-toc",
+    "document",
+    "emphasis",
+    "feed",
+    "figure",
+    "form",
+    "generic",
+    "graphics-document",
+    "graphics-object",
+    "graphics-symbol",
+    "grid",
+    "gridcell",
+    "group",
+    "heading",
+    "img",
+    "insertion",
+    "link",
+    "list",
+    "listbox",
+    "listitem",
+    "log",
+    "main",
+    "mark",
+    "marquee",
+    "math",
+    "menu",
+    "menubar",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "meter",
+    "navigation",
+    "none",
+    "note",
+    "option",
+    "paragraph",
+    "presentation",
+    "progressbar",
+    "radio",
+    "radiogroup",
+    "region",
+    "row",
+    "rowgroup",
+    "rowheader",
+    "scrollbar",
+    "search",
+    "searchbox",
+    "separator",
+    "slider",
+    "spinbutton",
+    "status",
+    "strong",
+    "subscript",
+    "superscript",
+    "switch",
+    "tab",
+    "table",
+    "tablist",
+    "tabpanel",
+    "term",
+    "textbox",
+    "time",
+    "timer",
+    "toolbar",
+    "tooltip",
+    "tree",
+    "treegrid",
+    "treeitem",
+};
+
+const dom_elements = [_][]const u8{
+    "a",
+    "abbr",
+    "acronym",
+    "address",
+    "applet",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "base",
+    "bdi",
+    "bdo",
+    "big",
+    "blink",
+    "blockquote",
+    "body",
+    "br",
+    "button",
+    "canvas",
+    "caption",
+    "center",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "content",
+    "data",
+    "datalist",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "embed",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "font",
+    "footer",
+    "form",
+    "frame",
+    "frameset",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "hr",
+    "html",
+    "i",
+    "iframe",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "keygen",
+    "label",
+    "legend",
+    "li",
+    "link",
+    "main",
+    "map",
+    "mark",
+    "marquee",
+    "menu",
+    "menuitem",
+    "meta",
+    "meter",
+    "nav",
+    "noembed",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "param",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "rtc",
+    "ruby",
+    "s",
+    "samp",
+    "script",
+    "section",
+    "select",
+    "small",
+    "source",
+    "spacer",
+    "span",
+    "strike",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "title",
+    "tr",
+    "track",
+    "tt",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
+    "xmp",
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
+pub const jsx_a11y_aria_role = @import("jsx_a11y_aria_role.zig");
 pub const jsx_a11y_aria_unsupported_elements = @import("jsx_a11y_aria_unsupported_elements.zig");
 pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
@@ -1819,6 +1820,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_aria_unsupported_elements) {
             try jsx_a11y_aria_unsupported_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+        }
+        if (self.options.jsx_a11y_aria_role) {
+            try jsx_a11y_aria_role.check(self.allocator, self.diagnostics, ctx.tree, opening);
         }
         if (self.options.jsx_a11y_scope) {
             try jsx_a11y_scope.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -67,6 +67,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_aria_role.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_aria_unsupported_elements.zig");
 }
 

--- a/tests/rules/jsx_a11y_aria_role.zig
+++ b/tests/rules/jsx_a11y_aria_role.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "Elements with ARIA roles must use a valid, non-abstract ARIA role.";
+
+test "reports jsx-a11y/aria-role for invalid and abstract roles" {
+    const source =
+        \\const one = <div role="foo" />;
+        \\const two = <span role="widget" />;
+        \\const three = <section role="button foo" />;
+        \\const four = <div role />;
+        \\const five = <div role={null} />;
+        \\const six = <div role={false} />;
+        \\const seven = <div role={`${name}`} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.jsx_a11y_aria_role.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/aria-role valid roles and non-dom elements" {
+    const source =
+        \\const one = <div role="button" />;
+        \\const two = <span role="button link" />;
+        \\const three = <div role={`button`} />;
+        \\const four = <Foo role="foo" />;
+        \\const five = <Div role="foo" />;
+        \\const six = <foo role="foo" />;
+        \\const seven = <div role={role} />;
+        \\const eight = <div role={undefined} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_role.id));
+}
+
+test "can disable jsx-a11y/aria-role" {
+    const source =
+        \\const node = <div role="foo" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_aria_role = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_role.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_aria_role.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/aria-role for fishlint's warn configuration with ignoreNonDOM behavior
- validate DOM role attributes against aria-query non-abstract roles, including space-separated role lists
- add CLI disable support plus focused invalid, valid, dynamic, custom-component, and disabled coverage

## Tests
- zig build test --summary all -- 'jsx-a11y/aria-role'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-aria-role=off, and --rules=jsx-a11y/aria-role