### PR TITLE
feat: port jsx-a11y alt-text

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_self_import: bool = true,
+    jsx_a11y_alt_text: bool = true,
     jsx_a11y_anchor_has_content: bool = true,
     jsx_a11y_aria_props: bool = true,
     jsx_a11y_aria_proptypes: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
+        } else if (std.mem.eql(u8, arg, "--jsx-a11y-alt-text=off")) {
+            options.jsx_a11y_alt_text = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-anchor-has-content=off")) {
             options.jsx_a11y_anchor_has_content = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-aria-props=off")) {
@@ -1162,6 +1164,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-self-import=off Disable import/no-self-import
+        \\  --jsx-a11y-alt-text=off   Disable jsx-a11y/alt-text
         \\  --jsx-a11y-anchor-has-content=off Disable jsx-a11y/anchor-has-content
         \\  --jsx-a11y-aria-props=off Disable jsx-a11y/aria-props
         \\  --jsx-a11y-aria-proptypes=off Disable jsx-a11y/aria-proptypes

--- a/src/rules/jsx_a11y_alt_text.zig
+++ b/src/rules/jsx_a11y_alt_text.zig
@@ -1,0 +1,345 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jsx-a11y/alt-text";
+
+pub fn checkOpeningElement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (std.mem.eql(u8, tag_name, "img")) {
+        try checkImg(allocator, diagnostics, tree, opening, index, tag_name);
+    } else if (std.mem.eql(u8, tag_name, "area")) {
+        try checkArea(allocator, diagnostics, tree, opening, index);
+    } else if (std.mem.eql(u8, tag_name, "input")) {
+        try checkInputImage(allocator, diagnostics, tree, opening, index);
+    }
+}
+
+pub fn checkElement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return,
+    };
+    const tag_name = elementName(tree, opening.name) orelse return;
+    if (!std.mem.eql(u8, tag_name, "object")) return;
+
+    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
+        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")) or
+        titleHasValue(tree, attributeNamed(tree, opening, "title")) or
+        hasAccessibleChild(tree, element))
+    {
+        return;
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.",
+        tree.span(index),
+    );
+}
+
+fn checkImg(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+    tag_name: []const u8,
+) Allocator.Error!void {
+    const alt = attributeNamed(tree, opening, "alt");
+    if (alt == null) {
+        if (isPresentationRole(tree, opening)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Prefer alt=\"\" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML.",
+                tree.span(index),
+            );
+            return;
+        }
+        if (attributeNamed(tree, opening, "aria-label")) |attribute| {
+            if (!ariaLabelHasValue(tree, attribute)) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images.",
+                    tree.span(index),
+                );
+            }
+            return;
+        }
+        if (attributeNamed(tree, opening, "aria-labelledby")) |attribute| {
+            if (!ariaLabelHasValue(tree, attribute)) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "The aria-labelledby attribute must have a value. The alt attribute is preferred over aria-labelledby for images.",
+                    tree.span(index),
+                );
+            }
+            return;
+        }
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "{s} elements must have an alt prop, either with meaningful text, or an empty string for decorative images.",
+            .{tag_name},
+        );
+        return;
+    }
+
+    if (altValueIsValid(tree, alt.?)) return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Invalid alt value for {s}. Use alt=\"\" for presentational images.",
+        .{tag_name},
+    );
+}
+
+fn checkArea(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
+        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
+    {
+        return;
+    }
+
+    const alt = attributeNamed(tree, opening, "alt");
+    if (alt != null and altValueIsValid(tree, alt.?)) return;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
+        tree.span(index),
+    );
+}
+
+fn checkInputImage(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const typ = attributeNamed(tree, opening, "type") orelse return;
+    const type_value = propValue(tree, typ.value) orelse return;
+    switch (type_value) {
+        .string => |string| if (!std.mem.eql(u8, string, "image")) return,
+        else => return,
+    }
+
+    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
+        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
+    {
+        return;
+    }
+
+    const alt = attributeNamed(tree, opening, "alt");
+    if (alt != null and altValueIsValid(tree, alt.?)) return;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
+        tree.span(index),
+    );
+}
+
+const PropValue = union(enum) {
+    string: []const u8,
+    boolean: bool,
+    number: []const u8,
+};
+
+fn propValue(tree: *const ast.Tree, value_index: ast.NodeIndex) ?PropValue {
+    if (value_index == .null) return .{ .boolean = true };
+    return switch (tree.data(value_index)) {
+        .string_literal => |literal| valueFromString(tree.string(literal.value)),
+        .jsx_expression_container => |container| expressionValue(tree, container.expression),
+        else => null,
+    };
+}
+
+fn expressionValue(tree: *const ast.Tree, expression_index: ast.NodeIndex) ?PropValue {
+    return switch (tree.data(expression_index)) {
+        .string_literal => |literal| valueFromString(tree.string(literal.value)),
+        .boolean_literal => |literal| .{ .boolean = literal.value },
+        .numeric_literal => |literal| .{ .number = tree.string(literal.raw) },
+        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined")) null else null,
+        .null_literal => null,
+        .template_literal => |literal| templateValue(tree, literal),
+        else => null,
+    };
+}
+
+fn valueFromString(value: []const u8) PropValue {
+    if (std.ascii.eqlIgnoreCase(value, "true")) return .{ .boolean = true };
+    if (std.ascii.eqlIgnoreCase(value, "false")) return .{ .boolean = false };
+    return .{ .string = value };
+}
+
+fn templateValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?PropValue {
+    if (literal.expressions.len != 0) return .{ .string = "{expression}" };
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return .{ .string = "" };
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| valueFromString(tree.string(element.cooked)),
+        else => null,
+    };
+}
+
+fn ariaLabelHasValue(tree: *const ast.Tree, attribute: ?ast.JSXAttribute) bool {
+    const attr = attribute orelse return false;
+    const value = propValue(tree, attr.value) orelse return false;
+    return switch (value) {
+        .string => |string| string.len != 0,
+        else => true,
+    };
+}
+
+fn titleHasValue(tree: *const ast.Tree, attribute: ?ast.JSXAttribute) bool {
+    const attr = attribute orelse return false;
+    const value = propValue(tree, attr.value) orelse return false;
+    return switch (value) {
+        .string => |string| string.len != 0,
+        else => true,
+    };
+}
+
+fn altValueIsValid(tree: *const ast.Tree, attribute: ast.JSXAttribute) bool {
+    if (attribute.value == .null) return false;
+    const value = propValue(tree, attribute.value) orelse return false;
+    return switch (value) {
+        .string => true,
+        .boolean => |boolean| boolean,
+        .number => |number| number.len != 0,
+    };
+}
+
+fn isPresentationRole(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+    const role = attributeNamed(tree, opening, "role") orelse return false;
+    const value = propValue(tree, role.value) orelse return false;
+    return switch (value) {
+        .string => |string| std.mem.eql(u8, string, "presentation") or std.mem.eql(u8, string, "none"),
+        else => false,
+    };
+}
+
+fn hasAccessibleChild(tree: *const ast.Tree, element: ast.JSXElement) bool {
+    for (tree.extra(element.children)) |child_index| {
+        switch (tree.data(child_index)) {
+            .jsx_text => |text| {
+                if (tree.string(text.value).len != 0) return true;
+            },
+            .jsx_element => |child| {
+                if (!isHiddenFromScreenReader(tree, child)) return true;
+            },
+            .jsx_expression_container => |container| {
+                switch (tree.data(container.expression)) {
+                    .identifier_reference => |identifier| {
+                        if (!std.mem.eql(u8, tree.string(identifier.name), "undefined")) return true;
+                    },
+                    else => return true,
+                }
+            },
+            else => {},
+        }
+    }
+
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return false,
+    };
+    return attributeNamed(tree, opening, "dangerouslySetInnerHTML") != null or attributeNamed(tree, opening, "children") != null;
+}
+
+fn isHiddenFromScreenReader(tree: *const ast.Tree, element: ast.JSXElement) bool {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return false,
+    };
+    const tag_name = elementName(tree, opening.name) orelse return false;
+
+    if (std.mem.eql(u8, tag_name, "input")) {
+        if (attributeNamed(tree, opening, "type")) |attribute| {
+            if (propValue(tree, attribute.value)) |value| {
+                switch (value) {
+                    .string => |string| if (std.ascii.eqlIgnoreCase(string, "hidden")) return true,
+                    else => {},
+                }
+            }
+        }
+    }
+
+    const aria_hidden = attributeNamed(tree, opening, "aria-hidden") orelse return false;
+    const value = propValue(tree, aria_hidden.value) orelse return false;
+    return switch (value) {
+        .boolean => |boolean| boolean,
+        else => false,
+    };
+}
+
+fn attributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, expected: []const u8) ?ast.JSXAttribute {
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+        if (std.ascii.eqlIgnoreCase(name, expected)) return attribute;
+    }
+    return null;
+}
+
+fn elementName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
 pub const jsx_a11y_aria_proptypes = @import("jsx_a11y_aria_proptypes.zig");
