### PR TITLE
feat: port react no-multi-comp

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -215,6 +215,7 @@ pub const Options = struct {
     react_no_children_prop: bool = true,
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
+    react_no_multi_comp: bool = true,
     react_no_redundant_should_component_update: bool = true,
     react_no_render_return_value: bool = true,
     react_no_will_update_set_state: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -495,6 +495,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_find_dom_node = false;
         } else if (std.mem.eql(u8, arg, "--react-no-is-mounted=off")) {
             options.react_no_is_mounted = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-multi-comp=off")) {
+            options.react_no_multi_comp = false;
         } else if (std.mem.eql(u8, arg, "--react-no-redundant-should-component-update=off")) {
             options.react_no_redundant_should_component_update = false;
         } else if (std.mem.eql(u8, arg, "--react-no-render-return-value=off")) {
@@ -1292,6 +1294,7 @@ fn printHelp() void {
         \\  --react-no-children-prop=off Disable react/no-children-prop
         \\  --react-no-find-dom-node=off Disable react/no-find-dom-node
         \\  --react-no-is-mounted=off Disable react/no-is-mounted
+        \\  --react-no-multi-comp=off Disable react/no-multi-comp
         \\  --react-no-redundant-should-component-update=off Disable react/no-redundant-should-component-update
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
         \\  --react-no-will-update-set-state=off Disable react/no-will-update-set-state

--- a/src/rules/react_no_multi_comp.zig
+++ b/src/rules/react_no_multi_comp.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-multi-comp";
+
+pub const State = struct {
+    component_count: usize = 0,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (!isReactComponentClass(tree, class)) return;
+
+    state.component_count += 1;
+    if (state.component_count <= 1) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Declare only one React component per file",
+        tree.span(index),
+    );
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!isIdentifierReferenceNamed(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -205,6 +205,7 @@ pub const react_no_children_prop = @import("react_no_children_prop.zig");
 pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
+pub const react_no_multi_comp = @import("react_no_multi_comp.zig");
 pub const react_no_redundant_should_component_update = @import("react_no_redundant_should_component_update.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
@@ -568,6 +569,7 @@ const BasicVisitor = struct {
     react_no_array_index_key_state: react_no_array_index_key.State = .{},
     react_jsx_no_bind_state: react_jsx_no_bind.State = .{},
     react_jsx_key_state: react_jsx_key.State = .{},
+    react_no_multi_comp_state: react_no_multi_comp.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
@@ -663,6 +665,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_require_render_return) {
             try react_require_render_return.checkClass(self.allocator, self.diagnostics, ctx.tree, class, self.react_require_render_return_state);
+        }
+        if (self.options.react_no_multi_comp) {
+            try react_no_multi_comp.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, &self.react_no_multi_comp_state);
         }
         if (self.options.react_no_redundant_should_component_update) {
             try react_no_redundant_should_component_update.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, ctx.path.parent());

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -735,6 +735,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_multi_comp.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_string_refs.zig");
 }
 

--- a/tests/rules/react_no_multi_comp.zig
+++ b/tests/rules/react_no_multi_comp.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-multi-comp for multiple non stateless components" {
+    const source =
+        \\class One extends React.Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\class Two extends React.PureComponent {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\class Three extends Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_multi_comp.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+    try std.testing.expectEqualStrings("Declare only one React component per file", diagnostic.message);
+}
+
+test "allows react/no-multi-comp ignored stateless and single class components" {
+    const source =
+        \\class One extends React.Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\function Two() {
+        \\  return <div />;
+        \\}
+        \\const Three = () => <span />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_multi_comp.id));
+}
+
+test "can disable react/no-multi-comp" {
+    const source =
+        \\class One extends React.Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\class Two extends React.Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_no_multi_comp = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_multi_comp.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_multi_comp.id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add react/no-multi-comp for fishlint's `ignoreStateless: true` configuration
- report the second and later ES6 class React components in a file while ignoring stateless function components
- add CLI disable support plus focused coverage for multiple class components, ignored stateless components, and disabled configuration

## Tests
- `zig build test --summary all -- 'react/no-multi-comp'`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- CLI smoke for default error, `--react-no-multi-comp=off`, and `--rules=react/no-multi-comp`
