### PR TITLE
feat: port alipay ant no phantom dependencies

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -87,6 +87,7 @@ pub const Options = struct {
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_no_import_src: bool = true,
+    alipay_ant_no_phantom_dependencies: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,
     alipay_spmlint_valid_manual_expo: bool = true,
@@ -624,6 +625,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_ant_no_import_src);
     try std.testing.expect(options.setByCliName("@alipay/ant/no-import-src", true));
     try std.testing.expect(options.alipay_ant_no_import_src);
+
+    try std.testing.expect(!options.alipay_ant_no_phantom_dependencies);
+    try std.testing.expect(options.setByCliName("@alipay/ant/no-phantom-dependencies", true));
+    try std.testing.expect(options.alipay_ant_no_phantom_dependencies);
 
     try std.testing.expect(!options.alipay_ant_disallow_typos);
     try std.testing.expect(options.setByCliName("@alipay/ant/disallow-typos", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -241,6 +241,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_disallow_typos = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
             options.alipay_ant_no_import_src = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
+            options.alipay_ant_no_phantom_dependencies = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
             options.alipay_spmlint_use_labeled_spm = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-click=off")) {
@@ -996,7 +998,7 @@ fn lintFileJson(
     };
     defer allocator.free(source);
 
-    var result = try lint.lintSource(allocator, source, path, options);
+    var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
     defer result.deinit(allocator);
 
     stats.files += 1;
@@ -1037,7 +1039,7 @@ fn lintFile(
     };
     defer allocator.free(source);
 
-    var result = try lint.lintSource(allocator, source, path, options);
+    var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
     defer result.deinit(allocator);
 
     stats.files += 1;
@@ -1211,6 +1213,7 @@ fn printHelp() void {
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
+        \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
         \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo

--- a/src/root.zig
+++ b/src/root.zig
@@ -18,6 +18,16 @@ pub fn lintSource(
     path: []const u8,
     options: Options,
 ) Allocator.Error!Result {
+    return lintSourceWithIo(allocator, null, source, path, options);
+}
+
+pub fn lintSourceWithIo(
+    allocator: Allocator,
+    io: ?std.Io,
+    source: []const u8,
+    path: []const u8,
+    options: Options,
+) Allocator.Error!Result {
     var diagnostics: core.DiagnosticList = .empty;
     errdefer core.freeDiagnostics(allocator, &diagnostics);
 
@@ -36,7 +46,7 @@ pub fn lintSource(
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
-        try rules.runSemantic(allocator, &diagnostics, &tree, semantic_result, effective_options);
+        try rules.runSemantic(allocator, &diagnostics, &tree, io, path, semantic_result, effective_options);
     } else {
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
@@ -123,6 +133,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_global_is_nan or
         options.no_implied_eval or
         options.no_import_assign or
+        options.alipay_ant_no_phantom_dependencies or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/alipay_ant_no_phantom_dependencies.zig
+++ b/src/rules/alipay_ant_no_phantom_dependencies.zig
@@ -1,0 +1,564 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-phantom-dependencies";
+
+const max_config_file_size = 1024 * 1024;
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
+const DependencyConfig = struct {
+    allocator: Allocator,
+    dependencies: std.StringHashMap(void),
+    aliases: std.ArrayList([]const u8),
+
+    fn deinit(self: *DependencyConfig) void {
+        var iter = self.dependencies.iterator();
+        while (iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.dependencies.deinit();
+
+        for (self.aliases.items) |alias| {
+            self.allocator.free(alias);
+        }
+        self.aliases.deinit(self.allocator);
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    const project_root = try findProjectRoot(allocator, io, file_path);
+    defer allocator.free(project_root);
+
+    const lerna_path = try std.fs.path.join(allocator, &.{ project_root, "lerna.json" });
+    defer allocator.free(lerna_path);
+    if (exists(io, lerna_path)) return;
+
+    var config = try readDependencyConfig(allocator, io, project_root);
+    defer config.deinit();
+
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .config = &config,
+        .reference_lookup = &reference_lookup,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    config: *const DependencyConfig,
+    reference_lookup: *const ReferenceLookup,
+
+    pub fn enter_program(
+        self: *Visitor,
+        program: ast.Program,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        for (ctx.tree.extra(program.body)) |statement_index| {
+            switch (ctx.tree.data(statement_index)) {
+                .import_declaration => |declaration| {
+                    try self.checkImportString(ctx.tree, statement_index, importSource(ctx.tree, declaration));
+                },
+                .export_named_declaration => |declaration| {
+                    try self.checkImportString(ctx.tree, statement_index, exportNamedSource(ctx.tree, declaration));
+                },
+                .export_all_declaration => |declaration| {
+                    try self.checkImportString(ctx.tree, statement_index, exportAllSource(ctx.tree, declaration));
+                },
+                else => {},
+            }
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.isGlobalRequireReference(ctx.tree, call.callee)) return .proceed;
+        const source = requireSource(ctx.tree, call) orelse return .proceed;
+        try self.checkImportString(ctx.tree, index, source);
+        return .proceed;
+    }
+
+    fn isGlobalRequireReference(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        const name = identifierReferenceName(tree, unwrapTransparent(tree, index)) orelse return false;
+        if (!std.mem.eql(u8, name, "require")) return false;
+        return (self.reference_lookup.get(unwrapTransparent(tree, index)) orelse .none) == .none;
+    }
+
+    fn checkImportString(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        node_index: ast.NodeIndex,
+        import_string: ?[]const u8,
+    ) Allocator.Error!void {
+        const package_name = missingDependency(self.config, import_string) orelse return;
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(node_index),
+            "检测到未在 package.json 中声明的依赖: {s}",
+            .{package_name},
+        );
+    }
+};
+
+fn readDependencyConfig(
+    allocator: Allocator,
+    io: std.Io,
+    project_root: []const u8,
+) Allocator.Error!DependencyConfig {
+    var dependencies = std.StringHashMap(void).init(allocator);
+    errdefer dependencies.deinit();
+
+    var aliases: std.ArrayList([]const u8) = .empty;
+    errdefer aliases.deinit(allocator);
+
+    for (node_dependencies) |dependency| {
+        try addDependency(allocator, &dependencies, dependency);
+    }
+    try addDependency(allocator, &dependencies, "@qiaozhi/page");
+
+    const package_path = try std.fs.path.join(allocator, &.{ project_root, "package.json" });
+    defer allocator.free(package_path);
+    try readPackageJson(allocator, io, package_path, &dependencies);
+
+    const tsconfig_path = try std.fs.path.join(allocator, &.{ project_root, "tsconfig.json" });
+    defer allocator.free(tsconfig_path);
+    try readTsConfigAliases(allocator, io, tsconfig_path, &aliases);
+
+    try readSmallfishConfig(allocator, io, project_root, &dependencies, &aliases);
+
+    return .{
+        .allocator = allocator,
+        .dependencies = dependencies,
+        .aliases = aliases,
+    };
+}
+
+fn addDependency(
+    allocator: Allocator,
+    dependencies: *std.StringHashMap(void),
+    name: []const u8,
+) Allocator.Error!void {
+    if (dependencies.contains(name)) return;
+    const owned = try allocator.dupe(u8, name);
+    errdefer allocator.free(owned);
+    try dependencies.put(owned, {});
+}
+
+fn readPackageJson(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    dependencies: *std.StringHashMap(void),
+) Allocator.Error!void {
+    const source = readConfigFile(allocator, io, path) orelse return;
+    defer allocator.free(source);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch return;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return,
+    };
+
+    const dependency_keys = [_][]const u8{
+        "devDependencies",
+        "peerDependencies",
+        "dependencies",
+        "optionalDependencies",
+    };
+
+    for (dependency_keys) |key| {
+        const value = root.get(key) orelse continue;
+        const object = switch (value) {
+            .object => |object| object,
+            else => continue,
+        };
+
+        var iter = object.iterator();
+        while (iter.next()) |entry| {
+            try addDependency(allocator, dependencies, entry.key_ptr.*);
+        }
+    }
+}
+
+fn addAlias(
+    allocator: Allocator,
+    aliases: *std.ArrayList([]const u8),
+    name: []const u8,
+) Allocator.Error!void {
+    const trimmed = if (std.mem.endsWith(u8, name, "$")) name[0 .. name.len - 1] else name;
+    for (aliases.items) |alias| {
+        if (std.mem.eql(u8, alias, trimmed)) return;
+    }
+    try aliases.append(allocator, try allocator.dupe(u8, trimmed));
+}
+
+fn readTsConfigAliases(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    aliases: *std.ArrayList([]const u8),
+) Allocator.Error!void {
+    const source = readConfigFile(allocator, io, path) orelse return;
+    defer allocator.free(source);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch return;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return,
+    };
+    const compiler_options = switch (root.get("compilerOptions") orelse return) {
+        .object => |object| object,
+        else => return,
+    };
+    const paths = switch (compiler_options.get("paths") orelse return) {
+        .object => |object| object,
+        else => return,
+    };
+
+    var iter = paths.iterator();
+    while (iter.next()) |entry| {
+        try addAlias(allocator, aliases, entry.key_ptr.*);
+    }
+}
+
+fn readSmallfishConfig(
+    allocator: Allocator,
+    io: std.Io,
+    project_root: []const u8,
+    dependencies: *std.StringHashMap(void),
+    aliases: *std.ArrayList([]const u8),
+) Allocator.Error!void {
+    const js_path = try std.fs.path.join(allocator, &.{ project_root, "smallfish.config.js" });
+    defer allocator.free(js_path);
+    const ts_path = try std.fs.path.join(allocator, &.{ project_root, "smallfish.config.ts" });
+    defer allocator.free(ts_path);
+
+    var source: ?[]u8 = readConfigFile(allocator, io, js_path);
+    var source_path = js_path;
+    if (readConfigFile(allocator, io, ts_path)) |ts_source| {
+        if (source) |js_source| allocator.free(js_source);
+        source = ts_source;
+        source_path = ts_path;
+    }
+
+    const config_source = source orelse return;
+    defer allocator.free(config_source);
+    if (config_source.len == 0) return;
+
+    try addDependency(allocator, dependencies, "react");
+    try addDependency(allocator, dependencies, "react-dom");
+    try addDependency(allocator, dependencies, "antd-mobile");
+
+    var tree = parser.parse(allocator, config_source, .{
+        .source_type = .script,
+        .lang = ast.Lang.fromPath(source_path),
+    }) catch return;
+    defer tree.deinit();
+
+    var visitor = SmallfishAliasVisitor{
+        .allocator = allocator,
+        .aliases = aliases,
+    };
+    try traverser.basic.traverse(SmallfishAliasVisitor, &tree, &visitor);
+}
+
+const SmallfishAliasVisitor = struct {
+    allocator: Allocator,
+    aliases: *std.ArrayList([]const u8),
+
+    pub fn enter_object_property(
+        self: *SmallfishAliasVisitor,
+        property: ast.ObjectProperty,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const key = nodeName(ctx.tree, property.key) orelse return .proceed;
+        if (!std.mem.eql(u8, key, "alias")) return .proceed;
+
+        const alias_object = switch (ctx.tree.data(property.value)) {
+            .object_expression => |object| object,
+            else => return .proceed,
+        };
+
+        for (ctx.tree.extra(alias_object.properties)) |item| {
+            const alias_property = switch (ctx.tree.data(item)) {
+                .object_property => |object_property| object_property,
+                else => continue,
+            };
+
+            if (nodeName(ctx.tree, alias_property.key)) |name| {
+                try addAlias(self.allocator, self.aliases, name);
+            }
+            if (nodeName(ctx.tree, alias_property.value)) |name| {
+                try addAlias(self.allocator, self.aliases, name);
+            }
+        }
+
+        return .proceed;
+    }
+};
+
+fn nodeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn readConfigFile(allocator: Allocator, io: std.Io, path: []const u8) ?[]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const directory_path = std.fs.path.dirname(path) orelse return null;
+        const basename = std.fs.path.basename(path);
+        var directory = std.Io.Dir.openDirAbsolute(io, directory_path, .{}) catch return null;
+        defer directory.close(io);
+        return directory.readFileAlloc(io, basename, allocator, .limited(max_config_file_size)) catch null;
+    }
+
+    return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_config_file_size)) catch null;
+}
+
+fn missingDependency(config: *const DependencyConfig, import_string: ?[]const u8) ?[]const u8 {
+    const source = import_string orelse return null;
+    if (source.len == 0) return null;
+
+    for (config.aliases.items) |alias| {
+        if (std.mem.startsWith(u8, source, alias)) return null;
+    }
+
+    const package_name = parsePackageNameFromImport(source) orelse return null;
+    if (config.dependencies.contains(package_name)) return null;
+    return package_name;
+}
+
+fn parsePackageNameFromImport(import_string: []const u8) ?[]const u8 {
+    if (std.mem.startsWith(u8, import_string, "~") or
+        std.mem.startsWith(u8, import_string, "/") or
+        std.mem.startsWith(u8, import_string, "#") or
+        std.mem.startsWith(u8, import_string, "@/") or
+        std.mem.startsWith(u8, import_string, "./") or
+        std.mem.startsWith(u8, import_string, "../") or
+        std.mem.startsWith(u8, import_string, "@smallfish/") or
+        std.mem.startsWith(u8, import_string, "smallfish:") or
+        std.mem.startsWith(u8, import_string, "minifish:") or
+        std.mem.startsWith(u8, import_string, "@qiaozhi/") or
+        std.mem.eql(u8, import_string, "@wukong") or
+        std.mem.startsWith(u8, import_string, "@wukong/") or
+        std.mem.eql(u8, import_string, ".") or
+        std.mem.eql(u8, import_string, ".."))
+    {
+        return null;
+    }
+
+    if (std.mem.startsWith(u8, import_string, "@")) {
+        const scope_end = std.mem.indexOfScalarPos(u8, import_string, 1, '/') orelse return import_string;
+        const name_end = std.mem.indexOfScalarPos(u8, import_string, scope_end + 1, '/') orelse import_string.len;
+        return import_string[0..name_end];
+    }
+
+    const end = std.mem.indexOfScalar(u8, import_string, '/') orelse import_string.len;
+    return import_string[0..end];
+}
+
+fn findProjectRoot(allocator: Allocator, io: std.Io, file_path: []const u8) Allocator.Error![]u8 {
+    const absolute_file = if (std.fs.path.isAbsolute(file_path))
+        try allocator.dupe(u8, file_path)
+    else blk: {
+        const cwd = std.process.currentPathAlloc(io, allocator) catch {
+            break :blk try std.fs.path.resolve(allocator, &.{file_path});
+        };
+        defer allocator.free(cwd);
+        break :blk try std.fs.path.resolve(allocator, &.{ cwd, file_path });
+    };
+    defer allocator.free(absolute_file);
+
+    var current = try allocator.dupe(u8, std.fs.path.dirname(absolute_file) orelse ".");
+    errdefer allocator.free(current);
+
+    while (true) {
+        const package_path = try std.fs.path.join(allocator, &.{ current, "package.json" });
+        defer allocator.free(package_path);
+        if (exists(io, package_path)) return current;
+
+        const parent = std.fs.path.dirname(current) orelse return current;
+        if (std.mem.eql(u8, parent, current)) return current;
+
+        const next = try allocator.dupe(u8, parent);
+        allocator.free(current);
+        current = next;
+    }
+}
+
+fn exists(io: std.Io, path: []const u8) bool {
+    if (std.fs.path.isAbsolute(path)) {
+        std.Io.Dir.accessAbsolute(io, path, .{}) catch return false;
+        return true;
+    }
+
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return stringLiteralValue(tree, declaration.source);
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    return stringLiteralValue(tree, declaration.source);
+}
+
+fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration) ?[]const u8 {
+    return stringLiteralValue(tree, declaration.source);
+}
+
+fn requireSource(tree: *const ast.Tree, call: ast.CallExpression) ?[]const u8 {
+    if (call.arguments.len == 0) return null;
+    const first = tree.extra(call.arguments)[0];
+    return stringLiteralValue(tree, first);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+const node_dependencies = [_][]const u8{
+    "assert",
+    "assert/strict",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "dns/promises",
+    "domain",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "inspector/promises",
+    "module",
+    "net",
+    "os",
+    "path",
+    "path/posix",
+    "path/win32",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "readline/promises",
+    "repl",
+    "stream",
+    "stream/consumers",
+    "stream/promises",
+    "stream/web",
+    "string_decoder",
+    "sys",
+    "timers",
+    "timers/promises",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "util/types",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+};
+
+test "alipay ant no phantom dependencies parses package names like fishlint" {
+    try std.testing.expectEqualStrings("react", parsePackageNameFromImport("react/jsx-runtime").?);
+    try std.testing.expectEqualStrings("@scope/pkg", parsePackageNameFromImport("@scope/pkg/sub/path").?);
+    try std.testing.expect(parsePackageNameFromImport("./local") == null);
+    try std.testing.expect(parsePackageNameFromImport("@qiaozhi/foo") == null);
+    try std.testing.expect(parsePackageNameFromImport("@wukong/router") == null);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
+pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
 pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manual_expo.zig");
@@ -368,9 +369,24 @@ pub fn runSemantic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    io: ?std.Io,
+    file_path: []const u8,
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.alipay_ant_no_phantom_dependencies) {
+        if (io) |actual_io| {
+            try alipay_ant_no_phantom_dependencies.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+                semantic_result.symbol_table,
+            );
+        }
+    }
+
     if (options.block_scoped_var) {
         try block_scoped_var.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }


### PR DESCRIPTION
## Summary
- port fishlint's `@alipay/ant/no-phantom-dependencies` rule
- read package.json, tsconfig paths, lerna disable state, and smallfish aliases/dependencies through CLI I/O
- preserve the existing `lintSource` API by adding `lintSourceWithIo` for file-system-backed rules

## Validation
- `zig build test --summary all -- alipay_ant_no_phantom_dependencies`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- fishlint comparison fixtures for package.json deps, tsconfig aliases, require shadowing, lerna disable, and smallfish config
- CLI smoke for `--alipay-ant-no-phantom-dependencies=off`
