### PR TITLE
feat: port spmlint valid manual pv

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
+    alipay_spmlint_valid_manual_pv: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
@@ -628,6 +629,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_spmlint_use_labeled_spm);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/use-labeled-spm", true));
     try std.testing.expect(options.alipay_spmlint_use_labeled_spm);
+
+    try std.testing.expect(!options.alipay_spmlint_valid_manual_pv);
+    try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-pv", true));
+    try std.testing.expect(options.alipay_spmlint_valid_manual_pv);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -243,6 +243,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
             options.alipay_spmlint_use_labeled_spm = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-pv=off")) {
+            options.alipay_spmlint_valid_manual_pv = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
         } else if (std.mem.eql(u8, arg, "--import-newline-after-import=off")) {
@@ -1204,6 +1206,7 @@ fn printHelp() void {
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
+        \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd

--- a/src/rules/alipay_spmlint_valid_manual_pv.zig
+++ b/src/rules/alipay_spmlint_valid_manual_pv.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/spmLint/valid-manual-pv";
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    if (!isTracertCallNamed(tree, call, "logPv")) return;
+
+    const args = tree.extra(call.arguments);
+    if (args.len == 0) return;
+    if (passesObjectParam(tree, args[0])) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "函数 logPv 第一个参数类型为 Object",
+        tree.span(args[0]),
+    );
+}
+
+fn isTracertCallNamed(tree: *const ast.Tree, call: ast.CallExpression, name: []const u8) bool {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = memberPropertyName(tree, callee) orelse return false;
+    return std.mem.eql(u8, property, name) and isTracertReceiver(tree, callee.object);
+}
+
+fn passesObjectParam(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .object_expression,
+        .call_expression,
+        .conditional_expression,
+        => true,
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .member_expression => |member| !member.computed and memberPropertyName(tree, member) != null,
+        else => false,
+    };
+}
+
+fn isTracertReceiver(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (isTracertIdentifier(tree, index)) return true;
+
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    return !member.computed and isTracertIdentifier(tree, member.property);
+}
+
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) return null;
+    return identifierName(tree, member.property);
+}
+
+fn isTracertIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = identifierName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, "tracert") or
+        std.mem.eql(u8, name, "Tracert") or
+        std.mem.eql(u8, name, "$tracert");
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -27,6 +27,7 @@ pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
+pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
@@ -1751,6 +1752,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_spmlint_use_labeled_spm) {
             try alipay_spmlint_use_labeled_spm.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.alipay_spmlint_valid_manual_pv) {
+            try alipay_spmlint_valid_manual_pv.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.react_no_find_dom_node) {
             try react_no_find_dom_node.check(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -55,6 +55,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_spmlint_valid_manual_pv.zig");
+}
+
+comptime {
     _ = @import("rules/import_first.zig");
 }
 

--- a/tests/rules/alipay_spmlint_valid_manual_pv.zig
+++ b/tests/rules/alipay_spmlint_valid_manual_pv.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/spmLint/valid-manual-pv for invalid logPv first params" {
+    const source =
+        \\tracert.logPv(null);
+        \\tracert.logPv('111');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_spmlint_valid_manual_pv.id));
+    try std.testing.expectEqualStrings("函数 logPv 第一个参数类型为 Object", result.diagnostics[0].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/spmLint/valid-manual-pv valid logPv usages" {
+    const source =
+        \\tracert.logPv();
+        \\this.tracert.logPv();
+        \\this.$tracert.logPv();
+        \\this.Tracert.logPv();
+        \\window.Tracert.logPv();
+        \\Tracert.logPv();
+        \\tracert.logPv({a:1});
+        \\tracert.logPv({a:1}, {b:2});
+        \\tracert.logPv(a);
+        \\tracert.logPv(a());
+        \\tracert.logPv(a.b);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_pv.id));
+}
+
+test "can disable @alipay/spmLint/valid-manual-pv" {
+    const source =
+        \\tracert.logPv(null);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .alipay_spmlint_valid_manual_pv = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_pv.id));
+}


### PR DESCRIPTION
## Summary
- port `@alipay/spmLint/valid-manual-pv` from fishlint
- register the rule in default options, CLI help, and call-expression traversal
- add focused tests for invalid first params, valid `logPv` usages, and disabling

## Validation
- `zig build test --summary all -- alipay_spmlint_valid_manual_pv`
- fishlint/ESLint official fixture comparison for `@alipay/spmLint/valid-manual-pv`: 2 diagnostics matched exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/spmLint/valid-manual-pv` and `--alipay-spmlint-valid-manual-pv=off`
