### PR TITLE
feat: port typescript-eslint no-unnecessary-parameter-property-assignment

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -244,6 +244,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
+| [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -266,6 +266,7 @@ pub const Options = struct {
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_typedef: bool = true,
     typescript_eslint_unified_signatures: bool = true,
+    typescript_eslint_no_unnecessary_parameter_property_assignment: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_useless_empty_export: bool = true,
@@ -582,6 +583,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.typescript_eslint_no_wrapper_object_types);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-wrapper-object-types", true));
     try std.testing.expect(options.typescript_eslint_no_wrapper_object_types);
+
+    try std.testing.expect(!options.typescript_eslint_no_unnecessary_parameter_property_assignment);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-unnecessary-parameter-property-assignment", true));
+    try std.testing.expect(options.typescript_eslint_no_unnecessary_parameter_property_assignment);
 
     try std.testing.expect(!options.jsx_a11y_aria_props);
     try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -601,6 +601,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_typedef = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-unified-signatures=off")) {
             options.typescript_eslint_unified_signatures = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-parameter-property-assignment=off")) {
+            options.typescript_eslint_no_unnecessary_parameter_property_assignment = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unnecessary-type-constraint=off")) {
             options.typescript_eslint_no_unnecessary_type_constraint = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-useless-constructor=off")) {
@@ -1353,6 +1355,7 @@ fn printHelp() void {
         \\  --typescript-eslint-triple-slash-reference=off Disable @typescript-eslint/triple-slash-reference
         \\  --typescript-eslint-typedef=off Disable @typescript-eslint/typedef
         \\  --typescript-eslint-unified-signatures=off Disable @typescript-eslint/unified-signatures
+        \\  --typescript-eslint-no-unnecessary-parameter-property-assignment=off Disable @typescript-eslint/no-unnecessary-parameter-property-assignment
         \\  --typescript-eslint-no-unnecessary-type-constraint=off Disable @typescript-eslint/no-unnecessary-type-constraint
         \\  --typescript-eslint-no-useless-empty-export=off Disable @typescript-eslint/no-useless-empty-export
         \\  --typescript-eslint-no-unused-expressions=off Disable @typescript-eslint/no-unused-expressions

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -260,6 +260,7 @@ pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_a
 pub const typescript_eslint_triple_slash_reference = @import("typescript_eslint_triple_slash_reference.zig");
 pub const typescript_eslint_typedef = @import("typescript_eslint_typedef.zig");
 pub const typescript_eslint_unified_signatures = @import("typescript_eslint_unified_signatures.zig");
+pub const typescript_eslint_no_unnecessary_parameter_property_assignment = @import("typescript_eslint_no_unnecessary_parameter_property_assignment.zig");
 pub const typescript_eslint_no_unnecessary_type_constraint = @import("typescript_eslint_no_unnecessary_type_constraint.zig");
 pub const typescript_eslint_no_useless_constructor = @import("typescript_eslint_no_useless_constructor.zig");
 pub const typescript_eslint_no_useless_empty_export = @import("typescript_eslint_no_useless_empty_export.zig");
@@ -707,6 +708,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
+        if (self.options.typescript_eslint_no_unnecessary_parameter_property_assignment) {
+            try typescript_eslint_no_unnecessary_parameter_property_assignment.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_unnecessary_parameter_property_assignment.zig
+++ b/src/rules/typescript_eslint_no_unnecessary_parameter_property_assignment.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-unnecessary-parameter-property-assignment";
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (method.kind != .constructor) continue;
+
+        const function = switch (tree.data(method.value)) {
+            .function => |function| function,
+            else => continue,
+        };
+        try checkConstructor(allocator, diagnostics, tree, function);
+    }
+}
+
+fn checkConstructor(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    const params = switch (tree.data(function.params)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    var parameter_properties: std.ArrayList([]const u8) = .empty;
+    defer parameter_properties.deinit(allocator);
+
+    for (tree.extra(params.items)) |param_index| {
+        const parameter_property = switch (tree.data(param_index)) {
+            .ts_parameter_property => |parameter_property| parameter_property,
+            else => continue,
+        };
+        const name = parameterPropertyName(tree, parameter_property) orelse continue;
+        try parameter_properties.append(allocator, name);
+    }
+
+    if (parameter_properties.items.len == 0 or function.body == .null) return;
+
+    const body = switch (tree.data(function.body)) {
+        .function_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |statement_index| {
+        try checkStatement(allocator, diagnostics, tree, statement_index, parameter_properties.items);
+    }
+}
+
+fn checkStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement_index: ast.NodeIndex,
+    parameter_properties: []const []const u8,
+) Allocator.Error!void {
+    switch (tree.data(statement_index)) {
+        .expression_statement => |statement| try checkExpression(allocator, diagnostics, tree, statement.expression, parameter_properties),
+        .block_statement => |block| {
+            for (tree.extra(block.body)) |child_statement| {
+                try checkStatement(allocator, diagnostics, tree, child_statement, parameter_properties);
+            }
+        },
+        .if_statement => |statement| {
+            try checkStatement(allocator, diagnostics, tree, statement.consequent, parameter_properties);
+            if (statement.alternate != .null) {
+                try checkStatement(allocator, diagnostics, tree, statement.alternate, parameter_properties);
+            }
+        },
+        else => {},
+    }
+}
+
+fn checkExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression_index: ast.NodeIndex,
+    parameter_properties: []const []const u8,
+) Allocator.Error!void {
+    const expression = switch (tree.data(expression_index)) {
+        .assignment_expression => |expression| expression,
+        else => return,
+    };
+    if (expression.operator != .assign) return;
+
+    const assignment = unnecessaryAssignment(tree, expression, parameter_properties) orelse return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(expression_index),
+        "Assignment to parameter property `{s}` is unnecessary.",
+        .{assignment},
+    );
+}
+
+fn unnecessaryAssignment(
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    parameter_properties: []const []const u8,
+) ?[]const u8 {
+    const left_name = thisPropertyName(tree, expression.left) orelse return null;
+    const right_name = identifierName(tree, expression.right) orelse return null;
+    if (!std.mem.eql(u8, left_name, right_name)) return null;
+
+    for (parameter_properties) |parameter_property| {
+        if (std.mem.eql(u8, parameter_property, left_name)) return parameter_property;
+    }
+    return null;
+}
+
+fn parameterPropertyName(tree: *const ast.Tree, property: ast.TSParameterProperty) ?[]const u8 {
+    return switch (tree.data(property.parameter)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .assignment_pattern => |pattern| switch (tree.data(pattern.left)) {
+            .binding_identifier => |identifier| tree.string(identifier.name),
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn thisPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    if (member.computed) return null;
+    if (tree.data(member.object) != .this_expression) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -979,6 +979,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_unnecessary_parameter_property_assignment.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_no_unnecessary_type_constraint.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_unnecessary_parameter_property_assignment.zig
+++ b/tests/rules/typescript_eslint_no_unnecessary_parameter_property_assignment.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-unnecessary-parameter-property-assignment for redundant constructor assignments" {
+    const source =
+        \\class User {
+        \\  constructor(private name: string, readonly id = 1) {
+        \\    this.name = name;
+        \\    if (id) {
+        \\      this.id = id;
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_unnecessary_parameter_property_assignment.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_unnecessary_parameter_property_assignment.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows assignments that are not from the matching parameter property" {
+    const source =
+        \\class User {
+        \\  constructor(private name: string, private id: number, value: string) {
+        \\    this.name = value;
+        \\    this.id = 2;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unnecessary_parameter_property_assignment.id));
+}
+
+test "can disable @typescript-eslint/no-unnecessary-parameter-property-assignment" {
+    const source =
+        \\class User {
+        \\  constructor(private name: string) {
+        \\    this.name = name;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unnecessary_parameter_property_assignment = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unnecessary_parameter_property_assignment.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-unnecessary-parameter-property-assignment for redundant constructor assignments to parameter properties
- scan constructor bodies, including nested block/if statements, while avoiding nested function/class traversal
- wire the rule into Options, CLI flags, docs, traversal, and tests

## Validation
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke: constructor parameter properties report redundant this.name = name and this.id = id assignments