### PR TITLE
feat: port spmlint valid manual param

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,
     alipay_spmlint_valid_manual_expo: bool = true,
+    alipay_spmlint_valid_manual_param: bool = true,
     alipay_spmlint_valid_manual_pv: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
@@ -639,6 +640,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_spmlint_valid_manual_expo);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-expo", true));
     try std.testing.expect(options.alipay_spmlint_valid_manual_expo);
+
+    try std.testing.expect(!options.alipay_spmlint_valid_manual_param);
+    try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-param", true));
+    try std.testing.expect(options.alipay_spmlint_valid_manual_param);
 
     try std.testing.expect(!options.alipay_spmlint_valid_manual_pv);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-pv", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_spmlint_valid_manual_click = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-expo=off")) {
             options.alipay_spmlint_valid_manual_expo = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-param=off")) {
+            options.alipay_spmlint_valid_manual_param = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-pv=off")) {
             options.alipay_spmlint_valid_manual_pv = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
@@ -1212,6 +1214,7 @@ fn printHelp() void {
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
         \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo
+        \\  --alipay-spmlint-valid-manual-param=off Disable @alipay/spmLint/valid-manual-param
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import

--- a/src/rules/alipay_spmlint_valid_manual_param.zig
+++ b/src/rules/alipay_spmlint_valid_manual_param.zig
@@ -1,0 +1,233 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/spmLint/valid-manual-param";
+
+const ParamType = enum {
+    object,
+    spm_id,
+    expo_direction,
+
+    fn name(self: ParamType) []const u8 {
+        return switch (self) {
+            .object => "object",
+            .spm_id => "spmId",
+            .expo_direction => "expoDirection",
+        };
+    }
+};
+
+const ParamCheck = union(enum) {
+    pass,
+    param_type,
+    spm_id_click,
+    spm_id_expo,
+    expo_direction,
+};
+
+const log_pv_expected = [_]ParamType{.object};
+const set_expected = [_]ParamType{.object};
+const click_expected = [_]ParamType{ .spm_id, .object, .object, .object };
+const expo_expected = [_]ParamType{ .spm_id, .expo_direction, .object, .object, .object };
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    if (!isTracertCallNamed(tree, call, "call")) return;
+
+    const args = tree.extra(call.arguments);
+    if (args.len == 0) {
+        try addRequireParam(allocator, diagnostics, tree, call, "call");
+        return;
+    }
+
+    const fn_name = stringLiteralValue(tree, args[0]) orelse return;
+    const expected_params = defaultParamsForFn(fn_name) orelse return;
+    const params = args[1..];
+
+    if (!std.mem.eql(u8, fn_name, "logPv") and params.len == 0) {
+        try addRequireParam(allocator, diagnostics, tree, call, fn_name);
+    }
+
+    for (params, 0..) |arg, index| {
+        const expected = if (index < expected_params.len) expected_params[index] else null;
+        switch (checkParam(tree, arg, expected, fn_name)) {
+            .pass => {},
+            .spm_id_click => try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "点击埋点 spmId 格式应为 a.b.c.d、c.d",
+                tree.span(arg),
+            ),
+            .spm_id_expo => try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "曝光埋点 spmId 格式应为 a.b.c?.d、c?.d",
+                tree.span(arg),
+            ),
+            .expo_direction => try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(arg),
+                "函数 {s} 第 {d} 参数类型为字符串(曝光方向)",
+                .{ fn_name, index + 1 },
+            ),
+            .param_type => {
+                const expected_name = if (expected) |param_type| param_type.name() else "undefined";
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    tree.span(arg),
+                    "函数 {s} 第 {d} 参数类型为{s}",
+                    .{ fn_name, index + 1, expected_name },
+                );
+            },
+        }
+    }
+}
+
+fn addRequireParam(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    fn_name: []const u8,
+) Allocator.Error!void {
+    const span = switch (tree.data(call.callee)) {
+        .member_expression => |member| tree.span(member.property),
+        else => tree.span(call.callee),
+    };
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        span,
+        "函数 {s} 需要传递参数",
+        .{fn_name},
+    );
+}
+
+fn defaultParamsForFn(fn_name: []const u8) ?[]const ParamType {
+    if (std.mem.eql(u8, fn_name, "logPv")) return log_pv_expected[0..];
+    if (std.mem.eql(u8, fn_name, "set")) return set_expected[0..];
+    if (std.mem.eql(u8, fn_name, "click")) return click_expected[0..];
+    if (std.mem.eql(u8, fn_name, "expo")) return expo_expected[0..];
+    return null;
+}
+
+fn checkParam(tree: *const ast.Tree, index: ast.NodeIndex, expected: ?ParamType, fn_name: []const u8) ParamCheck {
+    if (passesDynamicParam(tree, index)) return .pass;
+
+    const param_type = expected orelse return .param_type;
+    return switch (param_type) {
+        .object => if (tree.data(index) == .object_expression) .pass else .param_type,
+        .spm_id => checkSpmId(tree, index, fn_name),
+        .expo_direction => checkExpoDirection(tree, index),
+    };
+}
+
+fn checkSpmId(tree: *const ast.Tree, index: ast.NodeIndex, fn_name: []const u8) ParamCheck {
+    switch (tree.data(index)) {
+        .template_literal => return .pass,
+        .string_literal => |literal| {
+            const segments = countSegments(tree.string(literal.value));
+            if (std.mem.eql(u8, fn_name, "expo")) {
+                if (segments >= 1 and segments <= 4) return .pass;
+                return .spm_id_expo;
+            }
+            if (std.mem.eql(u8, fn_name, "click")) {
+                if (segments == 2 or segments == 4) return .pass;
+                return .spm_id_click;
+            }
+            return .pass;
+        },
+        else => return .param_type,
+    }
+}
+
+fn checkExpoDirection(tree: *const ast.Tree, index: ast.NodeIndex) ParamCheck {
+    return switch (tree.data(index)) {
+        .template_literal,
+        .string_literal,
+        .null_literal,
+        => .pass,
+        else => .expo_direction,
+    };
+}
+
+fn countSegments(value: []const u8) usize {
+    var count: usize = 1;
+    for (value) |char| {
+        if (char == '.') count += 1;
+    }
+    return count;
+}
+
+fn passesDynamicParam(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .call_expression,
+        .conditional_expression,
+        => true,
+        .identifier_reference => |identifier| !std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .member_expression => |member| identifierName(tree, member.property) != null,
+        else => false,
+    };
+}
+
+fn isTracertCallNamed(tree: *const ast.Tree, call: ast.CallExpression, name: []const u8) bool {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = identifierName(tree, callee.property) orelse return false;
+    return std.mem.eql(u8, property, name) and isTracertReceiver(tree, callee.object);
+}
+
+fn isTracertReceiver(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (isTracertIdentifier(tree, index)) return true;
+
+    const member = switch (tree.data(index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    return isTracertIdentifier(tree, member.property);
+}
+
+fn isTracertIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = identifierName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, "tracert") or
+        std.mem.eql(u8, name, "Tracert") or
+        std.mem.eql(u8, name, "$tracert");
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
 pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manual_expo.zig");
+pub const alipay_spmlint_valid_manual_param = @import("alipay_spmlint_valid_manual_param.zig");
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
@@ -1760,6 +1761,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_spmlint_valid_manual_expo) {
             try alipay_spmlint_valid_manual_expo.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
+        if (self.options.alipay_spmlint_valid_manual_param) {
+            try alipay_spmlint_valid_manual_param.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.alipay_spmlint_valid_manual_pv) {
             try alipay_spmlint_valid_manual_pv.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_spmlint_valid_manual_param.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_valid_manual_pv.zig");
 }
 

--- a/tests/rules/alipay_spmlint_valid_manual_param.zig
+++ b/tests/rules/alipay_spmlint_valid_manual_param.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports @alipay/spmLint/valid-manual-param for invalid Tracert.call usages" {
+    const source =
+        \\Tracert.call();
+        \\Tracert.call('logPv', '23');
+        \\Tracert.call('expo');
+        \\Tracert.call('expo','c2.d33', '', {}, {}, '23');
+        \\Tracert.call('expo','a1.b1.c33.d4.e5', '');
+        \\Tracert.call('expo','c33', {});
+        \\Tracert.call('click');
+        \\Tracert.call('click','c33', '3', {}, {});
+        \\Tracert.call('click',1);
+        \\Tracert.call('click',null);
+        \\Tracert.call('click',{});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.alipay_spmlint_valid_manual_param.id));
+    try std.testing.expectEqualStrings("函数 call 需要传递参数", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("函数 logPv 第 1 参数类型为object", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("曝光埋点 spmId 格式应为 a.b.c?.d、c?.d", result.diagnostics[4].message);
+    try std.testing.expectEqualStrings("点击埋点 spmId 格式应为 a.b.c.d、c.d", result.diagnostics[7].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/spmLint/valid-manual-param valid Tracert.call usages" {
+    const source =
+        \\Tracert.set('logPv');
+        \\Tracert.set({});
+        \\Tracert.call('logPv');
+        \\Tracert.call('logPv', {});
+        \\Tracert.call('expo', 'a1.b1.c1.d1');
+        \\Tracert.call('expo','c1');
+        \\Tracert.call('click','c1.d2');
+        \\Tracert.call('click', 'c1.d1', {}, {}, {});
+        \\var a = {}; Tracert.call('click', 'c1.d2', a.b, a.d, a);
+        \\var b = () => {}; Tracert.call('click', 'a1.b2.c1.d2', b, b, b);
+        \\Tracert.call(a);
+        \\Tracert.call('unknown');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_param.id));
+}
+
+test "can disable @alipay/spmLint/valid-manual-param" {
+    const source =
+        \\Tracert.call();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .alipay_spmlint_use_labeled_spm = false,
+        .alipay_spmlint_valid_manual_param = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_spmlint_valid_manual_param.id));
+}


### PR DESCRIPTION
## Summary
- port fishlint's no-options behavior for `@alipay/spmLint/valid-manual-param`
- validate `Tracert.call('<knownFn>', ...)` forwarding for `logPv`, `set`, `click`, and `expo`
- add CLI help, default options registration, and focused tests

## Validation
- `zig build test --summary all -- alipay_spmlint_valid_manual_param`
- fishlint/ESLint no-options fixture comparison for `@alipay/spmLint/valid-manual-param`: 12 diagnostics matched exactly
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke with `--rules=@alipay/spmLint/valid-manual-param` and `--alipay-spmlint-valid-manual-param=off`
