### PR TITLE
feat: port react no unused prop types

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -213,6 +213,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
+| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Implemented for fishlint's `customValidators: [], skipShapeProps: true` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Implemented for fishlint's `ignore: [], customValidators: [], skipUndeclared: false` configuration |
 
 ## TypeScript ESLint rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -244,6 +244,7 @@ pub const Options = struct {
     react_no_typos: bool = true,
     react_no_unknown_property: bool = true,
     react_prop_types: bool = true,
+    react_no_unused_prop_types: bool = true,
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
@@ -698,6 +699,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
+
+    try std.testing.expect(!options.react_no_unused_prop_types);
+    try std.testing.expect(options.setByCliName("react/no-unused-prop-types", true));
+    try std.testing.expect(options.react_no_unused_prop_types);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -553,6 +553,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_unknown_property = false;
         } else if (std.mem.eql(u8, arg, "--react-prop-types=off")) {
             options.react_prop_types = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-unused-prop-types=off")) {
+            options.react_no_unused_prop_types = false;
         } else if (std.mem.eql(u8, arg, "--react-no-unused-state=off")) {
             options.react_no_unused_state = false;
         } else if (std.mem.eql(u8, arg, "--react-no-string-refs=off")) {
@@ -1385,6 +1387,7 @@ fn printHelp() void {
         \\  --react-no-typos=off Disable react/no-typos
         \\  --react-no-unknown-property=off Disable react/no-unknown-property
         \\  --react-prop-types=off Disable react/prop-types
+        \\  --react-no-unused-prop-types=off Disable react/no-unused-prop-types
         \\  --react-no-unused-state=off Disable react/no-unused-state
         \\  --react-no-string-refs=off Disable react/no-string-refs
         \\  --react-no-unescaped-entities=off Disable react/no-unescaped-entities

--- a/src/rules/react_no_unused_prop_types.zig
+++ b/src/rules/react_no_unused_prop_types.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const react_prop_types = @import("react_prop_types.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-unused-prop-types";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var state = try react_prop_types.collect(allocator, tree);
+    defer state.deinit(allocator);
+
+    for (state.components.items) |component| {
+        if (!component.detected) continue;
+        try reportUnusedProps(allocator, diagnostics, tree, component, component.declared_props.items, "");
+    }
+}
+
+fn reportUnusedProps(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    component: react_prop_types.ComponentInfo,
+    props: []const react_prop_types.DeclaredProp,
+    prefix: []const u8,
+) Allocator.Error!void {
+    for (props) |prop| {
+        const full_name = if (prefix.len == 0)
+            try allocator.dupe(u8, prop.name)
+        else
+            try std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, prop.name });
+        defer allocator.free(full_name);
+
+        if (prop.kind == .shape or prop.kind == .exact) {
+            continue;
+        }
+
+        if (!componentUsesProp(component, prop.name) and !componentUsesProp(component, full_name)) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                tree.span(prop.node),
+                "'{s}' PropType is defined but prop is never used",
+                .{full_name},
+            );
+        }
+
+        try reportUnusedProps(allocator, diagnostics, tree, component, prop.children.items, full_name);
+    }
+}
+
+fn componentUsesProp(component: react_prop_types.ComponentInfo, name: []const u8) bool {
+    for (component.used_props.items) |used| {
+        if (std.mem.eql(u8, used.name, name)) return true;
+    }
+    return false;
+}

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -10,9 +10,16 @@ pub const id = "react/prop-types";
 
 const max_prop_depth = 16;
 
