### PR TITLE
feat: port react no-access-state-in-setstate

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -212,6 +212,7 @@ pub const Options = struct {
     react_jsx_uses_vars: bool = true,
     react_no_danger: bool = true,
     react_no_danger_with_children: bool = true,
+    react_no_access_state_in_setstate: bool = true,
     react_no_deprecated: bool = true,
     react_no_array_index_key: bool = true,
     react_no_children_prop: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -489,6 +489,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_danger = false;
         } else if (std.mem.eql(u8, arg, "--react-no-danger-with-children=off")) {
             options.react_no_danger_with_children = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-access-state-in-setstate=off")) {
+            options.react_no_access_state_in_setstate = false;
         } else if (std.mem.eql(u8, arg, "--react-no-deprecated=off")) {
             options.react_no_deprecated = false;
         } else if (std.mem.eql(u8, arg, "--react-no-array-index-key=off")) {
@@ -1299,6 +1301,7 @@ fn printHelp() void {
         \\  --react-jsx-uses-vars=off Disable react/jsx-uses-vars
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-danger-with-children=off Disable react/no-danger-with-children
+        \\  --react-no-access-state-in-setstate=off Disable react/no-access-state-in-setstate
         \\  --react-no-deprecated=off Disable react/no-deprecated
         \\  --react-no-array-index-key=off Disable react/no-array-index-key
         \\  --react-no-children-prop=off Disable react/no-children-prop

--- a/src/rules/react_no_access_state_in_setstate.zig
+++ b/src/rules/react_no_access_state_in_setstate.zig
@@ -1,0 +1,508 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-access-state-in-setstate";
+const message = "Use callback in setState when referencing the previous state.";
+
+const MethodUse = struct {
+    method_name: []const u8,
+    node: ast.NodeIndex,
+};
+
+const VariableUse = struct {
+    scope_node: ast.NodeIndex,
+    variable_name: []const u8,
+    node: ast.NodeIndex,
+};
+
+pub const State = struct {
+    methods: std.ArrayList(MethodUse) = .empty,
+    variables: std.ArrayList(VariableUse) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.methods.deinit(allocator);
+        self.variables.deinit(allocator);
+        self.* = .{};
+    }
+};
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (!isThisStateMember(tree, member)) return;
+    if (componentAncestor(tree, ctx) == null) return;
+    if (isInsideSetStateFirstArgument(tree, ctx)) return;
+    if (methodAncestorName(tree, ctx)) |method| {
+        try rememberMethod(allocator, state, method.name, index);
+    }
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (componentAncestor(tree, ctx) == null) return;
+
+    const scope_node = scopeAncestor(ctx) orelse return;
+    if (isThisExpression(tree, declarator.init)) {
+        try rememberDestructuredState(allocator, tree, declarator.id, scope_node, state);
+        return;
+    }
+
+    const state_node = firstThisStateNode(tree, declarator.init) orelse return;
+    try rememberBindingNames(allocator, tree, declarator.id, scope_node, state_node, state);
+
+    const method = methodAncestorName(tree, ctx) orelse return;
+    try rememberMethod(allocator, state, method.name, state_node);
+    _ = index;
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (componentAncestor(tree, ctx) == null) return;
+
+    if (bareCalleeName(tree, call.callee)) |callee_name| {
+        if (stateMethodNode(state, callee_name)) |state_node| {
+            if (methodAncestorName(tree, ctx)) |method| {
+                try rememberMethod(allocator, state, method.name, state_node);
+            }
+        }
+    }
+
+    if (!isThisSetStateCall(tree, call.callee)) return;
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return;
+
+    const scope_node = scopeAncestor(ctx) orelse index;
+    var reported = std.AutoHashMap(ast.NodeIndex, void).init(allocator);
+    defer reported.deinit();
+    try scanSetStateArgument(allocator, diagnostics, tree, arguments[0], scope_node, state, &reported);
+}
+
+fn scanSetStateArgument(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    scope_node: ast.NodeIndex,
+    state: *const State,
+    reported: *std.AutoHashMap(ast.NodeIndex, void),
+) Allocator.Error!void {
+    if (index == .null) return;
+    const current = unwrapTransparent(tree, index);
+    if (current == .null) return;
+
+    const data = tree.data(current);
+    switch (data) {
+        .member_expression => |member| {
+            if (isThisStateMember(tree, member)) {
+                try reportOnce(allocator, diagnostics, tree, current, reported);
+            }
+        },
+        .identifier_reference => |identifier| {
+            const name = tree.string(identifier.name);
+            if (stateVariableNode(state, scope_node, name)) |state_node| {
+                try reportOnce(allocator, diagnostics, tree, state_node, reported);
+            }
+        },
+        .call_expression => |call| {
+            if (bareCalleeName(tree, call.callee)) |callee_name| {
+                if (stateMethodNode(state, callee_name)) |state_node| {
+                    try reportOnce(allocator, diagnostics, tree, state_node, reported);
+                }
+            }
+        },
+        else => {},
+    }
+
+    try scanChildren(allocator, diagnostics, tree, data, scope_node, state, reported);
+}
+
+fn scanChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    data: ast.NodeData,
+    scope_node: ast.NodeIndex,
+    state: *const State,
+    reported: *std.AutoHashMap(ast.NodeIndex, void),
+) Allocator.Error!void {
+    switch (data) {
+        inline else => |node| {
+            const T = @TypeOf(node);
+            if (@typeInfo(T) != .@"struct") return;
+
+            inline for (@typeInfo(T).@"struct".fields) |field| {
+                if (field.type == ast.NodeIndex) {
+                    try scanSetStateArgument(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        @field(node, field.name),
+                        scope_node,
+                        state,
+                        reported,
+                    );
+                } else if (field.type == ast.IndexRange) {
+                    const range = @field(node, field.name);
+                    for (tree.extra(range)) |child| {
+                        try scanSetStateArgument(allocator, diagnostics, tree, child, scope_node, state, reported);
+                    }
+                }
+            }
+        },
+    }
+}
+
+fn reportOnce(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    reported: *std.AutoHashMap(ast.NodeIndex, void),
+) Allocator.Error!void {
+    if (reported.contains(node)) return;
+    try reported.put(node, {});
+    try core.addDiagnostic(allocator, diagnostics, .@"error", id, message, tree.span(node));
+}
+
+fn rememberMethod(allocator: Allocator, state: *State, method_name: []const u8, node: ast.NodeIndex) Allocator.Error!void {
+    for (state.methods.items) |entry| {
+        if (entry.node == node and std.mem.eql(u8, entry.method_name, method_name)) return;
+    }
+    try state.methods.append(allocator, .{ .method_name = method_name, .node = node });
+}
+
+fn rememberBindingNames(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    binding: ast.NodeIndex,
+    scope_node: ast.NodeIndex,
+    node: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (bindingIdentifierName(tree, binding)) |name| {
+        return rememberVariable(allocator, state, scope_node, name, node);
+    }
+
+    switch (tree.data(binding)) {
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try rememberBindingNames(allocator, tree, property.value, scope_node, node, state);
+            }
+        },
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try rememberBindingNames(allocator, tree, element, scope_node, node, state);
+            }
+        },
+        .assignment_pattern => |pattern| try rememberBindingNames(allocator, tree, pattern.left, scope_node, node, state),
+        .binding_rest_element => |rest| try rememberBindingNames(allocator, tree, rest.argument, scope_node, node, state),
+        else => {},
+    }
+}
+
+fn rememberDestructuredState(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    binding: ast.NodeIndex,
+    scope_node: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    const pattern = switch (tree.data(binding)) {
+        .object_pattern => |pattern| pattern,
+        else => return,
+    };
+
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        if (!std.mem.eql(u8, key, "state")) continue;
+
+        if (bindingIdentifierName(tree, property.value)) |name| {
+            try rememberVariable(allocator, state, scope_node, name, property.key);
+        }
+    }
+}
+
+fn rememberVariable(
+    allocator: Allocator,
+    state: *State,
+    scope_node: ast.NodeIndex,
+    variable_name: []const u8,
+    node: ast.NodeIndex,
+) Allocator.Error!void {
+    for (state.variables.items) |entry| {
+        if (entry.scope_node == scope_node and
+            entry.node == node and
+            std.mem.eql(u8, entry.variable_name, variable_name))
+        {
+            return;
+        }
+    }
+    try state.variables.append(allocator, .{
+        .scope_node = scope_node,
+        .variable_name = variable_name,
+        .node = node,
+    });
+}
+
+fn stateMethodNode(state: *const State, name: []const u8) ?ast.NodeIndex {
+    for (state.methods.items) |entry| {
+        if (std.mem.eql(u8, entry.method_name, name)) return entry.node;
+    }
+    return null;
+}
+
+fn stateVariableNode(state: *const State, scope_node: ast.NodeIndex, name: []const u8) ?ast.NodeIndex {
+    for (state.variables.items) |entry| {
+        if (entry.scope_node == scope_node and std.mem.eql(u8, entry.variable_name, name)) return entry.node;
+    }
+    return null;
+}
+
+fn firstThisStateNode(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+    const current = unwrapTransparent(tree, index);
+    if (current == .null) return null;
+
+    const data = tree.data(current);
+    switch (data) {
+        .member_expression => |member| {
+            if (isThisStateMember(tree, member)) return current;
+        },
+        else => {},
+    }
+
+    return firstThisStateChild(tree, data);
+}
+
+fn firstThisStateChild(tree: *const ast.Tree, data: ast.NodeData) ?ast.NodeIndex {
+    switch (data) {
+        inline else => |node| {
+            const T = @TypeOf(node);
+            if (@typeInfo(T) != .@"struct") return null;
+
+            inline for (@typeInfo(T).@"struct".fields) |field| {
+                if (field.type == ast.NodeIndex) {
+                    if (firstThisStateNode(tree, @field(node, field.name))) |found| return found;
+                } else if (field.type == ast.IndexRange) {
+                    const range = @field(node, field.name);
+                    for (tree.extra(range)) |child| {
+                        if (firstThisStateNode(tree, child)) |found| return found;
+                    }
+                }
+            }
+        },
+    }
+    return null;
+}
+
+fn componentAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.NodeIndex {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .class => |class| if (isReactComponentClass(tree, class)) return ancestor,
+            .object_expression => if (isCreateClassObject(tree, ancestor, ctx.path.ancestor(depth + 1))) return ancestor,
+            else => {},
+        }
+    }
+    return null;
+}
+
+const NamedNode = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+};
+
+fn methodAncestorName(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?NamedNode {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .method_definition => |method| {
+                const name = propertyName(tree, method.key, method.computed) orelse continue;
+                return .{ .name = name, .node = ancestor };
+            },
+            .object_property => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                return .{ .name = name, .node = ancestor };
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn scopeAncestor(ctx: *traverser.basic.Ctx) ?ast.NodeIndex {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (ctx.tree.data(ancestor)) {
+            .function,
+            .arrow_function_expression,
+            .method_definition,
+            .object_property,
+            .property_definition,
+            => return ancestor,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn isThisSetStateCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!isThisExpression(tree, member.object)) return false;
+    const name = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, name, "setState");
+}
+
+fn isInsideSetStateFirstArgument(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        const call = switch (tree.data(ancestor)) {
+            .call_expression => |call| call,
+            else => continue,
+        };
+        if (!isThisSetStateCall(tree, call.callee)) continue;
+
+        const arguments = tree.extra(call.arguments);
+        if (arguments.len == 0) return false;
+        const direct_child = ctx.path.ancestor(depth - 1) orelse return false;
+        return direct_child == arguments[0];
+    }
+    return false;
+}
+
+fn isThisStateMember(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    if (member.computed) return false;
+    if (!isThisExpression(tree, member.object)) return false;
+    const name = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, name, "state");
+}
+
+fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .this_expression => true,
+        else => false,
+    };
+}
+
+fn bareCalleeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return identifierReferenceName(tree, unwrapTransparent(tree, index));
+}
+
+fn isCreateClassObject(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0 or arguments[0] != index) return false;
+    return isCreateClassCallee(tree, call.callee);
+}
+
+fn isCreateClassCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const callee = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createReactClass");
+    }
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!identifierReferenceEquals(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "createClass");
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!identifierReferenceEquals(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed or index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceEquals(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -202,6 +202,7 @@ pub const react_jsx_uses_react = @import("react_jsx_uses_react.zig");
 pub const react_jsx_uses_vars = @import("react_jsx_uses_vars.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_danger_with_children = @import("react_no_danger_with_children.zig");
+pub const react_no_access_state_in_setstate = @import("react_no_access_state_in_setstate.zig");
 pub const react_no_deprecated = @import("react_no_deprecated.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
 pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
@@ -338,6 +339,7 @@ pub fn runBasic(
     defer visitor.react_no_array_index_key_state.deinit(allocator);
     defer visitor.react_jsx_no_bind_state.deinit(allocator);
     defer visitor.react_require_render_return_state.deinit(allocator);
+    defer visitor.react_no_access_state_in_setstate_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -569,6 +571,7 @@ const BasicVisitor = struct {
     react_button_has_type_state: react_button_has_type.State = .{},
     react_require_render_return_state: react_require_render_return.State = .{},
     react_no_danger_with_children_bindings: react_no_danger_with_children.ObjectBindings = .{},
+    react_no_access_state_in_setstate_state: react_no_access_state_in_setstate.State = .{},
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
     react_no_array_index_key_state: react_no_array_index_key.State = .{},
     react_jsx_no_bind_state: react_jsx_no_bind.State = .{},
@@ -901,7 +904,7 @@ const BasicVisitor = struct {
     pub fn enter_variable_declarator(
         self: *BasicVisitor,
         declarator: ast.VariableDeclarator,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_prefer_as_const) {
@@ -930,6 +933,16 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        if (self.options.react_no_access_state_in_setstate) {
+            try react_no_access_state_in_setstate.checkVariableDeclarator(
+                self.allocator,
+                ctx.tree,
+                declarator,
+                index,
+                ctx,
+                &self.react_no_access_state_in_setstate_state,
+            );
         }
         return .proceed;
     }
@@ -1650,6 +1663,17 @@ const BasicVisitor = struct {
         if (self.options.react_no_will_update_set_state) {
             try react_no_will_update_set_state.check(self.allocator, self.diagnostics, ctx.tree, call, ctx);
         }
+        if (self.options.react_no_access_state_in_setstate) {
+            try react_no_access_state_in_setstate.checkCallExpression(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                call,
+                index,
+                ctx,
+                &self.react_no_access_state_in_setstate_state,
+            );
+        }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state);
         }
@@ -1770,6 +1794,16 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.react_no_access_state_in_setstate) {
+            try react_no_access_state_in_setstate.checkMemberExpression(
+                self.allocator,
+                ctx.tree,
+                member,
+                index,
+                ctx,
+                &self.react_no_access_state_in_setstate_state,
+            );
         }
         if (self.options.react_no_this_in_sfc) {
             try react_no_this_in_sfc.check(self.allocator, self.diagnostics, ctx.tree, member, index, ctx);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -715,6 +715,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_access_state_in_setstate.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_deprecated.zig");
 }
 

--- a/tests/rules/react_no_access_state_in_setstate.zig
+++ b/tests/rules/react_no_access_state_in_setstate.zig
@@ -1,0 +1,163 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/no-access-state-in-setstate for this.state in setState arguments" {
+    const source =
+        \\class View extends React.Component {
+        \\  update() {
+        \\    this.setState({ count: this.state.count + 1 });
+        \\    this.setState(() => ({ label: this.state.label }));
+        \\    this.setState({ next: update() });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_access_state_in_setstate.id));
+    try std.testing.expect(hasMessage(result, "Use callback in setState when referencing the previous state."));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+}
+
+test "reports react/no-access-state-in-setstate for variables derived from state" {
+    const source =
+        \\class View extends React.Component {
+        \\  update() {
+        \\    const count = this.state.count;
+        \\    const label = this.state.label;
+        \\    this.setState({ count: count });
+        \\    this.setState({ label });
+        \\  }
+        \\}
+        \\class Other extends React.Component {
+        \\  update = () => {
+        \\    const enabled = this.state.enabled;
+        \\    this.setState({ enabled });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_access_state_in_setstate.id));
+}
+
+test "reports react/no-access-state-in-setstate for destructured state" {
+    const source =
+        \\class View extends React.Component {
+        \\  update() {
+        \\    const { state } = this;
+        \\    this.setState({ count: state.count });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_access_state_in_setstate.id));
+}
+
+test "matches react/no-access-state-in-setstate helper call behavior" {
+    const source =
+        \\class View extends React.Component {
+        \\  value() {
+        \\    return this.state.count;
+        \\  }
+        \\  update() {
+        \\    this.setState({ ok: this.value() });
+        \\    this.setState({ count: value() });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_access_state_in_setstate.id));
+}
+
+test "allows react/no-access-state-in-setstate outside previous state access" {
+    const source =
+        \\class View extends React.Component {
+        \\  update(nextCount) {
+        \\    this.setState((state) => ({ count: state.count + 1 }));
+        \\    this.setState({ count: nextCount });
+        \\  }
+        \\}
+        \\class Plain {
+        \\  update() {
+        \\    this.setState({ count: this.state.count + 1 });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_access_state_in_setstate.id));
+}
+
+test "can disable react/no-access-state-in-setstate" {
+    const source =
+        \\class View extends React.Component {
+        \\  update() {
+        \\    this.setState({ count: this.state.count + 1 });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_no_access_state_in_setstate = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_access_state_in_setstate.id));
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_access_state_in_setstate.id)) return diagnostic;
+    }
+    return null;
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, expected)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- port react/no-access-state-in-setstate with React class/createClass context checks
- track this.state-derived variables and destructured state in setState arguments
- add CLI off switch, help text, and focused rule tests

## Verification
- zig build test --summary all -- 'react/no-access-state-in-setstate'
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all