### PR TITLE
feat: port spmlint use labeled spm

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -87,6 +87,7 @@ pub const Options = struct {
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_no_import_src: bool = true,
+    alipay_spmlint_use_labeled_spm: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
@@ -328,6 +329,10 @@ pub const Options = struct {
 
         if (std.mem.startsWith(u8, cli_name, "@alipay/ant/")) {
             return self.setByPrefixedRuleName("alipay_ant_", cli_name["@alipay/ant/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "@alipay/spmLint/")) {
+            return self.setByPrefixedRuleName("alipay_spmlint_", cli_name["@alipay/spmLint/".len..], value);
         }
 
         if (std.mem.startsWith(u8, cli_name, "jsx-a11y/")) {
@@ -619,6 +624,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_ant_disallow_typos);
     try std.testing.expect(options.setByCliName("@alipay/ant/disallow-typos", true));
     try std.testing.expect(options.alipay_ant_disallow_typos);
+
+    try std.testing.expect(!options.alipay_spmlint_use_labeled_spm);
+    try std.testing.expect(options.setByCliName("@alipay/spmLint/use-labeled-spm", true));
+    try std.testing.expect(options.alipay_spmlint_use_labeled_spm);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -241,6 +241,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_disallow_typos = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
             options.alipay_ant_no_import_src = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
+            options.alipay_spmlint_use_labeled_spm = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
         } else if (std.mem.eql(u8, arg, "--import-newline-after-import=off")) {
@@ -1201,6 +1203,7 @@ fn printHelp() void {
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
+        \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd

--- a/src/rules/alipay_spmlint_use_labeled_spm.zig
+++ b/src/rules/alipay_spmlint_use_labeled_spm.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/spmLint/use-labeled-spm";
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return,
+    };
+
+    if (!isTrackedFnName(memberPropertyName(tree, callee) orelse return)) return;
+    if (!isTracertReceiver(tree, callee.object)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "请优先使用声明式埋点",
+        tree.span(index),
+    );
+}
+
+fn isTracertReceiver(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (isTracertIdentifier(tree, index)) return true;
+
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    return !member.computed and isTracertIdentifier(tree, member.property);
+}
+
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) return null;
+    return identifierReferenceName(tree, member.property);
+}
+
+fn isTracertIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, "tracert") or
+        std.mem.eql(u8, name, "Tracert") or
+        std.mem.eql(u8, name, "$tracert");
+}
+
+fn isTrackedFnName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "expo") or
+        std.mem.eql(u8, name, "logPv") or
+        std.mem.eql(u8, name, "click");
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
+pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
@@ -1747,6 +1748,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.alipay_spmlint_use_labeled_spm) {
+            try alipay_spmlint_use_labeled_spm.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         if (self.options.react_no_find_dom_node) {
             try react_no_find_dom_node.check(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -51,6 +51,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_spmlint_use_labeled_spm.zig");
+}
+
+comptime {
     _ = @import("rules/import_first.zig");
 }
 

--- a/tests/rules/alipay_spmlint_use_labeled_spm.zig
+++ b/tests/rules/alipay_spmlint_use_labeled_spm.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/spmLint/use-labeled-spm for manual tracert calls" {
+    const source =
+        \\this.tracert.expo('c1');
+        \\this.$tracert.click('c1.d1');
+        \\window.Tracert.logPv();
+        \\tracert.expo('c1');
+        \\Tracert.click('c1.d1');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.alipay_spmlint_use_labeled_spm.id));
+    try std.testing.expectEqualStrings("请优先使用声明式埋点", result.diagnostics[0].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "does not report @alipay/spmLint/use-labeled-spm for unrelated calls" {
+    const source =
+        \\a.expo();
+        \\a.logPv();
+        \\a.click();
+        \\expo();
+        \\logPv();
+        \\click();
+        \\this.tracert.set();
+        \\this['tracert'].expo('c1');
+        \\this.tracert['expo']('c1');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_use_labeled_spm.id));
+}
+
+test "can disable @alipay/spmLint/use-labeled-spm" {
+    const source =
+        \\this.tracert.expo('c1');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_use_labeled_spm.id));
+}


### PR DESCRIPTION
## Summary
- port `@alipay/spmLint/use-labeled-spm` from fishlint
- add `@alipay/spmLint/*` rule config prefix support and CLI help
- add focused tests for manual tracert calls, valid non-tracert calls, and disabling

## Validation
- `zig build test --summary all -- alipay_spmlint_use_labeled_spm`
- fishlint/ESLint official fixture comparison for `@alipay/spmLint/use-labeled-spm`: 19 diagnostics matched exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/spmLint/use-labeled-spm`, `--json`, and `--alipay-spmlint-use-labeled-spm=off`
