### PR TITLE
feat: port react prop types

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -213,6 +213,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
+| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Implemented for fishlint's `ignore: [], customValidators: [], skipUndeclared: false` configuration |
 
 ## TypeScript ESLint rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -243,6 +243,7 @@ pub const Options = struct {
     react_no_this_in_sfc: bool = true,
     react_no_typos: bool = true,
     react_no_unknown_property: bool = true,
+    react_prop_types: bool = true,
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
@@ -693,6 +694,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));
     try std.testing.expect(options.react_default_props_match_prop_types);
+
+    try std.testing.expect(!options.react_prop_types);
+    try std.testing.expect(options.setByCliName("react/prop-types", true));
+    try std.testing.expect(options.react_prop_types);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -551,6 +551,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_typos = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unknown-property=off")) {
             options.react_no_unknown_property = false;
+        } else if (std.mem.eql(u8, arg, "--react-prop-types=off")) {
+            options.react_prop_types = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unused-state=off")) {
             options.react_no_unused_state = false;
         } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
@@ -1382,6 +1384,7 @@ fn printHelp() void {
         \\  --react-no-this-in-sfc=off Disable react/no-this-in-sfc
         \\  --react-no-typos=off Disable react/no-typos
         \\  --react-no-unknown-property=off Disable react/no-unknown-property
+        \\  --react-prop-types=off Disable react/prop-types
         \\  --react-no-unused-state=off Disable react/no-unused-state
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -1,0 +1,1021 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/prop-types";
+
+const max_prop_depth = 16;
+
+const DeclaredProp = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+    accepts_any_children: bool = false,
+    children: std.ArrayList(DeclaredProp) = .empty,
+
+    fn deinit(self: *DeclaredProp, allocator: Allocator) void {
+        for (self.children.items) |*child| {
+            child.deinit(allocator);
+        }
+        self.children.deinit(allocator);
+    }
+};
+
+const UsedProp = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+};
+
+const ComponentInfo = struct {
+    name: ?[]const u8 = null,
+    node: ast.NodeIndex = .null,
+    detected: bool = false,
+    function_nodes: std.ArrayList(ast.NodeIndex) = .empty,
+    class_nodes: std.ArrayList(ast.NodeIndex) = .empty,
+    declared_props: std.ArrayList(DeclaredProp) = .empty,
+    used_props: std.ArrayList(UsedProp) = .empty,
+
+    fn deinit(self: *ComponentInfo, allocator: Allocator) void {
+        self.function_nodes.deinit(allocator);
+        self.class_nodes.deinit(allocator);
+        for (self.declared_props.items) |*prop| {
+            prop.deinit(allocator);
+        }
+        self.declared_props.deinit(allocator);
+        for (self.used_props.items) |used| {
+            allocator.free(used.name);
+        }
+        self.used_props.deinit(allocator);
+    }
+};
+
+const State = struct {
+    components: std.ArrayList(ComponentInfo) = .empty,
+
+    fn deinit(self: *State, allocator: Allocator) void {
+        for (self.components.items) |*component| {
+            component.deinit(allocator);
+        }
+        self.components.deinit(allocator);
+    }
+
+    fn ensureComponent(
+        self: *State,
+        allocator: Allocator,
+        name: ?[]const u8,
+        node: ast.NodeIndex,
+        detected: bool,
+    ) Allocator.Error!usize {
+        if (name) |component_name| {
+            for (self.components.items, 0..) |*component, index| {
+                if (component.name) |existing| {
+                    if (std.mem.eql(u8, existing, component_name)) {
+                        component.detected = component.detected or detected;
+                        if (component.node == .null) component.node = node;
+                        return index;
+                    }
+                }
+            }
+        }
+
+        try self.components.append(allocator, .{
+            .name = name,
+            .node = node,
+            .detected = detected,
+        });
+        return self.components.items.len - 1;
+    }
+
+    fn componentByFunction(self: *State, node: ast.NodeIndex) ?usize {
+        for (self.components.items, 0..) |component, index| {
+            for (component.function_nodes.items) |function_node| {
+                if (function_node == node) return index;
+            }
+        }
+        return null;
+    }
+
+    fn componentByClass(self: *State, node: ast.NodeIndex) ?usize {
+        for (self.components.items, 0..) |component, index| {
+            for (component.class_nodes.items) |class_node| {
+                if (class_node == node) return index;
+            }
+        }
+        return null;
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var state = State{};
+    defer state.deinit(allocator);
+
+    try collectComponents(allocator, tree, &state);
+
+    var visitor = UsageVisitor{
+        .allocator = allocator,
+        .state = &state,
+    };
+    defer visitor.component_stack.deinit(allocator);
+    defer visitor.props_stack.deinit(allocator);
+
+    try traverser.basic.traverse(UsageVisitor, tree, &visitor);
+    try finish(allocator, diagnostics, tree, &state);
+}
+
+fn collectComponents(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    state: *State,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        try collectTopLevelDeclaration(allocator, tree, statement_index, state);
+    }
+}
+
+fn collectTopLevelDeclaration(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    statement_index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    switch (tree.data(statement_index)) {
+        .function => |function| try collectFunctionDeclaration(allocator, tree, function, statement_index, state),
+        .class => |class| try collectClassDeclaration(allocator, tree, class, statement_index, state),
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                try collectVariableDeclarator(allocator, tree, declarator, declarator_index, state);
+            }
+        },
+        .expression_statement => |statement| try collectExpressionStatement(allocator, tree, statement.expression, state),
+        .export_named_declaration => |declaration| {
+            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state);
+        },
+        .export_default_declaration => |declaration| {
+            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state);
+        },
+        else => {},
+    }
+}
+
+fn collectFunctionDeclaration(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (!functionReturnsJSXOrNull(tree, index)) return;
+    const name = bindingIdentifierName(tree, function.id) orelse return;
+    if (!startsUppercase(name)) return;
+    const component_index = try state.ensureComponent(allocator, name, index, true);
+    try appendNode(allocator, &state.components.items[component_index].function_nodes, index);
+}
+
+fn collectClassDeclaration(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    if (!isComponentClass(tree, class)) return;
+    const name = bindingIdentifierName(tree, class.id) orelse return;
+    const component_index = try state.ensureComponent(allocator, name, index, true);
+    try appendNode(allocator, &state.components.items[component_index].class_nodes, index);
+    try collectClassPropTypes(allocator, tree, class, component_index, state);
+}
+
+fn collectVariableDeclarator(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    const name = bindingIdentifierName(tree, declarator.id) orelse return;
+    if (!startsUppercase(name) or declarator.init == .null) return;
+
+    const init = unwrapTransparent(tree, declarator.init);
+    switch (tree.data(init)) {
+        .function, .arrow_function_expression => {
+            if (!functionReturnsJSXOrNull(tree, init)) return;
+            const component_index = try state.ensureComponent(allocator, name, index, true);
+            try appendNode(allocator, &state.components.items[component_index].function_nodes, init);
+        },
+        .call_expression => |call| {
+            if (isCreateReactClassCall(tree, call)) {
+                const object = createClassObject(tree, call) orelse return;
+                const component_index = try state.ensureComponent(allocator, name, index, true);
+                try collectCreateClassPropTypes(allocator, tree, object, component_index, state);
+                return;
+            }
+
+            const wrapped = wrapperFunctionArgument(tree, call) orelse return;
+            if (!functionReturnsJSXOrNull(tree, wrapped)) return;
+            const component_index = try state.ensureComponent(allocator, name, index, true);
+            try appendNode(allocator, &state.components.items[component_index].function_nodes, wrapped);
+        },
+        else => {},
+    }
+}
+
+fn collectExpressionStatement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression_index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
+    const assignment = switch (tree.data(unwrapTransparent(tree, expression_index))) {
+        .assignment_expression => |assignment| assignment,
+        else => return,
+    };
+    if (assignment.operator != .assign) return;
+
+    const target = propTypesAssignmentTarget(tree, assignment.left) orelse return;
+    const component_index = try state.ensureComponent(allocator, target.component, assignment.left, false);
+    if (target.prop) |prop| {
+        try addDeclaredPropValue(allocator, tree, &state.components.items[component_index].declared_props, prop, assignment.left, assignment.right);
+    } else {
+        try collectPropTypesObject(allocator, tree, assignment.right, component_index, state);
+    }
+}
+
+fn collectClassPropTypes(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    component_index: usize,
+    state: *State,
+) Allocator.Error!void {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    for (tree.extra(body.body)) |member_index| {
+        const property = switch (tree.data(member_index)) {
+            .property_definition => |property| property,
+            else => continue,
+        };
+        if (!property.static) continue;
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        if (!std.mem.eql(u8, key, "propTypes")) continue;
+        try collectPropTypesObject(allocator, tree, property.value, component_index, state);
+    }
+}
+
+fn collectCreateClassPropTypes(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    object: ast.ObjectExpression,
+    component_index: usize,
+    state: *State,
+) Allocator.Error!void {
+    for (tree.extra(object.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        if (!std.mem.eql(u8, key, "propTypes")) continue;
+        try collectPropTypesObject(allocator, tree, property.value, component_index, state);
+    }
+}
+
+fn collectPropTypesObject(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    value: ast.NodeIndex,
+    component_index: usize,
+    state: *State,
+) Allocator.Error!void {
+    const object = switch (tree.data(unwrapTransparent(tree, value))) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(object.properties)) |property_index| {
+        switch (tree.data(property_index)) {
+            .object_property => |property| {
+                const name = propertyName(tree, property.key, property.computed) orelse continue;
+                try addDeclaredPropValue(
+                    allocator,
+                    tree,
+                    &state.components.items[component_index].declared_props,
+                    name,
+                    property_index,
+                    property.value,
+                );
+            },
+            else => {},
+        }
+    }
+}
+
+fn addDeclaredPropValue(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    props: *std.ArrayList(DeclaredProp),
+    name: []const u8,
+    node: ast.NodeIndex,
+    value: ast.NodeIndex,
+) Allocator.Error!void {
+    var prop = try ensureDeclaredProp(allocator, props, name, node);
+    const target = stripIsRequired(tree, value);
+
+    if (propTypeTargetName(tree, target)) |target_name| {
+        if (acceptsAnyChildren(target_name)) {
+            prop.accepts_any_children = true;
+        }
+    }
+
+    if (propTypeCall(tree, target)) |call| {
+        const callee_name = propTypeTargetName(tree, call.callee) orelse return;
+        if (acceptsAnyChildren(callee_name)) {
+            prop.accepts_any_children = true;
+            return;
+        }
+        if (std.mem.eql(u8, callee_name, "shape") or std.mem.eql(u8, callee_name, "exact")) {
+            const arguments = tree.extra(call.arguments);
+            if (arguments.len == 0) return;
+            try collectShapeChildren(allocator, tree, arguments[0], prop);
+        } else if (std.mem.eql(u8, callee_name, "arrayOf") or std.mem.eql(u8, callee_name, "objectOf")) {
+            const arguments = tree.extra(call.arguments);
+            if (arguments.len == 0) return;
+            const child_call = propTypeCall(tree, stripIsRequired(tree, arguments[0])) orelse return;
+            const child_name = propTypeTargetName(tree, child_call.callee) orelse return;
+            if (std.mem.eql(u8, child_name, "shape") or std.mem.eql(u8, child_name, "exact")) {
+                const child_arguments = tree.extra(child_call.arguments);
+                if (child_arguments.len > 0) try collectShapeChildren(allocator, tree, child_arguments[0], prop);
+            } else if (acceptsAnyChildren(child_name)) {
+                prop.accepts_any_children = true;
+            }
+        }
+    }
+}
+
+fn collectShapeChildren(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    value: ast.NodeIndex,
+    parent: *DeclaredProp,
+) Allocator.Error!void {
+    const object = switch (tree.data(unwrapTransparent(tree, value))) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(object.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const name = propertyName(tree, property.key, property.computed) orelse continue;
+        try addDeclaredPropValue(allocator, tree, &parent.children, name, property_index, property.value);
+    }
+}
+
+fn ensureDeclaredProp(
+    allocator: Allocator,
+    props: *std.ArrayList(DeclaredProp),
+    name: []const u8,
+    node: ast.NodeIndex,
+) Allocator.Error!*DeclaredProp {
+    for (props.items) |*prop| {
+        if (std.mem.eql(u8, prop.name, name)) return prop;
+    }
+    try props.append(allocator, .{ .name = name, .node = node });
+    return &props.items[props.items.len - 1];
+}
+
+const UsageVisitor = struct {
+    allocator: Allocator,
+    state: *State,
+    component_stack: std.ArrayList(?usize) = .empty,
+    props_stack: std.ArrayList(?[]const u8) = .empty,
+
+    fn currentComponent(self: *UsageVisitor) ?usize {
+        if (self.component_stack.items.len == 0) return null;
+        return self.component_stack.items[self.component_stack.items.len - 1];
+    }
+
+    fn currentPropsName(self: *UsageVisitor) ?[]const u8 {
+        if (self.props_stack.items.len == 0) return null;
+        return self.props_stack.items[self.props_stack.items.len - 1];
+    }
+
+    fn pushContext(self: *UsageVisitor, allocator: Allocator, component: ?usize, props_name: ?[]const u8) Allocator.Error!void {
+        try self.component_stack.append(allocator, component);
+        try self.props_stack.append(allocator, props_name);
+    }
+
+    fn popContext(self: *UsageVisitor) void {
+        _ = self.component_stack.pop();
+        _ = self.props_stack.pop();
+    }
+
+    pub fn enter_class(
+        self: *UsageVisitor,
+        _: ast.Class,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const component = self.state.componentByClass(index) orelse self.currentComponent();
+        try self.pushContext(self.allocator, component, self.currentPropsName());
+        return .proceed;
+    }
+
+    pub fn exit_class(self: *UsageVisitor, _: ast.Class, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.popContext();
+    }
+
+    pub fn enter_function(
+        self: *UsageVisitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const component = self.state.componentByFunction(index) orelse self.currentComponent();
+        var props_name = self.currentPropsName();
+        if (self.state.componentByFunction(index)) |component_index| {
+            props_name = try collectComponentParams(self.allocator, ctx.tree, function.params, component_index, self.state);
+        } else if (props_name != null and paramsContainBinding(ctx.tree, function.params, props_name.?)) {
+            props_name = null;
+        }
+        try self.pushContext(self.allocator, component, props_name);
+        return .proceed;
+    }
+
+    pub fn exit_function(self: *UsageVisitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.popContext();
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *UsageVisitor,
+        arrow: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const component = self.state.componentByFunction(index) orelse self.currentComponent();
+        var props_name = self.currentPropsName();
+        if (self.state.componentByFunction(index)) |component_index| {
+            props_name = try collectComponentParams(self.allocator, ctx.tree, arrow.params, component_index, self.state);
+        } else if (props_name != null and paramsContainBinding(ctx.tree, arrow.params, props_name.?)) {
+            props_name = null;
+        }
+        try self.pushContext(self.allocator, component, props_name);
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(self: *UsageVisitor, _: ast.ArrowFunctionExpression, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.popContext();
+    }
+
+    pub fn enter_member_expression(
+        self: *UsageVisitor,
+        _: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const component_index = self.currentComponent() orelse return .proceed;
+        var parts_buffer: [max_prop_depth][]const u8 = undefined;
+        const path = memberPropPath(ctx.tree, index, self.currentPropsName(), &parts_buffer) orelse return .proceed;
+        if (path.len == 0) return .proceed;
+        try addUsedProp(self.allocator, &self.state.components.items[component_index], path, memberDiagnosticNode(ctx.tree, index));
+        return .proceed;
+    }
+
+    pub fn enter_variable_declarator(
+        self: *UsageVisitor,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (declarator.init == .null) return .proceed;
+        const component_index = self.currentComponent() orelse return .proceed;
+        var parts_buffer: [max_prop_depth][]const u8 = undefined;
+        const prefix = propSourcePath(ctx.tree, declarator.init, self.currentPropsName(), &parts_buffer) orelse return .proceed;
+        try collectPatternUsage(self.allocator, ctx.tree, &self.state.components.items[component_index], declarator.id, prefix);
+        return .proceed;
+    }
+};
+
+fn collectComponentParams(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    component_index: usize,
+    state: *State,
+) Allocator.Error!?[]const u8 {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return null,
+    };
+    const items = tree.extra(params.items);
+    if (items.len == 0) return null;
+    const first = switch (tree.data(items[0])) {
+        .formal_parameter => |param| param.pattern,
+        else => items[0],
+    };
+    const pattern = unwrapAssignmentPattern(tree, first);
+    if (bindingIdentifierName(tree, pattern)) |name| return name;
+    try collectPatternUsage(allocator, tree, &state.components.items[component_index], pattern, &.{});
+    return null;
+}
+
+fn collectPatternUsage(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    component: *ComponentInfo,
+    pattern_index: ast.NodeIndex,
+    prefix: []const []const u8,
+) Allocator.Error!void {
+    const pattern = switch (tree.data(unwrapAssignmentPattern(tree, pattern_index))) {
+        .object_pattern => |pattern| pattern,
+        else => return,
+    };
+
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const key = propertyName(tree, property.key, property.computed) orelse continue;
+        var path_buffer: [max_prop_depth][]const u8 = undefined;
+        if (prefix.len + 1 > path_buffer.len) continue;
+        @memcpy(path_buffer[0..prefix.len], prefix);
+        path_buffer[prefix.len] = key;
+        const path = path_buffer[0 .. prefix.len + 1];
+        try addUsedProp(allocator, component, path, property.key);
+        try collectPatternUsage(allocator, tree, component, property.value, path);
+    }
+}
+
+fn addUsedProp(
+    allocator: Allocator,
+    component: *ComponentInfo,
+    parts: []const []const u8,
+    node: ast.NodeIndex,
+) Allocator.Error!void {
+    if (parts.len == 0) return;
+    const name = try joinParts(allocator, parts);
+    errdefer allocator.free(name);
+    for (component.used_props.items) |used| {
+        if (std.mem.eql(u8, used.name, name)) return allocator.free(name);
+    }
+    try component.used_props.append(allocator, .{ .name = name, .node = node });
+}
+
+fn finish(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *State,
+) Allocator.Error!void {
+    for (state.components.items) |component| {
+        if (!component.detected) continue;
+        for (component.used_props.items) |used| {
+            if (isDeclared(component.declared_props.items, used.name)) continue;
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(used.node),
+                "'{s}' is missing in props validation",
+                .{used.name},
+            );
+        }
+    }
+}
+
+fn isDeclared(props: []const DeclaredProp, full_name: []const u8) bool {
+    var iter = std.mem.splitScalar(u8, full_name, '.');
+    return isDeclaredParts(props, &iter);
+}
+
+fn isDeclaredParts(props: []const DeclaredProp, iter: *std.mem.SplitIterator(u8, .scalar)) bool {
+    const part = iter.next() orelse return true;
+    for (props) |prop| {
+        if (!std.mem.eql(u8, prop.name, part)) continue;
+        if (iter.peek() == null) return true;
+        if (prop.accepts_any_children) return true;
+        return isDeclaredParts(prop.children.items, iter);
+    }
+    return false;
+}
+
+fn memberPropPath(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    props_name: ?[]const u8,
+    buffer: *[max_prop_depth][]const u8,
+) ?[]const []const u8 {
+    return propSourcePath(tree, index, props_name, buffer);
+}
+
+fn propSourcePath(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    props_name: ?[]const u8,
+    buffer: *[max_prop_depth][]const u8,
+) ?[]const []const u8 {
+    var reversed: [max_prop_depth][]const u8 = undefined;
+    var len: usize = 0;
+    var current = unwrapTransparent(tree, index);
+
+    while (true) {
+        const member = switch (tree.data(current)) {
+            .member_expression => |member| member,
+            else => break,
+        };
+        if (len == reversed.len) return null;
+        reversed[len] = propertyName(tree, member.property, member.computed) orelse return null;
+        len += 1;
+        current = unwrapTransparent(tree, member.object);
+    }
+
+    if (props_name) |name| {
+        if (identifierReferenceName(tree, current)) |identifier| {
+            if (std.mem.eql(u8, identifier, name)) {
+                reverseInto(buffer, reversed[0..len]);
+                return buffer[0..len];
+            }
+        }
+    }
+
+    if (tree.data(current) == .this_expression and len >= 1 and std.mem.eql(u8, reversed[len - 1], "props")) {
+        const prop_len = len - 1;
+        reverseInto(buffer, reversed[0..prop_len]);
+        return buffer[0..prop_len];
+    }
+
+    return null;
+}
+
+fn reverseInto(buffer: *[max_prop_depth][]const u8, reversed: []const []const u8) void {
+    for (reversed, 0..) |_, index| {
+        buffer[index] = reversed[reversed.len - 1 - index];
+    }
+}
+
+fn memberDiagnosticNode(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return index,
+    };
+    return member.property;
+}
+
+fn propTypesAssignmentTarget(tree: *const ast.Tree, index: ast.NodeIndex) ?struct {
+    component: []const u8,
+    prop: ?[]const u8 = null,
+} {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return null;
+    if (std.mem.eql(u8, property, "propTypes")) {
+        const component = componentName(tree, member.object) orelse return null;
+        return .{ .component = component };
+    }
+
+    const parent = switch (tree.data(unwrapTransparent(tree, member.object))) {
+        .member_expression => |parent| parent,
+        else => return null,
+    };
+    const parent_property = propertyName(tree, parent.property, parent.computed) orelse return null;
+    if (!std.mem.eql(u8, parent_property, "propTypes")) return null;
+    const component = componentName(tree, parent.object) orelse return null;
+    return .{ .component = component, .prop = property };
+}
+
+fn createClassObject(tree: *const ast.Tree, call: ast.CallExpression) ?ast.ObjectExpression {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return null;
+    return switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+        .object_expression => |object| object,
+        else => null,
+    };
+}
+
+fn wrapperFunctionArgument(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+    if (!isComponentWrapperCall(tree, call)) return null;
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return null;
+    const first = unwrapTransparent(tree, arguments[0]);
+    switch (tree.data(first)) {
+        .function, .arrow_function_expression => return first,
+        .call_expression => |inner| return wrapperFunctionArgument(tree, inner),
+        else => return null,
+    }
+}
+
+fn isComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class != .null and isReactComponentSuper(tree, class.super_class)) return true;
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return false,
+    };
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        const key = propertyName(tree, method.key, method.computed) orelse continue;
+        if (std.mem.eql(u8, key, "render") and functionReturnsJSXOrNull(tree, method.value)) return true;
+    }
+    return false;
+}
+
+fn isReactComponentSuper(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const current = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, current)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+    const member = switch (tree.data(current)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn functionReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function => |function| function.body != .null and bodyReturnsJSXOrNull(tree, function.body),
+        .arrow_function_expression => |arrow| if (arrow.expression)
+            isJSXOrNullValue(tree, arrow.body)
+        else
+            bodyReturnsJSXOrNull(tree, arrow.body),
+        else => false,
+    };
+}
+
+fn bodyReturnsJSXOrNull(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    const range = switch (tree.data(body_index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return false,
+    };
+    return rangeReturnsJSXOrNull(tree, range);
+}
+
+fn rangeReturnsJSXOrNull(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |statement_index| {
+        if (statementReturnsJSXOrNull(tree, statement_index)) return true;
+    }
+    return false;
+}
+
+fn statementReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .return_statement => |statement| isJSXOrNullValue(tree, statement.argument),
+        .block_statement => |block| rangeReturnsJSXOrNull(tree, block.body),
+        .if_statement => |statement| statementReturnsJSXOrNull(tree, statement.consequent) or
+            statementReturnsJSXOrNull(tree, statement.alternate),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const case = switch (tree.data(case_index)) {
+                    .switch_case => |case| case,
+                    else => continue,
+                };
+                if (rangeReturnsJSXOrNull(tree, case.consequent)) return true;
+            }
+            return false;
+        },
+        .function,
+        .arrow_function_expression,
+        => false,
+        else => false,
+    };
+}
+
+fn isJSXOrNullValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .jsx_element,
+        .jsx_fragment,
+        .null_literal,
+        => true,
+        .call_expression => |call| isCreateElementCall(tree, call),
+        .conditional_expression => |expression| isJSXOrNullValue(tree, expression.consequent) or
+            isJSXOrNullValue(tree, expression.alternate),
+        .logical_expression => |expression| isJSXOrNullValue(tree, expression.right),
+        else => false,
+    };
+}
+
+fn isCreateElementCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "createElement");
+}
+
+fn isCreateReactClassCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createReactClass");
+    }
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "createClass");
+}
+
+fn isComponentWrapperCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "memo") or std.mem.eql(u8, name, "forwardRef");
+    }
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "memo") or std.mem.eql(u8, property, "forwardRef");
+}
+
+fn acceptsAnyChildren(name: []const u8) bool {
+    return std.mem.eql(u8, name, "any") or
+        std.mem.eql(u8, name, "array") or
+        std.mem.eql(u8, name, "object");
+}
+
+fn propTypeCall(tree: *const ast.Tree, node: ast.NodeIndex) ?ast.CallExpression {
+    return switch (tree.data(unwrapTransparent(tree, node))) {
+        .call_expression => |call| call,
+        else => null,
+    };
+}
+
+fn stripIsRequired(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return index,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return index;
+    if (!std.mem.eql(u8, property, "isRequired")) return index;
+    return member.object;
+}
+
+fn propTypeTargetName(tree: *const ast.Tree, node: ast.NodeIndex) ?[]const u8 {
+    const current = unwrapTransparent(tree, node);
+    const member = switch (tree.data(current)) {
+        .member_expression => |member| member,
+        else => return identifierReferenceName(tree, current),
+    };
+    return propertyName(tree, member.property, member.computed);
+}
+
+fn paramsContainBinding(tree: *const ast.Tree, params_index: ast.NodeIndex, name: []const u8) bool {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return false,
+    };
+    for (tree.extra(params.items)) |item| {
+        const pattern = switch (tree.data(item)) {
+            .formal_parameter => |param| param.pattern,
+            else => item,
+        };
+        if (patternContainsBinding(tree, pattern, name)) return true;
+    }
+    if (params.rest != .null and patternContainsBinding(tree, params.rest, name)) return true;
+    return false;
+}
+
+fn patternContainsBinding(tree: *const ast.Tree, pattern_index: ast.NodeIndex, name: []const u8) bool {
+    switch (tree.data(unwrapAssignmentPattern(tree, pattern_index))) {
+        .binding_identifier => |identifier| return std.mem.eql(u8, tree.string(identifier.name), name),
+        .binding_rest_element => |rest| return patternContainsBinding(tree, rest.argument, name),
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                if (patternContainsBinding(tree, property.value, name)) return true;
+            }
+            if (pattern.rest != .null and patternContainsBinding(tree, pattern.rest, name)) return true;
+            return false;
+        },
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                if (element != .null and patternContainsBinding(tree, element, name)) return true;
+            }
+            if (pattern.rest != .null and patternContainsBinding(tree, pattern.rest, name)) return true;
+            return false;
+        },
+        else => return false,
+    }
+}
+
+fn appendNode(allocator: Allocator, list: *std.ArrayList(ast.NodeIndex), node: ast.NodeIndex) Allocator.Error!void {
+    for (list.items) |existing| {
+        if (existing == node) return;
+    }
+    try list.append(allocator, node);
+}
+
+fn joinParts(allocator: Allocator, parts: []const []const u8) Allocator.Error![]const u8 {
+    var len: usize = 0;
+    for (parts, 0..) |part, index| {
+        len += part.len;
+        if (index != 0) len += 1;
+    }
+    const out = try allocator.alloc(u8, len);
+    var offset: usize = 0;
+    for (parts, 0..) |part, index| {
+        if (index != 0) {
+            out[offset] = '.';
+            offset += 1;
+        }
+        @memcpy(out[offset .. offset + part.len], part);
+        offset += part.len;
+    }
+    return out;
+}
+
+fn componentName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapAssignmentPattern(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .assignment_pattern => |pattern| unwrapAssignmentPattern(tree, pattern.left),
+        else => current,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null) return null;
+    return if (computed)
+        switch (tree.data(index)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn startsUppercase(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -232,6 +232,7 @@ pub const react_no_render_return_value = @import("react_no_render_return_value.z
 pub const react_no_this_in_sfc = @import("react_no_this_in_sfc.zig");
 pub const react_no_typos = @import("react_no_typos.zig");
 pub const react_no_unknown_property = @import("react_no_unknown_property.zig");
+pub const react_prop_types = @import("react_prop_types.zig");
 pub const react_no_unused_state = @import("react_no_unused_state.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
@@ -353,6 +354,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);
+    }
+    if (options.react_prop_types) {
+        try react_prop_types.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -819,6 +819,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_prop_types.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_unused_state.zig");
 }
 

--- a/tests/rules/react_prop_types.zig
+++ b/tests/rules/react_prop_types.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn propTypesOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_prop_types = true;
+    return options;
+}
+
+test "reports react/prop-types for missing function component props" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}{props.user.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  user: PropTypes.shape({
+        \\    id: PropTypes.string,
+        \\  }),
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'name' is missing in props validation"));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[1].message, "'user.name' is missing in props validation"));
+}
+
+test "allows react/prop-types declared object children" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.user.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  user: PropTypes.object,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prop_types.id));
+}
+
+test "reports react/prop-types for destructured parameters" {
+    const source =
+        \\import React from 'react';
+        \\function Foo({ name, user: { id } }) {
+        \\  return <div>{name}{id}</div>;
+        \\}
+        \\Foo.propTypes = {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'name' is missing in props validation"));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[1].message, "'user' is missing in props validation"));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[2].message, "'user.id' is missing in props validation"));
+}
+
+test "reports react/prop-types for class components" {
+    const source =
+        \\import React from 'react';
+        \\class Foo extends React.Component {
+        \\  render() {
+        \\    return <div>{this.props.name}</div>;
+        \\  }
+        \\}
+        \\Foo.propTypes = {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'name' is missing in props validation"));
+}
+
+test "does not treat uppercase non components as react/prop-types components" {
+    const source =
+        \\function Foo(props) {
+        \\  return props.name;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prop_types.id));
+}
+
+test "can disable react/prop-types" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+    ;
+
+    var options = propTypesOnly();
+    options.react_prop_types = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prop_types.id));
+}


### PR DESCRIPTION
## Summary
- add `react/prop-types` with fishlint's enabled default options
- collect React component props usage across function, arrow, class, memo/forwardRef, and prop destructuring patterns
- compare declared propTypes including nested shape/exact declarations and object/any escape hatches

## Validation
- `zig build test --summary all -- react_prop_types`
- fishlint parity fixtures for flat props, destructured props, object children, class components, wrappers, and non-components
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke: `--react-prop-types=off`
