### PR TITLE
feat: port react no-unused-state

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -227,6 +227,7 @@ pub const Options = struct {
     react_no_this_in_sfc: bool = true,
     react_no_typos: bool = true,
     react_no_unknown_property: bool = true,
+    react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
     react_prefer_es6_class: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -519,6 +519,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_typos = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unknown-property=off")) {
             options.react_no_unknown_property = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-unused-state=off")) {
+            options.react_no_unused_state = false;
         } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
             options.react_no_string_refs = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unescaped-entities=off")) {
@@ -1332,6 +1334,7 @@ fn printHelp() void {
         \\  --react-no-this-in-sfc=off Disable react/no-this-in-sfc
         \\  --react-no-typos=off Disable react/no-typos
         \\  --react-no-unknown-property=off Disable react/no-unknown-property
+        \\  --react-no-unused-state=off Disable react/no-unused-state
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities
         \\  --react-prefer-es6-class=off Disable react/prefer-es6-class

--- a/src/rules/react_no_unused_state.zig
+++ b/src/rules/react_no_unused_state.zig
@@ -1,0 +1,698 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-unused-state";
+
+const StateField = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+};
+
+pub const State = struct {
+    active: bool = false,
+    abandoned: bool = false,
+    component_index: ast.NodeIndex = .null,
+    aliases_active: bool = false,
+    state_param_name: ?[]const u8 = null,
+    state_fields: std.ArrayList(StateField) = .empty,
+    used_state_fields: std.StringHashMapUnmanaged(void) = .empty,
+    aliases: std.StringHashMapUnmanaged(void) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.state_fields.deinit(allocator);
+        self.used_state_fields.deinit(allocator);
+        self.aliases.deinit(allocator);
+        self.* = .{};
+    }
+
+    fn beginComponent(self: *State, allocator: Allocator, index: ast.NodeIndex) Allocator.Error!void {
+        if (self.active) return;
+        self.state_fields.clearRetainingCapacity();
+        self.used_state_fields.clearRetainingCapacity();
+        self.aliases.clearRetainingCapacity();
+        self.active = true;
+        self.abandoned = false;
+        self.component_index = index;
+        self.aliases_active = false;
+        self.state_param_name = null;
+        try self.used_state_fields.ensureTotalCapacity(allocator, 16);
+        try self.aliases.ensureTotalCapacity(allocator, 8);
+    }
+
+    fn finishComponent(
+        self: *State,
+        allocator: Allocator,
+        diagnostics: *core.DiagnosticList,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        if (!self.active or self.component_index != index) return;
+        defer {
+            self.active = false;
+            self.abandoned = false;
+            self.component_index = .null;
+            self.aliases_active = false;
+            self.state_param_name = null;
+            self.state_fields.clearRetainingCapacity();
+            self.used_state_fields.clearRetainingCapacity();
+            self.aliases.clearRetainingCapacity();
+        }
+
+        if (self.abandoned) return;
+
+        for (self.state_fields.items) |field| {
+            if (self.used_state_fields.contains(field.name)) continue;
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                tree.span(field.node),
+                "Unused state field: '{s}'",
+                .{field.name},
+            );
+        }
+    }
+
+    fn addStateField(self: *State, allocator: Allocator, name: []const u8, node: ast.NodeIndex) Allocator.Error!void {
+        if (!self.active or self.abandoned) return;
+        for (self.state_fields.items) |field| {
+            if (std.mem.eql(u8, field.name, name)) return;
+        }
+        try self.state_fields.append(allocator, .{ .name = name, .node = node });
+    }
+
+    fn addUsedStateField(self: *State, allocator: Allocator, name: []const u8) Allocator.Error!void {
+        if (!self.active or self.abandoned) return;
+        try self.used_state_fields.put(allocator, name, {});
+    }
+
+    fn addAlias(self: *State, allocator: Allocator, name: []const u8) Allocator.Error!void {
+        if (!self.active or self.abandoned or !self.aliases_active) return;
+        try self.aliases.put(allocator, name, {});
+    }
+};
+
+pub fn enterClass(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (isReactComponentClass(tree, class)) {
+        try state.beginComponent(allocator, index);
+    }
+}
+
+pub fn exitClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    try state.finishComponent(allocator, diagnostics, tree, index);
+}
+
+pub fn enterObjectExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (isCreateClassObject(tree, index, parent_index)) {
+        try state.beginComponent(allocator, index);
+    }
+}
+
+pub fn exitObjectExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    try state.finishComponent(allocator, diagnostics, tree, index);
+}
+
+pub fn enterMethodDefinition(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+    state.aliases_active = true;
+    state.aliases.clearRetainingCapacity();
+    state.state_param_name = lifecycleStateParameterName(tree, method);
+    try state.aliases.ensureTotalCapacity(allocator, 8);
+}
+
+pub fn exitMethodDefinition(_: ast.MethodDefinition, state: *State) void {
+    if (!state.active) return;
+    state.aliases_active = false;
+    state.aliases.clearRetainingCapacity();
+    state.state_param_name = null;
+}
+
+pub fn enterPropertyDefinition(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+
+    const name = propertyName(tree, property.key, property.computed);
+    if (!property.static and name != null and std.mem.eql(u8, name.?, "state")) {
+        if (objectExpression(tree, property.value)) |object| {
+            try addStateFieldsFromObject(allocator, tree, object, state);
+        }
+    }
+
+    if (!property.static and isArrowFunctionExpression(tree, property.value)) {
+        state.aliases_active = true;
+        state.aliases.clearRetainingCapacity();
+        state.state_param_name = null;
+        try state.aliases.ensureTotalCapacity(allocator, 8);
+    }
+}
+
+pub fn exitPropertyDefinition(property: ast.PropertyDefinition, tree: *const ast.Tree, state: *State) void {
+    if (!state.active) return;
+    if (!property.static and isArrowFunctionExpression(tree, property.value)) {
+        state.aliases_active = false;
+        state.aliases.clearRetainingCapacity();
+        state.state_param_name = null;
+    }
+}
+
+pub fn enterObjectProperty(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+    const parent = parent_index orelse return;
+    if (state.component_index != parent) return;
+
+    const key = propertyName(tree, property.key, property.computed) orelse return;
+    if (std.mem.eql(u8, key, "getInitialState")) {
+        const returned = returnArgument(tree, property.value) orelse return;
+        if (objectExpression(tree, returned)) |object| {
+            try addStateFieldsFromObject(allocator, tree, object, state);
+        }
+        return;
+    }
+
+    if (isFunctionLike(tree, property.value)) {
+        _ = index;
+        state.aliases_active = true;
+        state.aliases.clearRetainingCapacity();
+        state.state_param_name = null;
+        try state.aliases.ensureTotalCapacity(allocator, 8);
+    }
+}
+
+pub fn exitObjectProperty(property: ast.ObjectProperty, tree: *const ast.Tree, parent_index: ?ast.NodeIndex, state: *State) void {
+    if (!state.active) return;
+    const parent = parent_index orelse return;
+    if (state.component_index != parent) return;
+    const key = propertyName(tree, property.key, property.computed) orelse return;
+    if (!std.mem.eql(u8, key, "getInitialState") and isFunctionLike(tree, property.value)) {
+        state.aliases_active = false;
+        state.aliases.clearRetainingCapacity();
+        state.state_param_name = null;
+    }
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+    if (!isSetStateCall(tree, call)) return;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return;
+
+    const first = unwrapTransparent(tree, arguments[0]);
+    if (objectExpression(tree, first)) |object| {
+        try addStateFieldsFromObject(allocator, tree, object, state);
+        return;
+    }
+
+    const arrow = switch (tree.data(first)) {
+        .arrow_function_expression => |arrow| arrow,
+        else => return,
+    };
+    if (objectExpression(tree, arrow.body)) |object| {
+        try addStateFieldsFromObject(allocator, tree, object, state);
+    }
+    if (firstParameter(allocator, tree, arrow.params)) |param| {
+        switch (param.kind) {
+            .name => try state.addAlias(allocator, param.name.?),
+            .object_pattern => try handleStateDestructuring(allocator, tree, param.node, state),
+            .none => {},
+        }
+    }
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+
+    const left = unwrapTransparent(tree, expression.left);
+    const right = unwrapTransparent(tree, expression.right);
+
+    if (isThisStateMember(tree, left) and objectExpression(tree, right) != null and inConstructor(tree, ctx)) {
+        try addStateFieldsFromObject(allocator, tree, objectExpression(tree, right).?, state);
+        return;
+    }
+
+    try handleAssignment(allocator, tree, left, right, state);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned or declarator.init == .null) return;
+    try handleAssignment(allocator, tree, declarator.id, declarator.init, state);
+}
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (!state.active or state.abandoned) return;
+
+    if (isStateReference(tree, member.object, state)) {
+        if (member.computed and propertyName(tree, member.property, true) == null) {
+            state.abandoned = true;
+            return;
+        }
+        if (propertyName(tree, member.property, member.computed)) |name| {
+            try state.addUsedStateField(allocator, name);
+        }
+        return;
+    }
+
+    if (isStateReference(tree, index, state)) {
+        const parent = ctx.path.ancestor(1) orelse return;
+        if (tree.data(parent) == .call_expression) {
+            state.abandoned = true;
+        }
+    }
+}
+
+pub fn checkJSXSpreadAttribute(tree: *const ast.Tree, attribute: ast.JSXSpreadAttribute, state: *State) void {
+    if (state.active and isStateReference(tree, attribute.argument, state)) {
+        state.abandoned = true;
+    }
+}
+
+pub fn checkSpreadElement(tree: *const ast.Tree, element: ast.SpreadElement, state: *State) void {
+    if (state.active and isStateReference(tree, element.argument, state)) {
+        state.abandoned = true;
+    }
+}
+
+const FirstParameter = struct {
+    const Kind = enum { none, name, object_pattern };
+
+    kind: Kind = .none,
+    name: ?[]const u8 = null,
+    node: ast.NodeIndex = .null,
+};
+
+fn firstParameter(_: Allocator, tree: *const ast.Tree, params_index: ast.NodeIndex) ?FirstParameter {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return null,
+    };
+    const items = tree.extra(params.items);
+    if (items.len == 0) return null;
+    const pattern = switch (tree.data(items[0])) {
+        .formal_parameter => |parameter| parameter.pattern,
+        else => items[0],
+    };
+    if (bindingIdentifierName(tree, pattern)) |name| return .{ .kind = .name, .name = name, .node = pattern };
+    if (tree.data(unwrapTransparent(tree, pattern)) == .object_pattern) return .{ .kind = .object_pattern, .node = pattern };
+    return .{};
+}
+
+fn handleAssignment(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    left: ast.NodeIndex,
+    right: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (assignmentTargetName(tree, left)) |name| {
+        if (isStateReference(tree, right, state)) {
+            try state.addAlias(allocator, name);
+        }
+        return;
+    }
+
+    if (tree.data(unwrapTransparent(tree, left)) == .object_pattern) {
+        if (isStateReference(tree, right, state)) {
+            try handleStateDestructuring(allocator, tree, left, state);
+        } else if (tree.data(unwrapTransparent(tree, right)) == .this_expression) {
+            try handleThisDestructuring(allocator, tree, left, state);
+        }
+    }
+}
+
+fn handleThisDestructuring(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    pattern_index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    const pattern = switch (tree.data(unwrapTransparent(tree, pattern_index))) {
+        .object_pattern => |pattern| pattern,
+        else => return,
+    };
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        if (!std.mem.eql(u8, key, "state")) continue;
+        if (bindingIdentifierName(tree, property.value)) |name| {
+            try state.addAlias(allocator, name);
+        } else {
+            try handleStateDestructuring(allocator, tree, property.value, state);
+        }
+    }
+}
+
+fn handleStateDestructuring(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    pattern_index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    const pattern = switch (tree.data(unwrapTransparent(tree, pattern_index))) {
+        .object_pattern => |pattern| pattern,
+        else => return,
+    };
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        try state.addUsedStateField(allocator, key);
+    }
+    if (pattern.rest != .null) {
+        const rest = switch (tree.data(pattern.rest)) {
+            .binding_rest_element => |rest| rest,
+            else => return,
+        };
+        if (bindingIdentifierName(tree, rest.argument)) |name| {
+            try state.addAlias(allocator, name);
+        }
+    }
+}
+
+fn addStateFieldsFromObject(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    object: ast.ObjectExpression,
+    state: *State,
+) Allocator.Error!void {
+    for (tree.extra(object.properties)) |property_index| {
+        switch (tree.data(property_index)) {
+            .object_property => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                try state.addStateField(allocator, name, property_index);
+            },
+            .spread_element => state.abandoned = true,
+            else => {},
+        }
+    }
+}
+
+fn isStateReference(tree: *const ast.Tree, index: ast.NodeIndex, state: *const State) bool {
+    const current = unwrapTransparent(tree, index);
+    if (isThisStateMember(tree, current)) return true;
+    if (identifierReferenceName(tree, current)) |name| {
+        if (state.aliases_active and state.aliases.contains(name)) return true;
+        if (state.state_param_name) |state_param| {
+            if (std.mem.eql(u8, name, state_param)) return true;
+        }
+    }
+    return false;
+}
+
+fn isThisStateMember(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (!isThisExpression(tree, member.object)) return false;
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "state");
+}
+
+fn isSetStateCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (!isThisExpression(tree, member.object)) return false;
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "setState");
+}
+
+fn lifecycleStateParameterName(tree: *const ast.Tree, method: ast.MethodDefinition) ?[]const u8 {
+    const name = propertyName(tree, method.key, method.computed) orelse return null;
+    const accepts_state = (method.static and std.mem.eql(u8, name, "getDerivedStateFromProps")) or
+        std.mem.eql(u8, name, "shouldComponentUpdate") or
+        std.mem.eql(u8, name, "componentWillUpdate") or
+        std.mem.eql(u8, name, "UNSAFE_componentWillUpdate") or
+        std.mem.eql(u8, name, "getSnapshotBeforeUpdate") or
+        std.mem.eql(u8, name, "componentDidUpdate");
+    if (!accepts_state) return null;
+
+    const function = switch (tree.data(method.value)) {
+        .function => |function| function,
+        else => return null,
+    };
+    return nthParameterName(tree, function.params, 1);
+}
+
+fn nthParameterName(tree: *const ast.Tree, params_index: ast.NodeIndex, n: usize) ?[]const u8 {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return null,
+    };
+    const items = tree.extra(params.items);
+    if (items.len <= n) return null;
+    const pattern = switch (tree.data(items[n])) {
+        .formal_parameter => |parameter| parameter.pattern,
+        else => items[n],
+    };
+    return bindingIdentifierName(tree, pattern);
+}
+
+fn inConstructor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        const method = switch (tree.data(ancestor)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        return method.kind == .constructor;
+    }
+    return false;
+}
+
+fn returnArgument(tree: *const ast.Tree, function_index: ast.NodeIndex) ?ast.NodeIndex {
+    switch (tree.data(unwrapTransparent(tree, function_index))) {
+        .function => |function| return returnArgumentFromBody(tree, function.body),
+        .arrow_function_expression => |arrow| return if (arrow.expression) arrow.body else returnArgumentFromBody(tree, arrow.body),
+        else => return null,
+    }
+}
+
+fn returnArgumentFromBody(tree: *const ast.Tree, body_index: ast.NodeIndex) ?ast.NodeIndex {
+    if (body_index == .null) return null;
+    const body = switch (tree.data(body_index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return null,
+    };
+    var result: ?ast.NodeIndex = null;
+    for (tree.extra(body)) |statement_index| {
+        const statement = unwrapTransparent(tree, statement_index);
+        switch (tree.data(statement)) {
+            .return_statement => |return_statement| result = return_statement.argument,
+            else => {},
+        }
+    }
+    return result;
+}
+
+fn isCreateClassObject(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0 or arguments[0] != index) return false;
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createReactClass");
+    }
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "createClass");
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn isFunctionLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function, .arrow_function_expression => true,
+        else => false,
+    };
+}
+
+fn isArrowFunctionExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .arrow_function_expression => true,
+        else => false,
+    };
+}
+
+fn objectExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.ObjectExpression {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .object_expression => |object| object,
+        else => null,
+    };
+}
+
+fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .this_expression => true,
+        else => false,
+    };
+}
+
+fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return identifierReferenceName(tree, index) orelse bindingIdentifierName(tree, index);
+}
+
+fn nodeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| if (tree.extra(literal.expressions).len == 0 and tree.extra(literal.quasis).len == 1)
+            templateElementRaw(tree, tree.extra(literal.quasis)[0])
+        else
+            null,
+        else => null,
+    };
+}
+
+fn templateElementRaw(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null) return null;
+    if (computed) {
+        const current = unwrapTransparent(tree, index);
+        return switch (tree.data(current)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| if (tree.extra(literal.expressions).len == 0 and tree.extra(literal.quasis).len == 1)
+                templateElementRaw(tree, tree.extra(literal.quasis)[0])
+            else
+                null,
+            else => null,
+        };
+    }
+    return nodeName(tree, index);
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |assertion| current = assertion.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -216,6 +216,7 @@ pub const react_no_render_return_value = @import("react_no_render_return_value.z
 pub const react_no_this_in_sfc = @import("react_no_this_in_sfc.zig");
 pub const react_no_typos = @import("react_no_typos.zig");
 pub const react_no_unknown_property = @import("react_no_unknown_property.zig");
+pub const react_no_unused_state = @import("react_no_unused_state.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
 pub const react_no_string_refs = @import("react_no_string_refs.zig");
@@ -349,6 +350,7 @@ pub fn runBasic(
     defer visitor.react_require_render_return_state.deinit(allocator);
     defer visitor.react_no_access_state_in_setstate_state.deinit(allocator);
     defer visitor.react_no_typos_state.deinit(allocator);
+    defer visitor.react_no_unused_state_state.deinit(allocator);
     defer visitor.react_forbid_prop_types_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
@@ -594,6 +596,7 @@ const BasicVisitor = struct {
     react_jsx_key_state: react_jsx_key.State = .{},
     react_no_multi_comp_state: react_no_multi_comp.State = .{},
     react_no_typos_state: react_no_typos.State = .{},
+    react_no_unused_state_state: react_no_unused_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
@@ -711,6 +714,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_redundant_should_component_update) {
             try react_no_redundant_should_component_update.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, ctx.path.parent());
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.enterClass(self.allocator, ctx.tree, class, index, &self.react_no_unused_state_state);
+        }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
@@ -733,6 +739,17 @@ const BasicVisitor = struct {
             try typescript_eslint_no_unnecessary_parameter_property_assignment.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         return .proceed;
+    }
+
+    pub fn exit_class(
+        self: *BasicVisitor,
+        _: ast.Class,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.exitClass(self.allocator, self.diagnostics, ctx.tree, index, &self.react_no_unused_state_state) catch {};
+        }
     }
 
     pub fn enter_if_statement(
@@ -975,6 +992,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.collectVariableDeclarator(self.allocator, ctx.tree, declarator, &self.react_forbid_prop_types_state);
+        }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.checkVariableDeclarator(self.allocator, ctx.tree, declarator, &self.react_no_unused_state_state);
         }
         return .proceed;
     }