@@ -1797,6 +1798,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_danger_with_children) {
             try react_no_danger_with_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, &self.react_no_danger_with_children_bindings);
         }
+        if (self.options.jsx_a11y_alt_text) {
+            try jsx_a11y_alt_text.checkElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+        }
         if (self.options.jsx_a11y_anchor_has_content) {
             try jsx_a11y_anchor_has_content.check(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
@@ -1814,6 +1818,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
             try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+        }
+        if (self.options.jsx_a11y_alt_text) {
+            try jsx_a11y_alt_text.checkOpeningElement(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.jsx_a11y_no_access_key) {
             try jsx_a11y_no_access_key.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jsx_a11y_alt_text.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_anchor_has_content.zig");
 }
 

--- a/tests/rules/jsx_a11y_alt_text.zig
+++ b/tests/rules/jsx_a11y_alt_text.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports jsx-a11y/alt-text for missing and invalid alternatives" {
+    const source =
+        \\const one = <img />;
+        \\const two = <img role="presentation" />;
+        \\const three = <img alt />;
+        \\const four = <img aria-label="" />;
+        \\const five = <area />;
+        \\const six = <object />;
+        \\const seven = <input type="image" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.jsx_a11y_alt_text.id));
+    try std.testing.expect(hasMessage(result, "img elements must have an alt prop, either with meaningful text, or an empty string for decorative images."));
+    try std.testing.expect(hasMessage(result, "Prefer alt=\"\" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML."));
+    try std.testing.expect(hasMessage(result, "Invalid alt value for img. Use alt=\"\" for presentational images."));
+    try std.testing.expect(hasMessage(result, "The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images."));
+    try std.testing.expect(hasMessage(result, "Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop."));
+    try std.testing.expect(hasMessage(result, "Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props."));
+    try std.testing.expect(hasMessage(result, "<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop."));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+}
+
+test "allows jsx-a11y/alt-text valid alternatives and non matching elements" {
+    const source =
+        \\const one = <img alt="" />;
+        \\const two = <img alt="text" />;
+        \\const three = <img aria-label="label" />;
+        \\const four = <img aria-labelledby="id" />;
+        \\const five = <area alt="" />;
+        \\const six = <area aria-label="label" />;
+        \\const seven = <object title="title" />;
+        \\const eight = <object>text</object>;
+        \\const nine = <object aria-labelledby="id" />;
+        \\const ten = <input type="image" alt="submit" />;
+        \\const eleven = <input type="text" />;
+        \\const twelve = <input type={kind} />;
+        \\const thirteen = <Img />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_alt_text.id));
+}
+
+test "can disable jsx-a11y/alt-text" {
+    const source =
+        \\const node = <img />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .jsx_a11y_alt_text = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_alt_text.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.jsx_a11y_alt_text.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add jsx-a11y/alt-text for fishlint's warn configuration
- validate alternative text for img, area, object, and input type="image" with upstream diagnostic text
- add CLI disable support plus focused coverage for missing, invalid, labeled, presentational, object-child, and disabled cases

## Tests
- `zig build test --summary all -- 'jsx-a11y/alt-text'`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- CLI smoke for default warning, `--jsx-a11y-alt-text=off`, and `--rules=jsx-a11y/alt-text`
