### PR TITLE
[codex] Add benchmark chart script and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate": "node scripts/generate-corpus.mjs",
     "bench": "node scripts/run-benchmark.mjs",
+    "chart": "node scripts/render-chart.mjs",
     "codspeed": "node scripts/run-codspeed.mjs"
   },
   "devDependencies": {

--- a/benchmarks/scripts/render-chart.mjs
+++ b/benchmarks/scripts/render-chart.mjs
@@ -1,0 +1,129 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const input = process.argv[2] ?? "results/latest.json";
+const outputSvg = process.argv[3] ?? "results/latest.svg";
+const outputPng = outputSvg.replace(/\.svg$/i, ".png");
+
+const benchmark = JSON.parse(await readFile(input, "utf8"));
+const rows = benchmark.results
+  .map((result) => ({
+    name: result.name,
+    medianMs: result.summary.medianMs
+  }))
+  .sort((a, b) => a.medianMs - b.medianMs);
+
+const slowest = Math.max(...rows.map((row) => row.medianMs));
+const colors = new Map([
+  ["utoo-lint", "#ff7a45"],
+  ["oxlint", "#ec4899"],
+  ["biome", "#62cdf3"],
+  ["eslint", "#8b5cf6"]
+]);
+
+const width = 1200;
+const height = 520;
+const chartX = 72;
+const chartY = 76;
+const labelWidth = 150;
+const barX = chartX + labelWidth;
+const barMaxWidth = 760;
+const barHeight = 48;
+const rowGap = 84;
+const scaleMax = Math.log10(slowest);
+const bars = rows
+  .map((row, index) => {
+    const y = chartY + index * rowGap;
+    const color = colors.get(row.name) ?? "#94a3b8";
+    const barWidth = Math.max(82, Math.round((Math.log10(row.medianMs) / scaleMax) * barMaxWidth));
+
+    return `
+      <g>
+        <text x="${chartX + labelWidth - 28}" y="${y + 34}" class="tool" text-anchor="end">${escapeXml(displayName(row.name))}</text>
+        <rect x="${barX}" y="${y}" width="${barWidth}" height="${barHeight}" fill="${color}"/>
+        <text x="${barX + barWidth + 22}" y="${y + 34}" class="value">${formatMs(row.medianMs)}</text>
+      </g>`;
+  })
+  .join("\n");
+
+const generated = new Date(benchmark.generatedAt);
+const generatedLabel = Number.isNaN(generated.valueOf())
+  ? benchmark.generatedAt
+  : generated.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC"
+    });
+
+const subtitle = [
+  `${benchmark.targetFiles} TypeScript files`,
+  `${benchmark.rules.length} shared lint rules`,
+  "fresh CLI process",
+  `${benchmark.platform}/${benchmark.arch}`
+].join(" · ");
+
+const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <defs>
+    <filter id="softText" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <rect width="${width}" height="${height}" fill="#15120b"/>
+
+  <style>
+    text {
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+      filter: url(#softText);
+    }
+    .tool { fill: #d7d1c6; font-size: 25px; font-weight: 520; }
+    .value { fill: #d7d1c6; font-size: 25px; font-weight: 520; }
+    .caption { fill: #8d877c; font-size: 15px; font-weight: 520; }
+    .code { fill: #d7d1c6; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 15px; }
+  </style>
+
+  ${bars}
+
+  <text x="${barX + 20}" y="432" class="caption">Linting speed for ${escapeXml(subtitle)} · median wall-clock time · lower is better</text>
+  <text x="${barX + 376}" y="432" class="code"></text>
+  <text x="${barX + 20}" y="462" class="caption">Source: ${escapeXml(basename(input))} · generated ${escapeXml(generatedLabel)} · visual scale adjusted for readability</text>
+</svg>
+`;
+
+await mkdir(dirname(outputSvg), { recursive: true });
+await writeFile(outputSvg, svg);
+
+const raster = spawnSync("rsvg-convert", ["-w", String(width), "-h", String(height), "-f", "png", "-o", outputPng, outputSvg], {
+  encoding: "utf8"
+});
+
+if (raster.error || raster.status !== 0) {
+  const detail = [raster.error?.message, raster.stderr?.trim()].filter(Boolean).join("\n");
+  console.error(`Wrote ${outputSvg}`);
+  console.error(`Could not write ${outputPng} with rsvg-convert${detail ? `:\n${detail}` : "."}`);
+  process.exitCode = 1;
+} else {
+  console.log(`Wrote ${outputSvg}`);
+  console.log(`Wrote ${outputPng}`);
+}
+
+function displayName(name) {
+  if (name === "utoo-lint") return "utoo-lint";
+  return name[0].toUpperCase() + name.slice(1);
+}
+
+function formatMs(value) {
+  return `${value.toFixed(2)}ms`;
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}


### PR DESCRIPTION
## Summary

- Add a root MIT `LICENSE` file matching the npm package license metadata.
- Add `npm run chart` for benchmark result visualization.
- Add `benchmarks/scripts/render-chart.mjs` to render `results/latest.json` into SVG/PNG benchmark bars.

## Validation

- `cd benchmarks && npm run chart`
