### PR TITLE
feat: port import no cycle

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -180,6 +180,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
+| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -100,6 +100,7 @@ pub const Options = struct {
     import_namespace: bool = true,
     import_newline_after_import: bool = true,
     import_no_amd: bool = true,
+    import_no_cycle: bool = true,
     import_no_duplicates: bool = true,
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
@@ -676,6 +677,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_namespace);
     try std.testing.expect(options.setByCliName("import/namespace", true));
     try std.testing.expect(options.import_namespace);
+
+    try std.testing.expect(!options.import_no_cycle);
+    try std.testing.expect(options.setByCliName("import/no-cycle", true));
+    try std.testing.expect(options.import_no_cycle);
 
     try std.testing.expect(!options.import_no_named_as_default);
     try std.testing.expect(options.setByCliName("import/no-named-as-default", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -267,6 +267,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_newline_after_import = false;
         } else if (std.mem.eql(u8, arg, "--import-no-amd=off")) {
             options.import_no_amd = false;
+        } else if (std.mem.eql(u8, arg, "--import-no-cycle=off")) {
+            options.import_no_cycle = false;
         } else if (std.mem.eql(u8, arg, "--import-no-duplicates=off")) {
             options.import_no_duplicates = false;
         } else if (std.mem.eql(u8, arg, "--import-no-named-as-default=off")) {
@@ -1240,6 +1242,7 @@ fn printHelp() void {
         \\  --import-namespace=off    Disable import/namespace
         \\  --import-newline-after-import=off Disable import/newline-after-import
         \\  --import-no-amd=off        Disable import/no-amd
+        \\  --import-no-cycle=off      Disable import/no-cycle
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-named-as-default=off Disable import/no-named-as-default
         \\  --import-no-named-as-default-member=off Disable import/no-named-as-default-member

--- a/src/root.zig
+++ b/src/root.zig
@@ -138,6 +138,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_export or
         options.import_named or
         options.import_namespace or
+        options.import_no_cycle or
         options.import_no_named_as_default or
         options.import_no_named_as_default_member or
         options.no_invalid_regexp or

--- a/src/rules/import_no_cycle.zig
+++ b/src/rules/import_no_cycle.zig
@@ -1,0 +1,333 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/no-cycle";
+
+const max_source_size = 1024 * 1024;
+const max_depth = 1024;
+
+const Dependency = struct {
+    source: []const u8,
+    resolved: []const u8,
+    line: usize,
+
+    fn deinit(self: Dependency, allocator: Allocator) void {
+        allocator.free(self.source);
+        allocator.free(self.resolved);
+    }
+};
+
+const RouteStep = struct {
+    source: []const u8,
+    line: usize,
+
+    fn deinit(self: RouteStep, allocator: Allocator) void {
+        allocator.free(self.source);
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const normalized_file_path = try std.fs.path.resolve(allocator, &.{file_path});
+    defer allocator.free(normalized_file_path);
+
+    var dependencies = try collectDependencies(allocator, io, tree, normalized_file_path);
+    defer deinitDependencies(allocator, &dependencies);
+
+    for (dependencies.items) |dependency| {
+        if (std.mem.eql(u8, dependency.resolved, normalized_file_path)) continue;
+
+        var visited = std.StringHashMap(void).init(allocator);
+        defer freeVisited(allocator, &visited);
+
+        var route: std.ArrayList(RouteStep) = .empty;
+        defer deinitRoute(allocator, &route);
+
+        if (try hasCycle(allocator, io, dependency.resolved, normalized_file_path, &visited, &route, 0)) {
+            try reportCycle(allocator, diagnostics, tree, dependency.line, dependency.source, &route);
+        }
+    }
+}
+
+fn hasCycle(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    target: []const u8,
+    visited: *std.StringHashMap(void),
+    route: *std.ArrayList(RouteStep),
+    depth: usize,
+) Allocator.Error!bool {
+    if (depth >= max_depth) return false;
+    if (visited.contains(path)) return false;
+
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+    try visited.put(owned_path, {});
+
+    var dependencies = try collectFileDependencies(allocator, io, path);
+    defer deinitDependencies(allocator, &dependencies);
+
+    for (dependencies.items) |dependency| {
+        if (std.mem.eql(u8, dependency.resolved, target)) {
+            return true;
+        }
+    }
+
+    for (dependencies.items) |dependency| {
+        const source = try allocator.dupe(u8, dependency.source);
+        errdefer allocator.free(source);
+        try route.append(allocator, .{
+            .source = source,
+            .line = dependency.line,
+        });
+
+        if (try hasCycle(allocator, io, dependency.resolved, target, visited, route, depth + 1)) {
+            return true;
+        }
+
+        const removed = route.pop() orelse unreachable;
+        removed.deinit(allocator);
+    }
+
+    return false;
+}
+
+fn reportCycle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    line: usize,
+    source: []const u8,
+    route: *const std.ArrayList(RouteStep),
+) Allocator.Error!void {
+    const node = findDependencyNode(tree, line, source) orelse tree.root;
+
+    if (route.items.len == 0) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Dependency cycle detected.",
+            tree.span(node),
+        );
+        return;
+    }
+
+    const route_text = try formatRoute(allocator, route);
+    defer allocator.free(route_text);
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(node),
+        "Dependency cycle via {s}",
+        .{route_text},
+    );
+}
+
+fn formatRoute(allocator: Allocator, route: *const std.ArrayList(RouteStep)) Allocator.Error![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    for (route.items, 0..) |step, index| {
+        if (index > 0) try out.appendSlice(allocator, "=>");
+        const part = try std.fmt.allocPrint(allocator, "{s}:{d}", .{ step.source, step.line });
+        defer allocator.free(part);
+        try out.appendSlice(allocator, part);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn findDependencyNode(tree: *const ast.Tree, line: usize, source: []const u8) ?ast.NodeIndex {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return null,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| {
+                if (declaration.import_kind == .type) continue;
+                if (declaration.specifiers.len == 0) continue;
+                if (isOnlyTypeImport(tree, declaration)) continue;
+                const import_source = export_map.importSource(tree, declaration) orelse continue;
+                if (std.mem.eql(u8, import_source, source)) return statement_index;
+            },
+            .export_named_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                const export_source = exportNamedSource(tree, declaration) orelse continue;
+                if (std.mem.eql(u8, export_source, source)) return statement_index;
+            },
+            .export_all_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                const export_source = exportAllSource(tree, declaration) orelse continue;
+                if (std.mem.eql(u8, export_source, source)) return statement_index;
+            },
+            else => {},
+        }
+    }
+
+    _ = line;
+    return null;
+}
+
+fn collectFileDependencies(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+) Allocator.Error!std.ArrayList(Dependency) {
+    const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_source_size)) catch return .empty;
+    defer allocator.free(source);
+
+    var tree = parser.parse(allocator, source, .{
+        .source_type = ast.SourceType.fromPath(path),
+        .lang = ast.Lang.fromPath(path),
+    }) catch return .empty;
+    defer tree.deinit();
+    if (tree.hasErrors()) return .empty;
+
+    return collectDependenciesFromSource(allocator, io, &tree, path, source);
+}
+
+fn collectDependencies(
+    allocator: Allocator,
+    io: std.Io,
+    tree: *const ast.Tree,
+    path: []const u8,
+) Allocator.Error!std.ArrayList(Dependency) {
+    return collectDependenciesFromSource(allocator, io, tree, path, "");
+}
+
+fn collectDependenciesFromSource(
+    allocator: Allocator,
+    io: std.Io,
+    tree: *const ast.Tree,
+    path: []const u8,
+    source_text: []const u8,
+) Allocator.Error!std.ArrayList(Dependency) {
+    var dependencies: std.ArrayList(Dependency) = .empty;
+    errdefer deinitDependencies(allocator, &dependencies);
+
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return dependencies,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| {
+                if (declaration.import_kind == .type) continue;
+                if (declaration.specifiers.len == 0) continue;
+                if (isOnlyTypeImport(tree, declaration)) continue;
+                const source = export_map.importSource(tree, declaration) orelse continue;
+                try appendDependency(allocator, io, &dependencies, tree, source_text, path, source, statement_index);
+            },
+            .export_named_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                const source = exportNamedSource(tree, declaration) orelse continue;
+                try appendDependency(allocator, io, &dependencies, tree, source_text, path, source, statement_index);
+            },
+            .export_all_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                const source = exportAllSource(tree, declaration) orelse continue;
+                try appendDependency(allocator, io, &dependencies, tree, source_text, path, source, statement_index);
+            },
+            else => {},
+        }
+    }
+
+    return dependencies;
+}
+
+fn appendDependency(
+    allocator: Allocator,
+    io: std.Io,
+    dependencies: *std.ArrayList(Dependency),
+    tree: *const ast.Tree,
+    source_text: []const u8,
+    path: []const u8,
+    source: []const u8,
+    statement_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const resolved = try export_map.resolveRelativeModule(allocator, io, path, source) orelse return;
+    errdefer allocator.free(resolved);
+    const owned_source = try allocator.dupe(u8, source);
+    errdefer allocator.free(owned_source);
+
+    try dependencies.append(allocator, .{
+        .source = owned_source,
+        .resolved = resolved,
+        .line = lineForOffset(source_text, tree.span(statement_index).start),
+    });
+}
+
+fn isOnlyTypeImport(tree: *const ast.Tree, declaration: ast.ImportDeclaration) bool {
+    if (declaration.specifiers.len == 0) return false;
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        switch (tree.data(specifier_index)) {
+            .import_specifier => |specifier| {
+                if (specifier.import_kind != .type) return false;
+            },
+            else => return false,
+        }
+    }
+    return true;
+}
+
+fn lineForOffset(source: []const u8, offset: u32) usize {
+    const end = @min(@as(usize, @intCast(offset)), source.len);
+    var line: usize = 1;
+    for (source[0..end]) |char| {
+        if (char == '\n') line += 1;
+    }
+    return line;
+}
+
+fn deinitDependencies(allocator: Allocator, dependencies: *std.ArrayList(Dependency)) void {
+    for (dependencies.items) |dependency| dependency.deinit(allocator);
+    dependencies.deinit(allocator);
+}
+
+fn deinitRoute(allocator: Allocator, route: *std.ArrayList(RouteStep)) void {
+    for (route.items) |step| step.deinit(allocator);
+    route.deinit(allocator);
+}
+
+fn freeVisited(allocator: Allocator, visited: *std.StringHashMap(void)) void {
+    var iter = visited.iterator();
+    while (iter.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+    }
+    visited.deinit();
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -39,6 +39,7 @@ pub const import_named = @import("import_named.zig");
 pub const import_namespace = @import("import_namespace.zig");
 pub const import_newline_after_import = @import("import_newline_after_import.zig");
 pub const import_no_amd = @import("import_no_amd.zig");
+pub const import_no_cycle = @import("import_no_cycle.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_named_as_default = @import("import_no_named_as_default.zig");
 pub const import_no_named_as_default_member = @import("import_no_named_as_default_member.zig");
@@ -437,6 +438,17 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 semantic_result.symbol_table,
+            );
+        }
+    }
+    if (options.import_no_cycle) {
+        if (io) |actual_io| {
+            try import_no_cycle.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
             );
         }
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -99,6 +99,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_no_cycle.zig");
+}
+
+comptime {
     _ = @import("rules/import_no_duplicates.zig");
 }
 