@@ -1563,6 +1583,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_typos) {
             try react_no_typos.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_no_typos_state);
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.checkAssignmentExpression(self.allocator, ctx.tree, expression, ctx, &self.react_no_unused_state_state);
+        }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state);
         }
@@ -1718,6 +1741,9 @@ const BasicVisitor = struct {
                 &self.react_no_access_state_in_setstate_state,
             );
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.checkCallExpression(self.allocator, ctx.tree, call, &self.react_no_unused_state_state);
+        }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state);
         }
@@ -1851,6 +1877,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_this_in_sfc) {
             try react_no_this_in_sfc.check(self.allocator, self.diagnostics, ctx.tree, member, index, ctx);
+        }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.checkMemberExpression(self.allocator, ctx.tree, member, index, ctx, &self.react_no_unused_state_state);
         }
         if (self.options.typescript_eslint_no_extra_non_null_assertion) {
             try typescript_eslint_no_extra_non_null_assertion.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);
@@ -2041,10 +2070,24 @@ const BasicVisitor = struct {
         if (self.options.react_no_typos) {
             try react_no_typos.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx.path.ancestor(1), self.react_no_typos_state);
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.enterObjectExpression(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_no_unused_state_state);
+        }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state);
         }
         return .proceed;
+    }
+
+    pub fn exit_object_expression(
+        self: *BasicVisitor,
+        _: ast.ObjectExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.exitObjectExpression(self.allocator, self.diagnostics, ctx.tree, index, &self.react_no_unused_state_state) catch {};
+        }
     }
 
     pub fn enter_object_property(
@@ -2056,7 +2099,21 @@ const BasicVisitor = struct {
         if (self.options.object_shorthand) {
             try object_shorthand.check(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
+        }
         return .proceed;
+    }
+
+    pub fn exit_object_property(
+        self: *BasicVisitor,
+        property: ast.ObjectProperty,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.exitObjectProperty(property, ctx.tree, ctx.path.parent(), &self.react_no_unused_state_state);
+        }
     }
 
     pub fn enter_object_pattern(
@@ -2119,7 +2176,21 @@ const BasicVisitor = struct {
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, self.react_forbid_prop_types_state);
         }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.enterMethodDefinition(self.allocator, ctx.tree, method, &self.react_no_unused_state_state);
+        }
         return .proceed;
