### PR TITLE
feat: port react no-will-update-set-state

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -216,6 +216,7 @@ pub const Options = struct {
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
     react_no_render_return_value: bool = true,
+    react_no_will_update_set_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
     react_prefer_es6_class: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -497,6 +497,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_is_mounted = false;
         } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
             options.react_no_render_return_value = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-will-update-set-state=off")) {
+            options.react_no_will_update_set_state = false;
         } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
             options.react_no_string_refs = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
@@ -1289,6 +1291,7 @@ fn printHelp() void {
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
+        \\  --react-no-will-update-set-state=off Disable react/no-will-update-set-state
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --react-prefer-es6-class=off Disable react/prefer-es6-class

--- a/src/rules/react_no_will_update_set_state.zig
+++ b/src/rules/react_no_will_update_set_state.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-will-update-set-state";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (!isThisSetStateCall(tree, callee)) return;
+
+    const method_name = lifecycleAncestorName(tree, ctx) orelse return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(callee),
+        "Do not use setState in {s}",
+        .{method_name},
+    );
+}
+
+fn lifecycleAncestorName(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?[]const u8 {
+    var depth: usize = 0;
+    var ancestor_depth: usize = 1;
+    while (ctx.path.ancestor(ancestor_depth)) |ancestor| : (ancestor_depth += 1) {
+        switch (tree.data(ancestor)) {
+            .function => |function| {
+                if (function.type == .function_expression or function.type == .function_declaration) {
+                    depth += 1;
+                }
+            },
+            .method_definition => |method| {
+                const name = methodName(tree, method.key, method.computed) orelse continue;
+                if (isLifecycleName(name) and depth <= 1) return name;
+            },
+            .object_property => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                if (isLifecycleName(name) and depth <= 1) return name;
+            },
+            .property_definition => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                if (isLifecycleName(name) and depth <= 1) return name;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn isLifecycleName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "componentWillUpdate") or
+        std.mem.eql(u8, name, "UNSAFE_componentWillUpdate");
+}
+
+fn isThisSetStateCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    if (member.computed) return false;
+    if (tree.data(unwrapTransparent(tree, member.object)) != .this_expression) return false;
+    const name = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, name, "setState");
+}
+
+fn methodName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed) return null;
+    return propertyName(tree, key, computed);
+}
+
+fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed) return null;
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -206,6 +206,7 @@ pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
+pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
 pub const react_no_string_refs = @import("react_no_string_refs.zig");
 pub const react_no_unescaped_entities = @import("react_no_unescaped_entities.zig");
@@ -1608,6 +1609,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_render_return_value) {
             try react_no_render_return_value.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
+        }
+        if (self.options.react_no_will_update_set_state) {
+            try react_no_will_update_set_state.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
         }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -739,6 +739,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_will_update_set_state.zig");
+}
+
+comptime {
     _ = @import("rules/react_jsx_boolean_value.zig");
 }
 

--- a/tests/rules/react_no_will_update_set_state.zig
+++ b/tests/rules/react_no_will_update_set_state.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-will-update-set-state in componentWillUpdate lifecycles" {
+    const source =
+        \\class One extends React.Component {
+        \\  componentWillUpdate() {
+        \\    this.setState({ value: 1 });
+        \\  }
+        \\}
+        \\class Two extends React.Component {
+        \\  UNSAFE_componentWillUpdate() {
+        \\    this.setState({ value: 2 });
+        \\  }
+        \\}
+        \\const spec = {
+        \\  componentWillUpdate() {
+        \\    this.setState({ value: 3 });
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_will_update_set_state.id));
+    try std.testing.expect(hasMessage(result, "Do not use setState in componentWillUpdate"));
+    try std.testing.expect(hasMessage(result, "Do not use setState in UNSAFE_componentWillUpdate"));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+}
+
+test "allows react/no-will-update-set-state outside checked lifecycle contexts" {
+    const source =
+        \\class One extends React.Component {
+        \\  componentDidUpdate() {
+        \\    this.setState({ value: 1 });
+        \\  }
+        \\  componentWillUpdate() {
+        \\    function later() {
+        \\      this.setState({ value: 2 });
+        \\    }
+        \\  }
+        \\  ["componentWillUpdate"]() {
+        \\    this.setState({ value: 3 });
+        \\  }
+        \\}
+        \\const spec = {
+        \\  componentWillUpdate: function () {
+        \\    function later() {
+        \\      this.setState({ value: 4 });
+        \\    }
+        \\  },
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_will_update_set_state.id));
+}
+
+test "can disable react/no-will-update-set-state" {
+    const source =
+        \\class One extends React.Component {
+        \\  componentWillUpdate() {
+        \\    this.setState({ value: 1 });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_no_will_update_set_state = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_will_update_set_state.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_will_update_set_state.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add react/no-will-update-set-state for fishlint's error configuration
- detect `this.setState()` in `componentWillUpdate` and `UNSAFE_componentWillUpdate` class/object lifecycle methods
- add CLI disable support plus coverage for default nested-function behavior and disabled configuration

## Tests
- `zig build test --summary all -- 'react/no-will-update-set-state'`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- CLI smoke for default error, `--react-no-will-update-set-state=off`, and `--rules=react/no-will-update-set-state`
