### PR TITLE
feat: port typescript-eslint no-duplicate-enum-values

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -228,6 +228,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
+| [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -250,6 +250,7 @@ pub const Options = struct {
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
+    typescript_eslint_no_duplicate_enum_values: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
     typescript_eslint_no_invalid_void_type: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,
@@ -566,6 +567,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unused-vars", true));
     try std.testing.expect(options.typescript_eslint_no_unused_vars);
     try std.testing.expect(!options.no_unused_vars);
+
+    try std.testing.expect(!options.typescript_eslint_no_duplicate_enum_values);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-duplicate-enum-values", true));
+    try std.testing.expect(options.typescript_eslint_no_duplicate_enum_values);
 
     try std.testing.expect(!options.jsx_a11y_aria_props);
     try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -569,6 +569,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_extra_semi = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-extra-non-null-assertion=off")) {
             options.typescript_eslint_no_extra_non_null_assertion = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-duplicate-enum-values=off")) {
+            options.typescript_eslint_no_duplicate_enum_values = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-inferrable-types=off")) {
             options.typescript_eslint_no_inferrable_types = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-invalid-void-type=off")) {
@@ -1331,6 +1333,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-dupe-class-members=off Disable @typescript-eslint/no-dupe-class-members
         \\  --typescript-eslint-no-empty-interface=off Disable @typescript-eslint/no-empty-interface
         \\  --typescript-eslint-no-extra-non-null-assertion=off Disable @typescript-eslint/no-extra-non-null-assertion
+        \\  --typescript-eslint-no-duplicate-enum-values=off Disable @typescript-eslint/no-duplicate-enum-values
         \\  --typescript-eslint-no-inferrable-types=off Disable @typescript-eslint/no-inferrable-types
         \\  --typescript-eslint-no-invalid-void-type=off Disable @typescript-eslint/no-invalid-void-type
         \\  --typescript-eslint-no-namespace=off Disable @typescript-eslint/no-namespace

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -244,6 +244,7 @@ pub const typescript_eslint_no_empty_function = @import("typescript_eslint_no_em
 pub const typescript_eslint_no_empty_interface = @import("typescript_eslint_no_empty_interface.zig");
 pub const typescript_eslint_no_extra_semi = @import("typescript_eslint_no_extra_semi.zig");
 pub const typescript_eslint_no_extra_non_null_assertion = @import("typescript_eslint_no_extra_non_null_assertion.zig");
+pub const typescript_eslint_no_duplicate_enum_values = @import("typescript_eslint_no_duplicate_enum_values.zig");
 pub const typescript_eslint_no_inferrable_types = @import("typescript_eslint_no_inferrable_types.zig");
 pub const typescript_eslint_no_invalid_void_type = @import("typescript_eslint_no_invalid_void_type.zig");
 pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no_loss_of_precision.zig");
@@ -968,6 +969,18 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_consistent_type_definitions) {
             try typescript_eslint_consistent_type_definitions.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_enum_declaration(
+        self: *BasicVisitor,
+        declaration: ast.TSEnumDeclaration,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_duplicate_enum_values) {
+            try typescript_eslint_no_duplicate_enum_values.check(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/src/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-duplicate-enum-values";
+
+const EnumValue = union(enum) {
+    string: []const u8,
+    number: f64,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSEnumDeclaration,
+) Allocator.Error!void {
+    const body = switch (tree.data(declaration.body)) {
+        .ts_enum_body => |body| body,
+        else => return,
+    };
+
+    var seen: std.ArrayList(EnumValue) = .empty;
+    defer seen.deinit(allocator);
+
+    for (tree.extra(body.members)) |member_index| {
+        const member = switch (tree.data(member_index)) {
+            .ts_enum_member => |member| member,
+            else => continue,
+        };
+        const value = literalEnumValue(tree, member.initializer) orelse continue;
+
+        for (seen.items) |seen_value| {
+            if (enumValuesEqual(seen_value, value)) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .@"error",
+                    id,
+                    "Duplicate enum member value.",
+                    tree.span(member.initializer),
+                );
+                break;
+            }
+        } else {
+            try seen.append(allocator, value);
+        }
+    }
+}
+
+fn literalEnumValue(tree: *const ast.Tree, index: ast.NodeIndex) ?EnumValue {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .string_literal => |literal| .{ .string = tree.string(literal.value) },
+        .numeric_literal => |literal| .{ .number = literal.value(tree) },
+        else => null,
+    };
+}
+
+fn enumValuesEqual(left: EnumValue, right: EnumValue) bool {
+    return switch (left) {
+        .string => |left_string| switch (right) {
+            .string => |right_string| std.mem.eql(u8, left_string, right_string),
+            .number => false,
+        },
+        .number => |left_number| switch (right) {
+            .string => false,
+            .number => |right_number| left_number == right_number,
+        },
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -903,6 +903,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_duplicate_enum_values.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_empty_function.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-duplicate-enum-values for repeated literal enum values" {
+    const source =
+        \\enum Status {
+        \\  Pending = "pending",
+        \\  Waiting = "pending",
+        \\  Started = 1,
+        \\  AlsoStarted = 1,
+        \\  DecimalStarted = 1.0,
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_duplicate_enum_values.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "ignores implicit and computed enum initializers" {
+    const source =
+        \\const value = 1;
+        \\enum Status {
+        \\  First,
+        \\  Second,
+        \\  Computed = value,
+        \\  AlsoComputed = value,
+        \\  Expression = 1 + 1,
+        \\  AlsoExpression = 1 + 1,
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+}
+
+test "can disable @typescript-eslint/no-duplicate-enum-values" {
+    const source =
+        \\enum Status {
+        \\  Pending = "pending",
+        \\  Waiting = "pending",
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_duplicate_enum_values = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-duplicate-enum-values support for explicit string and number enum member initializers
- wire the rule into Options, CLI flags, docs, and rule traversal
- add tests for duplicate string/number literals, numeric equivalence, computed initializer ignores, and disable behavior

## Validation
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke: --rules=@typescript-eslint/no-duplicate-enum-values reports 3 duplicate literal enum values, ignores computed/implicit initializers, and reports 0 when disabled