### PR TITLE
feat: port spmlint valid manual click

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
+    alipay_spmlint_valid_manual_click: bool = true,
     alipay_spmlint_valid_manual_pv: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
@@ -629,6 +630,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_spmlint_use_labeled_spm);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/use-labeled-spm", true));
     try std.testing.expect(options.alipay_spmlint_use_labeled_spm);
+
+    try std.testing.expect(!options.alipay_spmlint_valid_manual_click);
+    try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-click", true));
+    try std.testing.expect(options.alipay_spmlint_valid_manual_click);
 
     try std.testing.expect(!options.alipay_spmlint_valid_manual_pv);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-pv", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -243,6 +243,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
             options.alipay_spmlint_use_labeled_spm = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-click=off")) {
+            options.alipay_spmlint_valid_manual_click = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-pv=off")) {
             options.alipay_spmlint_valid_manual_pv = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
@@ -1206,6 +1208,7 @@ fn printHelp() void {
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
+        \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import

--- a/src/rules/alipay_spmlint_valid_manual_click.zig
+++ b/src/rules/alipay_spmlint_valid_manual_click.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/spmLint/valid-manual-click";
+
+const expected_params = [_]ParamType{ .spm_id, .object, .object, .object };
+
+const ParamType = enum {
+    object,
+    spm_id,
+
+    fn name(self: ParamType) []const u8 {
+        return switch (self) {
+            .object => "object",
+            .spm_id => "spmId",
+        };
+    }
+};
+
+const ParamCheck = union(enum) {
+    pass,
+    param_type,
+    spm_id_click,
+};
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    if (!isTracertCallNamed(tree, call, "click")) return;
+
+    const args = tree.extra(call.arguments);
+    if (args.len == 0) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "函数 click 需要传递参数",
+            tree.span(call.callee),
+        );
+        return;
+    }
+
+    for (args, 0..) |arg, index| {
+        const expected = if (index < expected_params.len) expected_params[index] else null;
+        switch (checkParam(tree, arg, expected)) {
+            .pass => {},
+            .spm_id_click => try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "点击埋点 spmId 格式应为 a.b.c.d、c.d",
+                tree.span(arg),
+            ),
+            .param_type => {
+                const expected_name = if (expected) |param_type| param_type.name() else "undefined";
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    tree.span(arg),
+                    "函数 click 第 {d} 参数类型为{s}",
+                    .{ index + 1, expected_name },
+                );
+            },
+        }
+    }
+}
+
+fn checkParam(tree: *const ast.Tree, index: ast.NodeIndex, expected: ?ParamType) ParamCheck {
+    if (passesDynamicParam(tree, index)) return .pass;
+
+    const param_type = expected orelse return .param_type;
+    return switch (param_type) {
+        .object => if (tree.data(index) == .object_expression) .pass else .param_type,
+        .spm_id => checkSpmId(tree, index),
+    };
+}
+
+fn checkSpmId(tree: *const ast.Tree, index: ast.NodeIndex) ParamCheck {
+    switch (tree.data(index)) {
+        .template_literal => return .pass,
+        .string_literal => |literal| {
+            const value = tree.string(literal.value);
+            const segments = countSegments(value);
+            if (segments == 2 or segments == 4) return .pass;
+            return .spm_id_click;
+        },
+        else => return .param_type,
+    }
+}
+
+fn countSegments(value: []const u8) usize {
+    var count: usize = 1;
+    for (value) |char| {
+        if (char == '.') count += 1;
+    }
+    return count;
+}
+
+fn passesDynamicParam(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .call_expression,
+        .conditional_expression,
+        => true,
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .member_expression => |member| identifierName(tree, member.property) != null,
+        else => false,
+    };
+}
+
+fn isTracertCallNamed(tree: *const ast.Tree, call: ast.CallExpression, name: []const u8) bool {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = identifierName(tree, callee.property) orelse return false;
+    return std.mem.eql(u8, property, name) and isTracertReceiver(tree, callee.object);
+}
+
+fn isTracertReceiver(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (isTracertIdentifier(tree, index)) return true;
+
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    return isTracertIdentifier(tree, member.property);
+}
+
+fn isTracertIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = identifierName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, "tracert") or
+        std.mem.eql(u8, name, "Tracert") or
+        std.mem.eql(u8, name, "$tracert");
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -27,6 +27,7 @@ pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
+pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
@@ -1752,6 +1753,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_spmlint_use_labeled_spm) {
             try alipay_spmlint_use_labeled_spm.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.alipay_spmlint_valid_manual_click) {
+            try alipay_spmlint_valid_manual_click.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.alipay_spmlint_valid_manual_pv) {
             try alipay_spmlint_valid_manual_pv.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -55,6 +55,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_spmlint_valid_manual_click.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_valid_manual_pv.zig");
 }
 

--- a/tests/rules/alipay_spmlint_valid_manual_click.zig
+++ b/tests/rules/alipay_spmlint_valid_manual_click.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/spmLint/valid-manual-click invalid calls" {
+    const source =
+        \\tracert.click();
+        \\tracert.click({a:1});
+        \\tracert.click(1);
+        \\tracert.click(undefined);
+        \\tracert.click(null);
+        \\tracert.click('d1','a');
+        \\tracert.click('d1',{a:1},'b');
+        \\tracert.click('c2.d1',{a:1},{'b':1},'c');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.alipay_spmlint_valid_manual_click.id));
+    try std.testing.expectEqualStrings("函数 click 需要传递参数", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("函数 click 第 1 参数类型为spmId", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("点击埋点 spmId 格式应为 a.b.c.d、c.d", result.diagnostics[5].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/spmLint/valid-manual-click valid calls" {
+    const source =
+        \\tracert.click('c1.d1',{a:1},{b:1},{c:1});
+        \\var x = ''; tracert.click(`${x}`,{a:1},{b:1},{c:1});
+        \\tracert.click('c1.d1');
+        \\this.tracert.click('c1.d1');
+        \\this.$tracert.click('c1.d1');
+        \\this.Tracert.click('c1.d1');
+        \\Tracert.click('c1.d1');
+        \\window.Tracert.click('c1.d1');
+        \\tracert.click(a);
+        \\tracert.click(a ? "d1" : "c2");
+        \\tracert.click('c1.d1',{a:1});
+        \\tracert.click('c1.d1',a);
+        \\tracert.click('c1.d1',{a:1},{b:2});
+        \\tracert.click('c1.d1',a,b);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_click.id));
+}
+
+test "can disable @alipay/spmLint/valid-manual-click" {
+    const source =
+        \\tracert.click();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .alipay_spmlint_valid_manual_click = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_click.id));
+}


### PR DESCRIPTION
## Summary
- port `@alipay/spmLint/valid-manual-click` from fishlint
- validate required click params, `spmId` segment count, and object params
- add CLI help, default options registration, and focused tests

## Validation
- `zig build test --summary all -- alipay_spmlint_valid_manual_click`
- fishlint/ESLint official fixture comparison for `@alipay/spmLint/valid-manual-click`: 10 diagnostics matched exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/spmLint/valid-manual-click` and `--alipay-spmlint-valid-manual-click=off`
