### PR TITLE
feat: port alipay jsx handler names

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -87,6 +87,7 @@ pub const Options = struct {
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_exhaustive_deps: bool = true,
+    alipay_ant_jsx_handler_names: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
     alipay_ant_no_spread_params: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -241,6 +241,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_disallow_typos = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-exhaustive-deps=off")) {
             options.alipay_ant_exhaustive_deps = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-jsx-handler-names=off")) {
+            options.alipay_ant_jsx_handler_names = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
@@ -1244,6 +1246,7 @@ fn printHelp() void {
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
+        \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params

--- a/src/rules/alipay_ant_jsx_handler_names.zig
+++ b/src/rules/alipay_ant_jsx_handler_names.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/jsx-handler-names";
+
+const handler_prefix_message = "(on|handle)";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const prop_key = jsxIdentifierName(tree, attribute.name) orelse return;
+    if (std.mem.eql(u8, prop_key, "ref")) return;
+    if (!isEventHandlerProp(prop_key)) return;
+
+    const expression = jsxExpression(tree, attribute.value) orelse return;
+    if (isInlineArrow(tree, expression)) return;
+
+    const owned_prop_value = try normalizedExpressionSource(allocator, tree, expression);
+    defer allocator.free(owned_prop_value);
+
+    var prop_value: []const u8 = owned_prop_value;
+    prop_value = stripThisPrefix(prop_value);
+    prop_value = stripBindPrefix(prop_value);
+
+    if (isNamedHandler(prop_value)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Handler function for {s} prop key must be a camelCase name beginning with '{s}' only",
+        .{ prop_key, handler_prefix_message },
+    );
+}
+
+fn jsxExpression(tree: *const ast.Tree, value_index: ast.NodeIndex) ?ast.NodeIndex {
+    if (value_index == .null) return null;
+    return switch (tree.data(value_index)) {
+        .jsx_expression_container => |container| if (container.expression == .null) null else container.expression,
+        else => null,
+    };
+}
+
+fn isInlineArrow(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .arrow_function_expression => true,
+        else => false,
+    };
+}
+
+fn normalizedExpressionSource(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error![]u8 {
+    const span = tree.span(index);
+    if (span.start >= span.end or span.end > tree.source.len) return allocator.dupe(u8, "");
+
+    var normalized: std.ArrayList(u8) = .empty;
+    errdefer normalized.deinit(allocator);
+    for (tree.source[span.start..span.end]) |char| {
+        if (std.ascii.isWhitespace(char)) continue;
+        try normalized.append(allocator, char);
+    }
+    return normalized.toOwnedSlice(allocator);
+}
+
+fn stripThisPrefix(value: []const u8) []const u8 {
+    const prefix = "this.";
+    if (std.mem.startsWith(u8, value, prefix)) {
+        return value[prefix.len..];
+    }
+    return value;
+}
+
+fn stripBindPrefix(value: []const u8) []const u8 {
+    const bind = "::";
+    if (std.mem.lastIndexOf(u8, value, bind)) |index| {
+        return value[index + bind.len ..];
+    }
+    return value;
+}
+
+fn isEventHandlerProp(prop_key: []const u8) bool {
+    return startsWithHandlerPrefix(prop_key) and hasUppercaseAfterPrefix(prop_key);
+}
+
+fn isNamedHandler(value: []const u8) bool {
+    if (startsWithQualifiedHandler(value)) return true;
+    return startsWithHandlerPrefix(value) and hasUppercaseAfterPrefix(value);
+}
+
+fn startsWithQualifiedHandler(value: []const u8) bool {
+    if (std.mem.startsWith(u8, value, "props.")) {
+        const tail = value["props.".len..];
+        return startsWithHandlerPrefix(tail) and hasUppercaseAfterPrefix(tail);
+    }
+
+    const dot = std.mem.lastIndexOfScalar(u8, value, '.') orelse return false;
+    const tail = value[dot + 1 ..];
+    return startsWithHandlerPrefix(tail) and hasUppercaseAfterPrefix(tail);
+}
+
+fn startsWithHandlerPrefix(value: []const u8) bool {
+    return std.mem.startsWith(u8, value, "on") or std.mem.startsWith(u8, value, "handle");
+}
+
+fn hasUppercaseAfterPrefix(value: []const u8) bool {
+    if (std.mem.startsWith(u8, value, "handle")) {
+        return hasUppercaseAt(value, "handle".len);
+    }
+    if (std.mem.startsWith(u8, value, "on")) {
+        return hasUppercaseAt(value, "on".len);
+    }
+    return false;
+}
+
+fn hasUppercaseAt(value: []const u8, offset: usize) bool {
+    var index = offset;
+    while (index < value.len and std.ascii.isDigit(value[index])) : (index += 1) {}
+    if (index >= value.len) return false;
+    return std.ascii.isUpper(value[index]);
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
+pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
@@ -2127,6 +2128,9 @@ const BasicVisitor = struct {
         }
         if (self.options.jsx_a11y_aria_proptypes) {
             try jsx_a11y_aria_proptypes.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+        }
+        if (self.options.alipay_ant_jsx_handler_names) {
+            try alipay_ant_jsx_handler_names.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
         }
         if (self.options.react_no_danger) {
             try react_no_danger.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -55,6 +55,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_jsx_handler_names.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_spread_params.zig");
 }
 

--- a/tests/rules/alipay_ant_jsx_handler_names.zig
+++ b/tests/rules/alipay_ant_jsx_handler_names.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_jsx_handler_names = true;
+    return options;
+}
+
+test "reports @alipay/ant/jsx-handler-names for badly named event handlers" {
+    const source =
+        \\const view = (
+        \\  <View
+        \\    onClick={foo}
+        \\    handleTap={this.nope}
+        \\    onPress={props.bad}
+        \\    onSubmit={handleSubmit}
+        \\    onReady={onReady}
+        \\    onLoad={this.handleLoad}
+        \\    onFocus={props.onFocus}
+        \\    onInline={() => ok()}
+        \\    ref={badRef}
+        \\  />
+        \\);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.alipay_ant_jsx_handler_names.id));
+    try std.testing.expectEqualStrings(
+        "Handler function for onClick prop key must be a camelCase name beginning with '(on|handle)' only",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Handler function for handleTap prop key must be a camelCase name beginning with '(on|handle)' only",
+        result.diagnostics[1].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/jsx-handler-names valid handler prefixes and qualified names" {
+    const source =
+        \\const view = (
+        \\  <View
+        \\    onClick={handleClick}
+        \\    onTap={onTap}
+        \\    handlePress={actions.handlePress}
+        \\    onReady={this.props.onReady}
+        \\    on2Ready={handle2Ready}
+        \\  />
+        \\);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_jsx_handler_names.id));
+}
+
+test "can disable @alipay/ant/jsx-handler-names" {
+    const source = "const view = <View onClick={foo} />;\n";
+    var options = optionsOnly();
+    options.alipay_ant_jsx_handler_names = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_jsx_handler_names.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/jsx-handler-names for the Smallfish app default options
- report badly named JSX event handlers for on*/handle* props while allowing on*/handle* handler prefixes and qualified names
- add CLI toggle and focused tests

## Verification
- zig fmt src/rules/alipay_ant_jsx_handler_names.zig tests/rules/alipay_ant_jsx_handler_names.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- zig build
- git diff --check