### PR TITLE
feat: port import default

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -173,6 +173,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`import/default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/first`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md) | Implemented |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -93,6 +93,7 @@ pub const Options = struct {
     alipay_spmlint_valid_manual_expo: bool = true,
     alipay_spmlint_valid_manual_param: bool = true,
     alipay_spmlint_valid_manual_pv: bool = true,
+    import_default: bool = true,
     import_first: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
@@ -654,6 +655,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.alipay_spmlint_valid_manual_pv);
     try std.testing.expect(options.setByCliName("@alipay/spmLint/valid-manual-pv", true));
     try std.testing.expect(options.alipay_spmlint_valid_manual_pv);
+
+    try std.testing.expect(!options.import_default);
+    try std.testing.expect(options.setByCliName("import/default", true));
+    try std.testing.expect(options.import_default);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,6 +253,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_spmlint_valid_manual_param = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-pv=off")) {
             options.alipay_spmlint_valid_manual_pv = false;
+        } else if (std.mem.eql(u8, arg, "--import-default=off")) {
+            options.import_default = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
         } else if (std.mem.eql(u8, arg, "--import-newline-after-import=off")) {
@@ -1221,6 +1223,7 @@ fn printHelp() void {
         \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo
         \\  --alipay-spmlint-valid-manual-param=off Disable @alipay/spmLint/valid-manual-param
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
+        \\  --import-default=off      Disable import/default
         \\  --import-first=off         Disable import/first
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd

--- a/src/root.zig
+++ b/src/root.zig
@@ -134,6 +134,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_implied_eval or
         options.no_import_assign or
         options.alipay_ant_no_phantom_dependencies or
+        options.import_default or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/import_default.zig
+++ b/src/rules/import_default.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/default";
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const default_specifier = defaultSpecifier(tree, declaration) orelse continue;
+        const source = export_map.importSource(tree, declaration) orelse continue;
+
+        const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse continue;
+        defer allocator.free(resolved);
+
+        const map = try export_map.readExportMap(allocator, io, resolved) orelse continue;
+        if (map.has_default) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(default_specifier),
+            "No default export found in imported module \"{s}\".",
+            .{source},
+        );
+    }
+}
+
+fn defaultSpecifier(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?ast.NodeIndex {
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        switch (tree.data(specifier_index)) {
+            .import_default_specifier => return specifier_index,
+            else => {},
+        }
+    }
+    return null;
+}

