### PR TITLE
feat: port alipay no spread params

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -89,6 +89,7 @@ pub const Options = struct {
     alipay_ant_exhaustive_deps: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
+    alipay_ant_no_spread_params: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,
     alipay_spmlint_valid_manual_expo: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -245,6 +245,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
             options.alipay_ant_no_phantom_dependencies = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
+            options.alipay_ant_no_spread_params = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
             options.alipay_spmlint_use_labeled_spm = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-click=off")) {
@@ -1242,6 +1244,7 @@ fn printHelp() void {
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
+        \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
         \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo

--- a/src/root.zig
+++ b/src/root.zig
@@ -122,6 +122,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_async_promise_executor or
         options.alipay_ant_exhaustive_deps or
         options.no_buffer_constructor or
+        options.alipay_ant_no_spread_params or
         options.no_class_assign or
         options.no_const_assign or
         options.no_eval or

--- a/src/rules/alipay_ant_no_spread_params.zig
+++ b/src/rules/alipay_ant_no_spread_params.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-spread-params";
+
+const SymbolId = traverser.semantic.SymbolId;
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const SymbolSet = std.AutoHashMap(SymbolId, void);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var reference_lookup = ReferenceLookup.init(allocator);
+    defer reference_lookup.deinit();
+
+    var decl_symbols = DeclSymbolMap.init(allocator);
+    defer decl_symbols.deinit();
+
+    var symbol_iter = symbol_table.iterSymbols();
+    while (symbol_iter.next()) |entry| {
+        for (symbol_table.symbolDecls(entry.id)) |decl| {
+            try decl_symbols.put(decl, entry.id);
+        }
+    }
+
+    var reference_iter = symbol_table.iterReferences();
+    while (reference_iter.next()) |entry| {
+        if (entry.reference.kind != .value) continue;
+        try reference_lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    var param_symbols = SymbolSet.init(allocator);
+    defer param_symbols.deinit();
+
+    var param_visitor = ParamVisitor{
+        .decl_symbols = &decl_symbols,
+        .param_symbols = &param_symbols,
+    };
+    try traverser.basic.traverse(ParamVisitor, tree, &param_visitor);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .reference_lookup = &reference_lookup,
+        .param_symbols = &param_symbols,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const ParamVisitor = struct {
+    decl_symbols: *const DeclSymbolMap,
+    param_symbols: *SymbolSet,
+
+    pub fn enter_formal_parameter(
+        self: *ParamVisitor,
+        parameter: ast.FormalParameter,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        switch (ctx.tree.data(parameter.pattern)) {
+            .binding_identifier => try self.collectBinding(ctx.tree, parameter.pattern),
+            else => {},
+        }
+        return .proceed;
+    }
+
+    fn collectBinding(self: *ParamVisitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        if (index == .null) return;
+
+        switch (tree.data(index)) {
+            .binding_identifier => {
+                const symbol_id = self.decl_symbols.get(index) orelse return;
+                if (symbol_id != .none) try self.param_symbols.put(symbol_id, {});
+            },
+            else => {},
+        }
+    }
+};
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    reference_lookup: *const ReferenceLookup,
+    param_symbols: *const SymbolSet,
+
+    pub fn enter_jsx_spread_attribute(
+        self: *Visitor,
+        attribute: ast.JSXSpreadAttribute,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const argument = unwrapTransparent(ctx.tree, attribute.argument);
+        switch (ctx.tree.data(argument)) {
+            .identifier_reference => {},
+            else => return .proceed,
+        }
+
+        const symbol_id = self.reference_lookup.get(argument) orelse return .proceed;
+        if (symbol_id == .none or !self.param_symbols.contains(symbol_id)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "不要简单的使用类似`...props`的方式在组件中相互传值, 会造成代码维护/CR难度增大",
+            ctx.tree.span(index),
+        );
+        return .proceed;
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -28,6 +28,7 @@ pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
+pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
 pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manual_expo.zig");
@@ -412,6 +413,10 @@ pub fn runSemantic(
 
     if (options.alipay_ant_exhaustive_deps) {
         try alipay_ant_exhaustive_deps.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.alipay_ant_no_spread_params) {
+        try alipay_ant_no_spread_params.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.import_default) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -55,6 +55,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_spread_params.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_use_labeled_spm.zig");
 }
 

--- a/tests/rules/alipay_ant_no_spread_params.zig
+++ b/tests/rules/alipay_ant_no_spread_params.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_spread_params = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-spread-params for JSX spread function params" {
+    const source =
+        \\function App(props) {
+        \\  return <View {...props} />;
+        \\}
+        \\const Nested = (props) => {
+        \\  return function Child() {
+        \\    return <View {...props} />;
+        \\  };
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_no_spread_params.id));
+    try std.testing.expectEqualStrings(
+        "不要简单的使用类似`...props`的方式在组件中相互传值, 会造成代码维护/CR难度增大",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "does not report @alipay/ant/no-spread-params for non-param spreads" {
+    const source =
+        \\const moduleProps = {};
+        \\function App(props) {
+        \\  const localProps = props;
+        \\  return (
+        \\    <>
+        \\      <View {...localProps} />
+        \\      <View {...moduleProps} />
+        \\      <View {...props.value} />
+        \\    </>
+        \\  );
+        \\}
+        \\function Rest({ value, ...rest }) {
+        \\  return <View {...rest} />;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_spread_params.id));
+}
+
+test "can disable @alipay/ant/no-spread-params" {
+    const source =
+        \\function App(props) {
+        \\  return <View {...props} />;
+        \\}
+    ;
+
+    var options = optionsOnly();
+    options.alipay_ant_no_spread_params = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_spread_params.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-spread-params into the native semantic lint pipeline
- detect JSX spreads whose argument resolves to a direct function parameter
- add CLI/config support and regression coverage for fishlint-compatible cases

## Validation
- zig build test
- zig build
- fishlint smallfish/app gap audit no longer reports @alipay/ant/no-spread-params
