### PR TITLE
feat: port react no-this-in-sfc

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -220,6 +220,7 @@ pub const Options = struct {
     react_no_redundant_should_component_update: bool = true,
     react_no_render_return_value: bool = true,
     react_no_will_update_set_state: bool = true,
+    react_no_this_in_sfc: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
     react_prefer_es6_class: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -505,6 +505,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_render_return_value = false;
         } else if (std.mem.eql(u8, arg, "--react-no-will-update-set-state=off")) {
             options.react_no_will_update_set_state = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-this-in-sfc=off")) {
+            options.react_no_this_in_sfc = false;
         } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
             options.react_no_string_refs = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
@@ -1301,6 +1303,7 @@ fn printHelp() void {
         \\  --react-no-redundant-should-component-update=off Disable react/no-redundant-should-component-update
         \\  --react-no-render-return-value=off Disable react/no-render-return-value
         \\  --react-no-will-update-set-state=off Disable react/no-will-update-set-state
+        \\  --react-no-this-in-sfc=off Disable react/no-this-in-sfc
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --react-prefer-es6-class=off Disable react/prefer-es6-class

--- a/src/rules/react_no_this_in_sfc.zig
+++ b/src/rules/react_no_this_in_sfc.zig
@@ -1,0 +1,227 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-this-in-sfc";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (tree.data(unwrapTransparent(tree, member.object)) != .this_expression) return;
+    if (parentStatelessComponent(tree, ctx) == null) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Stateless functional components should not use `this`",
+        tree.span(index),
+    );
+}
+
+fn parentStatelessComponent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.NodeIndex {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .function => |function| {
+                if (isStatelessFunctionComponent(tree, function, ancestor, ctx.path.ancestor(depth + 1))) return ancestor;
+            },
+            .arrow_function_expression => |arrow| {
+                if (isStatelessArrowComponent(tree, arrow, ancestor, ctx.path.ancestor(depth + 1))) return ancestor;
+            },
+            .class => return null,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn isStatelessFunctionComponent(
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+) bool {
+    if (function.async and function.generator) return false;
+    if (!functionReturnsJSXOrNull(tree, index)) return false;
+
+    if (function.type == .function_declaration) {
+        const name = bindingIdentifierName(tree, function.id) orelse return true;
+        return startsUppercase(name);
+    }
+
+    return functionExpressionHasComponentParent(tree, parent_index);
+}
+
+fn isStatelessArrowComponent(
+    tree: *const ast.Tree,
+    arrow: ast.ArrowFunctionExpression,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+) bool {
+    _ = arrow;
+    if (!functionReturnsJSXOrNull(tree, index)) return false;
+    return functionExpressionHasComponentParent(tree, parent_index);
+}
+
+fn functionExpressionHasComponentParent(tree: *const ast.Tree, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    return switch (tree.data(parent)) {
+        .variable_declarator => |declarator| identifierBindingStartsUppercase(tree, declarator.id),
+        .assignment_expression => |expression| identifierReferenceStartsUppercase(tree, expression.left),
+        .export_default_declaration => true,
+        .object_property => false,
+        else => false,
+    };
+}
+
+fn functionReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function => |function| function.body != .null and bodyReturnsJSXOrNull(tree, function.body),
+        .arrow_function_expression => |arrow| if (arrow.expression)
+            isJSXOrNullValue(tree, arrow.body)
+        else
+            bodyReturnsJSXOrNull(tree, arrow.body),
+        else => false,
+    };
+}
+
+fn bodyReturnsJSXOrNull(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    const range = switch (tree.data(body_index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return false,
+    };
+    return rangeReturnsJSXOrNull(tree, range);
+}
+
+fn rangeReturnsJSXOrNull(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |statement_index| {
+        if (statementReturnsJSXOrNull(tree, statement_index)) return true;
+    }
+    return false;
+}
+
+fn statementReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .return_statement => |statement| isJSXOrNullValue(tree, statement.argument),
+        .block_statement => |block| rangeReturnsJSXOrNull(tree, block.body),
+        .if_statement => |statement| statementReturnsJSXOrNull(tree, statement.consequent) or
+            statementReturnsJSXOrNull(tree, statement.alternate),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const case = switch (tree.data(case_index)) {
+                    .switch_case => |case| case,
+                    else => continue,
+                };
+                if (rangeReturnsJSXOrNull(tree, case.consequent)) return true;
+            }
+            return false;
+        },
+        .function,
+        .arrow_function_expression,
+        => false,
+        else => false,
+    };
+}
+
+fn isJSXOrNullValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .jsx_element,
+        .jsx_fragment,
+        .null_literal,
+        => true,
+        .call_expression => |call| isCreateElementCall(tree, call),
+        .conditional_expression => |conditional| isJSXOrNullValue(tree, conditional.consequent) or
+            isJSXOrNullValue(tree, conditional.alternate),
+        .logical_expression => |logical| isJSXOrNullValue(tree, logical.left) or isJSXOrNullValue(tree, logical.right),
+        .sequence_expression => |sequence| {
+            if (sequence.expressions.len == 0) return false;
+            const items = tree.extra(sequence.expressions);
+            return isJSXOrNullValue(tree, items[items.len - 1]);
+        },
+        else => false,
+    };
+}
+
+fn isCreateElementCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createElement");
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!identifierReferenceEquals(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = propertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "createElement");
+}
+
+fn identifierBindingStartsUppercase(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = bindingIdentifierName(tree, index) orelse return false;
+    return startsUppercase(name);
+}
+
+fn identifierReferenceStartsUppercase(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = identifierReferenceName(tree, unwrapTransparent(tree, index)) orelse return false;
+    return startsUppercase(name);
+}
+
+fn startsUppercase(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceEquals(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -209,6 +209,7 @@ pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_multi_comp = @import("react_no_multi_comp.zig");
 pub const react_no_redundant_should_component_update = @import("react_no_redundant_should_component_update.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
+pub const react_no_this_in_sfc = @import("react_no_this_in_sfc.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
 pub const react_no_string_refs = @import("react_no_string_refs.zig");
@@ -1743,6 +1744,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_env) {
             try no_process_env.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.react_no_this_in_sfc) {
+            try react_no_this_in_sfc.check(self.allocator, self.diagnostics, ctx.tree, member, index, ctx);
         }
         if (self.options.typescript_eslint_no_extra_non_null_assertion) {
             try typescript_eslint_no_extra_non_null_assertion.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -735,6 +735,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_this_in_sfc.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_redundant_should_component_update.zig");
 }
 

--- a/tests/rules/react_no_this_in_sfc.zig
+++ b/tests/rules/react_no_this_in_sfc.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-this-in-sfc for function components" {
+    const source =
+        \\function Button() {
+        \\  return <button>{this.props.label}</button>;
+        \\}
+        \\
+        \\const Link = () => <a>{this.context.url}</a>;
+        \\
+        \\const Icon = function () {
+        \\  return React.createElement('span', null, this.props.name);
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_this_in_sfc.id));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("Stateless functional components should not use `this`", diagnostic.message);
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+}
+
+test "allows react/no-this-in-sfc outside stateless function components" {
+    const source =
+        \\function helper() {
+        \\  return this.value;
+        \\}
+        \\
+        \\class Button extends React.Component {
+        \\  render() {
+        \\    return <button>{this.props.label}</button>;
+        \\  }
+        \\}
+        \\
+        \\const lower = () => <span>{this.value}</span>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_this_in_sfc.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_this_in_sfc.id)) return diagnostic;
+    }
+    return null;
+}
+
+test "can disable react/no-this-in-sfc" {
+    const source =
+        \\function Button() {
+        \\  return <button>{this.props.label}</button>;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+        .react_no_this_in_sfc = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_this_in_sfc.id));
+}


### PR DESCRIPTION
Summary:
- Add react/no-this-in-sfc for this.* access inside stateless function components
- Wire the rule into options, CLI disabling, and root member-expression checks
- Cover function declarations, variable function components, React.createElement returns, non-components, and disabling

Tests:
- zig build test --summary all -- 'react/no-this-in-sfc'\n- zig build test -Doptimize=ReleaseFast -j1 --summary all\n- zig build -Doptimize=ReleaseFast --summary all\n- CLI smoke for --rules=react/no-this-in-sfc and --react-no-this-in-sfc=off