### PR TITLE
feat: port import no named as default member

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -180,6 +180,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
+| [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -100,6 +100,7 @@ pub const Options = struct {
     import_no_amd: bool = true,
     import_no_duplicates: bool = true,
     import_no_named_as_default: bool = true,
+    import_no_named_as_default_member: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_anchor_has_content: bool = true,
@@ -669,6 +670,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_named_as_default);
     try std.testing.expect(options.setByCliName("import/no-named-as-default", true));
     try std.testing.expect(options.import_no_named_as_default);
+
+    try std.testing.expect(!options.import_no_named_as_default_member);
+    try std.testing.expect(options.setByCliName("import/no-named-as-default-member", true));
+    try std.testing.expect(options.import_no_named_as_default_member);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -267,6 +267,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-named-as-default=off")) {
             options.import_no_named_as_default = false;
+        } else if (std.mem.eql(u8, arg, "--import-no-named-as-default-member=off")) {
+            options.import_no_named_as_default_member = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-alt-text=off")) {
@@ -1234,6 +1236,7 @@ fn printHelp() void {
         \\  --import-no-amd=off        Disable import/no-amd
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-named-as-default=off Disable import/no-named-as-default
+        \\  --import-no-named-as-default-member=off Disable import/no-named-as-default-member
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-alt-text=off   Disable jsx-a11y/alt-text
         \\  --jsx-a11y-anchor-has-content=off Disable jsx-a11y/anchor-has-content

--- a/src/root.zig
+++ b/src/root.zig
@@ -137,6 +137,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_default or
         options.import_named or
         options.import_no_named_as_default or
+        options.import_no_named_as_default_member or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/import_no_named_as_default_member.zig
+++ b/src/rules/import_no_named_as_default_member.zig
@@ -1,0 +1,183 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/no-named-as-default-member";
+
+const DefaultImport = struct {
+    name: []const u8,
+    source: []const u8,
+    map: export_map.ExportMap,
+};
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    var imports = std.ArrayList(DefaultImport).empty;
+    defer {
+        for (imports.items) |*import| {
+            import.map.deinit();
+        }
+        imports.deinit(allocator);
+    }
+
+    try collectDefaultImports(allocator, io, tree, file_path, &imports);
+    if (imports.items.len == 0) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .imports = imports.items,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+fn collectDefaultImports(
+    allocator: Allocator,
+    io: std.Io,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    imports: *std.ArrayList(DefaultImport),
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const source = export_map.importSource(tree, declaration) orelse continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .import_default_specifier => |specifier| specifier,
+                else => continue,
+            };
+            const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+            const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse continue;
+            defer allocator.free(resolved);
+
+            var remote = try export_map.readExportMap(allocator, io, resolved) orelse continue;
+            errdefer remote.deinit();
+            try imports.append(allocator, .{
+                .name = local,
+                .source = source,
+                .map = remote,
+            });
+        }
+    }
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    imports: []const DefaultImport,
+
+    pub fn enter_member_expression(
+        self: *Visitor,
+        member: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const object = identifierReferenceName(ctx.tree, member.object) orelse return .proceed;
+        const property = memberPropertyName(ctx.tree, member) orelse return .proceed;
+        try self.reportIfNamedExport(ctx.tree, index, object, property);
+        return .proceed;
+    }
+
+    pub fn enter_variable_declarator(
+        self: *Visitor,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const object = identifierReferenceName(ctx.tree, declarator.init) orelse return .proceed;
+        const pattern = switch (ctx.tree.data(declarator.id)) {
+            .object_pattern => |pattern| pattern,
+            else => return .proceed,
+        };
+
+        for (ctx.tree.extra(pattern.properties)) |property_index| {
+            const property = switch (ctx.tree.data(property_index)) {
+                .binding_property => |property| property,
+                else => continue,
+            };
+            if (property.computed) continue;
+            const key = moduleExportName(ctx.tree, property.key) orelse continue;
+            try self.reportIfNamedExport(ctx.tree, property.key, object, key);
+        }
+        return .proceed;
+    }
+
+    fn reportIfNamedExport(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        node: ast.NodeIndex,
+        object: []const u8,
+        property: []const u8,
+    ) Allocator.Error!void {
+        if (std.mem.eql(u8, property, "default")) return;
+        const import = self.findDefaultImport(object) orelse return;
+        if (!import.map.hasNamed(property)) return;
+
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(node),
+            "Caution: `{s}` also has a named export `{s}`. Check if you meant to write `import {{{s}}} from '{s}'` instead.",
+            .{ object, property, property, import.source },
+        );
+    }
+
+    fn findDefaultImport(self: *Visitor, name: []const u8) ?*const DefaultImport {
+        for (self.imports) |*import| {
+            if (std.mem.eql(u8, import.name, name)) return import;
+        }
+        return null;
+    }
+};
+
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) return null;
+    return moduleExportName(tree, member.property);
+}
+
+fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -39,6 +39,7 @@ pub const import_newline_after_import = @import("import_newline_after_import.zig
 pub const import_no_amd = @import("import_no_amd.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_named_as_default = @import("import_no_named_as_default.zig");
+pub const import_no_named_as_default_member = @import("import_no_named_as_default_member.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
@@ -417,6 +418,17 @@ pub fn runSemantic(
     if (options.import_no_named_as_default) {
         if (io) |actual_io| {
             try import_no_named_as_default.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
+    }
+    if (options.import_no_named_as_default_member) {
+        if (io) |actual_io| {
+            try import_no_named_as_default_member.run(
                 allocator,
                 actual_io,
                 diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_no_named_as_default_member.zig");
+}
+
+comptime {
     _ = @import("rules/import_no_self_import.zig");
 }
 

--- a/tests/rules/import_no_named_as_default_member.zig
+++ b/tests/rules/import_no_named_as_default_member.zig
@@ -1,0 +1,117 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/no-named-as-default-member for default import member lookups that are named exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data =
+        \\export default {};
+        \\export const named = 1;
+        \\export const other = 2;
+        ,
+    });
+
+    const source =
+        \\import mod from "./mod";
+        \\mod.named;
+        \\mod.default;
+        \\mod.missing;
+        \\const { other, missing } = mod;
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_unused_expressions = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_named_as_default_member.id));
+    try std.testing.expectEqualStrings(
+        "Caution: `mod` also has a named export `named`. Check if you meant to write `import {named} from './mod'` instead.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Caution: `mod` also has a named export `other`. Check if you meant to write `import {other} from './mod'` instead.",
+        result.diagnostics[1].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "does not report import/no-named-as-default-member for packages unresolved modules or missing properties" {
+    const source =
+        \\import mod from "pkg";
+        \\mod.named;
+    ;
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, "fixture.ts", .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_unused_expressions = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_named_as_default_member.id));
+}
+
+test "can disable import/no-named-as-default-member" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/mod.ts",
+        .data =
+        \\export default {};
+        \\export const named = 1;
+        ,
+    });
+
+    const source =
+        \\import mod from "./mod";
+        \\mod.named;
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .import_no_named_as_default_member = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_unused_expressions = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_named_as_default_member.id));
+}


### PR DESCRIPTION
## Summary
- add import/no-named-as-default-member for default import member lookups and object destructuring
- report fishlint-compatible warning diagnostics when member names are named exports
- wire rule config, CLI disable flag, docs, and tests

## Verification
- zig build test --summary all -- import_no_named_as_default_member
- fishlint parity fixture for member access and destructuring warnings
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-no-named-as-default-member=off