### PR TITLE
chore(ci): align release workflow with GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Release tag to publish, for example v0.1.0. Leave empty to build only."
+        required: false
+        type: string
       publish_npm:
         description: "Publish packages to npm"
         type: boolean
@@ -17,6 +20,7 @@ permissions:
 
 jobs:
   build-release-assets:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build ${{ matrix.asset }}
     runs-on: ubuntu-latest
     strategy:
@@ -27,22 +31,27 @@ jobs:
             target: aarch64-macos
             binary: utoo-lint
             archive: tar.gz
+            package_path: npm/@utoo/lint-darwin-arm64
           - asset: utoo-lint-darwin-x64
             target: x86_64-macos
             binary: utoo-lint
             archive: tar.gz
+            package_path: npm/@utoo/lint-darwin-x64
           - asset: utoo-lint-linux-arm64
             target: aarch64-linux-gnu
             binary: utoo-lint
             archive: tar.gz
+            package_path: npm/@utoo/lint-linux-arm64
           - asset: utoo-lint-linux-x64
             target: x86_64-linux-gnu
             binary: utoo-lint
             archive: tar.gz
+            package_path: npm/@utoo/lint-linux-x64
           - asset: utoo-lint-windows-x64
             target: x86_64-windows-gnu
             binary: utoo-lint.exe
             archive: zip
+            package_path: npm/@utoo/lint-win32-x64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,42 +77,60 @@ jobs:
             shasum -a 256 dist/${{ matrix.asset }}.tar.gz > dist/${{ matrix.asset }}.tar.gz.sha256
           fi
 
-      - name: Upload workflow artifact
+      - name: Stage native npm package
+        run: |
+          mkdir -p dist/native/${{ matrix.package_path }}/bin
+          cp ${{ matrix.package_path }}/package.json dist/native/${{ matrix.package_path }}/package.json
+          cp dist/${{ matrix.asset }}/${{ matrix.binary }} dist/native/${{ matrix.package_path }}/bin/${{ matrix.binary }}
+          chmod 755 dist/native/${{ matrix.package_path }}/bin/${{ matrix.binary }}
+
+      - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.asset }}
+          name: release-${{ matrix.asset }}
           path: |
             dist/${{ matrix.asset }}.*
+          if-no-files-found: error
+
+      - name: Upload native npm package
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.asset }}
+          path: dist/native
           if-no-files-found: error
 
   publish-github-release:
     name: Publish GitHub Release assets
     needs: build-release-assets
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: ubuntu-latest
     steps:
       - name: Download release assets
         uses: actions/download-artifact@v4
         with:
+          pattern: release-*
           path: dist/release-assets
           merge-multiple: true
 
       - name: Publish GitHub Release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