--- a/tests/rules/import_no_cycle.zig
+++ b/tests/rules/import_no_cycle.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports import/no-cycle for direct and indirect relative import cycles" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.ts",
+        .data = "import { entry } from './entry';\nexport const direct = entry;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/middle.ts",
+        .data = "import { leaf } from './leaf';\nexport const middle = leaf;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/leaf.ts",
+        .data = "import { entry } from './entry';\nexport const leaf = entry;\n",
+    });
+
+    const source =
+        \\import { direct } from './direct';
+        \\import { middle } from './middle';
+        \\export const entry = direct + middle;
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.ts",
+        .data = source,
+    });
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_cycle.id));
+    try std.testing.expectEqualStrings("Dependency cycle detected.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Dependency cycle via ./leaf:1", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqual(.@"error", ruleDiagnostic(result, 0).severity);
+}
+
+test "ignores import/no-cycle type imports unresolved modules and self imports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/typeOnly.ts",
+        .data = "import type { Value } from './entry';\n",
+    });
+
+    const source =
+        \\import type { Value } from './typeOnly';
+        \\import './missing';
+        \\import './entry';
+        \\export type { Value } from './typeOnly';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.ts",
+        .data = source,
+    });
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .import_no_self_import = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
+}
+
+test "can disable import/no-cycle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.ts",
+        .data = "import { entry } from './entry';\nexport const direct = entry;\n",
+    });
+
+    const source = "import { direct } from './direct';\nexport const entry = direct;\n";
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.ts",
+        .data = source,
+    });
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .import_no_cycle = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
+}
+
+fn ruleDiagnostic(result: lint.Result, index: usize) lint.Diagnostic {
+    var seen: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.import_no_cycle.id)) continue;
+        if (seen == index) return diagnostic;
+        seen += 1;
+    }
+    unreachable;
+}


### PR DESCRIPTION
## Summary
- add import/no-cycle detection for relative import and re-export dependency graphs
- match fishlint behavior for direct/indirect cycles and skip type-only, unresolved, self, and side-effect-only imports
- wire rule config, CLI disable flag, docs, and tests

## Verification
- zig build test --summary all -- import_no_cycle
- fishlint parity fixture for direct and indirect named import cycles
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-no-cycle=off