### PR TITLE
feat: port react jsx-filename-extension

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -199,6 +199,7 @@ pub const Options = struct {
     prefer_spread: bool = true,
     prefer_template: bool = true,
     react_jsx_boolean_value: bool = true,
+    react_jsx_filename_extension: bool = true,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
     react_jsx_no_bind: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -463,6 +463,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_template = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-boolean-value=off")) {
             options.react_jsx_boolean_value = false;
+        } else if (std.mem.eql(u8, arg, "--react-jsx-filename-extension=off")) {
+            options.react_jsx_filename_extension = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-duplicate-props=off")) {
             options.react_jsx_no_duplicate_props = false;
         } else if (std.mem.eql(u8, arg, "--react-jsx-no-comment-textnodes=off")) {
@@ -1302,6 +1304,7 @@ fn printHelp() void {
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread
         \\  --react-jsx-boolean-value=off Disable react/jsx-boolean-value
+        \\  --react-jsx-filename-extension=off Disable react/jsx-filename-extension
         \\  --react-jsx-no-duplicate-props=off Disable react/jsx-no-duplicate-props
         \\  --react-jsx-no-comment-textnodes=off Disable react/jsx-no-comment-textnodes
         \\  --react-jsx-no-bind=off Disable react/jsx-no-bind

--- a/src/root.zig
+++ b/src/root.zig
@@ -26,10 +26,7 @@ pub fn lintSource(
         effective_options.typescript_eslint_no_namespace = false;
     }
 
-    var tree = try parser.parse(allocator, source, .{
-        .source_type = ast.SourceType.fromPath(path),
-        .lang = ast.Lang.fromPath(path),
-    });
+    var tree = try parseSource(allocator, source, path);
     defer tree.deinit();
 
     const needs_semantic = hasSemanticRules(effective_options);
@@ -48,6 +45,46 @@ pub fn lintSource(
     return .{
         .diagnostics = try diagnostics.toOwnedSlice(allocator),
     };
+}
+
+fn parseSource(allocator: Allocator, source: []const u8, path: []const u8) Allocator.Error!ast.Tree {
+    var tree = try parser.parse(allocator, source, .{
+        .source_type = ast.SourceType.fromPath(path),
+        .lang = ast.Lang.fromPath(path),
+    });
+
+    const fallback_lang = jsxFallbackLang(path) orelse return tree;
+    if (!tree.hasErrors()) return tree;
+
+    var fallback_tree = try parser.parse(allocator, source, .{
+        .source_type = ast.SourceType.fromPath(path),
+        .lang = fallback_lang,
+    });
+    if (fallback_tree.hasErrors()) {
+        fallback_tree.deinit();
+        return tree;
+    }
+
+    tree.deinit();
+    return fallback_tree;
+}
+
+fn jsxFallbackLang(path: []const u8) ?ast.Lang {
+    if (std.mem.endsWith(u8, path, ".js") or
+        std.mem.endsWith(u8, path, ".mjs") or
+        std.mem.endsWith(u8, path, ".cjs"))
+    {
+        return .jsx;
+    }
+
+    if (std.mem.endsWith(u8, path, ".ts") or
+        std.mem.endsWith(u8, path, ".mts") or
+        std.mem.endsWith(u8, path, ".cts"))
+    {
+        return .tsx;
+    }
+
+    return null;
 }
 
 pub fn isLintablePath(path: []const u8) bool {

--- a/src/rules/react_jsx_filename_extension.zig
+++ b/src/rules/react_jsx_filename_extension.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/jsx-filename-extension";
+
+const allowed_extensions = [_][]const u8{
+    ".jsx",
+    ".js",
+    ".tsx",
+    ".ts",
+    ".vue",
+};
+
+pub const State = struct {
+    reported: bool = false,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (state.reported or isAllowedExtension(file_path)) return;
+
+    state.reported = true;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "JSX not allowed in files with extension '{s}'",
+        .{extension(file_path)},
+    );
+}
+
+fn isAllowedExtension(file_path: []const u8) bool {
+    for (&allowed_extensions) |allowed| {
+        if (std.mem.endsWith(u8, file_path, allowed)) return true;
+    }
+    return false;
+}
+
+fn extension(file_path: []const u8) []const u8 {
+    const basename = std.fs.path.basename(file_path);
+    const dot_index = std.mem.lastIndexOfScalar(u8, basename, '.') orelse return "";
+    if (dot_index == 0) return "";
+    return basename[dot_index..];
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -191,6 +191,7 @@ pub const prefer_spread = @import("prefer_spread.zig");
 pub const prefer_template = @import("prefer_template.zig");
 pub const react_button_has_type = @import("react_button_has_type.zig");
 pub const react_jsx_boolean_value = @import("react_jsx_boolean_value.zig");
+pub const react_jsx_filename_extension = @import("react_jsx_filename_extension.zig");
 pub const react_jsx_no_duplicate_props = @import("react_jsx_no_duplicate_props.zig");
 pub const react_jsx_no_comment_textnodes = @import("react_jsx_no_comment_textnodes.zig");
 pub const react_jsx_no_bind = @import("react_jsx_no_bind.zig");
@@ -588,6 +589,7 @@ const BasicVisitor = struct {
     react_forbid_prop_types_state: react_forbid_prop_types.State = .{},
     react_no_children_prop_bindings: react_no_children_prop.ReactBindings = .{},
     react_no_array_index_key_state: react_no_array_index_key.State = .{},
+    react_jsx_filename_extension_state: react_jsx_filename_extension.State = .{},
     react_jsx_no_bind_state: react_jsx_no_bind.State = .{},
     react_jsx_key_state: react_jsx_key.State = .{},
     react_no_multi_comp_state: react_no_multi_comp.State = .{},
@@ -1919,6 +1921,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_children_prop) {
             try react_no_children_prop.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
+        if (self.options.react_jsx_filename_extension) {
+            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state);
+        }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
@@ -1933,6 +1938,18 @@ const BasicVisitor = struct {
         }
         if (self.options.react_void_dom_elements_no_children) {
             try react_void_dom_elements_no_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_jsx_fragment(
+        self: *BasicVisitor,
+        _: ast.JSXFragment,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.react_jsx_filename_extension) {
+            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -715,6 +715,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_jsx_filename_extension.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_access_state_in_setstate.zig");
 }
 

--- a/tests/rules/react_jsx_filename_extension.zig
+++ b/tests/rules/react_jsx_filename_extension.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports react/jsx-filename-extension for JSX in disallowed extensions" {
+    const source =
+        \\const view = <div />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(hasMessage(result, "JSX not allowed in files with extension '.mjs'"));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+}
+
+test "reports react/jsx-filename-extension for JSX fragments" {
+    const source =
+        \\const view = <></>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cts", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(hasMessage(result, "JSX not allowed in files with extension '.cts'"));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+}
+
+test "reports react/jsx-filename-extension only once per file" {
+    const source =
+        \\const one = <div />;
+        \\const two = <span />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+}
+
+test "allows react/jsx-filename-extension for fishlint allowed extensions" {
+    const source =
+        \\const view = <div />;
+    ;
+
+    var js_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer js_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(js_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(js_result, "parse"));
+
+    var jsx_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer jsx_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(jsx_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(jsx_result, "parse"));
+
+    var ts_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", baseOptions());
+    defer ts_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(ts_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(ts_result, "parse"));
+
+    var tsx_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", baseOptions());
+    defer tsx_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(tsx_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(tsx_result, "parse"));
+}
+
+test "preserves parser diagnostics when JSX fallback still fails" {
+    const source =
+        \\const view = <div;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(helpers.hasRule(result, "parse"));
+}
+
+test "can disable react/jsx-filename-extension" {
+    const source =
+        \\const view = <div />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_jsx_filename_extension = false,
+        .react_jsx_uses_react = false,
+        .react_jsx_uses_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_jsx_uses_react = false,
+        .react_jsx_uses_vars = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_jsx_filename_extension.id) and
+            std.mem.eql(u8, diagnostic.message, expected))
+        {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- port `react/jsx-filename-extension` using the fishlint allowed extension set: `.jsx`, `.js`, `.tsx`, `.ts`, `.vue`
- add JSX/TSX parse fallback for `.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, and `.cts` when the regular parse fails, so JSX rules can inspect JSX in those files instead of only seeing parse errors
- register the rule in options, traversal, CLI `--rules`, and help output
- add tests for allowed extensions, disallowed extensions, fragments, one diagnostic per file, fallback parse failures, and disabling the rule

## Validation
- `zig build test --summary all -- 'react/jsx-filename-extension'`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- compared fixture diagnostics against `eslint-plugin-react` with fishlint `extensions` config
- CLI smoke for allowed `.js`, rejected `.mjs`, `--react-jsx-filename-extension=off`, and `--help`