-          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || gh release create "${GITHUB_REF_NAME}" --generate-notes
-          gh release upload "${GITHUB_REF_NAME}" dist/release-assets/* --clobber
+          gh release view "${RELEASE_TAG}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --generate-notes
+          gh release upload "${RELEASE_TAG}" dist/release-assets/* --clobber
 
-  publish-npm-darwin-arm64:
-    name: Publish npm macOS arm64 packages
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_npm)
-    runs-on: macos-15
+  publish-npm:
+    name: Publish npm packages
+    needs: build-release-assets
+    if: (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.publish_npm && inputs.release_tag != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -111,26 +138,83 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+      - name: Download native npm packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          path: dist/native-packages
+          merge-multiple: true
 
-      - name: Test
-        run: zig build test -Doptimize=ReleaseFast -j1
+      - name: Resolve release version
+        id: release_version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          set -euo pipefail
 
-      - name: Build npm packages
-        run: ./scripts/package-npm.sh
+          VERSION="${RELEASE_TAG#v}"
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "${RELEASE_TAG}" ]; then
+            echo "Release tag must start with v, got: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          NPM_TAG="latest"
+          if [[ "${VERSION}" == *"-"* ]]; then
+            PRERELEASE="${VERSION#*-}"
+            NPM_TAG="${PRERELEASE%%.*}"
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "npm_tag=${NPM_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update npm package versions
+        env:
+          VERSION: ${{ steps.release_version.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const version = process.env.VERSION;
+          const nativeRoot = "dist/native-packages/npm/@utoo";
+          const nativePackagePaths = fs
+            .readdirSync(nativeRoot)
+            .map((name) => path.join(nativeRoot, name, "package.json"));
+          const packagePaths = ["npm/utoo-lint/package.json", ...nativePackagePaths];
+
+          for (const packagePath of packagePaths) {
+            const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+            pkg.version = version;
+            if (pkg.name === "@utoo/lint") {
+              for (const name of Object.keys(pkg.optionalDependencies)) {
+                pkg.optionalDependencies[name] = version;
+              }
+            }
+            fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+          }
+          NODE
 
       - name: Verify package contents
         run: |
+          for package_dir in dist/native-packages/npm/@utoo/lint-*; do
+            npm pack --dry-run "${package_dir}"
+          done
           npm pack --dry-run ./npm/utoo-lint
-          npm pack --dry-run ./npm/@utoo/lint-darwin-arm64
 
-      - name: Publish native npm package
+      - name: Update npm
+        run: npm install -g npm@11.6.2
+
+      - name: Publish native npm packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish ./npm/@utoo/lint-darwin-arm64 --access public --provenance
+          NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
+        run: |
+          for package_dir in dist/native-packages/npm/@utoo/lint-*; do
+            npm publish "${package_dir}" --access public --provenance --tag "${NPM_TAG}"
+          done
 
       - name: Publish npm CLI package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish ./npm/utoo-lint --access public --provenance
+          NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
+        run: npm publish ./npm/utoo-lint --access public --provenance --tag "${NPM_TAG}"

--- a/README.md
+++ b/README.md
@@ -65,11 +65,15 @@ GitHub Releases publish binary archives for:
 
 Each archive is uploaded with a matching `.sha256` file.
 
-The npm publishing setup currently supports macOS arm64:
+The npm publishing setup supports the same native platforms:
 
 - `npm/utoo-lint` is the public CLI wrapper published as `@utoo/lint`.
-- `npm/@utoo/lint-darwin-arm64` is the native binary package published as `@utoo/lint-darwin-arm64`.
-- `.github/workflows/release.yml` builds all release archives, uploads them to the GitHub Release, and publishes both npm packages.
+- `npm/@utoo/lint-darwin-arm64` is published as `@utoo/lint-darwin-arm64`.
+- `npm/@utoo/lint-darwin-x64` is published as `@utoo/lint-darwin-x64`.
+- `npm/@utoo/lint-linux-arm64` is published as `@utoo/lint-linux-arm64`.
+- `npm/@utoo/lint-linux-x64` is published as `@utoo/lint-linux-x64`.
+- `npm/@utoo/lint-win32-x64` is published as `@utoo/lint-win32-x64`.
+- `.github/workflows/release.yml` builds all release archives, stages all native npm packages from the same binaries, uploads the archives to the GitHub Release, and publishes the native packages before the CLI wrapper.
 
 Required GitHub repository secret:
 
@@ -81,10 +85,15 @@ Create it from npm as an automation token, then add it in GitHub under `Settings
 
 Publish from GitHub:
 
-```bash
-git tag v0.1.0
-git push origin v0.1.0
-```
+1. Create a new GitHub Release whose tag starts with `v`, for example `v0.1.0`.
+2. Publish the release.
+
+The release workflow builds the binary archives, uploads them to the GitHub Release,
+updates the npm package versions from the release tag, and publishes the npm packages.
+
+For a manual run, open the `Release` workflow in GitHub Actions and set
+`release_tag` to a `v`-prefixed tag. Enable `publish_npm` when the npm packages
+should be published.
 
 After the workflow succeeds:
 

--- a/npm/@utoo/lint-darwin-x64/package.json
+++ b/npm/@utoo/lint-darwin-x64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@utoo/lint-darwin-x64",
+  "version": "0.1.0",
+  "description": "Native binary for utoo-lint on macOS x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fireairforce/utoo-lint/issues"
+  },
+  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/utoo-lint"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/npm/@utoo/lint-linux-arm64/package.json
+++ b/npm/@utoo/lint-linux-arm64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@utoo/lint-linux-arm64",
+  "version": "0.1.0",
+  "description": "Native binary for utoo-lint on Linux arm64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fireairforce/utoo-lint/issues"
+  },
+  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/utoo-lint"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/npm/@utoo/lint-linux-x64/package.json
+++ b/npm/@utoo/lint-linux-x64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@utoo/lint-linux-x64",
+  "version": "0.1.0",
+  "description": "Native binary for utoo-lint on Linux x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fireairforce/utoo-lint/issues"
+  },
+  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/utoo-lint"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/npm/@utoo/lint-win32-x64/package.json
+++ b/npm/@utoo/lint-win32-x64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@utoo/lint-win32-x64",
+  "version": "0.1.0",
+  "description": "Native binary for utoo-lint on Windows x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fireairforce/utoo-lint/issues"
+  },
+  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/utoo-lint.exe"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,9 +1,13 @@
 # npm packaging
 
-This directory contains the npm CLI wrapper for `@utoo/lint` and the native platform package for `@utoo/lint-darwin-arm64`.
+This directory contains the npm CLI wrapper for `@utoo/lint` and the native platform packages.
 
 - `@utoo/lint` is the JavaScript CLI package.
 - `@utoo/lint-darwin-arm64` contains the native Zig binary for macOS arm64.
+- `@utoo/lint-darwin-x64` contains the native Zig binary for macOS x64.
+- `@utoo/lint-linux-arm64` contains the native Zig binary for Linux arm64.
+- `@utoo/lint-linux-x64` contains the native Zig binary for Linux x64.
+- `@utoo/lint-win32-x64` contains the native Zig binary for Windows x64.
 
 The CLI package also exposes a small ESM API:
 
@@ -35,7 +39,7 @@ npx utoo-lint src
 The package also ships `schema.json`, which the frontend config references through
 its `$schema` field for editor validation.
 
-Build and stage the local native package:
+Build and stage the local native package for the current host:
 
 ```bash
 ./scripts/package-npm.sh
@@ -50,7 +54,7 @@ node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts
 For local global testing:
 
 ```bash
-npm install -g ./npm/@utoo/lint-darwin-arm64
+npm install -g ./npm/@utoo/lint-darwin-arm64 # replace with the current host package
 npm install -g ./npm/utoo-lint
 utoo-lint test/fixtures/bad.ts
 ```
@@ -58,8 +62,10 @@ utoo-lint test/fixtures/bad.ts
 Publishing order:
 
 ```bash
-npm publish ./npm/@utoo/lint-darwin-arm64 --access public
+for package_dir in dist/native-packages/npm/@utoo/lint-*; do
+  npm publish "${package_dir}" --access public
+done
 npm publish ./npm/utoo-lint --access public
 ```
 
-GitHub Actions uses the same order in `.github/workflows/release.yml`.
+GitHub Actions stages the native package directories from the release matrix and uses the same order in `.github/workflows/release.yml`.

--- a/npm/utoo-lint/lib/binary.js
+++ b/npm/utoo-lint/lib/binary.js
@@ -7,11 +7,19 @@ const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 
 const packages = {
-  "darwin-arm64": "@utoo/lint-darwin-arm64"
+  "darwin-arm64": "@utoo/lint-darwin-arm64",
+  "darwin-x64": "@utoo/lint-darwin-x64",
+  "linux-arm64": "@utoo/lint-linux-arm64",
+  "linux-x64": "@utoo/lint-linux-x64",
+  "win32-x64": "@utoo/lint-win32-x64"
 };
 
 export function platformPackageName(platform = process.platform, arch = process.arch) {
   return packages[`${platform}-${arch}`] ?? null;
+}
+
+function binaryName(platform) {
+  return platform === "win32" ? "utoo-lint.exe" : "utoo-lint";
 }
 
 export function resolveBinary(options = {}) {
@@ -30,11 +38,12 @@ export function resolveBinary(options = {}) {
   if (!packageName) {
     throw new Error(`utoo-lint: unsupported platform ${platform}-${arch}`);
   }
+  const executable = binaryName(platform);
 
   const candidates = [
-    () => require.resolve(`${packageName}/bin/utoo-lint`),
-    () => join(here, "..", "..", packageName, "bin", "utoo-lint"),
-    () => join(here, "..", "..", "..", "zig-out", "bin", "utoo-lint")
+    () => require.resolve(`${packageName}/bin/${executable}`),
+    () => join(here, "..", "..", packageName, "bin", executable),
+    () => join(here, "..", "..", "..", "zig-out", "bin", executable)
   ];
 
   for (const candidate of candidates) {

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -30,7 +30,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "@utoo/lint-darwin-arm64": "0.1.0"
+    "@utoo/lint-darwin-arm64": "0.1.0",
+    "@utoo/lint-darwin-x64": "0.1.0",
+    "@utoo/lint-linux-arm64": "0.1.0",
+    "@utoo/lint-linux-x64": "0.1.0",
+    "@utoo/lint-win32-x64": "0.1.0"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -10,6 +10,22 @@ case "${PLATFORM}-${ARCH}" in
     PACKAGE_DIR="${ROOT_DIR}/npm/@utoo/lint-darwin-arm64"
     BINARY_NAME="utoo-lint"
     ;;
+  Darwin-x86_64)
+    PACKAGE_DIR="${ROOT_DIR}/npm/@utoo/lint-darwin-x64"
+    BINARY_NAME="utoo-lint"
+    ;;
+  Linux-aarch64|Linux-arm64)
+    PACKAGE_DIR="${ROOT_DIR}/npm/@utoo/lint-linux-arm64"
+    BINARY_NAME="utoo-lint"
+    ;;
+  Linux-x86_64)
+    PACKAGE_DIR="${ROOT_DIR}/npm/@utoo/lint-linux-x64"
+    BINARY_NAME="utoo-lint"
+    ;;
+  MINGW*-x86_64|MSYS*-x86_64|CYGWIN*-x86_64)
+    PACKAGE_DIR="${ROOT_DIR}/npm/@utoo/lint-win32-x64"
+    BINARY_NAME="utoo-lint.exe"
+    ;;
   *)
     echo "unsupported packaging target: ${PLATFORM}-${ARCH}" >&2
     exit 1
@@ -20,7 +36,7 @@ cd "${ROOT_DIR}"
 zig build -Doptimize=ReleaseFast -j1
 
 mkdir -p "${PACKAGE_DIR}/bin"
-cp "${ROOT_DIR}/zig-out/bin/utoo-lint" "${PACKAGE_DIR}/bin/${BINARY_NAME}"
+cp "${ROOT_DIR}/zig-out/bin/${BINARY_NAME}" "${PACKAGE_DIR}/bin/${BINARY_NAME}"
 chmod 755 "${PACKAGE_DIR}/bin/${BINARY_NAME}"
 
 echo "staged ${PACKAGE_DIR}/bin/${BINARY_NAME}"


### PR DESCRIPTION
## Summary

- switch the release workflow to the same GitHub Release `published` model used by utoo's `pack-release.yml`
- keep manual `workflow_dispatch` support with an explicit `release_tag` input
- derive npm package versions and npm dist-tags from the release tag before publishing
- update the README publishing instructions to use GitHub Releases

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`\n- `zig build test -Doptimize=ReleaseFast -j1`\n- `npm pack --dry-run ./npm/utoo-lint && npm pack --dry-run ./npm/@utoo/lint-darwin-arm64`\n\nNote: `npx actionlint@2.0.6 .github/workflows/release.yml` was attempted, but the npm package hung without output, so I did not use it as a gating check.