### PR TITLE
feat: port import no named as default

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -179,6 +179,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
+| [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -99,6 +99,7 @@ pub const Options = struct {
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
+    import_no_named_as_default: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_anchor_has_content: bool = true,
@@ -664,6 +665,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_named);
     try std.testing.expect(options.setByCliName("import/named", true));
     try std.testing.expect(options.import_named);
+
+    try std.testing.expect(!options.import_no_named_as_default);
+    try std.testing.expect(options.setByCliName("import/no-named-as-default", true));
+    try std.testing.expect(options.import_no_named_as_default);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -265,6 +265,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_amd = false;
         } else if (std.mem.eql(u8, arg, "--import-no-duplicates=off")) {
             options.import_no_duplicates = false;
+        } else if (std.mem.eql(u8, arg, "--import-no-named-as-default=off")) {
+            options.import_no_named_as_default = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-alt-text=off")) {
@@ -1231,6 +1233,7 @@ fn printHelp() void {
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
+        \\  --import-no-named-as-default=off Disable import/no-named-as-default
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-alt-text=off   Disable jsx-a11y/alt-text
         \\  --jsx-a11y-anchor-has-content=off Disable jsx-a11y/anchor-has-content

--- a/src/root.zig
+++ b/src/root.zig
@@ -136,6 +136,7 @@ fn hasSemanticRules(options: Options) bool {
         options.alipay_ant_no_phantom_dependencies or
         options.import_default or
         options.import_named or
+        options.import_no_named_as_default or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/import_no_named_as_default.zig
+++ b/src/rules/import_no_named_as_default.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/no-named-as-default";
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const source = export_map.importSource(tree, declaration) orelse continue;
+
+        const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse continue;
+        defer allocator.free(resolved);
+
+        var remote = try export_map.readExportMap(allocator, io, resolved) orelse continue;
+        defer remote.deinit();
+        if (!remote.has_default) continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .import_default_specifier => |specifier| specifier,
+                else => continue,
+            };
+            const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+            if (std.mem.eql(u8, local, "default")) continue;
+            if (!remote.hasNamed(local)) continue;
+
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                tree.span(specifier_index),
+                "Using exported name '{s}' as identifier for default import.",
+                .{local},
+            );
+        }
+    }
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -38,6 +38,7 @@ pub const import_named = @import("import_named.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
+pub const import_no_named_as_default = @import("import_no_named_as_default.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
@@ -405,6 +406,17 @@ pub fn runSemantic(
     if (options.import_named) {
         if (io) |actual_io| {
             try import_named.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
+    }
+    if (options.import_no_named_as_default) {
+        if (io) |actual_io| {
+            try import_no_named_as_default.run(
                 allocator,
                 actual_io,
                 diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -95,6 +95,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_no_named_as_default.zig");
+}
+
+comptime {
     _ = @import("rules/import_no_self_import.zig");
 }
 

--- a/tests/rules/import_no_named_as_default.zig
+++ b/tests/rules/import_no_named_as_default.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/no-named-as-default for default import names that are also named exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data =
+        \\export default function actualDefault() {}
+        \\export const Button = 1;
+        ,
+    });
+
+    const source =
+        \\import Button from "./mod";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_no_named_as_default.id));
+    try std.testing.expectEqualStrings(
+        "Using exported name 'Button' as identifier for default import.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "does not report import/no-named-as-default without a default export or matching named export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/named-only.ts",
+        .data = "export const Button = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/default-only.ts",
+        .data = "export default function actualDefault() {}\n",
+    });
+
+    const source =
+        \\import Button from "./named-only";
+        \\import Button from "./default-only";
+        \\import Button from "pkg";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_named_as_default.id));
+}
+
+test "can disable import/no-named-as-default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data =
+        \\export default function actualDefault() {}
+        \\export const Button = 1;
+        ,
+    });
+
+    const source =
+        \\import Button from "./mod";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .import_no_named_as_default = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_named_as_default.id));
+}


### PR DESCRIPTION
## Summary
- add import/no-named-as-default for default imports whose local name matches a remote named export
- wire rule config, CLI disable flag, docs, and tests

## Verification
- zig build test --summary all -- import_no_named_as_default
- fishlint parity fixture for default import name collision
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-no-named-as-default=off