### PR TITLE
feat: port react no-redundant-should-component-update

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -215,6 +215,7 @@ pub const Options = struct {
     react_no_children_prop: bool = true,
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
+    react_no_redundant_should_component_update: bool = true,
     react_no_render_return_value: bool = true,
     react_no_will_update_set_state: bool = true,
     react_no_string_refs: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -495,6 +495,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_find_dom_node = false;
         } else if (std.mem.eql(u8, arg, "--react-no-is-mounted=off")) {
             options.react_no_is_mounted = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-redundant-should-component-update=off")) {
+            options.react_no_redundant_should_component_update = false;
         } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
             options.react_no_render_return_value = false;
         } else if (std.mem.eql(u8, arg, "--react-no-will-update-set-state=off")) {
@@ -1290,6 +1292,7 @@ fn printHelp() void {
         \\  --react-no-children-prop=off Disable react/no-children-prop
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
+        \\  --react-no-redundant-should-component-update=off Disable react/no-redundant-should-component-update
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
         \\  --react-no-will-update-set-state=off Disable react/no-will-update-set-state
         \\  --react-no-string-refs=off Disable react/no-string-refs

--- a/src/rules/react_no_redundant_should_component_update.zig
+++ b/src/rules/react_no_redundant_should_component_update.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-redundant-should-component-update";
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    index: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isPureComponentClass(tree, class)) return;
+    if (!hasShouldComponentUpdate(tree, class)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "{s} does not need shouldComponentUpdate when extending React.PureComponent.",
+        .{className(tree, class, parent)},
+    );
+}
+
+fn isPureComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "PureComponent");
+    }
+
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!isIdentifierReferenceNamed(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "PureComponent");
+}
+
+fn hasShouldComponentUpdate(tree: *const ast.Tree, class: ast.Class) bool {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return false,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        switch (tree.data(member_index)) {
+            .method_definition => |method| {
+                const name = propertyName(tree, method.key, method.computed) orelse continue;
+                if (std.mem.eql(u8, name, "shouldComponentUpdate")) return true;
+            },
+            .property_definition => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                if (std.mem.eql(u8, name, "shouldComponentUpdate")) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+fn className(tree: *const ast.Tree, class: ast.Class, parent: ?ast.NodeIndex) []const u8 {
+    if (bindingIdentifierName(tree, class.id)) |name| return name;
+    if (parent) |parent_index| {
+        if (tree.data(parent_index) == .variable_declarator) {
+            const declarator = tree.data(parent_index).variable_declarator;
+            if (bindingIdentifierName(tree, declarator.id)) |name| return name;
+        }
+    }
+    return "";
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -205,6 +205,7 @@ pub const react_no_children_prop = @import("react_no_children_prop.zig");
 pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
+pub const react_no_redundant_should_component_update = @import("react_no_redundant_should_component_update.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
@@ -654,7 +655,7 @@ const BasicVisitor = struct {
     pub fn enter_class(
         self: *BasicVisitor,
         class: ast.Class,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.constructor_super) {
@@ -662,6 +663,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_require_render_return) {
             try react_require_render_return.checkClass(self.allocator, self.diagnostics, ctx.tree, class, self.react_require_render_return_state);
+        }
+        if (self.options.react_no_redundant_should_component_update) {
+            try react_no_redundant_should_component_update.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, ctx.path.parent());
         }
         if (self.options.no_this_before_super) {
             try no_this_before_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -731,6 +731,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_redundant_should_component_update.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_string_refs.zig");
 }
 

--- a/tests/rules/react_no_redundant_should_component_update.zig
+++ b/tests/rules/react_no_redundant_should_component_update.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-redundant-should-component-update for PureComponent classes" {
+    const source =
+        \\class One extends React.PureComponent {
+        \\  shouldComponentUpdate() {
+        \\    return true;
+        \\  }
+        \\}
+        \\class Two extends PureComponent {
+        \\  shouldComponentUpdate = () => true;
+        \\}
+        \\const Three = class extends React.PureComponent {
+        \\  shouldComponentUpdate() {
+        \\    return true;
+        \\  }
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_redundant_should_component_update.id));
+    try std.testing.expect(hasMessage(result, "One does not need shouldComponentUpdate when extending React.PureComponent."));
+    try std.testing.expect(hasMessage(result, "Two does not need shouldComponentUpdate when extending React.PureComponent."));
+    try std.testing.expect(hasMessage(result, "Three does not need shouldComponentUpdate when extending React.PureComponent."));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+}
+
+test "allows react/no-redundant-should-component-update when not extending PureComponent" {
+    const source =
+        \\class One extends React.Component {
+        \\  shouldComponentUpdate() {
+        \\    return true;
+        \\  }
+        \\}
+        \\class Two extends React.PureComponent {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\class Three extends React.PureComponent {
+        \\  ["shouldComponentUpdate"]() {
+        \\    return true;
+        \\  }
+        \\}
+        \\class Four extends React.PureComponent {
+        \\  "shouldComponentUpdate"() {
+        \\    return true;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_redundant_should_component_update.id));
+}
+
+test "can disable react/no-redundant-should-component-update" {
+    const source =
+        \\class One extends React.PureComponent {
+        \\  shouldComponentUpdate() {
+        \\    return true;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_no_redundant_should_component_update = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_redundant_should_component_update.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_redundant_should_component_update.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, message: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, message)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add react/no-redundant-should-component-update for fishlint's error configuration
- detect `shouldComponentUpdate` methods and class fields on classes extending `React.PureComponent` or `PureComponent`
- add CLI disable support plus coverage for class declarations, class expressions, allowed non-PureComponent cases, and disabled configuration

## Tests
- `zig build test --summary all -- 'react/no-redundant-should-component-update'`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- CLI smoke for default error, `--react-no-redundant-should-component-update=off`, and `--rules=react/no-redundant-should-component-update`
