### PR TITLE
feat: port typescript-eslint no-useless-empty-export

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -246,6 +246,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
+| [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -267,6 +267,7 @@ pub const Options = struct {
     typescript_eslint_unified_signatures: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
+    typescript_eslint_no_useless_empty_export: bool = true,
     typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_var_requires: bool = true,
@@ -571,6 +572,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.typescript_eslint_no_duplicate_enum_values);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-duplicate-enum-values", true));
     try std.testing.expect(options.typescript_eslint_no_duplicate_enum_values);
+
+    try std.testing.expect(!options.typescript_eslint_no_useless_empty_export);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-useless-empty-export", true));
+    try std.testing.expect(options.typescript_eslint_no_useless_empty_export);
 
     try std.testing.expect(!options.jsx_a11y_aria_props);
     try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -603,6 +603,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
             options.typescript_eslint_no_useless_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-empty-export=off")) {
+            options.typescript_eslint_no_useless_empty_export = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unused-expressions=off")) {
             options.typescript_eslint_no_unused_expressions = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unused-vars=off")) {
@@ -1347,6 +1349,7 @@ fn printHelp() void {
         \\  --typescript-eslint-typedef=off Disable @typescript-eslint/typedef
         \\  --typescript-eslint-unified-signatures=off Disable @typescript-eslint/unified-signatures
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
+        \\  --typescript-eslint-no-useless-empty-export=off Disable @typescript-eslint/no-useless-empty-export
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -261,6 +261,7 @@ pub const typescript_eslint_typedef = @import("typescript_eslint_typedef.zig");
 pub const typescript_eslint_unified_signatures = @import("typescript_eslint_unified_signatures.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
+pub const typescript_eslint_no_useless_empty_export = @import("typescript_eslint_no_useless_empty_export.zig");
 pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_no_unused_expressions.zig");
 pub const typescript_eslint_no_unused_vars = @import("typescript_eslint_no_unused_vars.zig");
 pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no_use_before_define.zig");
@@ -630,6 +631,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_unified_signatures) {
             try typescript_eslint_unified_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, program.body);
+        }
+        if (self.options.typescript_eslint_no_useless_empty_export) {
+            try typescript_eslint_no_useless_empty_export.check(self.allocator, self.diagnostics, ctx.tree, program);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_useless_empty_export.zig
+++ b/src/rules/typescript_eslint_no_useless_empty_export.zig
@@ -1,0 +1,62 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "@typescript-eslint/no-useless-empty-export";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+) Allocator.Error!void {
+    const body = tree.extra(program.body);
+    var module_statement_count: usize = 0;
+
+    for (body) |statement_index| {
+        if (isTopLevelModuleStatement(tree, statement_index)) {
+            module_statement_count += 1;
+        }
+    }
+
+    if (module_statement_count <= 1) return;
+
+    for (body) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .export_named_declaration => |declaration| declaration,
+            else => continue,
+        };
+        if (!isEmptyExport(tree, declaration)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "`export {}` is unnecessary when another import or export exists.",
+            tree.span(statement_index),
+        );
+    }
+}
+
+fn isTopLevelModuleStatement(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .import_declaration,
+        .export_default_declaration,
+        .export_all_declaration,
+        .ts_import_equals_declaration,
+        .ts_export_assignment,
+        .ts_namespace_export_declaration,
+        => true,
+        .export_named_declaration => true,
+        else => false,
+    };
+}
+
+fn isEmptyExport(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) bool {
+    return declaration.declaration == .null and
+        declaration.source == .null and
+        tree.extra(declaration.specifiers).len == 0;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -983,6 +983,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_useless_empty_export.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unused_expressions.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_useless_empty_export.zig
+++ b/tests/rules/typescript_eslint_no_useless_empty_export.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-useless-empty-export when another import or export exists" {
+    const source =
+        \\import value from "mod";
+        \\export {};
+        \\export const name = value;
+        \\export {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_useless_empty_export.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_useless_empty_export.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows a single empty export that makes a script a module" {
+    const source =
+        \\const local = 1;
+        \\export {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_useless_empty_export.id));
+}
+
+test "does not treat empty re-exports as useless empty exports" {
+    const source =
+        \\export {} from "mod";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_useless_empty_export.id));
+}
+
+test "can disable @typescript-eslint/no-useless-empty-export" {
+    const source =
+        \\import value from "mod";
+        \\export {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_useless_empty_export = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_useless_empty_export.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-useless-empty-export support
- report empty exports only when another top-level import/export already makes the file a module
- wire the rule into Options, CLI flags, docs, traversal, and tests

## Validation
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke: reports one useless empty export with another import/export, allows a single module-marker export, and reports 0 when disabled