### PR TITLE
feat: port jsx-a11y role-has-required-aria-props

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -99,6 +99,7 @@ pub const Options = struct {
     jsx_a11y_img_redundant_alt: bool = true,
     jsx_a11y_no_access_key: bool = true,
     jsx_a11y_no_distracting_elements: bool = true,
+    jsx_a11y_role_has_required_aria_props: bool = true,
     jsx_a11y_scope: bool = true,
     no_invalid_regexp: bool = true,
     no_irregular_whitespace: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -265,6 +265,8 @@ pub fn main(init: std.process.Init) !void {
             options.jsx_a11y_no_access_key = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-no-distracting-elements=off")) {
             options.jsx_a11y_no_distracting_elements = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-role-has-required-aria-props=off")) {
+            options.jsx_a11y_role_has_required_aria_props = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-scope=off")) {
             options.jsx_a11y_scope = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
@@ -1169,6 +1171,7 @@ fn printHelp() void {
         \\  --jsx-a11y-img-redundant-alt=off Disable jsx-a11y/img-redundant-alt
         \\  --jsx-a11y-no-access-key=off Disable jsx-a11y/no-access-key
         \\  --jsx-a11y-no-distracting-elements=off Disable jsx-a11y/no-distracting-elements
+        \\  --jsx-a11y-role-has-required-aria-props=off Disable jsx-a11y/role-has-required-aria-props
         \\  --jsx-a11y-scope=off      Disable jsx-a11y/scope
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace

--- a/src/rules/jsx_a11y_role_has_required_aria_props.zig
+++ b/src/rules/jsx_a11y_role_has_required_aria_props.zig
@@ -1,0 +1,317 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/role-has-required-aria-props";
+
+const RequiredRole = struct {
+    role: []const u8,
+    props: []const []const u8,
+    props_message: []const u8,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+) Allocator.Error!void {
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!isDomElement(tag_name)) return;
+
+    const role_attribute = attributeNamed(tree, opening, "role") orelse return;
+    const role_value = roleLiteralValue(tree, role_attribute.value) orelse return;
+    if (isSemanticRoleElement(tree, opening, tag_name, role_value)) return;
+
+    var roles = std.mem.splitScalar(u8, role_value, ' ');
+    while (roles.next()) |role| {
+        const required = requiredRole(role) orelse continue;
+        if (hasAllRequiredProps(tree, opening, required.props)) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(role_attribute.name),
+            "Elements with the ARIA role \"{s}\" must have the following attributes defined: {s}",
+            .{ role, required.props_message },
+        );
+    }
+}
+
+fn hasAllRequiredProps(tree: *const ast.Tree, opening: ast.JSXOpeningElement, props: []const []const u8) bool {
+    for (props) |prop| {
+        if (attributeNamed(tree, opening, prop) == null) return false;
+    }
+    return true;
+}
+
+fn roleLiteralValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?[]const u8 {
+    if (value_index == .null) return "true";
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| literalRoleValue(tree.string(literal.value)),
+        .jsx_expression_container => |container| roleExpressionValue(tree, container.expression),
+        else => null,
+    };
+}
+
+fn roleExpressionValue(tree: *const ast.Tree, expression_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(expression_index)) {
+        .string_literal => |literal| literalRoleValue(tree.string(literal.value)),
+        .template_literal => |literal| templateRoleValue(tree, literal),
+        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined")) null else null,
+        .boolean_literal => |literal| if (literal.value) "true" else "false",
+        .null_literal => null,
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn literalRoleValue(value: []const u8) []const u8 {
+    if (std.ascii.eqlIgnoreCase(value, "true")) return "true";
+    if (std.ascii.eqlIgnoreCase(value, "false")) return "false";
+    return value;
+}
+
+fn templateRoleValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn isSemanticRoleElement(tree: *const ast.Tree, opening: ast.JSXOpeningElement, tag_name: []const u8, role: []const u8) bool {
+    if (std.mem.eql(u8, tag_name, "input")) {
+        const typ = attributeNamed(tree, opening, "type") orelse return false;
+        const type_value = literalStringValue(tree, typ.value) orelse return false;
+        if (std.ascii.eqlIgnoreCase(type_value, "checkbox")) {
+            return std.mem.eql(u8, role, "checkbox") or std.mem.eql(u8, role, "switch");
+        }
+        if (std.ascii.eqlIgnoreCase(type_value, "radio")) {
+            return std.mem.eql(u8, role, "radio");
+        }
+        return false;
+    }
+
+    if (std.mem.eql(u8, tag_name, "select")) {
+        if (attributeNamed(tree, opening, "multiple") != null) return std.mem.eql(u8, role, "listbox");
+        return std.mem.eql(u8, role, "combobox");
+    }
+
+    if (std.mem.eql(u8, tag_name, "progress")) return std.mem.eql(u8, role, "progressbar");
+    if (std.mem.eql(u8, tag_name, "meter")) return std.mem.eql(u8, role, "meter");
+    return false;
+}
+
+fn literalStringValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?[]const u8 {
+    if (value_index == .null) return null;
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .jsx_expression_container => |container| switch (tree.data(container.expression)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn requiredRole(role: []const u8) ?RequiredRole {
+    for (required_roles) |required| {
+        if (std.mem.eql(u8, role, required.role)) return required;
+    }
+    return null;
+}
+
+fn attributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, expected: []const u8) ?ast.JSXAttribute {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (std.ascii.eqlIgnoreCase(name, expected)) return attribute;
+    }
+    return null;
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isDomElement(name: []const u8) bool {
+    for (dom_elements) |element| {
+        if (std.mem.eql(u8, name, element)) return true;
+    }
+    return false;
+}
+
+const props_aria_checked = [_][]const u8{"aria-checked"};
+const props_combobox = [_][]const u8{ "aria-controls", "aria-expanded" };
+const props_aria_level = [_][]const u8{"aria-level"};
+const props_meter = [_][]const u8{"aria-valuenow"};
+const props_aria_selected = [_][]const u8{"aria-selected"};
+const props_scrollbar = [_][]const u8{ "aria-controls", "aria-valuenow" };
+
+const required_roles = [_]RequiredRole{
+    .{ .role = "checkbox", .props = &props_aria_checked, .props_message = "aria-checked" },
+    .{ .role = "combobox", .props = &props_combobox, .props_message = "aria-controls,aria-expanded" },
+    .{ .role = "heading", .props = &props_aria_level, .props_message = "aria-level" },
+    .{ .role = "menuitemcheckbox", .props = &props_aria_checked, .props_message = "aria-checked" },
+    .{ .role = "menuitemradio", .props = &props_aria_checked, .props_message = "aria-checked" },
+    .{ .role = "meter", .props = &props_meter, .props_message = "aria-valuenow" },
+    .{ .role = "option", .props = &props_aria_selected, .props_message = "aria-selected" },
+    .{ .role = "radio", .props = &props_aria_checked, .props_message = "aria-checked" },
+    .{ .role = "scrollbar", .props = &props_scrollbar, .props_message = "aria-controls,aria-valuenow" },
+    .{ .role = "slider", .props = &props_meter, .props_message = "aria-valuenow" },
+    .{ .role = "switch", .props = &props_aria_checked, .props_message = "aria-checked" },
+    .{ .role = "treeitem", .props = &props_aria_selected, .props_message = "aria-selected" },
+};
+
+const dom_elements = [_][]const u8{
+    "a",
+    "abbr",
+    "acronym",
+    "address",
+    "applet",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "base",
+    "bdi",
+    "bdo",
+    "big",
+    "blink",
+    "blockquote",
+    "body",
+    "br",
+    "button",
+    "canvas",
+    "caption",
+    "center",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "content",
+    "data",
+    "datalist",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "embed",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "font",
+    "footer",
+    "form",
+    "frame",
+    "frameset",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "hr",
+    "html",
+    "i",
+    "iframe",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "keygen",
+    "label",
+    "legend",
+    "li",
+    "link",
+    "main",
+    "map",
+    "mark",
+    "marquee",
+    "menu",
+    "menuitem",
+    "meta",
+    "meter",
+    "nav",
+    "noembed",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "param",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "rtc",
+    "ruby",
+    "s",
+    "samp",
+    "script",
+    "section",
+    "select",
+    "small",
+    "source",
+    "spacer",
+    "span",
+    "strike",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "title",
+    "tr",
+    "track",
+    "tt",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
+    "xmp",
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -38,6 +38,7 @@ pub const jsx_a11y_iframe_has_title = @import("jsx_a11y_iframe_has_title.zig");
 pub const jsx_a11y_img_redundant_alt = @import("jsx_a11y_img_redundant_alt.zig");
 pub const jsx_a11y_no_access_key = @import("jsx_a11y_no_access_key.zig");
 pub const jsx_a11y_no_distracting_elements = @import("jsx_a11y_no_distracting_elements.zig");
+pub const jsx_a11y_role_has_required_aria_props = @import("jsx_a11y_role_has_required_aria_props.zig");
 pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const new_cap = @import("new_cap.zig");
@@ -1831,6 +1832,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_aria_role) {
             try jsx_a11y_aria_role.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        if (self.options.jsx_a11y_role_has_required_aria_props) {
+            try jsx_a11y_role_has_required_aria_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
         }
         if (self.options.jsx_a11y_scope) {
             try jsx_a11y_scope.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_role_has_required_aria_props.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_scope.zig");
 }
 

--- a/tests/rules/jsx_a11y_role_has_required_aria_props.zig
+++ b/tests/rules/jsx_a11y_role_has_required_aria_props.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports jsx-a11y/role-has-required-aria-props missing required props" {
+    const source =
+        \\const one = <div role="checkbox" />;
+        \\const two = <div role="heading" />;
+        \\const three = <div role="heading checkbox" />;
+        \\const four = <div role="combobox" aria-controls="id" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.jsx_a11y_role_has_required_aria_props.id));
+    try std.testing.expect(hasMessage(result, "Elements with the ARIA role \"checkbox\" must have the following attributes defined: aria-checked"));
+    try std.testing.expect(hasMessage(result, "Elements with the ARIA role \"heading\" must have the following attributes defined: aria-level"));
+    try std.testing.expect(hasMessage(result, "Elements with the ARIA role \"combobox\" must have the following attributes defined: aria-controls,aria-expanded"));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/role-has-required-aria-props satisfied dynamic and semantic cases" {
+    const source =
+        \\const one = <div role="checkbox" aria-checked="false" />;
+        \\const two = <div role="combobox" aria-controls="id" aria-expanded="false" />;
+        \\const three = <Foo role="checkbox" />;
+        \\const four = <div role={role} />;
+        \\const five = <input type="checkbox" role="switch" />;
+        \\const six = <div role="button" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_role_has_required_aria_props.id));
+}
+
+test "can disable jsx-a11y/role-has-required-aria-props" {
+    const source =
+        \\const node = <div role="checkbox" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_role_has_required_aria_props = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_role_has_required_aria_props.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_role_has_required_aria_props.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/role-has-required-aria-props for fishlint's warn configuration
- validate required aria props for explicit ARIA roles, including multi-role values and semantic input/select skips
- add CLI disable support plus focused missing, satisfied, semantic, dynamic, and disabled coverage

## Tests
- zig build test --summary all -- 'jsx-a11y/role-has-required-aria-props'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast -j1\n- CLI smoke for default warning, --jsx-a11y-role-has-required-aria-props=off, and --rules=jsx-a11y/role-has-required-aria-props