### PR TITLE
feat: port import export

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -174,6 +174,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`import/default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
+| [`import/export`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md) | Implemented for duplicate local exports and relative `export *` |
 | [`import/first`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md) | Implemented |
 | [`import/named`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -94,6 +94,7 @@ pub const Options = struct {
     alipay_spmlint_valid_manual_param: bool = true,
     alipay_spmlint_valid_manual_pv: bool = true,
     import_default: bool = true,
+    import_export: bool = true,
     import_first: bool = true,
     import_named: bool = true,
     import_newline_after_import: bool = true,
@@ -662,6 +663,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_default);
     try std.testing.expect(options.setByCliName("import/default", true));
     try std.testing.expect(options.import_default);
+
+    try std.testing.expect(!options.import_export);
+    try std.testing.expect(options.setByCliName("import/export", true));
+    try std.testing.expect(options.import_export);
 
     try std.testing.expect(!options.import_named);
     try std.testing.expect(options.setByCliName("import/named", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -255,6 +255,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_spmlint_valid_manual_pv = false;
         } else if (std.mem.eql(u8, arg, "--import-default=off")) {
             options.import_default = false;
+        } else if (std.mem.eql(u8, arg, "--import-export=off")) {
+            options.import_export = false;
         } else if (std.mem.eql(u8, arg, "--import-first=off")) {
             options.import_first = false;
         } else if (std.mem.eql(u8, arg, "--import-named=off")) {
@@ -1230,6 +1232,7 @@ fn printHelp() void {
         \\  --alipay-spmlint-valid-manual-param=off Disable @alipay/spmLint/valid-manual-param
         \\  --alipay-spmlint-valid-manual-pv=off Disable @alipay/spmLint/valid-manual-pv
         \\  --import-default=off      Disable import/default
+        \\  --import-export=off       Disable import/export
         \\  --import-first=off         Disable import/first
         \\  --import-named=off        Disable import/named
         \\  --import-newline-after-import=off Disable import/newline-after-import

--- a/src/root.zig
+++ b/src/root.zig
@@ -135,6 +135,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_import_assign or
         options.alipay_ant_no_phantom_dependencies or
         options.import_default or
+        options.import_export or
         options.import_named or
         options.import_no_named_as_default or
         options.import_no_named_as_default_member or

--- a/src/rules/import_export.zig
+++ b/src/rules/import_export.zig
@@ -1,0 +1,347 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/export";
+
+const ExportNode = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+};
+
+const EmptyExportAll = struct {
+    source: []const u8,
+    node: ast.NodeIndex,
+};
+
+const NamedList = std.ArrayList(ExportNode);
+
+const ExportState = struct {
+    allocator: Allocator,
+    exports: std.StringHashMap(NamedList),
+    order: std.ArrayList([]const u8),
+    empty_export_alls: std.ArrayList(EmptyExportAll),
+
+    fn init(allocator: Allocator) ExportState {
+        return .{
+            .allocator = allocator,
+            .exports = std.StringHashMap(NamedList).init(allocator),
+            .order = .empty,
+            .empty_export_alls = .empty,
+        };
+    }
+
+    fn deinit(self: *ExportState) void {
+        for (self.order.items) |name| {
+            if (self.exports.getPtr(name)) |nodes| nodes.deinit(self.allocator);
+            self.allocator.free(name);
+        }
+        self.exports.deinit();
+        self.order.deinit(self.allocator);
+        self.empty_export_alls.deinit(self.allocator);
+    }
+
+    fn add(self: *ExportState, name: []const u8, node: ast.NodeIndex) Allocator.Error!void {
+        const gop = try self.exports.getOrPut(name);
+        if (!gop.found_existing) {
+            const owned = try self.allocator.dupe(u8, name);
+            errdefer self.allocator.free(owned);
+            gop.key_ptr.* = owned;
+            gop.value_ptr.* = .empty;
+            try self.order.append(self.allocator, owned);
+        }
+        try gop.value_ptr.append(self.allocator, .{
+            .name = gop.key_ptr.*,
+            .node = node,
+        });
+    }
+
+    fn addEmptyExportAll(self: *ExportState, source: []const u8, node: ast.NodeIndex) Allocator.Error!void {
+        try self.empty_export_alls.append(self.allocator, .{
+            .source = source,
+            .node = node,
+        });
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    var state = ExportState.init(allocator);
+    defer state.deinit();
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .export_default_declaration => try state.add("default", statement_index),
+            .export_named_declaration => |declaration| try collectNamedDeclaration(
+                allocator,
+                io,
+                tree,
+                file_path,
+                declaration,
+                statement_index,
+                &state,
+            ),
+            .export_all_declaration => |declaration| try collectExportAll(
+                allocator,
+                io,
+                tree,
+                file_path,
+                declaration,
+                statement_index,
+                &state,
+            ),
+            else => {},
+        }
+    }
+
+    try reportDuplicates(allocator, diagnostics, tree, &state);
+    try reportEmptyExportAlls(allocator, diagnostics, tree, &state);
+}
+
+fn collectNamedDeclaration(
+    allocator: Allocator,
+    io: std.Io,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    declaration: ast.ExportNamedDeclaration,
+    declaration_index: ast.NodeIndex,
+    state: *ExportState,
+) Allocator.Error!void {
+    if (declaration.export_kind == .type) return;
+
+    if (exportNamedSource(tree, declaration)) |source| {
+        var remote = try readRemoteMap(allocator, io, file_path, source) orelse return;
+        defer remote.deinit();
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .export_specifier => |specifier| specifier,
+                else => continue,
+            };
+            if (specifier.export_kind == .type) continue;
+            const local = moduleExportName(tree, specifier.local) orelse continue;
+            if (!remote.hasNamed(local)) continue;
+            const exported = moduleExportName(tree, specifier.exported) orelse continue;
+            try state.add(exported, specifier.exported);
+        }
+        return;
+    }
+
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .export_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.export_kind == .type) continue;
+        const exported = moduleExportName(tree, specifier.exported) orelse continue;
+        try state.add(exported, specifier.exported);
+    }
+
+    if (declaration.declaration == .null) return;
+    try collectDeclarationNames(allocator, tree, declaration.declaration, declaration_index, state);
+}
+
+fn collectExportAll(
+    allocator: Allocator,
+    io: std.Io,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    declaration: ast.ExportAllDeclaration,
+    declaration_index: ast.NodeIndex,
+    state: *ExportState,
+) Allocator.Error!void {
+    if (declaration.export_kind == .type) return;
+    if (declaration.exported != .null) return;
+
+    const source = exportAllSource(tree, declaration) orelse return;
+    var remote = try readRemoteMap(allocator, io, file_path, source) orelse return;
+    defer remote.deinit();
+
+    var has_named = false;
+    var iter = remote.named.iterator();
+    while (iter.next()) |entry| {
+        has_named = true;
+        try state.add(entry.key_ptr.*, declaration_index);
+    }
+
+    if (!has_named) {
+        try state.addEmptyExportAll(source, declaration.source);
+    }
+}
+
+fn reportDuplicates(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *const ExportState,
+) Allocator.Error!void {
+    for (state.order.items) |name| {
+        const nodes = state.exports.get(name) orelse continue;
+        if (nodes.items.len <= 1) continue;
+
+        for (nodes.items) |export_node| {
+            if (std.mem.eql(u8, export_node.name, "default")) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Multiple default exports.",
+                    tree.span(export_node.node),
+                );
+            } else {
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    tree.span(export_node.node),
+                    "Multiple exports of name '{s}'.",
+                    .{export_node.name},
+                );
+            }
+        }
+    }
+}
+
+fn reportEmptyExportAlls(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *const ExportState,
+) Allocator.Error!void {
+    for (state.empty_export_alls.items) |empty_export| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(empty_export.node),
+            "No named exports found in module '{s}'.",
+            .{empty_export.source},
+        );
+    }
+}
+
+fn collectDeclarationNames(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declaration_index: ast.NodeIndex,
+    report_node: ast.NodeIndex,
+    state: *ExportState,
+) Allocator.Error!void {
+    switch (tree.data(declaration_index)) {
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                try collectBindingNames(allocator, tree, declarator.id, report_node, state);
+            }
+        },
+        .function => |function| {
+            const name = bindingIdentifierName(tree, function.id) orelse return;
+            try state.add(name, report_node);
+        },
+        .class => |class| {
+            const name = bindingIdentifierName(tree, class.id) orelse return;
+            try state.add(name, report_node);
+        },
+        .ts_type_alias_declaration => |declaration| try state.add(bindingIdentifierName(tree, declaration.id) orelse return, report_node),
+        .ts_interface_declaration => |declaration| try state.add(bindingIdentifierName(tree, declaration.id) orelse return, report_node),
+        .ts_enum_declaration => |declaration| try state.add(bindingIdentifierName(tree, declaration.id) orelse return, report_node),
+        .ts_module_declaration => |declaration| try state.add(bindingIdentifierName(tree, declaration.id) orelse return, report_node),
+        else => {},
+    }
+}
+
+fn collectBindingNames(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    report_node: ast.NodeIndex,
+    state: *ExportState,
+) Allocator.Error!void {
+    if (index == .null) return;
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try state.add(tree.string(identifier.name), report_node),
+        .assignment_pattern => |pattern| try collectBindingNames(allocator, tree, pattern.left, report_node, state),
+        .binding_rest_element => |element| try collectBindingNames(allocator, tree, element.argument, report_node, state),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try collectBindingNames(allocator, tree, element, report_node, state);
+            }
+            try collectBindingNames(allocator, tree, pattern.rest, report_node, state);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try collectBindingNames(allocator, tree, property.value, report_node, state);
+            }
+            try collectBindingNames(allocator, tree, pattern.rest, report_node, state);
+        },
+        else => {},
+    }
+}
+
+fn readRemoteMap(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!?export_map.ExportMap {
+    const resolved = try export_map.resolveRelativeModule(allocator, io, file_path, source) orelse return null;
+    defer allocator.free(resolved);
+    return export_map.readExportMap(allocator, io, resolved);
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const alipay_spmlint_valid_manual_param = @import("alipay_spmlint_valid_manu
 pub const alipay_spmlint_valid_manual_pv = @import("alipay_spmlint_valid_manual_pv.zig");
 pub const import_first = @import("import_first.zig");
 pub const import_default = @import("import_default.zig");
+pub const import_export = @import("import_export.zig");
 pub const import_named = @import("import_named.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
@@ -396,6 +397,17 @@ pub fn runSemantic(
     if (options.import_default) {
         if (io) |actual_io| {
             try import_default.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
+    }
+    if (options.import_export) {
+        if (io) |actual_io| {
+            try import_export.run(
                 allocator,
                 actual_io,
                 diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -75,6 +75,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_export.zig");
+}
+
+comptime {
     _ = @import("rules/import_first.zig");
 }
 

--- a/tests/rules/import_export.zig
+++ b/tests/rules/import_export.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/export for duplicate local exports" {
+    const source =
+        \\export default 1;
+        \\export default 2;
+        \\export const named = 1;
+        \\export { named };
+        \\const alias = 1;
+        \\export { alias as named };
+    ;
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, "fixture.ts", .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.import_export.id));
+    try std.testing.expectEqualStrings("Multiple default exports.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Multiple default exports.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("Multiple exports of name 'named'.", ruleDiagnostic(result, 2).message);
+    try std.testing.expectEqualStrings("Multiple exports of name 'named'.", ruleDiagnostic(result, 3).message);
+    try std.testing.expectEqualStrings("Multiple exports of name 'named'.", ruleDiagnostic(result, 4).message);
+    try std.testing.expectEqual(.warning, ruleDiagnostic(result, 0).severity);
+}
+
+test "reports import/export for duplicate star exports and empty star exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/one.ts",
+        .data = "export const shared = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/two.ts",
+        .data = "export const shared = 2;\nexport const unique = 1;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/defaultOnly.ts",
+        .data = "export default 1;\n",
+    });
+
+    const source =
+        \\export * from "./one";
+        \\export * from "./two";
+        \\export * from "./defaultOnly";
+    ;
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.import_export.id));
+    try std.testing.expectEqualStrings("Multiple exports of name 'shared'.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Multiple exports of name 'shared'.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("No named exports found in module './defaultOnly'.", ruleDiagnostic(result, 2).message);
+}
+
+test "can disable import/export" {
+    const source =
+        \\export default 1;
+        \\export default 2;
+    ;
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, "fixture.ts", .{
+        .eol_last = false,
+        .import_export = false,
+        .import_newline_after_import = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_export.id));
+}
+
+fn ruleDiagnostic(result: lint.Result, index: usize) lint.Diagnostic {
+    var seen: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.import_export.id)) continue;
+        if (seen == index) return diagnostic;
+        seen += 1;
+    }
+    unreachable;
+}


### PR DESCRIPTION
## Summary
- add import/export duplicate export detection for local exports and relative export * re-exports
- report fishlint-compatible warnings for duplicate star exports and empty named export modules
- wire rule config, CLI disable flag, docs, and tests

## Verification
- zig build test --summary all -- import_export
- fishlint parity fixture for duplicate export * and empty named export diagnostics
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-export=off