### PR TITLE
feat: port typescript-eslint no-wrapper-object-types

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -251,6 +251,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
+| [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |
 | [`@typescript-eslint/restrict-plus-operands`](https://typescript-eslint.io/rules/restrict-plus-operands/) | Implemented for primitive literals and explicit primitive annotations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -272,6 +272,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_var_requires: bool = true,
+    typescript_eslint_no_wrapper_object_types: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,
     typescript_eslint_restrict_plus_operands: bool = true,
@@ -577,6 +578,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.typescript_eslint_no_useless_empty_export);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-useless-empty-export", true));
     try std.testing.expect(options.typescript_eslint_no_useless_empty_export);
+
+    try std.testing.expect(!options.typescript_eslint_no_wrapper_object_types);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-wrapper-object-types", true));
+    try std.testing.expect(options.typescript_eslint_no_wrapper_object_types);
 
     try std.testing.expect(!options.jsx_a11y_aria_props);
     try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -615,6 +615,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_use_before_define = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-var-requires=off")) {
             options.typescript_eslint_no_var_requires = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-wrapper-object-types=off")) {
+            options.typescript_eslint_no_wrapper_object_types = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-as-const=off")) {
             options.typescript_eslint_prefer_as_const = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-prefer-namespace-keyword=off")) {
@@ -1355,6 +1357,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-useless-empty-export=off Disable @typescript-eslint/no-useless-empty-export
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions
         \\  --typescript-eslint-no-unused-vars=off Disable @typescript-eslint/no-unused-vars
+        \\  --typescript-eslint-no-wrapper-object-types=off Disable @typescript-eslint/no-wrapper-object-types
         \\  --typescript-eslint-prefer-as-const=off Disable @typescript-eslint/prefer-as-const
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
         \\  --typescript-eslint-restrict-plus-operands=off Disable @typescript-eslint/restrict-plus-operands

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -267,6 +267,7 @@ pub const typescript_eslint_no_unused_expressions = @import("typescript_eslint_n
 pub const typescript_eslint_no_unused_vars = @import("typescript_eslint_no_unused_vars.zig");
 pub const typescript_eslint_no_use_before_define = @import("typescript_eslint_no_use_before_define.zig");
 pub const typescript_eslint_no_var_requires = @import("typescript_eslint_no_var_requires.zig");
+pub const typescript_eslint_no_wrapper_object_types = @import("typescript_eslint_no_wrapper_object_types.zig");
 pub const typescript_eslint_prefer_as_const = @import("typescript_eslint_prefer_as_const.zig");
 pub const typescript_eslint_prefer_namespace_keyword = @import("typescript_eslint_prefer_namespace_keyword.zig");
 pub const typescript_eslint_restrict_plus_operands = @import("typescript_eslint_restrict_plus_operands.zig");
@@ -1068,8 +1069,14 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_array_type) {
             try typescript_eslint_array_type.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference, index);
         }
-        if (self.options.typescript_eslint_ban_types) {
+        const wrapper_object_type_reported =
+            self.options.typescript_eslint_no_wrapper_object_types and
+            typescript_eslint_no_wrapper_object_types.isWrapperObjectTypeReference(ctx.tree, reference);
+        if (self.options.typescript_eslint_ban_types and !wrapper_object_type_reported) {
             try typescript_eslint_ban_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
+        }
+        if (self.options.typescript_eslint_no_wrapper_object_types) {
+            try typescript_eslint_no_wrapper_object_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_wrapper_object_types.zig
+++ b/src/rules/typescript_eslint_no_wrapper_object_types.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-wrapper-object-types";
+
+const WrapperObjectType = struct {
+    name: []const u8,
+    replacement: []const u8,
+};
+
+pub fn checkTypeReference(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    reference: ast.TSTypeReference,
+) Allocator.Error!void {
+    const wrapper = wrapperObjectTypeReference(tree, reference) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(reference.type_name),
+        "Prefer `{s}` instead of the wrapper object type `{s}`.",
+        .{ wrapper.replacement, wrapper.name },
+    );
+}
+
+pub fn isWrapperObjectTypeReference(tree: *const ast.Tree, reference: ast.TSTypeReference) bool {
+    return wrapperObjectTypeReference(tree, reference) != null;
+}
+
+fn wrapperObjectTypeReference(tree: *const ast.Tree, reference: ast.TSTypeReference) ?WrapperObjectType {
+    const name = typeName(tree, reference.type_name) orelse return null;
+    return wrapperObjectType(name);
+}
+
+fn wrapperObjectType(name: []const u8) ?WrapperObjectType {
+    if (std.mem.eql(u8, name, "String")) return .{ .name = "String", .replacement = "string" };
+    if (std.mem.eql(u8, name, "Boolean")) return .{ .name = "Boolean", .replacement = "boolean" };
+    if (std.mem.eql(u8, name, "Number")) return .{ .name = "Number", .replacement = "number" };
+    if (std.mem.eql(u8, name, "BigInt")) return .{ .name = "BigInt", .replacement = "bigint" };
+    if (std.mem.eql(u8, name, "Symbol")) return .{ .name = "Symbol", .replacement = "symbol" };
+    if (std.mem.eql(u8, name, "Object")) return .{ .name = "Object", .replacement = "object" };
+    return null;
+}
+
+fn typeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1011,6 +1011,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_wrapper_object_types.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_prefer_as_const.zig");
 }
 

--- a/tests/rules/typescript_eslint_ban_types.zig
+++ b/tests/rules/typescript_eslint_ban_types.zig
@@ -16,6 +16,7 @@ test "reports @typescript-eslint/ban-types for fishlint banned default types" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
         .no_unused_vars = false,
         .no_undef = false,
+        .typescript_eslint_no_wrapper_object_types = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/typescript_eslint_no_wrapper_object_types.zig
+++ b/tests/rules/typescript_eslint_no_wrapper_object_types.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-wrapper-object-types for built-in wrapper object types" {
+    const source =
+        \\let text: String;
+        \\let flag: Boolean;
+        \\let count: Number;
+        \\let big: BigInt;
+        \\let sym: Symbol;
+        \\let value: Object;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_ban_types = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_no_wrapper_object_types.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_wrapper_object_types.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "does not report primitives, lowercase object, Function, or qualified names" {
+    const source =
+        \\let text: string;
+        \\let flag: boolean;
+        \\let count: number;
+        \\let big: bigint;
+        \\let sym: symbol;
+        \\let value: object;
+        \\let fn: Function;
+        \\let namespaced: NS.String;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_ban_types = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_wrapper_object_types.id));
+}
+
+test "does not duplicate @typescript-eslint/ban-types diagnostics for wrapper object types" {
+    const source =
+        \\let text: String;
+        \\let fn: Function;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_wrapper_object_types.id));
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_ban_types.id));
+}
+
+test "can disable @typescript-eslint/no-wrapper-object-types" {
+    const source =
+        \\let text: String;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_wrapper_object_types = false,
+        .typescript_eslint_ban_types = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_wrapper_object_types.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_types.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-wrapper-object-types for String, Boolean, Number, BigInt, Symbol, and Object type references
- avoid duplicate diagnostics with @typescript-eslint/ban-types when both rules are enabled, while preserving ban-types coverage for Function
- wire the rule into Options, CLI flags, docs, traversal, and tests

## Validation
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke: String reports @typescript-eslint/no-wrapper-object-types and Function reports @typescript-eslint/ban-types when both rules are enabled