### PR TITLE
feat: port spmlint valid manual expo

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -89,6 +89,7 @@ pub const Options = struct {
     alipay_ant_no_import_src: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,
+    alipay_spmlint_valid_manual_expo: bool = true,
     alipay_spmlint_valid_manual_pv: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
@@ -634,6 +635,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_spmlint_valid_manual_click);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-click", true));
     try std.testing.expect(options.alipay_spmlint_valid_manual_click);
+
+    try std.testing.expect(!options.alipay_spmlint_valid_manual_expo);
+    try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-expo", true));
+    try std.testing.expect(options.alipay_spmlint_valid_manual_expo);
 
     try std.testing.expect(!options.alipay_spmlint_valid_manual_pv);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-pv", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -245,6 +245,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_spmlint_use_labeled_spm = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-click=off")) {
             options.alipay_spmlint_valid_manual_click = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-expo=off")) {
+            options.alipay_spmlint_valid_manual_expo = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-pv=off")) {
             options.alipay_spmlint_valid_manual_pv = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
@@ -1209,6 +1211,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
+        \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import

--- a/src/rules/alipay_spmlint_valid_manual_expo.zig
+++ b/src/rules/alipay_spmlint_valid_manual_expo.zig
@@ -1,0 +1,186 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/spmLint/valid-manual-expo";
+
+const ParamType = enum {
+    object,
+    spm_id,
+    expo_direction,
+
+    fn name(self: ParamType) []const u8 {
+        return switch (self) {
+            .object => "object",
+            .spm_id => "spmId",
+            .expo_direction => "expoDirection",
+        };
+    }
+};
+
+const ParamCheck = union(enum) {
+    pass,
+    param_type,
+    spm_id_expo,
+    expo_direction,
+};
+
+const TracertName = enum {
+    tracert,
+    Tracert,
+    dollar_tracert,
+};
+
+const lowercase_expected = [_]ParamType{ .spm_id, .object, .object, .object };
+const uppercase_expected = [_]ParamType{ .spm_id, .expo_direction, .object, .object, .object };
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    const tracert_name = tracertCallName(tree, call, "expo") orelse return;
+    const expected_params = if (tracert_name == .Tracert) uppercase_expected[0..] else lowercase_expected[0..];
+
+    const args = tree.extra(call.arguments);
+    if (args.len == 0) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "函数 expo 需要传递参数",
+            tree.span(call.callee),
+        );
+        return;
+    }
+
+    for (args, 0..) |arg, index| {
+        const expected = if (index < expected_params.len) expected_params[index] else null;
+        switch (checkParam(tree, arg, expected)) {
+            .pass => {},
+            .spm_id_expo => try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "曝光埋点 spmId 格式应为 a.b.c?.d、c?.d",
+                tree.span(arg),
+            ),
+            .expo_direction => try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(arg),
+                "函数 expo 第 {d} 参数类型为字符串(曝光方向)",
+                .{index + 1},
+            ),
+            .param_type => {
+                const expected_name = if (expected) |param_type| param_type.name() else "undefined";
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    tree.span(arg),
+                    "函数 expo 第 {d} 参数类型为{s}",
+                    .{ index + 1, expected_name },
+                );
+            },
+        }
+    }
+}
+
+fn checkParam(tree: *const ast.Tree, index: ast.NodeIndex, expected: ?ParamType) ParamCheck {
+    if (passesDynamicParam(tree, index)) return .pass;
+
+    const param_type = expected orelse return .param_type;
+    return switch (param_type) {
+        .object => if (tree.data(index) == .object_expression) .pass else .param_type,
+        .spm_id => checkSpmId(tree, index),
+        .expo_direction => checkExpoDirection(tree, index),
+    };
+}
+
+fn checkSpmId(tree: *const ast.Tree, index: ast.NodeIndex) ParamCheck {
+    switch (tree.data(index)) {
+        .template_literal => return .pass,
+        .string_literal => |literal| {
+            const segments = countSegments(tree.string(literal.value));
+            if (segments >= 1 and segments <= 4) return .pass;
+            return .spm_id_expo;
+        },
+        else => return .param_type,
+    }
+}
+
+fn checkExpoDirection(tree: *const ast.Tree, index: ast.NodeIndex) ParamCheck {
+    return switch (tree.data(index)) {
+        .template_literal,
+        .string_literal,
+        .null_literal,
+        => .pass,
+        else => .expo_direction,
+    };
+}
+
+fn countSegments(value: []const u8) usize {
+    var count: usize = 1;
+    for (value) |char| {
+        if (char == '.') count += 1;
+    }
+    return count;
+}
+
+fn passesDynamicParam(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .call_expression,
+        .conditional_expression,
+        => true,
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .member_expression => |member| identifierName(tree, member.property) != null,
+        else => false,
+    };
+}
+
+fn tracertCallName(tree: *const ast.Tree, call: ast.CallExpression, name: []const u8) ?TracertName {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const property = identifierName(tree, callee.property) orelse return null;
+    if (!std.mem.eql(u8, property, name)) return null;
+    return tracertReceiverName(tree, callee.object);
+}
+
+fn tracertReceiverName(tree: *const ast.Tree, index: ast.NodeIndex) ?TracertName {
+    if (tracertIdentifierName(tree, index)) |name| return name;
+
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    return tracertIdentifierName(tree, member.property);
+}
+
+fn tracertIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?TracertName {
+    const name = identifierName(tree, index) orelse return null;
+    if (std.mem.eql(u8, name, "tracert")) return .tracert;
+    if (std.mem.eql(u8, name, "Tracert")) return .Tracert;
+    if (std.mem.eql(u8, name, "$tracert")) return .dollar_tracert;
+    return null;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -28,6 +28,7 @@ pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
+pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manual_expo.zig");
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
@@ -1756,6 +1757,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_spmlint_valid_manual_click) {
             try alipay_spmlint_valid_manual_click.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
+        if (self.options.alipay_spmlint_valid_manual_expo) {
+            try alipay_spmlint_valid_manual_expo.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.alipay_spmlint_valid_manual_pv) {
             try alipay_spmlint_valid_manual_pv.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_spmlint_valid_manual_expo.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_valid_manual_pv.zig");
 }
 

--- a/tests/rules/alipay_spmlint_valid_manual_expo.zig
+++ b/tests/rules/alipay_spmlint_valid_manual_expo.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/spmLint/valid-manual-expo invalid calls" {
+    const source =
+        \\tracert.expo('a1.b1.c1.d1.e1');
+        \\Tracert.expo('a1.b1.c1.d1.e1',{});
+        \\window.Tracert.expo('a1.b1.c1.d1.e1',{});
+        \\tracert.expo();
+        \\tracert.expo({a:1});
+        \\tracert.expo(1);
+        \\tracert.expo(undefined);
+        \\tracert.expo(null);
+        \\tracert.expo('c1','a');
+        \\tracert.expo('c1',{a:1},'b');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.alipay_spmlint_valid_manual_expo.id));
+    try std.testing.expectEqualStrings("曝光埋点 spmId 格式应为 a.b.c?.d、c?.d", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("函数 expo 第 2 参数类型为字符串(曝光方向)", result.diagnostics[2].message);
+    try std.testing.expectEqualStrings("函数 expo 需要传递参数", result.diagnostics[5].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/spmLint/valid-manual-expo valid calls" {
+    const source =
+        \\Tracert.expo('c1', null, {});
+        \\window.Tracert.expo('c1.d1', '', {});
+        \\tracert.expo('c1');
+        \\this.tracert.expo('c1');
+        \\this.$tracert.expo('c1');
+        \\this.Tracert.expo('c1');
+        \\Tracert.expo('c1');
+        \\Tracert.expo('c1', '');
+        \\window.Tracert.expo('c1');
+        \\tracert.expo(a);
+        \\tracert.expo(a ? "c1" : "c2");
+        \\tracert.expo('c1',{a:1});
+        \\tracert.expo('c1',a);
+        \\tracert.expo('c1',{a:1},{b:2});
+        \\tracert.expo('c1',a,b);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_expo.id));
+}
+
+test "can disable @alipay/spmLint/valid-manual-expo" {
+    const source =
+        \\tracert.expo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .alipay_spmlint_valid_manual_expo = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_expo.id));
+}


### PR DESCRIPTION
## Summary
- port `@alipay/spmLint/valid-manual-expo` from fishlint
- validate required expo params, `spmId` segment count, Tracert exposure direction params, and object params
- add CLI help, default options registration, and focused tests

## Validation
- `zig build test --summary all -- alipay_spmlint_valid_manual_expo`
- fishlint/ESLint official fixture comparison for `@alipay/spmLint/valid-manual-expo`: 12 diagnostics matched exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/spmLint/valid-manual-expo` and `--alipay-spmlint-valid-manual-expo=off`
