### PR TITLE
feat: port import named

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -175,6 +175,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`import/default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/first`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md) | Implemented |
+| [`import/named`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -95,6 +95,7 @@ pub const Options = struct {
     alipay_spmlint_valid_manual_pv: bool = true,
     import_default: bool = true,
     import_first: bool = true,
+    import_named: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
@@ -659,6 +660,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_default);
     try std.testing.expect(options.setByCliName("import/default", true));
     try std.testing.expect(options.import_default);
+
+    try std.testing.expect(!options.import_named);
+    try std.testing.expect(options.setByCliName("import/named", true));
+    try std.testing.expect(options.import_named);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -257,6 +257,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_default = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
+        } else if (std.mem.eql(u8, arg, "--import-named=off")) {
+            options.import_named = false;
         } else if (std.mem.eql(u8, arg, "--import-newline-after-import=off")) {
             options.import_newline_after_import = false;
         } else if (std.mem.eql(u8, arg, "--import-no-amd=off")) {
@@ -1225,6 +1227,7 @@ fn printHelp() void {
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-default=off      Disable import/default
         \\  --import-first=off         Disable import/first
+        \\  --import-named=off        Disable import/named
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates

--- a/src/root.zig
+++ b/src/root.zig
@@ -135,6 +135,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_import_assign or
         options.alipay_ant_no_phantom_dependencies or
         options.import_default or
+        options.import_named or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/import_default.zig
+++ b/src/rules/import_default.zig
@@ -32,7 +32,8 @@ pub fn run(
         const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse continue;
         defer allocator.free(resolved);
 
-        const map = try export_map.readExportMap(allocator, io, resolved) orelse continue;
+        var map = try export_map.readExportMap(allocator, io, resolved) orelse continue;
+        defer map.deinit();
         if (map.has_default) continue;
 
         try core.addDiagnosticFmt(

--- a/src/rules/import_export_map.zig
+++ b/src/rules/import_export_map.zig
@@ -19,7 +19,41 @@ const max_source_size = 1024 * 1024;
 const max_reexport_depth = 8;
 
 pub const ExportMap = struct {
+    allocator: Allocator,
     has_default: bool = false,
+    named: std.StringHashMap(void),
+
+    pub fn init(allocator: Allocator) ExportMap {
+        return .{
+            .allocator = allocator,
+            .named = std.StringHashMap(void).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *ExportMap) void {
+        var iter = self.named.iterator();
+        while (iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.named.deinit();
+        self.* = undefined;
+    }
+
+    pub fn addNamed(self: *ExportMap, name: []const u8) Allocator.Error!void {
+        if (std.mem.eql(u8, name, "default")) {
+            self.has_default = true;
+            return;
+        }
+        if (self.named.contains(name)) return;
+        const owned = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned);
+        try self.named.put(owned, {});
+    }
+
+    pub fn hasNamed(self: *const ExportMap, name: []const u8) bool {
+        if (std.mem.eql(u8, name, "default")) return self.has_default;
+        return self.named.contains(name);
+    }
 };
 
 pub fn resolveRelativeModule(
@@ -107,12 +141,14 @@ fn readExportMapInner(
         else => return null,
     };
 
-    var map = ExportMap{};
+    var map = ExportMap.init(allocator);
+    errdefer map.deinit();
     for (tree.extra(program.body)) |statement_index| {
         switch (tree.data(statement_index)) {
             .export_default_declaration => map.has_default = true,
             .export_named_declaration => |declaration| {
                 if (declaration.export_kind == .type) continue;
+                try collectNamedDeclarationExports(allocator, &tree, declaration, &map, path, io, visited, depth);
                 if (hasDefaultSpecifier(&tree, declaration)) {
                     if (exportNamedSource(&tree, declaration)) |reexport_source| {
                         if (try reexportHasDefault(allocator, io, path, reexport_source, visited, depth)) {
@@ -127,11 +163,11 @@ fn readExportMapInner(
                 if (declaration.export_kind == .type) continue;
                 if (declaration.exported != .null) {
                     if (moduleExportName(&tree, declaration.exported)) |name| {
-                        if (std.mem.eql(u8, name, "default")) {
-                            map.has_default = true;
-                        }
+                        try map.addNamed(name);
                     }
+                    continue;
                 }
+                try collectExportAll(allocator, io, path, &tree, declaration, &map, visited, depth);
             },
             else => {},
         }
@@ -151,8 +187,151 @@ fn reexportHasDefault(
     const resolved = try resolveRelativeModule(allocator, io, path, source) orelse return false;
     defer allocator.free(resolved);
 
-    const map = try readExportMapInner(allocator, io, resolved, visited, depth + 1) orelse return false;
+    var map = try readExportMapInner(allocator, io, resolved, visited, depth + 1) orelse return false;
+    defer map.deinit();
     return map.has_default;
+}
+
+fn reexportHasNamed(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    source: []const u8,
+    name: []const u8,
+    visited: *std.StringHashMap(void),
+    depth: usize,
+) Allocator.Error!bool {
+    const resolved = try resolveRelativeModule(allocator, io, path, source) orelse return false;
+    defer allocator.free(resolved);
+
+    var map = try readExportMapInner(allocator, io, resolved, visited, depth + 1) orelse return false;
+    defer map.deinit();
+    return map.hasNamed(name);
+}
+
+fn collectExportAll(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    tree: *const ast.Tree,
+    declaration: ast.ExportAllDeclaration,
+    map: *ExportMap,
+    visited: *std.StringHashMap(void),
+    depth: usize,
+) Allocator.Error!void {
+    const source = exportAllSource(tree, declaration) orelse return;
+    const resolved = try resolveRelativeModule(allocator, io, path, source) orelse return;
+    defer allocator.free(resolved);
+
+    var remote = try readExportMapInner(allocator, io, resolved, visited, depth + 1) orelse return;
+    defer remote.deinit();
+
+    var iter = remote.named.iterator();
+    while (iter.next()) |entry| {
+        try map.addNamed(entry.key_ptr.*);
+    }
+}
+
+fn collectNamedDeclarationExports(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declaration: ast.ExportNamedDeclaration,
+    map: *ExportMap,
+    path: []const u8,
+    io: std.Io,
+    visited: *std.StringHashMap(void),
+    depth: usize,
+) Allocator.Error!void {
+    if (exportNamedSource(tree, declaration)) |source| {
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .export_specifier => |specifier| specifier,
+                else => continue,
+            };
+            if (specifier.export_kind == .type) continue;
+            const local = moduleExportName(tree, specifier.local) orelse continue;
+            const exported = moduleExportName(tree, specifier.exported) orelse continue;
+            if (try reexportHasNamed(allocator, io, path, source, local, visited, depth)) {
+                try map.addNamed(exported);
+            }
+        }
+        return;
+    }
+
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .export_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.export_kind == .type) continue;
+        const exported = moduleExportName(tree, specifier.exported) orelse continue;
+        try map.addNamed(exported);
+    }
+
+    if (declaration.declaration == .null) return;
+    try collectDeclarationNames(allocator, tree, declaration.declaration, map);
+}
+
+fn collectDeclarationNames(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declaration_index: ast.NodeIndex,
+    map: *ExportMap,
+) Allocator.Error!void {
+    switch (tree.data(declaration_index)) {
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                try collectBindingNames(allocator, tree, declarator.id, map);
+            }
+        },
+        .function => |function| {
+            const name = bindingIdentifierName(tree, function.id) orelse return;
+            try map.addNamed(name);
+        },
+        .class => |class| {
+            const name = bindingIdentifierName(tree, class.id) orelse return;
+            try map.addNamed(name);
+        },
+        .ts_type_alias_declaration => |declaration| try map.addNamed(bindingIdentifierName(tree, declaration.id) orelse return),
+        .ts_interface_declaration => |declaration| try map.addNamed(bindingIdentifierName(tree, declaration.id) orelse return),
+        .ts_enum_declaration => |declaration| try map.addNamed(bindingIdentifierName(tree, declaration.id) orelse return),
+        else => {},
+    }
+}
+
+fn collectBindingNames(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    map: *ExportMap,
+) Allocator.Error!void {
+    if (index == .null) return;
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try map.addNamed(tree.string(identifier.name)),
+        .assignment_pattern => |pattern| try collectBindingNames(allocator, tree, pattern.left, map),
+        .binding_rest_element => |element| try collectBindingNames(allocator, tree, element.argument, map),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try collectBindingNames(allocator, tree, element, map);
+            }
+            try collectBindingNames(allocator, tree, pattern.rest, map);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try collectBindingNames(allocator, tree, property.value, map);
+            }
+            try collectBindingNames(allocator, tree, pattern.rest, map);
+        },
+        else => {},
+    }
 }
 
 fn hasDefaultSpecifier(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) bool {
@@ -176,11 +355,27 @@ fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclarat
     };
 }
 
+fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
 fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     if (index == .null) return null;
     return switch (tree.data(index)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
         else => null,
     };
 }

--- a/src/rules/import_named.zig
+++ b/src/rules/import_named.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/named";
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| try checkImportDeclaration(
+                allocator,
+                io,
+                diagnostics,
+                tree,
+                file_path,
+                declaration,
+            ),
+            .export_named_declaration => |declaration| try checkExportNamedDeclaration(
+                allocator,
+                io,
+                diagnostics,
+                tree,
+                file_path,
+                declaration,
+            ),
+            else => {},
+        }
+    }
+}
+
+fn checkImportDeclaration(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    declaration: ast.ImportDeclaration,
+) Allocator.Error!void {
+    if (declaration.import_kind == .type) return;
+    const source = export_map.importSource(tree, declaration) orelse return;
+
+    var remote = try readRemoteMap(allocator, io, file_path, source) orelse return;
+    defer remote.deinit();
+
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .import_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.import_kind == .type) continue;
+        const imported = moduleExportName(tree, specifier.imported) orelse continue;
+        if (remote.hasNamed(imported)) continue;
+        try reportMissing(allocator, diagnostics, tree, specifier.imported, imported, source);
+    }
+}
+
+fn checkExportNamedDeclaration(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    declaration: ast.ExportNamedDeclaration,
+) Allocator.Error!void {
+    if (declaration.export_kind == .type) return;
+    const source = exportNamedSource(tree, declaration) orelse return;
+
+    var remote = try readRemoteMap(allocator, io, file_path, source) orelse return;
+    defer remote.deinit();
+
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .export_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.export_kind == .type) continue;
+        const local = moduleExportName(tree, specifier.local) orelse continue;
+        if (remote.hasNamed(local)) continue;
+        try reportMissing(allocator, diagnostics, tree, specifier.local, local, source);
+    }
+}
+
+fn readRemoteMap(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!?export_map.ExportMap {
+    const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse return null;
+    defer allocator.free(resolved);
+    return export_map.readExportMap(allocator, io, resolved);
+}
+
+fn reportMissing(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    name: []const u8,
+    source: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(node),
+        "{s} not found in '{s}'",
+        .{ name, source },
+    );
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const alipay_spmlint_valid_manual_param = @import("alipay_spmlint_valid_manu
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_default = @import("import_default.zig");
+pub const import_named = @import("import_named.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
@@ -393,6 +394,17 @@ pub fn runSemantic(
     if (options.import_default) {
         if (io) |actual_io| {
             try import_default.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
+    }
+    if (options.import_named) {
+        if (io) |actual_io| {
+            try import_named.run(
                 allocator,
                 actual_io,
                 diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -79,6 +79,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_named.zig");
+}
+
+comptime {
     _ = @import("rules/import_newline_after_import.zig");
 }
 

--- a/tests/rules/import_named.zig
+++ b/tests/rules/import_named.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/named for missing named imports and re-exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data =
+        \\export const named = 1;
+        \\export const alias = 2;
+        \\export default 3;
+        ,
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/extra.ts",
+        .data = "export const star = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/barrel.ts",
+        .data =
+        \\export * from './extra';
+        \\export { alias as renamed } from './mod';
+        ,
+    });
+
+    const source =
+        \\import { named, alias, missing } from "./mod";
+        \\import { star, renamed } from "./barrel";
+        \\export { named, absent as stillAbsent } from "./mod";
+    ;
+
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_named.id));
+    try std.testing.expectEqualStrings("missing not found in './mod'", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("absent not found in './mod'", result.diagnostics[1].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "does not report import/named for defaults side effects type imports or unresolved modules" {
+    const source =
+        \\import defaultValue from "./mod";
+        \\import "./setup";
+        \\import type { MissingType } from "./mod";
+        \\import { anything } from "pkg";
+        \\export { local };
+        \\const local = 1;
+    ;
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, "fixture.ts", .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_named.id));
+}
+
+test "can disable import/named" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data = "export const named = 1;\n",
+    });
+
+    const source =
+        \\import { missing } from "./mod";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_named = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_named.id));
+}


### PR DESCRIPTION
## Summary
- add import/named checking for ESM named imports and named re-exports
- extend the shared import export-map utility with named exports, export * propagation, and named re-export validation
- add CLI/config/docs/test coverage for import/named

## Verification
- zig build test --summary all -- import_default import_named
- fishlint parity fixtures for missing named imports, missing named re-exports, and export * missing lookups
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-named=off