### PR TITLE
feat: port jsx-a11y anchor-has-content

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
+    jsx_a11y_anchor_has_content: bool = true,
     jsx_a11y_aria_props: bool = true,
     jsx_a11y_aria_proptypes: bool = true,
     jsx_a11y_aria_role: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-anchor-has-content=off")) {
+            options.jsx_a11y_anchor_has_content = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-props=off")) {
             options.jsx_a11y_aria_props = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-proptypes=off")) {
@@ -1158,6 +1160,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
+        \\  --jsx-a11y-anchor-has-content=off Disable jsx-a11y/anchor-has-content
         \\  --jsx-a11y-aria-props=off Disable jsx-a11y/aria-props
         \\  --jsx-a11y-aria-proptypes=off Disable jsx-a11y/aria-proptypes
         \\  --jsx-a11y-aria-role=off Disable jsx-a11y/aria-role

--- a/src/rules/jsx_a11y_anchor_has_content.zig
+++ b/src/rules/jsx_a11y_anchor_has_content.zig
@@ -1,0 +1,147 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/anchor-has-content";
+
+const message = "Anchors must have content and the content must be accessible by a screen reader.";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return,
+    };
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!std.mem.eql(u8, tag_name, "a")) return;
+
+    if (hasAccessibleChild(tree, element) or hasAnyAttribute(tree, opening, &.{ "title", "aria-label" })) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn hasAccessibleChild(tree: *const ast.Tree, element: ast.JSXElement) bool {
+    for (tree.extra(element.children)) |child_index| {
+        switch (tree.data(child_index)) {
+            .jsx_text => |text| {
+                if (tree.string(text.value).len != 0) return true;
+            },
+            .jsx_element => |child| {
+                if (!isHiddenFromScreenReader(tree, child)) return true;
+            },
+            .jsx_expression_container => |container| {
+                if (tree.data(container.expression) == .identifier_reference) {
+                    const identifier = tree.data(container.expression).identifier_reference;
+                    if (!std.mem.eql(u8, tree.string(identifier.name), "undefined")) return true;
+                } else {
+                    return true;
+                }
+            },
+            else => {},
+        }
+    }
+
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return false,
+    };
+    return hasAnyAttribute(tree, opening, &.{ "dangerouslySetInnerHTML", "children" });
+}
+
+fn isHiddenFromScreenReader(tree: *const ast.Tree, element: ast.JSXElement) bool {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return false,
+    };
+    const tag_name = elementName(tree, opening.name) orelse return false;
+
+    if (std.mem.eql(u8, tag_name, "input")) {
+        if (attributeNamed(tree, opening, "type")) |attribute| {
+            if (literalStringValue(tree, attribute.value)) |value| {
+                if (std.ascii.eqlIgnoreCase(value, "hidden")) return true;
+            }
+        }
+    }
+
+    const aria_hidden = attributeNamed(tree, opening, "aria-hidden") orelse return false;
+    return propValueIsTrue(tree, aria_hidden.value);
+}
+
+fn propValueIsTrue(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+    if (value_index == .null) return true;
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| std.ascii.eqlIgnoreCase(tree.string(literal.value), "true"),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .boolean_literal => |literal| literal.value,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn literalStringValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?[]const u8 {
+    if (value_index == .null) return null;
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn hasAnyAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement, names: []const []const u8) bool {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        for (names) |expected| {
+            if (std.mem.eql(u8, name, expected)) return true;
+        }
+    }
+    return false;
+}
+
+fn attributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, expected: []const u8) ?ast.JSXAttribute {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (std.mem.eql(u8, name, expected)) return attribute;
+    }
+    return null;
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
 pub const jsx_a11y_aria_proptypes = @import("jsx_a11y_aria_proptypes.zig");
 pub const jsx_a11y_aria_role = @import("jsx_a11y_aria_role.zig");
@@ -1794,6 +1795,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_danger_with_children) {
             try react_no_danger_with_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, &self.react_no_danger_with_children_bindings);
+        }
+        if (self.options.jsx_a11y_anchor_has_content) {
+            try jsx_a11y_anchor_has_content.check(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
         if (self.options.react_void_dom_elements_no_children) {
             try react_void_dom_elements_no_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_anchor_has_content.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_aria_props.zig");
 }
 

--- a/tests/rules/jsx_a11y_anchor_has_content.zig
+++ b/tests/rules/jsx_a11y_anchor_has_content.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const message = "Anchors must have content and the content must be accessible by a screen reader.";
+
+test "reports jsx-a11y/anchor-has-content for empty anchors" {
+    const source =
+        \\const one = <a />;
+        \\const two = <a></a>;
+        \\const three = <a>{undefined}</a>;
+        \\const four = <a><span aria-hidden /></a>;
+        \\const five = <a><input type="hidden" /></a>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.jsx_a11y_anchor_has_content.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(message, diagnostic.message);
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/anchor-has-content accessible content and labels" {
+    const source =
+        \\const one = <a>text</a>;
+        \\const two = <a>{text}</a>;
+        \\const three = <a>{false}</a>;
+        \\const four = <a><span /></a>;
+        \\const five = <a title="x" />;
+        \\const six = <a aria-label="x" />;
+        \\const seven = <a dangerouslySetInnerHTML={{ __html: html }} />;
+        \\const eight = <a children="text" />;
+        \\const nine = <A />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_anchor_has_content.id));
+}
+
+test "can disable jsx-a11y/anchor-has-content" {
+    const source =
+        \\const node = <a />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_anchor_has_content = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_anchor_has_content.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_anchor_has_content.id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -11,6 +11,7 @@ test "reports react/jsx-no-target-blank for external and dynamic links without n
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
         .eol_last = false,
+        .jsx_a11y_anchor_has_content = false,
         .no_undef = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary
- add jsx-a11y/anchor-has-content for fishlint's warn configuration
- require <a> elements to have accessible children or title/aria-label, including aria-hidden/input hidden child handling
- add CLI disable support and focused coverage for empty, accessible, labeled, dangerous-html, children-prop, and disabled cases

## Tests
- zig build test --summary all -- 'jsx-a11y/anchor-has-content'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-anchor-has-content=off, and --rules=jsx-a11y/anchor-has-content