--- a/src/rules/import_export_map.zig
+++ b/src/rules/import_export_map.zig
@@ -1,0 +1,210 @@
+const std = @import("std");
+const parser = @import("parser");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const extensions = [_][]const u8{
+    ".ts",
+    ".cts",
+    ".mts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+};
+
+const max_source_size = 1024 * 1024;
+const max_reexport_depth = 8;
+
+pub const ExportMap = struct {
+    has_default: bool = false,
+};
+
+pub fn resolveRelativeModule(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!?[]const u8 {
+    if (!isRelativeImport(source)) return null;
+
+    const directory = std.fs.path.dirname(file_path) orelse ".";
+    const imported_path = try std.fs.path.resolve(allocator, &.{ directory, source });
+    errdefer allocator.free(imported_path);
+
+    if (isFile(io, imported_path)) return imported_path;
+
+    for (extensions) |extension| {
+        const with_extension = try std.mem.concat(allocator, u8, &.{ imported_path, extension });
+        if (isFile(io, with_extension)) {
+            allocator.free(imported_path);
+            return with_extension;
+        }
+        allocator.free(with_extension);
+    }
+
+    for (extensions) |extension| {
+        const index_name = try std.mem.concat(allocator, u8, &.{ "index", extension });
+        defer allocator.free(index_name);
+
+        const index_path = try std.fs.path.join(allocator, &.{ imported_path, index_name });
+        if (isFile(io, index_path)) {
+            allocator.free(imported_path);
+            return index_path;
+        }
+        allocator.free(index_path);
+    }
+
+    allocator.free(imported_path);
+    return null;
+}
+
+pub fn readExportMap(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+) Allocator.Error!?ExportMap {
+    var visited = std.StringHashMap(void).init(allocator);
+    defer {
+        var iter = visited.iterator();
+        while (iter.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        visited.deinit();
+    }
+
+    return readExportMapInner(allocator, io, path, &visited, 0);
+}
+
+fn readExportMapInner(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    visited: *std.StringHashMap(void),
+    depth: usize,
+) Allocator.Error!?ExportMap {
+    if (depth > max_reexport_depth) return null;
+    if (visited.contains(path)) return null;
+
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+    try visited.put(owned_path, {});
+
+    const source = readFile(allocator, io, path) orelse return null;
+    defer allocator.free(source);
+
+    var tree = parser.parse(allocator, source, .{
+        .source_type = ast.SourceType.fromPath(path),
+        .lang = ast.Lang.fromPath(path),
+    }) catch return null;
+    defer tree.deinit();
+    if (tree.hasErrors()) return null;
+
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return null,
+    };
+
+    var map = ExportMap{};
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .export_default_declaration => map.has_default = true,
+            .export_named_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                if (hasDefaultSpecifier(&tree, declaration)) {
+                    if (exportNamedSource(&tree, declaration)) |reexport_source| {
+                        if (try reexportHasDefault(allocator, io, path, reexport_source, visited, depth)) {
+                            map.has_default = true;
+                        }
+                    } else {
+                        map.has_default = true;
+                    }
+                }
+            },
+            .export_all_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                if (declaration.exported != .null) {
+                    if (moduleExportName(&tree, declaration.exported)) |name| {
+                        if (std.mem.eql(u8, name, "default")) {
+                            map.has_default = true;
+                        }
+                    }
+                }
+            },
+            else => {},
+        }
+    }
+
+    return map;
+}
+
+fn reexportHasDefault(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    source: []const u8,
+    visited: *std.StringHashMap(void),
+    depth: usize,
+) Allocator.Error!bool {
+    const resolved = try resolveRelativeModule(allocator, io, path, source) orelse return false;
+    defer allocator.free(resolved);
+
+    const map = try readExportMapInner(allocator, io, resolved, visited, depth + 1) orelse return false;
+    return map.has_default;
+}
+
+fn hasDefaultSpecifier(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) bool {
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .export_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.export_kind == .type) continue;
+        const exported = moduleExportName(tree, specifier.exported) orelse continue;
+        if (std.mem.eql(u8, exported, "default")) return true;
+    }
+    return false;
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+pub fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+pub fn isRelativeImport(source: []const u8) bool {
+    return std.mem.startsWith(u8, source, "./") or
+        std.mem.startsWith(u8, source, "../") or
+        std.mem.eql(u8, source, ".") or
+        std.mem.eql(u8, source, "..");
+}
+
+fn readFile(allocator: Allocator, io: std.Io, path: []const u8) ?[]const u8 {
+    return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_source_size)) catch null;
+}
+
+fn isFile(io: std.Io, path: []const u8) bool {
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return false;
+    file.close(io);
+    return true;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -33,6 +33,7 @@ pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manua
 pub const alipay_spmlint_valid_manual_param = @import("alipay_spmlint_valid_manual_param.zig");
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
+pub const import_default = @import("import_default.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
@@ -385,6 +386,18 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 semantic_result.symbol_table,
+            );
+        }
+    }
+
+    if (options.import_default) {
+        if (io) |actual_io| {
+            try import_default.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
             );
         }
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -71,6 +71,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_default.zig");
+}
+
+comptime {
     _ = @import("rules/import_first.zig");
 }
 

--- a/tests/rules/import_default.zig
+++ b/tests/rules/import_default.zig
@@ -1,0 +1,152 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/default for default imports without a default export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.createDirPath(std.testing.io, "src/dir");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/named.ts",
+        .data = "export const named = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/has-default.ts",
+        .data = "export default function Component() {}\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/dir/index.ts",
+        .data = "export default class FromIndex {}\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/reexport.ts",
+        .data = "export { default } from './has-default';\n",
+    });
+
+    const source =
+        \\import missing from "./named";
+        \\import present from "./has-default";
+        \\import indexed from "./dir";
+        \\import reexported from "./reexport";
+    ;
+
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_default.id));
+    try std.testing.expectEqualStrings(
+        "No default export found in imported module \"./named\".",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "reports import/default when a default re-export target has no default export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/named.ts",
+        .data = "export const named = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/reexport.ts",
+        .data = "export { default } from './named';\n",
+    });
+
+    const source =
+        \\import missing from "./reexport";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_default.id));
+    try std.testing.expectEqualStrings(
+        "No default export found in imported module \"./reexport\".",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report import/default for side effect named type or unresolved imports" {
+    const source =
+        \\import "./setup";
+        \\import type TypeOnly from "./named";
+        \\import { named } from "./named";
+        \\import pkg from "pkg";
+    ;
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_default.id));
+}
+
+test "can disable import/default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/named.ts",
+        .data = "export const named = 1;\n",
+    });
+
+    const source =
+        \\import missing from "./named";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_default = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_default.id));
+}


### PR DESCRIPTION
## Summary
- add import/default checking for default imports against local module export maps
- resolve relative imports with fishlint's extension/index lookup order
- add shared import export-map utility for follow-up import rules

## Verification
- zig build test --summary all -- import_default
- fishlint parity fixtures for missing default and bad default re-export
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-default=off