### PR TITLE
feat: port import no unresolved

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -184,6 +184,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
+| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions and `smallfish:`/`minifish:` ignores |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -104,6 +104,7 @@ pub const Options = struct {
     import_no_duplicates: bool = true,
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
+    import_no_unresolved: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_anchor_has_content: bool = true,
@@ -691,6 +692,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_named_as_default_member);
     try std.testing.expect(options.setByCliName("import/no-named-as-default-member", true));
     try std.testing.expect(options.import_no_named_as_default_member);
+
+    try std.testing.expect(!options.import_no_unresolved);
+    try std.testing.expect(options.setByCliName("import/no-unresolved", true));
+    try std.testing.expect(options.import_no_unresolved);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -275,6 +275,8 @@ pub fn main(init: std.process.Init) !void {
             options.import_no_named_as_default = false;
         } else if (std.mem.eql(u8, arg, "--import-no-named-as-default-member=off")) {
             options.import_no_named_as_default_member = false;
+        } else if (std.mem.eql(u8, arg, "--import-no-unresolved=off")) {
+            options.import_no_unresolved = false;
         } else if (std.mem.eql(u8, arg, "--import-no-self-import=off")) {
             options.import_no_self_import = false;
         } else if (std.mem.eql(u8, arg, "--jsx-a11y-alt-text=off")) {
@@ -1250,6 +1252,7 @@ fn printHelp() void {
         \\  --import-no-duplicates=off Disable import/no-duplicates
         \\  --import-no-named-as-default=off Disable import/no-named-as-default
         \\  --import-no-named-as-default-member=off Disable import/no-named-as-default-member
+        \\  --import-no-unresolved=off Disable import/no-unresolved
         \\  --import-no-self-import=off Disable import/no-self-import
         \\  --jsx-a11y-alt-text=off   Disable jsx-a11y/alt-text
         \\  --jsx-a11y-anchor-has-content=off Disable jsx-a11y/anchor-has-content

--- a/src/root.zig
+++ b/src/root.zig
@@ -141,6 +141,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_no_cycle or
         options.import_no_named_as_default or
         options.import_no_named_as_default_member or
+        options.import_no_unresolved or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/import_no_unresolved.zig
+++ b/src/rules/import_no_unresolved.zig
@@ -1,0 +1,356 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const export_map = @import("import_export_map.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "import/no-unresolved";
+
+const max_package_json_size = 128 * 1024;
+
+const resolve_extensions = [_][]const u8{
+    "",
+    ".js",
+    ".jsx",
+    ".json",
+    ".ts",
+    ".tsx",
+    ".d.ts",
+    ".mjs",
+    ".cjs",
+    ".mts",
+    ".cts",
+};
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| {
+                if (declaration.import_kind == .type) continue;
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+            },
+            .export_named_declaration => |declaration| {
+                if (declaration.export_kind == .type or declaration.source == .null) continue;
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+            },
+            .export_all_declaration => |declaration| {
+                if (declaration.export_kind == .type) continue;
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+            },
+            else => {},
+        }
+    }
+
+    var visitor = DynamicImportVisitor{
+        .allocator = allocator,
+        .io = io,
+        .diagnostics = diagnostics,
+        .file_path = file_path,
+    };
+    try traverser.basic.traverse(DynamicImportVisitor, tree, &visitor);
+}
+
+const DynamicImportVisitor = struct {
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    file_path: []const u8,
+
+    pub fn enter_import_expression(
+        self: *DynamicImportVisitor,
+        expression: ast.ImportExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, expression.source);
+        return .proceed;
+    }
+};
+
+fn checkSourceNode(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    source_node: ast.NodeIndex,
+) Allocator.Error!void {
+    const source = stringLiteralValue(tree, source_node) orelse return;
+    if (shouldIgnore(source)) return;
+    if (try resolves(allocator, io, file_path, source)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(source_node),
+        "Unable to resolve path to module '{s}'.",
+        .{source},
+    );
+}
+
+fn resolves(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!bool {
+    if (source.len == 0) return false;
+    if (isBuiltinModule(source)) return true;
+
+    if (export_map.isRelativeImport(source)) {
+        const resolved = try resolveRelativeModule(allocator, io, file_path, source) orelse return false;
+        allocator.free(resolved);
+        return true;
+    }
+
+    if (std.fs.path.isAbsolute(source)) {
+        const resolved = try resolveAsFileOrDirectory(allocator, io, source) orelse return false;
+        allocator.free(resolved);
+        return true;
+    }
+
+    return try resolveNodeModule(allocator, io, file_path, source);
+}
+
+fn resolveRelativeModule(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!?[]const u8 {
+    const directory = std.fs.path.dirname(file_path) orelse ".";
+    const imported_path = try std.fs.path.resolve(allocator, &.{ directory, source });
+    defer allocator.free(imported_path);
+    return resolveAsFileOrDirectory(allocator, io, imported_path);
+}
+
+fn resolveNodeModule(
+    allocator: Allocator,
+    io: std.Io,
+    file_path: []const u8,
+    source: []const u8,
+) Allocator.Error!bool {
+    const package = packageName(source) orelse return false;
+    const subpath = source[package.len..];
+
+    var current = try std.fs.path.resolve(allocator, &.{std.fs.path.dirname(file_path) orelse "."});
+    defer allocator.free(current);
+
+    while (true) {
+        const package_dir = try std.fs.path.join(allocator, &.{ current, "node_modules", package });
+        if (isDirectory(io, package_dir)) {
+            if (subpath.len > 0) {
+                const without_slash = if (subpath[0] == '/') subpath[1..] else subpath;
+                const target = try std.fs.path.join(allocator, &.{ package_dir, without_slash });
+                allocator.free(package_dir);
+                defer allocator.free(target);
+                const resolved = try resolveAsFileOrDirectory(allocator, io, target) orelse return false;
+                allocator.free(resolved);
+                return true;
+            }
+
+            const resolved = try resolvePackageDirectory(allocator, io, package_dir);
+            allocator.free(package_dir);
+            if (resolved) |path| {
+                allocator.free(path);
+                return true;
+            }
+            return false;
+        }
+        allocator.free(package_dir);
+
+        const parent = std.fs.path.dirname(current) orelse return false;
+        if (std.mem.eql(u8, parent, current)) return false;
+        const next = try allocator.dupe(u8, parent);
+        allocator.free(current);
+        current = next;
+    }
+}
+
+fn resolveAsFileOrDirectory(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+) Allocator.Error!?[]const u8 {
+    if (isFile(io, path)) {
+        const owned = try allocator.dupe(u8, path);
+        return owned;
+    }
+
+    for (resolve_extensions) |extension| {
+        if (extension.len == 0) continue;
+        const with_extension = try std.mem.concat(allocator, u8, &.{ path, extension });
+        if (isFile(io, with_extension)) return with_extension;
+        allocator.free(with_extension);
+    }
+
+    if (!isDirectory(io, path)) return null;
+    if (try resolvePackageDirectory(allocator, io, path)) |resolved| return resolved;
+
+    for (resolve_extensions) |extension| {
+        if (extension.len == 0) continue;
+        const index_name = try std.mem.concat(allocator, u8, &.{ "index", extension });
+        defer allocator.free(index_name);
+        const index_path = try std.fs.path.join(allocator, &.{ path, index_name });
+        if (isFile(io, index_path)) return index_path;
+        allocator.free(index_path);
+    }
+
+    return null;
+}
+
+fn resolvePackageDirectory(
+    allocator: Allocator,
+    io: std.Io,
+    package_dir: []const u8,
+) Allocator.Error!?[]const u8 {
+    const package_json_path = try std.fs.path.join(allocator, &.{ package_dir, "package.json" });
+    defer allocator.free(package_json_path);
+
+    if (readFile(allocator, io, package_json_path)) |source| {
+        defer allocator.free(source);
+        if (packageMain(allocator, source)) |main_path| {
+            defer allocator.free(main_path);
+            if (main_path.len > 0) {
+                const candidate = try std.fs.path.join(allocator, &.{ package_dir, main_path });
+                defer allocator.free(candidate);
+                if (try resolveAsFileOrDirectory(allocator, io, candidate)) |resolved| return resolved;
+            }
+        }
+    }
+
+    for (resolve_extensions) |extension| {
+        if (extension.len == 0) continue;
+        const index_name = try std.mem.concat(allocator, u8, &.{ "index", extension });
+        defer allocator.free(index_name);
+        const index_path = try std.fs.path.join(allocator, &.{ package_dir, index_name });
+        if (isFile(io, index_path)) return index_path;
+        allocator.free(index_path);
+    }
+
+    return null;
+}
+
+fn packageMain(allocator: Allocator, source: []const u8) ?[]const u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch return null;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return null,
+    };
+
+    const fields = [_][]const u8{ "module", "main" };
+    for (fields) |field| {
+        const value = root.get(field) orelse continue;
+        const string = switch (value) {
+            .string => |string| string,
+            else => continue,
+        };
+        return allocator.dupe(u8, string) catch null;
+    }
+    return null;
+}
+
+fn readFile(allocator: Allocator, io: std.Io, path: []const u8) ?[]u8 {
+    return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_package_json_size)) catch null;
+}
+
+fn isFile(io: std.Io, path: []const u8) bool {
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return false;
+    return stat.kind == .file;
+}
+
+fn isDirectory(io: std.Io, path: []const u8) bool {
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return false;
+    return stat.kind == .directory;
+}
+
+fn packageName(source: []const u8) ?[]const u8 {
+    if (source.len == 0 or source[0] == '/' or source[0] == '.') return null;
+    if (source[0] != '@') {
+        const slash = std.mem.indexOfScalar(u8, source, '/') orelse source.len;
+        return source[0..slash];
+    }
+
+    const first_slash = std.mem.indexOfScalarPos(u8, source, 1, '/') orelse return null;
+    const second_slash = std.mem.indexOfScalarPos(u8, source, first_slash + 1, '/') orelse source.len;
+    return source[0..second_slash];
+}
+
+fn shouldIgnore(source: []const u8) bool {
+    return std.mem.startsWith(u8, source, "smallfish:") or
+        std.mem.startsWith(u8, source, "minifish:");
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn isBuiltinModule(source: []const u8) bool {
+    const name = if (std.mem.startsWith(u8, source, "node:")) source["node:".len..] else source;
+    return builtin_modules.has(name);
+}
+
+const builtin_modules = std.StaticStringMap(void).initComptime(.{
+    .{ "assert", {} },
+    .{ "async_hooks", {} },
+    .{ "buffer", {} },
+    .{ "child_process", {} },
+    .{ "cluster", {} },
+    .{ "console", {} },
+    .{ "constants", {} },
+    .{ "crypto", {} },
+    .{ "dgram", {} },
+    .{ "diagnostics_channel", {} },
+    .{ "dns", {} },
+    .{ "domain", {} },
+    .{ "events", {} },
+    .{ "fs", {} },
+    .{ "http", {} },
+    .{ "http2", {} },
+    .{ "https", {} },
+    .{ "inspector", {} },
+    .{ "module", {} },
+    .{ "net", {} },
+    .{ "os", {} },
+    .{ "path", {} },
+    .{ "perf_hooks", {} },
+    .{ "process", {} },
+    .{ "punycode", {} },
+    .{ "querystring", {} },
+    .{ "readline", {} },
+    .{ "repl", {} },
+    .{ "stream", {} },
+    .{ "string_decoder", {} },
+    .{ "sys", {} },
+    .{ "timers", {} },
+    .{ "tls", {} },
+    .{ "tty", {} },
+    .{ "url", {} },
+    .{ "util", {} },
+    .{ "v8", {} },
+    .{ "vm", {} },
+    .{ "wasi", {} },
+    .{ "worker_threads", {} },
+    .{ "zlib", {} },
+});

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -43,6 +43,7 @@ pub const import_no_cycle = @import("import_no_cycle.zig");
 pub const import_no_duplicates = @import("import_no_duplicates.zig");
 pub const import_no_named_as_default = @import("import_no_named_as_default.zig");
 pub const import_no_named_as_default_member = @import("import_no_named_as_default_member.zig");
+pub const import_no_unresolved = @import("import_no_unresolved.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
@@ -474,6 +475,17 @@ pub fn runSemantic(
     if (options.import_no_named_as_default_member) {
         if (io) |actual_io| {
             try import_no_named_as_default_member.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
+    }
+    if (options.import_no_unresolved) {
+        if (io) |actual_io| {
+            try import_no_unresolved.run(
                 allocator,
                 actual_io,
                 diagnostics,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -115,6 +115,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/import_no_unresolved.zig");
+}
+
+comptime {
     _ = @import("rules/import_no_self_import.zig");
 }
 

--- a/tests/rules/import_no_unresolved.zig
+++ b/tests/rules/import_no_unresolved.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.import_no_unresolved = true;
+    options.parser_semantic_errors = false;
+    return options;
+}
+
+test "reports import/no-unresolved for missing static and dynamic imports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source =
+        \\import missing from './missing';
+        \\export { value } from './also-missing';
+        \\export * from './export-all-missing';
+        \\import('./dynamic-missing');
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.import_no_unresolved.id));
+    try std.testing.expectEqualStrings("Unable to resolve path to module './missing'.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Unable to resolve path to module './also-missing'.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("Unable to resolve path to module './export-all-missing'.", ruleDiagnostic(result, 2).message);
+    try std.testing.expectEqualStrings("Unable to resolve path to module './dynamic-missing'.", ruleDiagnostic(result, 3).message);
+}
+
+test "allows import/no-unresolved resolved relative files directories and json files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src/dir");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/util.ts", .data = "export const util = 1;\n" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/dir/index.jsx", .data = "export const dir = 1;\n" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/data.json", .data = "{}\n" });
+    const source =
+        \\import { util } from './util';
+        \\import { dir } from './dir';
+        \\import data from './data.json';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
+}
+
+test "allows import/no-unresolved ignored prefixes builtins and packages" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src/node_modules/pkg/lib");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/node_modules/pkg/package.json", .data = "{\"main\":\"lib/main.js\"}\n" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/node_modules/pkg/lib/main.js", .data = "module.exports = 1;\n" });
+    try tmp.dir.createDirPath(std.testing.io, "src/node_modules/@scope/pkg");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/node_modules/@scope/pkg/index.js", .data = "module.exports = 1;\n" });
+
+    const source =
+        \\import fs from 'fs';
+        \\import path from 'node:path';
+        \\import small from 'smallfish:foo';
+        \\import mini from 'minifish:bar';
+        \\import pkg from 'pkg';
+        \\import scoped from '@scope/pkg';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
+}
+
+test "reports import/no-unresolved for missing packages" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source = "import missing from 'definitely-missing-package';\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_no_unresolved.id));
+    try std.testing.expectEqualStrings("Unable to resolve path to module 'definitely-missing-package'.", ruleDiagnostic(result, 0).message);
+}
+
+test "can disable import/no-unresolved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source = "import missing from './missing';\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var options = optionsOnly();
+    options.import_no_unresolved = false;
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
+}
+
+fn entryPath(tmp: *std.testing.TmpDir) ![]u8 {
+    return std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.js",
+    });
+}
+
+fn ruleDiagnostic(result: lint.Result, index: usize) lint.Diagnostic {
+    var seen: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.import_no_unresolved.id)) continue;
+        if (seen == index) return diagnostic;
+        seen += 1;
+    }
+    unreachable;
+}


### PR DESCRIPTION
## Summary
- add fishlint-aligned import/no-unresolved diagnostics for static imports, re-exports, and dynamic import() sources
- resolve relative files/directories, bare packages, scoped packages, package entrypoints, Node builtins, and fishlint's configured extensions
- ignore fishlint smallfish:/minifish: module prefixes and expose --import-no-unresolved=off

## Validation
- zig build test --summary all -- import_no_unresolved
- zig build --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --import-no-unresolved=off
- fishlint parity cases for missing imports, allowed paths, missing packages, and require() default ignore
- fishlint enabled-rule gap audit confirms import/no-unresolved is no longer missing for JS/TS extensions