### PR TITLE
feat: port alipay ant disallow typos

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -85,6 +85,7 @@ pub const Options = struct {
     no_implicit_coercion: bool = true,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
+    alipay_ant_disallow_typos: bool = true,
     alipay_ant_no_import_src: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
@@ -614,6 +615,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_ant_no_import_src);
     try std.testing.expect(options.setByCliName("@alipay/ant/no-import-src", true));
     try std.testing.expect(options.alipay_ant_no_import_src);
+
+    try std.testing.expect(!options.alipay_ant_disallow_typos);
+    try std.testing.expect(options.setByCliName("@alipay/ant/disallow-typos", true));
+    try std.testing.expect(options.alipay_ant_disallow_typos);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -237,6 +237,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
             options.no_import_assign = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-disallow-typos=off")) {
+            options.alipay_ant_disallow_typos = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
@@ -1197,6 +1199,7 @@ fn printHelp() void {
         \\  --no-implicit-coercion=off Disable no-implicit-coercion
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
+        \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import

--- a/src/rules/alipay_ant_disallow_typos.zig
+++ b/src/rules/alipay_ant_disallow_typos.zig
@@ -1,0 +1,177 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/disallow-typos";
+
+const Typo = struct {
+    right: []const u8,
+    msg: []const u8 = "",
+    matcher: Matcher,
+};
+
+const Matcher = union(enum) {
+    followed_by_punctuation_or_end: []const []const u8,
+    followed_by_non_punctuation: []const []const u8,
+    contains_any: []const []const u8,
+    contains_with_whitespace_between: struct { left: []const u8, right: []const u8 },
+    receipt,
+};
+
+const typos = [_]Typo{
+    .{ .right = "请稍候", .matcher = .{ .followed_by_punctuation_or_end = &.{ "请稍后", "请稍後" } } },
+    .{ .right = "請稍候", .matcher = .{ .followed_by_punctuation_or_end = &.{ "請稍后", "請稍後" } } },
+    .{ .right = "稍候", .matcher = .{ .followed_by_punctuation_or_end = &.{ "稍后", "稍後" } } },
+    .{ .right = "請稍後", .matcher = .{ .followed_by_non_punctuation = &.{"請稍候"} } },
+    .{ .right = "请稍后", .matcher = .{ .followed_by_non_punctuation = &.{"请稍候"} } },
+    .{ .right = "稍后", .matcher = .{ .followed_by_non_punctuation = &.{"稍候"} } },
+    .{
+        .right = "登录",
+        .msg = "。注意台湾地区是`『登入』`。",
+        .matcher = .{ .contains_with_whitespace_between = .{ .left = "登", .right = "陆" } },
+    },
+    .{
+        .right = "登錄",
+        .msg = "。注意台湾地区是`『登入』`。",
+        .matcher = .{ .contains_with_whitespace_between = .{ .left = "登", .right = "陸" } },
+    },
+    .{
+        .right = "账号",
+        .msg = "。注意台湾地区使用 `帳号`",
+        .matcher = .{ .contains_any = &.{"帐号"} },
+    },
+    .{
+        .right = "账单",
+        .msg = "。注意台湾地区是『`帳`單』香港地区是『`賬`單』",
+        .matcher = .{ .contains_any = &.{"帐单"} },
+    },
+    .{ .right = "账户", .matcher = .{ .contains_any = &.{"帐户"} } },
+    .{ .right = "賬户", .matcher = .{ .contains_any = &.{"帳户"} } },
+    .{ .right = "提醒方式", .matcher = .{ .contains_any = &.{"提醒渠道"} } },
+    .{ .right = "即时消息", .matcher = .{ .contains_any = &.{"及时消息"} } },
+    .{ .right = "到账时间", .matcher = .{ .contains_any = &.{"入账时间"} } },
+    .{
+        .right = "凭证",
+        .msg = "。涉及付款、转账的操作，最后成功生成的单据为“凭证”，一般产品操作成功生成的单据，可视情况使用“详单”。",
+        .matcher = .receipt,
+    },
+    .{ .right = "转账", .matcher = .{ .contains_any = &.{"转钱"} } },
+};
+
+pub fn checkStringLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.StringLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkText(allocator, diagnostics, tree.string(literal.value), tree.span(index));
+}
+
+pub fn checkTemplateLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.TemplateLiteral,
+) Allocator.Error!void {
+    for (tree.extra(literal.quasis)) |quasi_index| {
+        const span = tree.span(quasi_index);
+        if (span.start > span.end or span.end > tree.source.len) continue;
+
+        try checkText(allocator, diagnostics, tree.source[span.start..span.end], span);
+    }
+}
+
+fn checkText(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    value: []const u8,
+    span: ast.Span,
+) Allocator.Error!void {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+
+    for (typos) |typo| {
+        if (!matches(trimmed, typo.matcher)) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            span,
+            "影响用户体验的错别字 `{s}`，应该是 `{s}`{s}",
+            .{ trimmed, typo.right, typo.msg },
+        );
+        return;
+    }
+}
+
+fn matches(value: []const u8, matcher: Matcher) bool {
+    return switch (matcher) {
+        .followed_by_punctuation_or_end => |needles| containsFollowedByPunctuationOrEnd(value, needles),
+        .followed_by_non_punctuation => |needles| containsFollowedByNonPunctuation(value, needles),
+        .contains_any => |needles| containsAny(value, needles),
+        .contains_with_whitespace_between => |parts| containsWithWhitespaceBetween(value, parts.left, parts.right),
+        .receipt => std.mem.indexOf(u8, value, "回单") != null and std.mem.indexOf(u8, value, "电子回单") == null,
+    };
+}
+
+fn containsAny(value: []const u8, needles: []const []const u8) bool {
+    for (needles) |needle| {
+        if (std.mem.indexOf(u8, value, needle) != null) return true;
+    }
+    return false;
+}
+
+fn containsFollowedByPunctuationOrEnd(value: []const u8, needles: []const []const u8) bool {
+    for (needles) |needle| {
+        var start: usize = 0;
+        while (std.mem.indexOfPos(u8, value, start, needle)) |index| {
+            const after = index + needle.len;
+            if (after == value.len or startsWithBoundaryPunctuation(value[after..])) return true;
+            start = after;
+        }
+    }
+    return false;
+}
+
+fn containsFollowedByNonPunctuation(value: []const u8, needles: []const []const u8) bool {
+    for (needles) |needle| {
+        var start: usize = 0;
+        while (std.mem.indexOfPos(u8, value, start, needle)) |index| {
+            const after = index + needle.len;
+            if (after < value.len and !startsWithBoundaryPunctuation(value[after..])) return true;
+            start = after;
+        }
+    }
+    return false;
+}
+
+fn containsWithWhitespaceBetween(value: []const u8, left: []const u8, right: []const u8) bool {
+    var start: usize = 0;
+    while (std.mem.indexOfPos(u8, value, start, left)) |index| {
+        var after_left = index + left.len;
+        while (after_left < value.len and isAsciiWhitespace(value[after_left])) : (after_left += 1) {}
+        if (std.mem.startsWith(u8, value[after_left..], right)) return true;
+        start = index + left.len;
+    }
+    return false;
+}
+
+fn startsWithBoundaryPunctuation(value: []const u8) bool {
+    return std.mem.startsWith(u8, value, ".") or
+        std.mem.startsWith(u8, value, "。") or
+        std.mem.startsWith(u8, value, "!") or
+        std.mem.startsWith(u8, value, "！") or
+        std.mem.startsWith(u8, value, ",") or
+        std.mem.startsWith(u8, value, "，") or
+        std.mem.startsWith(u8, value, "?") or
+        std.mem.startsWith(u8, value, "？");
+}
+
+fn isAsciiWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n' or char == '\x0b' or char == '\x0c';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -24,6 +24,7 @@ pub const eol_last = @import("eol_last.zig");
 pub const for_direction = @import("for_direction.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
+pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
@@ -1513,6 +1514,9 @@ const BasicVisitor = struct {
         if (self.options.no_template_curly_in_string) {
             try no_template_curly_in_string.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
+        if (self.options.alipay_ant_disallow_typos) {
+            try alipay_ant_disallow_typos.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
         if (self.options.no_useless_escape) {
             try no_useless_escape.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, index);
         }
@@ -1530,6 +1534,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_escape) {
             try no_useless_escape.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);
+        }
+        if (self.options.alipay_ant_disallow_typos) {
+            try alipay_ant_disallow_typos.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -43,6 +43,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_disallow_typos.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_import_src.zig");
 }
 

--- a/tests/rules/alipay_ant_disallow_typos.zig
+++ b/tests/rules/alipay_ant_disallow_typos.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/ant/disallow-typos for string and template literals" {
+    const source =
+        \\const a = "请稍后";
+        \\const b = `登 陆成功`;
+        \\const c = `付款回单`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.alipay_ant_disallow_typos.id));
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+    try std.testing.expectEqualStrings(
+        "影响用户体验的错别字 `请稍后`，应该是 `请稍候`",
+        result.diagnostics[0].message,
+    );
+}
+
+test "respects ordered typo patterns and punctuation boundaries" {
+    const source =
+        \\const a = "请稍候处理";
+        \\const b = "请稍候。";
+        \\const c = "稍候处理";
+        \\const d = "稍候。";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_disallow_typos.id));
+    try std.testing.expectEqualStrings(
+        "影响用户体验的错别字 `请稍候处理`，应该是 `请稍后`",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "影响用户体验的错别字 `稍候处理`，应该是 `稍后`",
+        result.diagnostics[1].message,
+    );
+}
+
+test "reports configured words and skips electronic receipts" {
+    const source =
+        \\const a = "帐号";
+        \\const b = "帐单";
+        \\const c = "提醒渠道";
+        \\const d = "及时消息";
+        \\const e = "入账时间";
+        \\const f = "电子回单";
+        \\const g = "转钱";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.alipay_ant_disallow_typos.id));
+}
+
+test "does not report @alipay/ant/disallow-typos for accepted wording" {
+    const source =
+        \\const a = "请稍候。";
+        \\const b = "请稍后处理";
+        \\const c = "登录";
+        \\const d = "账号";
+        \\const e = "电子回单";
+        \\const f = `登\\n陆`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_disallow_typos.id));
+}
+
+test "can disable @alipay/ant/disallow-typos" {
+    const source =
+        \\const a = "请稍后";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_ant_disallow_typos = false,
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_disallow_typos.id));
+}


### PR DESCRIPTION
## Summary
- port `@alipay/ant/disallow-typos` from fishlint
- register the rule in default options, CLI help, and basic traversal
- add focused tests for typo matching, boundary behavior, raw template text, and disabling

## Validation
- `zig build test --summary all -- alipay_ant_disallow_typos`
- fishlint/ESLint fixture comparison for `@alipay/ant/disallow-typos`
- full typo table fixture comparison: 18 ESLint diagnostics matched utoo-lint diagnostics exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/ant/disallow-typos`, `--json`, and `--alipay-ant-disallow-typos=off`