-const DeclaredProp = struct {
+pub const DeclaredKind = enum {
+    normal,
+    shape,
+    exact,
+};
+
+pub const DeclaredProp = struct {
     name: []const u8,
     node: ast.NodeIndex,
+    kind: DeclaredKind = .normal,
     accepts_any_children: bool = false,
     children: std.ArrayList(DeclaredProp) = .empty,
 
@@ -24,12 +31,12 @@ const DeclaredProp = struct {
     }
 };
 
-const UsedProp = struct {
+pub const UsedProp = struct {
     name: []const u8,
     node: ast.NodeIndex,
 };
 
-const ComponentInfo = struct {
+pub const ComponentInfo = struct {
     name: ?[]const u8 = null,
     node: ast.NodeIndex = .null,
     detected: bool = false,
@@ -52,10 +59,10 @@ const ComponentInfo = struct {
     }
 };
 
-const State = struct {
+pub const State = struct {
     components: std.ArrayList(ComponentInfo) = .empty,
 
-    fn deinit(self: *State, allocator: Allocator) void {
+    pub fn deinit(self: *State, allocator: Allocator) void {
         for (self.components.items) |*component| {
             component.deinit(allocator);
         }
@@ -113,8 +120,18 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
-    var state = State{};
+    var state = try collect(allocator, tree);
     defer state.deinit(allocator);
+
+    try finish(allocator, diagnostics, tree, &state);
+}
+
+pub fn collect(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+) Allocator.Error!State {
+    var state = State{};
+    errdefer state.deinit(allocator);
 
     try collectComponents(allocator, tree, &state);
 
@@ -126,7 +143,7 @@ pub fn run(
     defer visitor.props_stack.deinit(allocator);
 
     try traverser.basic.traverse(UsageVisitor, tree, &visitor);
-    try finish(allocator, diagnostics, tree, &state);
+    return state;
 }
 
 fn collectComponents(
@@ -352,6 +369,7 @@ fn addDeclaredPropValue(
             return;
         }
         if (std.mem.eql(u8, callee_name, "shape") or std.mem.eql(u8, callee_name, "exact")) {
+            prop.kind = if (std.mem.eql(u8, callee_name, "shape")) .shape else .exact;
             const arguments = tree.extra(call.arguments);
             if (arguments.len == 0) return;
             try collectShapeChildren(allocator, tree, arguments[0], prop);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -233,6 +233,7 @@ pub const react_no_this_in_sfc = @import("react_no_this_in_sfc.zig");
 pub const react_no_typos = @import("react_no_typos.zig");
 pub const react_no_unknown_property = @import("react_no_unknown_property.zig");
 pub const react_prop_types = @import("react_prop_types.zig");
+pub const react_no_unused_prop_types = @import("react_no_unused_prop_types.zig");
 pub const react_no_unused_state = @import("react_no_unused_state.zig");
 pub const react_no_will_update_set_state = @import("react_no_will_update_set_state.zig");
 pub const react_require_render_return = @import("react_require_render_return.zig");
@@ -357,6 +358,9 @@ pub fn runBasic(
     }
     if (options.react_prop_types) {
         try react_prop_types.run(allocator, diagnostics, tree);
+    }
+    if (options.react_no_unused_prop_types) {
+        try react_no_unused_prop_types.run(allocator, diagnostics, tree);
     }
 
     var visitor = BasicVisitor{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -823,6 +823,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_unused_prop_types.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_unused_state.zig");
 }
 

--- a/tests/rules/react_no_unused_prop_types.zig
+++ b/tests/rules/react_no_unused_prop_types.zig
@@ -1,0 +1,108 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn noUnusedPropTypesOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_no_unused_prop_types = true;
+    return options;
+}
+
+test "reports react/no-unused-prop-types for unused prop type declarations" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  age: PropTypes.number,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", noUnusedPropTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'age' PropType is defined but prop is never used"));
+}
+
+test "skips react/no-unused-prop-types shape props for fishlint configuration" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  user: PropTypes.shape({
+        \\    age: PropTypes.number,
+        \\  }),
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", noUnusedPropTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_prop_types.id));
+}
+
+test "reports react/no-unused-prop-types object props" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  user: PropTypes.object,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", noUnusedPropTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'user' PropType is defined but prop is never used"));
+}
+
+test "reports react/no-unused-prop-types for class components" {
+    const source =
+        \\import React from 'react';
+        \\class Foo extends React.Component {
+        \\  render() {
+        \\    return <div>{this.props.name}</div>;
+        \\  }
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  age: PropTypes.number,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", noUnusedPropTypesOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'age' PropType is defined but prop is never used"));
+}
+
+test "can disable react/no-unused-prop-types" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  age: PropTypes.number,
+        \\};
+    ;
+
+    var options = noUnusedPropTypesOnly();
+    options.react_no_unused_prop_types = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_prop_types.id));
+}


### PR DESCRIPTION
## Summary
- add `react/no-unused-prop-types` for fishlint's `customValidators: [], skipShapeProps: true` configuration
- reuse the `react/prop-types` component props analysis for declared and used props
- expose the shared props collection path and mark shape/exact declarations for no-unused behavior

## Validation
- `zig build test --summary all -- react_no_unused_prop_types`
- fishlint parity fixtures for flat unused props, skipped shape props, object props, and class components
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- CLI smoke: `--react-no-unused-prop-types=off`
