### PR TITLE
feat: port typescript-eslint no-unsafe-declaration-merging

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -241,6 +241,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
+| [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -264,6 +264,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_this_alias: bool = true,
+    typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_typedef: bool = true,
     typescript_eslint_unified_signatures: bool = true,
@@ -588,6 +589,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.typescript_eslint_no_unnecessary_parameter_property_assignment);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unnecessary-parameter-property-assignment", true));
     try std.testing.expect(options.typescript_eslint_no_unnecessary_parameter_property_assignment);
+
+    try std.testing.expect(!options.typescript_eslint_no_unsafe_declaration_merging);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-unsafe-declaration-merging", true));
+    try std.testing.expect(options.typescript_eslint_no_unsafe_declaration_merging);
 
     try std.testing.expect(!options.jsx_a11y_aria_props);
     try std.testing.expect(options.setByCliName("jsx-a11y/aria-props", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -597,6 +597,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_no_shadow = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-this-alias=off")) {
             options.typescript_eslint_no_this_alias = false;
+        } else if (std.mem.eql(u8, arg, "--typescript-eslint-no-unsafe-declaration-merging=off")) {
+            options.typescript_eslint_no_unsafe_declaration_merging = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-triple-slash-reference=off")) {
             options.typescript_eslint_triple_slash_reference = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-typedef=off")) {
@@ -1355,6 +1357,7 @@ fn printHelp() void {
         \\  --typescript-eslint-no-loop-func=off Disable @typescript-eslint/no-loop-func
         \\  --typescript-eslint-no-shadow=off Disable @typescript-eslint/no-shadow
         \\  --typescript-eslint-no-this-alias=off Disable @typescript-eslint/no-this-alias
+        \\  --typescript-eslint-no-unsafe-declaration-merging=off Disable @typescript-eslint/no-unsafe-declaration-merging
         \\  --typescript-eslint-triple-slash-reference=off Disable @typescript-eslint/triple-slash-reference
         \\  --typescript-eslint-typedef=off Disable @typescript-eslint/typedef
         \\  --typescript-eslint-unified-signatures=off Disable @typescript-eslint/unified-signatures

--- a/src/root.zig
+++ b/src/root.zig
@@ -115,6 +115,7 @@ fn hasSemanticRules(options: Options) bool {
         options.typescript_eslint_no_require_imports or
         options.typescript_eslint_no_loop_func or
         options.typescript_eslint_no_shadow or
+        options.typescript_eslint_no_unsafe_declaration_merging or
         options.typescript_eslint_no_unused_vars or
         options.typescript_eslint_no_use_before_define or
         options.typescript_eslint_no_var_requires;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -258,6 +258,7 @@ pub const typescript_eslint_no_redeclare = @import("typescript_eslint_no_redecla
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
 pub const typescript_eslint_no_shadow = @import("typescript_eslint_no_shadow.zig");
 pub const typescript_eslint_no_this_alias = @import("typescript_eslint_no_this_alias.zig");
+pub const typescript_eslint_no_unsafe_declaration_merging = @import("typescript_eslint_no_unsafe_declaration_merging.zig");
 pub const typescript_eslint_triple_slash_reference = @import("typescript_eslint_triple_slash_reference.zig");
 pub const typescript_eslint_typedef = @import("typescript_eslint_typedef.zig");
 pub const typescript_eslint_unified_signatures = @import("typescript_eslint_unified_signatures.zig");
@@ -401,6 +402,10 @@ pub fn runSemantic(
 
     if (use_typescript_no_redeclare) {
         try typescript_eslint_no_redeclare.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.typescript_eslint_no_unsafe_declaration_merging and tree.isTs()) {
+        try typescript_eslint_no_unsafe_declaration_merging.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     const use_typescript_no_shadow = options.typescript_eslint_no_shadow and tree.isTs();

--- a/src/rules/typescript_eslint_no_unsafe_declaration_merging.zig
+++ b/src/rules/typescript_eslint_no_unsafe_declaration_merging.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-unsafe-declaration-merging";
+
+const DeclKind = enum {
+    class,
+    interface,
+};
+
+const DeclKindMap = std.AutoHashMap(ast.NodeIndex, DeclKind);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var decl_kinds = DeclKindMap.init(allocator);
+    defer decl_kinds.deinit();
+
+    var visitor = DeclKindVisitor{ .decl_kinds = &decl_kinds };
+    try traverser.basic.traverse(DeclKindVisitor, tree, &visitor);
+
+    var iter = symbol_table.iterSymbols();
+    while (iter.next()) |entry| {
+        const decls = symbol_table.symbolDecls(entry.id);
+        if (decls.len <= 1) continue;
+
+        var has_class = false;
+        var has_interface = false;
+        for (decls) |decl| {
+            switch (decl_kinds.get(decl) orelse continue) {
+                .class => has_class = true,
+                .interface => has_interface = true,
+            }
+        }
+        if (!has_class or !has_interface) continue;
+
+        const name = tree.string(entry.symbol.name);
+        for (decls) |decl| {
+            if (decl_kinds.get(decl) == null) continue;
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                tree.span(decl),
+                "Unsafe declaration merging between class and interface `{s}`.",
+                .{name},
+            );
+        }
+    }
+}
+
+const DeclKindVisitor = struct {
+    decl_kinds: *DeclKindMap,
+
+    pub fn enter_class(
+        self: *DeclKindVisitor,
+        class: ast.Class,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (class.id != .null) {
+            try self.decl_kinds.put(class.id, .class);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_interface_declaration(
+        self: *DeclKindVisitor,
+        declaration: ast.TSInterfaceDeclaration,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.decl_kinds.put(declaration.id, .interface);
+        return .proceed;
+    }
+};

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -971,6 +971,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/typescript_eslint_no_unsafe_declaration_merging.zig");
+}
+
+comptime {
     _ = @import("rules/typescript_eslint_triple_slash_reference.zig");
 }
 

--- a/tests/rules/typescript_eslint_no_unsafe_declaration_merging.zig
+++ b/tests/rules/typescript_eslint_no_unsafe_declaration_merging.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @typescript-eslint/no-unsafe-declaration-merging for class and interface with same name" {
+    const source =
+        \\class User {
+        \\  name = "";
+        \\}
+        \\interface User {
+        \\  id: string;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_unsafe_declaration_merging.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_redeclare.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_unsafe_declaration_merging.id)) {
+            try std.testing.expectEqual(lint.Severity.@"error", diagnostic.severity);
+        }
+    }
+}
+
+test "allows safe declaration merging forms" {
+    const source =
+        \\interface User {
+        \\  id: string;
+        \\}
+        \\interface User {
+        \\  name: string;
+        \\}
+        \\class Store {}
+        \\namespace Store {
+        \\  export const version = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unsafe_declaration_merging.id));
+}
+
+test "can disable @typescript-eslint/no-unsafe-declaration-merging" {
+    const source =
+        \\class User {}
+        \\interface User {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_unsafe_declaration_merging = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unsafe_declaration_merging.id));
+}
+
+test "runs @typescript-eslint/no-unsafe-declaration-merging when it is the only enabled semantic rule" {
+    const source =
+        \\class User {}
+        \\interface User {}
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.typescript_eslint_no_unsafe_declaration_merging = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_unsafe_declaration_merging.id));
+}


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-unsafe-declaration-merging using the semantic symbol table
- report class/interface declaration merging while allowing interface/interface and namespace/class merges
- wire the rule into semantic gating, Options, CLI flags, docs, and tests

## Validation
- zig build test -Doptimize=ReleaseFast -j1
- zig build -Doptimize=ReleaseFast -j1
- CLI smoke: --rules=@typescript-eslint/no-unsafe-declaration-merging reports class/interface User declarations