### PR TITLE
feat: port alipay ant no-import-src

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -85,6 +85,7 @@ pub const Options = struct {
     no_implicit_coercion: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
+    alipay_ant_no_import_src: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
@@ -308,6 +309,10 @@ pub const Options = struct {
 
         if (std.mem.startsWith(u8, cli_name, "import/")) {
             return self.setByPrefixedRuleName("import_", cli_name["import/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "@alipay/ant/")) {
+            return self.setByPrefixedRuleName("alipay_ant_", cli_name["@alipay/ant/".len..], value);
         }
 
         if (std.mem.startsWith(u8, cli_name, "jsx-a11y/")) {
@@ -571,6 +576,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_duplicates);
     try std.testing.expect(options.setByCliName("import/no-duplicates", true));
     try std.testing.expect(options.import_no_duplicates);
+
+    try std.testing.expect(!options.alipay_ant_no_import_src);
+    try std.testing.expect(options.setByCliName("@alipay/ant/no-import-src", true));
+    try std.testing.expect(options.alipay_ant_no_import_src);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -237,6 +237,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
             options.no_import_assign = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
+            options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
         } else if (std.mem.eql(u8, arg, "--import-newline-after-import=off")) {
@@ -1167,6 +1169,7 @@ fn printHelp() void {
         \\  --no-implicit-coercion=off Disable no-implicit-coercion
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
+        \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd

--- a/src/rules/alipay_ant_no_import_src.zig
+++ b/src/rules/alipay_ant_no_import_src.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-import-src";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+) Allocator.Error!void {
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        const source = importSource(tree, declaration) orelse continue;
+        if (!matchesImportSrcPattern(source)) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(statement_index),
+            "Import code from '{s}' may break your App for compatibility issues.",
+            .{source},
+        );
+    }
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn matchesImportSrcPattern(source: []const u8) bool {
+    if (source.len == 0) return false;
+
+    var end = source.len;
+    if (source[end - 1] == '/') {
+        end -= 1;
+        if (end == 0) return false;
+    }
+
+    const trimmed = source[0..end];
+    var src_segment_index: usize = 0;
+    var found_src_segment = false;
+    var segment_count: usize = 0;
+
+    var iter = std.mem.splitScalar(u8, trimmed, '/');
+    while (iter.next()) |segment| {
+        if (segment.len == 0) return false;
+        if (!found_src_segment and std.mem.eql(u8, segment, "src")) {
+            src_segment_index = segment_count;
+            found_src_segment = true;
+        }
+        segment_count += 1;
+    }
+
+    if (!found_src_segment) return false;
+
+    var index: usize = 0;
+    iter = std.mem.splitScalar(u8, trimmed, '/');
+    while (iter.next()) |segment| : (index += 1) {
+        if (index < src_segment_index) {
+            if (!isPrefixSegment(segment)) return false;
+        } else if (index > src_segment_index) {
+            if (!isPathSegment(segment)) return false;
+        }
+    }
+
+    return true;
+}
+
+fn isPrefixSegment(segment: []const u8) bool {
+    if (segment.len == 0) return false;
+
+    const start: usize = if (segment[0] == '@') 1 else 0;
+    if (start >= segment.len) return false;
+    if (!isSegmentFirstChar(segment[start])) return false;
+
+    for (segment[start + 1 ..]) |char| {
+        if (!isSegmentRestChar(char)) return false;
+    }
+    return true;
+}
+
+fn isPathSegment(segment: []const u8) bool {
+    if (segment.len == 0) return false;
+    if (!isSegmentFirstChar(segment[0])) return false;
+
+    for (segment[1..]) |char| {
+        if (!isSegmentRestChar(char)) return false;
+    }
+    return true;
+}
+
+fn isSegmentFirstChar(char: u8) bool {
+    return std.ascii.isAlphanumeric(char) or char == '-' or char == '*' or char == '~';
+}
+
+fn isSegmentRestChar(char: u8) bool {
+    return isSegmentFirstChar(char) or char == '.' or char == '_';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -24,6 +24,7 @@ pub const eol_last = @import("eol_last.zig");
 pub const for_direction = @import("for_direction.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
+pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
@@ -587,6 +588,9 @@ const BasicVisitor = struct {
         }
         if (self.options.import_no_duplicates) {
             try import_no_duplicates.check(self.allocator, self.diagnostics, ctx.tree, program);
+        }
+        if (self.options.alipay_ant_no_import_src) {
+            try alipay_ant_no_import_src.check(self.allocator, self.diagnostics, ctx.tree, program);
         }
         if (self.options.import_no_self_import) {
             try import_no_self_import.check(self.allocator, self.diagnostics, ctx.tree, program, self.file_path);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -43,6 +43,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_import_src.zig");
+}
+
+comptime {
     _ = @import("rules/import_first.zig");
 }
 

--- a/tests/rules/alipay_ant_no_import_src.zig
+++ b/tests/rules/alipay_ant_no_import_src.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/ant/no-import-src for package src imports" {
+    const source =
+        \\import direct from "src";
+        \\import trailing from "src/";
+        \\import nested from "src/features/button";
+        \\import scoped from "@scope/pkg/src/components/button";
+        \\import packageSrc from "foo-bar/src";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.alipay_ant_no_import_src.id));
+    try std.testing.expectEqualStrings(
+        "Import code from 'src' may break your App for compatibility issues.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "does not report @alipay/ant/no-import-src for relative or non-matching imports" {
+    const source =
+        \\import relative from "./src";
+        \\import parent from "../src";
+        \\import prefixed from "src_utils/button";
+        \\import invalidSegment from "src/_internal";
+        \\import packageRoot from "@scope/pkg";
+        \\import doubleSlash from "pkg//src";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_import_src.id));
+}
+
+test "can disable @alipay/ant/no-import-src" {
+    const source =
+        \\import direct from "src/features/button";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_ant_no_import_src = false,
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_import_src.id));
+}


### PR DESCRIPTION
Summary:
- Add @alipay/ant/no-import-src as a basic import declaration rule
- Wire @alipay/ant config-name mapping and the CLI off switch
- Cover package src imports, relative/non-matching imports, and rule disabling

Tests:
- zig build test --summary all -- '@alipay/ant/no-import-src'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast --summary all\n- CLI smoke for --rules=@alipay/ant/no-import-src and --alipay-ant-no-import-src=off