### PR TITLE
feat: port alipay prefer import from stdlib

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
     alipay_ant_no_spread_params: bool = true,
+    alipay_ant_prefer_import_from_stdlib: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,
     alipay_spmlint_valid_manual_expo: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_phantom_dependencies = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
             options.alipay_ant_no_spread_params = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-from-stdlib=off")) {
+            options.alipay_ant_prefer_import_from_stdlib = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
             options.alipay_spmlint_use_labeled_spm = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-valid-manual-click=off")) {
@@ -1245,6 +1247,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
+        \\  --alipay-ant-prefer-import-from-stdlib=off Disable @alipay/ant/prefer-import-from-stdlib
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click
         \\  --alipay-spmlint-valid-manual-expo=off Disable @alipay/spmLint/valid-manual-expo

--- a/src/root.zig
+++ b/src/root.zig
@@ -123,6 +123,7 @@ fn hasSemanticRules(options: Options) bool {
         options.alipay_ant_exhaustive_deps or
         options.no_buffer_constructor or
         options.alipay_ant_no_spread_params or
+        options.alipay_ant_prefer_import_from_stdlib or
         options.no_class_assign or
         options.no_const_assign or
         options.no_eval or

--- a/src/rules/alipay_ant_prefer_import_from_stdlib.zig
+++ b/src/rules/alipay_ant_prefer_import_from_stdlib.zig
@@ -1,0 +1,310 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-import-from-stdlib";
+
+const max_config_file_size = 1024 * 1024;
+
+const ProjectType = enum {
+    smallfish,
+    minifish,
+    other,
+};
+
+const StdlibPackage = struct {
+    name: []const u8,
+    stdlib_path: []const u8,
+    version: u32,
+};
+
+const stdlib_packages = [_]StdlibPackage{
+    .{ .name = "lodash", .stdlib_path = "lodash", .version = 4 },
+    .{ .name = "classnames", .stdlib_path = "classnames", .version = 2 },
+    .{ .name = "lodash-es", .stdlib_path = "lodash", .version = 4 },
+    .{ .name = "@alipay/fm-request", .stdlib_path = "request", .version = 1 },
+    .{ .name = "dayjs", .stdlib_path = "dayjs", .version = 1 },
+    .{ .name = "zustand", .stdlib_path = "zustand", .version = 4 },
+};
+
+const VersionMap = std.StringHashMap(u32);
+
+pub fn run(
+    allocator: Allocator,
+    io: std.Io,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const project_root = try findProjectRoot(allocator, io, file_path);
+    defer allocator.free(project_root);
+
+    const project_type = detectProjectType(allocator, io, project_root) catch .other;
+    const stdlib_package = switch (project_type) {
+        .smallfish => "smallfish:stdlib",
+        .minifish => "@alipay/stdlib",
+        .other => return,
+    };
+
+    var versions = try readPackageVersions(allocator, io, project_root);
+    defer freeVersions(allocator, &versions);
+    if (versions.count() == 0) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .versions = &versions,
+        .stdlib_package = stdlib_package,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    versions: *const VersionMap,
+    stdlib_package: []const u8,
+
+    pub fn enter_program(
+        self: *Visitor,
+        program: ast.Program,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        for (ctx.tree.extra(program.body)) |statement_index| {
+            const declaration = switch (ctx.tree.data(statement_index)) {
+                .import_declaration => |declaration| declaration,
+                else => continue,
+            };
+            try self.checkImport(ctx.tree, statement_index, importSource(ctx.tree, declaration));
+        }
+        return .proceed;
+    }
+
+    fn checkImport(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        node_index: ast.NodeIndex,
+        source: ?[]const u8,
+    ) Allocator.Error!void {
+        const import_source = source orelse return;
+        const package_name = parsePackageNameFromImport(import_source) orelse return;
+        const stdlib = stdlibPackage(package_name) orelse return;
+        const version = self.versions.get(package_name) orelse return;
+        if (version != stdlib.version) return;
+
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            tree.span(node_index),
+            "推荐通过 {s}/{s} 使用 {s}, 可以统一依赖版本，防止 tree-shaking 失效。",
+            .{ self.stdlib_package, stdlib.stdlib_path, package_name },
+        );
+    }
+};
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn stdlibPackage(package_name: []const u8) ?StdlibPackage {
+    for (stdlib_packages) |package| {
+        if (std.mem.eql(u8, package.name, package_name)) return package;
+    }
+    return null;
+}
+
+fn parsePackageNameFromImport(source: []const u8) ?[]const u8 {
+    if (source.len == 0 or
+        std.mem.startsWith(u8, source, "~") or
+        std.mem.startsWith(u8, source, "/") or
+        std.mem.startsWith(u8, source, "#") or
+        std.mem.startsWith(u8, source, "@/") or
+        std.mem.startsWith(u8, source, "./") or
+        std.mem.startsWith(u8, source, "../") or
+        std.mem.startsWith(u8, source, "@smallfish/") or
+        std.mem.startsWith(u8, source, "smallfish:") or
+        std.mem.startsWith(u8, source, "minifish:") or
+        std.mem.startsWith(u8, source, "@qiaozhi/") or
+        std.mem.eql(u8, source, "@wukong") or
+        std.mem.startsWith(u8, source, "@wukong/"))
+    {
+        return null;
+    }
+
+    if (source[0] == '@') {
+        const first_slash = std.mem.indexOfScalarPos(u8, source, 1, '/') orelse return source;
+        const second_slash = std.mem.indexOfScalarPos(u8, source, first_slash + 1, '/') orelse return source;
+        return source[0..second_slash];
+    }
+
+    const slash = std.mem.indexOfScalar(u8, source, '/') orelse return source;
+    return source[0..slash];
+}
+
+fn readPackageVersions(
+    allocator: Allocator,
+    io: std.Io,
+    project_root: []const u8,
+) Allocator.Error!VersionMap {
+    var versions = VersionMap.init(allocator);
+    errdefer versions.deinit();
+
+    const package_path = try std.fs.path.join(allocator, &.{ project_root, "package.json" });
+    defer allocator.free(package_path);
+
+    const source = readConfigFile(allocator, io, package_path) orelse return versions;
+    defer allocator.free(source);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch return versions;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return versions,
+    };
+
+    try readDependencyVersions(allocator, &versions, root.get("devDependencies"));
+    try readDependencyVersions(allocator, &versions, root.get("dependencies"));
+    return versions;
+}
+
+fn readDependencyVersions(
+    allocator: Allocator,
+    versions: *VersionMap,
+    value: ?std.json.Value,
+) Allocator.Error!void {
+    const object = switch (value orelse return) {
+        .object => |object| object,
+        else => return,
+    };
+
+    var iter = object.iterator();
+    while (iter.next()) |entry| {
+        const version_source = switch (entry.value_ptr.*) {
+            .string => |version| version,
+            else => continue,
+        };
+        const major = getMajorVersion(version_source) orelse continue;
+        try putVersion(allocator, versions, entry.key_ptr.*, major);
+    }
+}
+
+fn putVersion(
+    allocator: Allocator,
+    versions: *VersionMap,
+    name: []const u8,
+    major: u32,
+) Allocator.Error!void {
+    const result = try versions.getOrPut(name);
+    if (result.found_existing) {
+        result.value_ptr.* = major;
+        return;
+    }
+
+    const owned_name = try allocator.dupe(u8, name);
+    result.key_ptr.* = owned_name;
+    result.value_ptr.* = major;
+}
+
+fn freeVersions(allocator: Allocator, versions: *VersionMap) void {
+    var iter = versions.iterator();
+    while (iter.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+    }
+    versions.deinit();
+}
+
+fn getMajorVersion(version: []const u8) ?u32 {
+    for (version, 0..) |char, index| {
+        if (!std.ascii.isDigit(char)) continue;
+        var end = index + 1;
+        while (end < version.len and std.ascii.isDigit(version[end])) : (end += 1) {}
+        return std.fmt.parseUnsigned(u32, version[index..end], 10) catch null;
+    }
+    return null;
+}
+
+fn detectProjectType(allocator: Allocator, io: std.Io, project_root: []const u8) Allocator.Error!ProjectType {
+    const smallfish_js = try std.fs.path.join(allocator, &.{ project_root, "smallfish.config.js" });
+    defer allocator.free(smallfish_js);
+    if (exists(io, smallfish_js)) return .smallfish;
+
+    const smallfish_ts = try std.fs.path.join(allocator, &.{ project_root, "smallfish.config.ts" });
+    defer allocator.free(smallfish_ts);
+    if (exists(io, smallfish_ts)) return .smallfish;
+
+    const minifish_js = try std.fs.path.join(allocator, &.{ project_root, "minifish.config.js" });
+    defer allocator.free(minifish_js);
+    if (exists(io, minifish_js)) return .minifish;
+
+    const minifish_ts = try std.fs.path.join(allocator, &.{ project_root, "minifish.config.ts" });
+    defer allocator.free(minifish_ts);
+    if (exists(io, minifish_ts)) return .minifish;
+
+    return .other;
+}
+
+fn readConfigFile(allocator: Allocator, io: std.Io, path: []const u8) ?[]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const directory_path = std.fs.path.dirname(path) orelse return null;
+        const basename = std.fs.path.basename(path);
+        var directory = std.Io.Dir.openDirAbsolute(io, directory_path, .{}) catch return null;
+        defer directory.close(io);
+        return directory.readFileAlloc(io, basename, allocator, .limited(max_config_file_size)) catch null;
+    }
+    return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_config_file_size)) catch null;
+}
+
+fn findProjectRoot(allocator: Allocator, io: std.Io, file_path: []const u8) Allocator.Error![]u8 {
+    const absolute_file = if (std.fs.path.isAbsolute(file_path))
+        try allocator.dupe(u8, file_path)
+    else blk: {
+        const cwd = std.process.currentPathAlloc(io, allocator) catch {
+            break :blk try std.fs.path.resolve(allocator, &.{file_path});
+        };
+        defer allocator.free(cwd);
+        break :blk try std.fs.path.resolve(allocator, &.{ cwd, file_path });
+    };
+    defer allocator.free(absolute_file);
+
+    var current = try allocator.dupe(u8, std.fs.path.dirname(absolute_file) orelse ".");
+    errdefer allocator.free(current);
+
+    while (true) {
+        const package_path = try std.fs.path.join(allocator, &.{ current, "package.json" });
+        defer allocator.free(package_path);
+        if (exists(io, package_path)) return current;
+
+        const parent = std.fs.path.dirname(current) orelse break;
+        if (std.mem.eql(u8, parent, current)) break;
+        const next = try allocator.dupe(u8, parent);
+        allocator.free(current);
+        current = next;
+    }
+
+    return current;
+}
+
+fn exists(io: std.Io, path: []const u8) bool {
+    if (std.fs.path.isAbsolute(path)) {
+        const directory_path = std.fs.path.dirname(path) orelse return false;
+        const basename = std.fs.path.basename(path);
+        var directory = std.Io.Dir.openDirAbsolute(io, directory_path, .{}) catch return false;
+        defer directory.close(io);
+        const stat = directory.statFile(io, basename, .{}) catch return false;
+        return stat.kind == .file;
+    }
+
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return false;
+    return stat.kind == .file;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig")
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
+pub const alipay_ant_prefer_import_from_stdlib = @import("alipay_ant_prefer_import_from_stdlib.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
 pub const alipay_spmlint_valid_manual_expo = @import("alipay_spmlint_valid_manual_expo.zig");
@@ -417,6 +418,18 @@ pub fn runSemantic(
 
     if (options.alipay_ant_no_spread_params) {
         try alipay_ant_no_spread_params.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.alipay_ant_prefer_import_from_stdlib) {
+        if (io) |actual_io| {
+            try alipay_ant_prefer_import_from_stdlib.run(
+                allocator,
+                actual_io,
+                diagnostics,
+                tree,
+                file_path,
+            );
+        }
     }
 
     if (options.import_default) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_import_from_stdlib.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_use_labeled_spm.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_import_from_stdlib.zig
+++ b/tests/rules/alipay_ant_prefer_import_from_stdlib.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_import_from_stdlib = true;
+    options.parser_semantic_errors = false;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-import-from-stdlib for smallfish dependency versions" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeProject(&tmp, "smallfish.config.js");
+    const source =
+        \\import lodash from 'lodash';
+        \\import debounce from 'lodash/debounce';
+        \\import cx from 'classnames';
+        \\import dayjs from 'dayjs';
+        \\import request from '@alipay/fm-request';
+        \\import zustand from 'zustand/middleware';
+        \\import lodashEs from 'lodash-es';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.alipay_ant_prefer_import_from_stdlib.id));
+    try std.testing.expectEqualStrings(
+        "推荐通过 smallfish:stdlib/lodash 使用 lodash, 可以统一依赖版本，防止 tree-shaking 失效。",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "推荐通过 smallfish:stdlib/request 使用 @alipay/fm-request, 可以统一依赖版本，防止 tree-shaking 失效。",
+        result.diagnostics[4].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "reports @alipay/ant/prefer-import-from-stdlib for minifish stdlib package" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeProject(&tmp, "minifish.config.ts");
+    const source = "import lodash from 'lodash';\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.alipay_ant_prefer_import_from_stdlib.id));
+    try std.testing.expectEqualStrings(
+        "推荐通过 @alipay/stdlib/lodash 使用 lodash, 可以统一依赖版本，防止 tree-shaking 失效。",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report @alipay/ant/prefer-import-from-stdlib outside matching projects or versions" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "package.json",
+        .data =
+        \\{
+        \\  "dependencies": {
+        \\    "lodash": "^3.10.1",
+        \\    "dayjs": "workspace:*"
+        \\  }
+        \\}
+        ,
+    });
+    const source =
+        \\import lodash from 'lodash';
+        \\import dayjs from 'dayjs';
+        \\import already from 'smallfish:stdlib/lodash';
+        \\import local from './lodash';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_import_from_stdlib.id));
+}
+
+test "can disable @alipay/ant/prefer-import-from-stdlib" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeProject(&tmp, "smallfish.config.js");
+    const source = "import lodash from 'lodash';\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var options = optionsOnly();
+    options.alipay_ant_prefer_import_from_stdlib = false;
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_import_from_stdlib.id));
+}
+
+fn writeProject(tmp: *std.testing.TmpDir, config_name: []const u8) !void {
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = config_name, .data = "export default {};\n" });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "package.json",
+        .data =
+        \\{
+        \\  "devDependencies": {
+        \\    "lodash": "^3.10.1"
+        \\  },
+        \\  "dependencies": {
+        \\    "lodash": "^4.17.21",
+        \\    "classnames": "^2.3.2",
+        \\    "lodash-es": "~4.17.21",
+        \\    "@alipay/fm-request": "^1.0.0",
+        \\    "dayjs": "^1.11.0",
+        \\    "zustand": "^4.4.0"
+        \\  }
+        \\}
+        ,
+    });
+}
+
+fn entryPath(tmp: *std.testing.TmpDir) ![]u8 {
+    return std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.js",
+    });
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-import-from-stdlib for Smallfish and Minifish projects
- read package.json dependency majors and report imports that should come from the configured stdlib package
- add CLI toggle and focused rule coverage

## Verification
- zig fmt src/rules/alipay_ant_prefer_import_from_stdlib.zig tests/rules/alipay_ant_prefer_import_from_stdlib.zig src/core.zig src/root.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- zig build
- git diff --check