+    }
+
+    pub fn exit_method_definition(
+        self: *BasicVisitor,
+        method: ast.MethodDefinition,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.exitMethodDefinition(method, &self.react_no_unused_state_state);
+        }
     }
 
     pub fn enter_property_definition(
@@ -2145,6 +2216,44 @@ const BasicVisitor = struct {
         }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, self.react_forbid_prop_types_state);
+        }
+        if (self.options.react_no_unused_state) {
+            try react_no_unused_state.enterPropertyDefinition(self.allocator, ctx.tree, property, &self.react_no_unused_state_state);
+        }
+        return .proceed;
+    }
+
+    pub fn exit_property_definition(
+        self: *BasicVisitor,
+        property: ast.PropertyDefinition,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.exitPropertyDefinition(property, ctx.tree, &self.react_no_unused_state_state);
+        }
+    }
+
+    pub fn enter_spread_element(
+        self: *BasicVisitor,
+        element: ast.SpreadElement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.checkSpreadElement(ctx.tree, element, &self.react_no_unused_state_state);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_jsx_spread_attribute(
+        self: *BasicVisitor,
+        attribute: ast.JSXSpreadAttribute,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (self.options.react_no_unused_state) {
+            react_no_unused_state.checkJSXSpreadAttribute(ctx.tree, attribute, &self.react_no_unused_state_state);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -763,6 +763,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_unused_state.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_redundant_should_component_update.zig");
 }
 

--- a/tests/rules/react_no_unused_state.zig
+++ b/tests/rules/react_no_unused_state.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports unused state fields declared in class components" {
+    const source =
+        \\class View extends React.Component {
+        \\  state = { classUnused: 1, used: 2 };
+        \\  constructor() {
+        \\    super();
+        \\    this.state = { ctorUnused: 1, title: '' };
+        \\  }
+        \\  render() {
+        \\    return <div>{this.state.title}{this.state.used}</div>;
+        \\  }
+        \\  update() {
+        \\    this.setState({ updateUnused: 1, count: 0 });
+        \\  }
+        \\  countIt() {
+        \\    return this.state.count;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_unused_state.id));
+    try std.testing.expect(hasMessage(result, "Unused state field: 'classUnused'"));
+    try std.testing.expect(hasMessage(result, "Unused state field: 'ctorUnused'"));
+    try std.testing.expect(hasMessage(result, "Unused state field: 'updateUnused'"));
+}
+
+test "marks aliases destructuring and lifecycle state parameters as used" {
+    const source =
+        \\class View extends React.Component {
+        \\  state = { a: 1, b: 2, c: 3, d: 4 };
+        \\  render() {
+        \\    const s = this.state;
+        \\    const { b, ...rest } = this.state;
+        \\    return <div>{s.a}{b}{rest.c}</div>;
+        \\  }
+        \\  componentDidUpdate(prevProps, prevState) {
+        \\    return prevState.d;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_state.id));
+}
+
+test "abandons component analysis for dynamic state usage" {
+    const source =
+        \\class View extends React.Component {
+        \\  state = { unused: 1 };
+        \\  render() {
+        \\    return <div {...this.state} />;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_state.id));
+}
+
+test "reports unused state fields from createReactClass getInitialState" {
+    const source =
+        \\createReactClass({
+        \\  getInitialState() {
+        \\    return { used: 1, unused: 2 };
+        \\  },
+        \\  render() {
+        \\    return <div>{this.state.used}</div>;
+        \\  },
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unused_state.id));
+    try std.testing.expect(hasMessage(result, "Unused state field: 'unused'"));
+}
+
+test "can disable react/no-unused-state" {
+    const source =
+        \\class View extends React.Component {
+        \\  state = { unused: 1 };
+        \\  render() {
+        \\    return <div />;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_jsx_no_undef = false,
+        .react_jsx_uses_react = false,
+        .react_no_unused_state = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_state.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_jsx_no_undef = false,
+        .react_jsx_uses_react = false,
+        .react_jsx_uses_vars = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_no_unused_state.id) and
+            std.mem.eql(u8, diagnostic.message, expected))
+        {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- Port `react/no-unused-state` with class component and `createReactClass` state-field tracking.
- Track state usage through `this.state`, state aliases, destructuring, lifecycle state parameters, and `setState` updater parameters.
- Add conservative bailouts for dynamic state access and state spreads, plus CLI/config wiring and focused tests.

## Validation
- `zig build test --summary all -- 'react/no-unused-state'`
- Compared representative fixtures against local `eslint-plugin-react` `react/no-unused-state`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke for default report, `--react-no-unused-state=off`, and help output
