### PR TITLE
feat: port react hooks rules of hooks

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -217,6 +217,12 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Implemented for fishlint's `customValidators: [], skipShapeProps: true` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Implemented for fishlint's `ignore: [], customValidators: [], skipUndeclared: false` configuration |
 
+## React Hooks rules
+
+| Rule | Status |
+| --- | --- |
+| [`react-hooks/rules-of-hooks`](https://legacy.reactjs.org/docs/hooks-rules.html) | Implemented for top-level, ordinary function, class method, callback, conditional branch, and loop checks |
+
 ## TypeScript ESLint rules
 
 | Rule | Status |

--- a/src/core.zig
+++ b/src/core.zig
@@ -253,6 +253,7 @@ pub const Options = struct {
     react_self_closing_comp: bool = true,
     react_style_prop_object: bool = true,
     react_void_dom_elements_no_children: bool = true,
+    react_hooks_rules_of_hooks: bool = true,
     radix: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,
@@ -357,6 +358,10 @@ pub const Options = struct {
 
         if (std.mem.startsWith(u8, cli_name, "react/")) {
             return self.setByPrefixedRuleName("react_", cli_name["react/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "react-hooks/")) {
+            return self.setByPrefixedRuleName("react_hooks_", cli_name["react-hooks/".len..], value);
         }
 
         inline for (@typeInfo(Options).@"struct".fields) |field| {
@@ -708,6 +713,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_no_unused_prop_types);
     try std.testing.expect(options.setByCliName("react/no-unused-prop-types", true));
     try std.testing.expect(options.react_no_unused_prop_types);
+
+    try std.testing.expect(!options.react_hooks_rules_of_hooks);
+    try std.testing.expect(options.setByCliName("react-hooks/rules-of-hooks", true));
+    try std.testing.expect(options.react_hooks_rules_of_hooks);
 
     try std.testing.expect(!options.setByCliName("unknown-rule", true));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -571,6 +571,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_style_prop_object = false;
         } else if (std.mem.eql(u8, arg, "--react-void-dom-elements-no-children=off")) {
             options.react_void_dom_elements_no_children = false;
+        } else if (std.mem.eql(u8, arg, "--react-hooks-rules-of-hooks=off")) {
+            options.react_hooks_rules_of_hooks = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
@@ -1398,6 +1400,7 @@ fn printHelp() void {
         \\  --react-self-closing-comp=off Disable react/self-closing-comp
         \\  --react-style-prop-object=off Disable react/style-prop-object
         \\  --react-void-dom-elements-no-children=off Disable react/void-dom-elements-no-children
+        \\  --react-hooks-rules-of-hooks=off Disable react-hooks/rules-of-hooks
         \\  --radix=off               Disable radix
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield

--- a/src/rules/react_hooks_rules_of_hooks.zig
+++ b/src/rules/react_hooks_rules_of_hooks.zig
@@ -1,0 +1,416 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react-hooks/rules-of-hooks";
+
+const FunctionContext = struct {
+    name: ?[]const u8,
+    directly_allowed: bool,
+    somewhere_inside_component_or_hook: bool,
+    class_method: bool,
+    branch_base: usize,
+    loop_base: usize,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+    };
+    defer visitor.function_stack.deinit(allocator);
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    function_stack: std.ArrayList(FunctionContext) = .empty,
+    branch_depth: usize = 0,
+    loop_depth: usize = 0,
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        try self.pushFunction(ctx.tree, index, parent, functionName(ctx.tree, index, parent, function.id));
+        return .proceed;
+    }
+
+    pub fn exit_function(self: *Visitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        _ = self.function_stack.pop();
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        try self.pushFunction(ctx.tree, index, parent, functionName(ctx.tree, index, parent, .null));
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        _ = self.function_stack.pop();
+    }
+
+    pub fn enter_if_statement(self: *Visitor, _: ast.IfStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.branch_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_if_statement(self: *Visitor, _: ast.IfStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.branch_depth -= 1;
+    }
+
+    pub fn enter_conditional_expression(self: *Visitor, _: ast.ConditionalExpression, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.branch_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_conditional_expression(self: *Visitor, _: ast.ConditionalExpression, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.branch_depth -= 1;
+    }
+
+    pub fn enter_switch_statement(self: *Visitor, _: ast.SwitchStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.branch_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_switch_statement(self: *Visitor, _: ast.SwitchStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.branch_depth -= 1;
+    }
+
+    pub fn enter_while_statement(self: *Visitor, _: ast.WhileStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.loop_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_while_statement(self: *Visitor, _: ast.WhileStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.loop_depth -= 1;
+    }
+
+    pub fn enter_do_while_statement(self: *Visitor, _: ast.DoWhileStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.loop_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_do_while_statement(self: *Visitor, _: ast.DoWhileStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.loop_depth -= 1;
+    }
+
+    pub fn enter_for_statement(self: *Visitor, _: ast.ForStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.loop_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_for_statement(self: *Visitor, _: ast.ForStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.loop_depth -= 1;
+    }
+
+    pub fn enter_for_in_statement(self: *Visitor, _: ast.ForInStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.loop_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_for_in_statement(self: *Visitor, _: ast.ForInStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.loop_depth -= 1;
+    }
+
+    pub fn enter_for_of_statement(self: *Visitor, _: ast.ForOfStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.loop_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_for_of_statement(self: *Visitor, _: ast.ForOfStatement, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.loop_depth -= 1;
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isHook(ctx.tree, call.callee)) {
+            try self.checkHook(ctx.tree, call.callee);
+        }
+        return .proceed;
+    }
+
+    fn pushFunction(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        parent: ast.NodeIndex,
+        name: ?[]const u8,
+    ) Allocator.Error!void {
+        const parent_inside = if (self.currentFunction()) |current|
+            current.somewhere_inside_component_or_hook or current.directly_allowed
+        else
+            false;
+        const directly_allowed = if (name) |function_name|
+            isComponentName(function_name) or isHookName(function_name)
+        else
+            isForwardRefOrMemoCallback(tree, index, parent);
+
+        try self.function_stack.append(self.allocator, .{
+            .name = name,
+            .directly_allowed = directly_allowed,
+            .somewhere_inside_component_or_hook = parent_inside or directly_allowed,
+            .class_method = isClassMethodValue(tree, index, parent),
+            .branch_base = self.branch_depth,
+            .loop_base = self.loop_depth,
+        });
+    }
+
+    fn currentFunction(self: *Visitor) ?FunctionContext {
+        if (self.function_stack.items.len == 0) return null;
+        return self.function_stack.items[self.function_stack.items.len - 1];
+    }
+
+    fn checkHook(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const hook_source = nodeSource(tree, callee);
+        const context = self.currentFunction() orelse {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.",
+                .{hook_source},
+            );
+            return;
+        };
+
+        const loop_delta = self.loop_depth - context.loop_base;
+        if (context.directly_allowed and loop_delta > 0) {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.",
+                .{hook_source},
+            );
+            return;
+        }
+
+        const branch_delta = self.branch_depth - context.branch_base;
+        if (context.directly_allowed and branch_delta > 0) {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" is called conditionally. React Hooks must be called in the exact same order in every component render.",
+                .{hook_source},
+            );
+            return;
+        }
+
+        if (context.directly_allowed) return;
+
+        if (context.class_method) {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.",
+                .{hook_source},
+            );
+            return;
+        }
+
+        if (context.name) |function_name| {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" is called in function \"{s}\" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word \"use\".",
+                .{ hook_source, function_name },
+            );
+            return;
+        }
+
+        if (context.somewhere_inside_component_or_hook) {
+            try self.report(
+                tree,
+                callee,
+                "React Hook \"{s}\" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.",
+                .{hook_source},
+            );
+        }
+    }
+
+    fn report(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) Allocator.Error!void {
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            fmt,
+            args,
+        );
+    }
+};
+
+fn isHook(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
+    if (identifierReferenceName(tree, callee)) |name| return isHookName(name);
+
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!isIdentifierReferenceNamed(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const member_name = propertyName(tree, member) orelse return false;
+    return isHookName(member_name);
+}
+
+fn functionName(tree: *const ast.Tree, index: ast.NodeIndex, parent: ast.NodeIndex, id_node: ast.NodeIndex) ?[]const u8 {
+    if (bindingName(tree, id_node)) |name| return name;
+
+    return switch (tree.data(parent)) {
+        .variable_declarator => |declarator| if (declarator.init == index) bindingName(tree, declarator.id) else null,
+        .assignment_expression => |assignment| if (assignment.right == index) expressionName(tree, assignment.left) else null,
+        .object_property => |property| if (property.value == index and !property.computed) propertyKeyName(tree, property.key) else null,
+        else => null,
+    };
+}
+
+fn isForwardRefOrMemoCallback(tree: *const ast.Tree, index: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    if (call.arguments.len == 0 or tree.extra(call.arguments)[0] != index) return false;
+    return isNamedCallee(tree, call.callee, "forwardRef") or
+        isNamedCallee(tree, call.callee, "memo") or
+        isReactMemberCallee(tree, call.callee, "forwardRef") or
+        isReactMemberCallee(tree, call.callee, "memo");
+}
+
+fn isNamedCallee(tree: *const ast.Tree, callee: ast.NodeIndex, name: []const u8) bool {
+    return isIdentifierReferenceNamed(tree, unwrapTransparent(tree, callee), name);
+}
+
+fn isReactMemberCallee(tree: *const ast.Tree, callee: ast.NodeIndex, name: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!isIdentifierReferenceNamed(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const member_name = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, member_name, name);
+}
+
+fn isClassMethodValue(tree: *const ast.Tree, index: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    return switch (tree.data(parent)) {
+        .method_definition => |method| method.value == index,
+        else => false,
+    };
+}
+
+fn isComponentName(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}
+
+fn isHookName(name: []const u8) bool {
+    if (!std.mem.startsWith(u8, name, "use")) return false;
+    return name.len == 3 or (name.len > 3 and !std.ascii.isLower(name[3]));
+}
+
+fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn expressionName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyKeyName(tree: *const ast.Tree, key: ast.NodeIndex) ?[]const u8 {
+    if (key == .null) return null;
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    const actual = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, actual, name);
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn nodeSource(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    if (span.start >= span.end or span.end > tree.source.len) return "useHook";
+    return std.mem.trim(u8, tree.source[span.start..span.end], " \t\r\n");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -244,6 +244,7 @@ pub const react_prefer_es6_class = @import("react_prefer_es6_class.zig");
 pub const react_style_prop_object = @import("react_style_prop_object.zig");
 pub const react_self_closing_comp = @import("react_self_closing_comp.zig");
 pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
+pub const react_hooks_rules_of_hooks = @import("react_hooks_rules_of_hooks.zig");
 pub const radix = @import("radix.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
@@ -356,6 +357,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);
+    }
+    if (options.react_hooks_rules_of_hooks) {
+        try react_hooks_rules_of_hooks.run(allocator, diagnostics, tree);
     }
     if (options.react_prop_types) {
         try react_prop_types.run(allocator, diagnostics, tree);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -919,6 +919,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_hooks_rules_of_hooks.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/react_hooks_rules_of_hooks.zig
+++ b/tests/rules/react_hooks_rules_of_hooks.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_hooks_rules_of_hooks = true;
+    return options;
+}
+
+test "allows react-hooks/rules-of-hooks in components hooks memo and forwardRef" {
+    const source =
+        \\function Component() {
+        \\  useState();
+        \\  React.useEffect(() => {});
+        \\}
+        \\function useFeature() {
+        \\  useMemo(() => 1, []);
+        \\}
+        \\const Wrapped = React.memo(() => {
+        \\  useState();
+        \\  return null;
+        \\});
+        \\const Refed = forwardRef((props, ref) => {
+        \\  useImperativeHandle(ref, () => ({}));
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_hooks_rules_of_hooks.id));
+}
+
+test "reports react-hooks/rules-of-hooks for conditional and looped hooks" {
+    const source =
+        \\function Component() {
+        \\  if (flag) {
+        \\    useState();
+        \\  }
+        \\  while (flag) {
+        \\    React.useEffect(() => {});
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_hooks_rules_of_hooks.id));
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[0].message, "is called conditionally") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[1].message, "may be executed more than once") != null);
+}
+
+test "reports react-hooks/rules-of-hooks invalid scopes" {
+    const source =
+        \\useState();
+        \\function helper() {
+        \\  useEffect(() => {});
+        \\}
+        \\class View {
+        \\  render() {
+        \\    useMemo(() => 1, []);
+        \\  }
+        \\}
+        \\function Component() {
+        \\  return items.map(() => {
+        \\    useCallback(() => {}, []);
+        \\  });
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.react_hooks_rules_of_hooks.id));
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[0].message, "cannot be called at the top level") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[1].message, "function \"helper\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[2].message, "cannot be called in a class component") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[3].message, "cannot be called inside a callback") != null);
+}
+
+test "can disable react-hooks/rules-of-hooks" {
+    const source =
+        \\function helper() {
+        \\  useState();
+        \\}
+    ;
+
+    var options = optionsOnly();
+    options.react_hooks_rules_of_hooks = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_hooks_rules_of_hooks.id));
+}


### PR DESCRIPTION
## Summary
- add fishlint-aligned react-hooks/rules-of-hooks diagnostics for top-level hook calls, ordinary functions, class methods, component callbacks, conditional branches, and loops
- support hook calls through bare identifiers and React.use* member expressions
- expose react-hooks/rules-of-hooks through config/--rules and --react-hooks-rules-of-hooks=off

## Validation
- zig build test --summary all -- react_hooks_rules_of_hooks "Options can enable rules by CLI name"
- zig build --summary all
- fishlint parity cases for top-level, ordinary function, class method, callback, conditional, loop, and allowed hook calls
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build -Doptimize=ReleaseFast --summary all
- CLI smoke for --react-hooks-rules-of-hooks=off
- fishlint enabled-rule gap audit confirms react-hooks/rules-of-hooks is no longer missing for JS/TS extensions