### PR TITLE
feat: port alipay prefer click with debounce

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -90,6 +90,7 @@ pub const Options = struct {
     alipay_ant_jsx_handler_names: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
+    alipay_ant_prefer_click_with_debounce: bool = true,
     alipay_ant_no_spread_params: bool = true,
     alipay_ant_prefer_import_from_stdlib: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
             options.alipay_ant_no_phantom_dependencies = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-click-with-debounce=off")) {
+            options.alipay_ant_prefer_click_with_debounce = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
             options.alipay_ant_no_spread_params = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-from-stdlib=off")) {
@@ -1249,6 +1251,7 @@ fn printHelp() void {
         \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
+        \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
         \\  --alipay-ant-prefer-import-from-stdlib=off Disable @alipay/ant/prefer-import-from-stdlib
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm

--- a/src/root.zig
+++ b/src/root.zig
@@ -121,6 +121,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_alert or
         options.no_async_promise_executor or
         options.alipay_ant_exhaustive_deps or
+        options.alipay_ant_prefer_click_with_debounce or
         options.no_buffer_constructor or
         options.alipay_ant_no_spread_params or
         options.alipay_ant_prefer_import_from_stdlib or

--- a/src/rules/alipay_ant_prefer_click_with_debounce.zig
+++ b/src/rules/alipay_ant_prefer_click_with_debounce.zig
@@ -1,0 +1,355 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-click-with-debounce";
+
+const message = "异步点击事件(async function)必须防抖处理.";
+const SymbolId = traverser.semantic.SymbolId;
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const DefinitionMap = std.AutoHashMap(ast.NodeIndex, ast.NodeIndex);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var reference_lookup = ReferenceLookup.init(allocator);
+    defer reference_lookup.deinit();
+
+    var decl_symbols = DeclSymbolMap.init(allocator);
+    defer decl_symbols.deinit();
+
+    var symbol_iter = symbol_table.iterSymbols();
+    while (symbol_iter.next()) |entry| {
+        for (symbol_table.symbolDecls(entry.id)) |decl| {
+            try decl_symbols.put(decl, entry.id);
+        }
+    }
+
+    var reference_iter = symbol_table.iterReferences();
+    while (reference_iter.next()) |entry| {
+        if (entry.reference.kind != .value) continue;
+        try reference_lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    var definitions = DefinitionMap.init(allocator);
+    defer definitions.deinit();
+
+    var definition_visitor = DefinitionVisitor{
+        .definitions = &definitions,
+    };
+    try traverser.basic.traverse(DefinitionVisitor, tree, &definition_visitor);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .reference_lookup = &reference_lookup,
+        .decl_symbols = &decl_symbols,
+        .definitions = &definitions,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const DefinitionVisitor = struct {
+    definitions: *DefinitionMap,
+
+    pub fn enter_variable_declarator(
+        self: *DefinitionVisitor,
+        declarator: ast.VariableDeclarator,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (bindingIdentifierName(ctx.tree, declarator.id) != null) {
+            try self.definitions.put(declarator.id, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_function(
+        self: *DefinitionVisitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (function.type != .function_declaration) return .proceed;
+        if (bindingIdentifierName(ctx.tree, function.id) != null) {
+            try self.definitions.put(function.id, index);
+        }
+        return .proceed;
+    }
+};
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    reference_lookup: *const ReferenceLookup,
+    decl_symbols: *const DeclSymbolMap,
+    definitions: *const DefinitionMap,
+
+    pub fn enter_jsx_element(
+        self: *Visitor,
+        element: ast.JSXElement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const on_click = onClickAttribute(ctx.tree, element) orelse return .proceed;
+        const click_handler = jsxExpression(ctx.tree, on_click.attribute.value) orelse return .proceed;
+
+        switch (ctx.tree.data(click_handler)) {
+            .identifier_reference => {
+                const definition = self.definitionForReference(click_handler) orelse return .proceed;
+                _ = try self.validateDefinition(ctx.tree, definition, click_handler);
+            },
+            .arrow_function_expression => |arrow| {
+                if (arrow.async) {
+                    try self.report(ctx.tree, on_click.index);
+                }
+            },
+            else => {},
+        }
+        return .proceed;
+    }
+
+    pub fn enter_variable_declarator(
+        self: *Visitor,
+        declarator: ast.VariableDeclarator,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const name = bindingIdentifierName(ctx.tree, declarator.id) orelse return .proceed;
+        if (std.mem.startsWith(u8, name, "DDD")) {
+            _ = try self.validateDefinition(ctx.tree, index, .null);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (function.type != .function_declaration) return .proceed;
+        const name = bindingIdentifierName(ctx.tree, function.id) orelse return .proceed;
+        if (std.mem.startsWith(u8, name, "DDD")) {
+            _ = try self.validateDefinition(ctx.tree, index, .null);
+        }
+        return .proceed;
+    }
+
+    fn definitionForReference(self: *Visitor, reference: ast.NodeIndex) ?ast.NodeIndex {
+        const symbol_id = self.reference_lookup.get(reference) orelse return null;
+        if (symbol_id == .none) return null;
+
+        var iter = self.decl_symbols.iterator();
+        while (iter.next()) |entry| {
+            if (entry.value_ptr.* != symbol_id) continue;
+            return self.definitions.get(entry.key_ptr.*);
+        }
+        return null;
+    }
+
+    fn validateDefinition(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        definition: ast.NodeIndex,
+        also_report_to: ast.NodeIndex,
+    ) Allocator.Error!bool {
+        return switch (tree.data(definition)) {
+            .variable_declarator => |declarator| try self.validateVariableDeclarator(tree, declarator, also_report_to),
+            .function => |function| try self.validateFunction(tree, function, definition, also_report_to),
+            else => false,
+        };
+    }
+
+    fn validateVariableDeclarator(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        declarator: ast.VariableDeclarator,
+        also_report_to: ast.NodeIndex,
+    ) Allocator.Error!bool {
+        if (declarator.init == .null) return false;
+
+        const init = unwrapTransparent(tree, declarator.init);
+        if (callExpression(tree, init)) |call| {
+            if (isDebouncedCall(tree, init, call)) return true;
+            if (isUseCallbackLikeCall(tree, call) and firstArgumentIsAsyncFunction(tree, call)) {
+                try self.report(tree, init);
+                try self.reportOptional(tree, also_report_to);
+                return true;
+            }
+        }
+
+        if (bindingIdentifierName(tree, declarator.id) != null and isAsyncFunctionExpression(tree, init)) {
+            try self.report(tree, declarator.id);
+            try self.reportOptional(tree, also_report_to);
+            return true;
+        }
+
+        return false;
+    }
+
+    fn validateFunction(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        function: ast.Function,
+        definition: ast.NodeIndex,
+        also_report_to: ast.NodeIndex,
+    ) Allocator.Error!bool {
+        _ = definition;
+        if (function.type != .function_declaration or function.id == .null or !function.async) return false;
+        try self.report(tree, function.id);
+        try self.reportOptional(tree, also_report_to);
+        return true;
+    }
+
+    fn reportOptional(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        if (index != .null) try self.report(tree, index);
+    }
+
+    fn report(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .@"error",
+            id,
+            message,
+            tree.span(index),
+        );
+    }
+};
+
+const AttributeWithIndex = struct {
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+};
+
+fn onClickAttribute(tree: *const ast.Tree, element: ast.JSXElement) ?AttributeWithIndex {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return null,
+    };
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = jsxIdentifierName(tree, attribute.name) orelse continue;
+        if (std.mem.eql(u8, name, "onClick")) {
+            return .{ .attribute = attribute, .index = attribute_index };
+        }
+    }
+    return null;
+}
+
+fn jsxExpression(tree: *const ast.Tree, value_index: ast.NodeIndex) ?ast.NodeIndex {
+    if (value_index == .null) return null;
+    return switch (tree.data(value_index)) {
+        .jsx_expression_container => |container| if (container.expression == .null) null else container.expression,
+        else => null,
+    };
+}
+
+fn isDebouncedCall(tree: *const ast.Tree, index: ast.NodeIndex, call: ast.CallExpression) bool {
+    const callee_name = identifierName(tree, unwrapTransparent(tree, call.callee)) orelse return false;
+    if (isUseCallbackLikeName(callee_name)) {
+        const first = firstArgument(tree, call) orelse return false;
+        const nested = callExpression(tree, unwrapTransparent(tree, first)) orelse return false;
+        return isDebouncedCall(tree, unwrapTransparent(tree, first), nested);
+    }
+    _ = index;
+    return containsIgnoreCase(callee_name, "debounce") or containsIgnoreCase(callee_name, "useLockFn");
+}
+
+fn isUseCallbackLikeCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee_name = identifierName(tree, unwrapTransparent(tree, call.callee)) orelse return false;
+    return isUseCallbackLikeName(callee_name);
+}
+
+fn isUseCallbackLikeName(name: []const u8) bool {
+    return std.mem.indexOf(u8, name, "useCallback") != null or
+        std.mem.indexOf(u8, name, "useMemoizedFn") != null;
+}
+
+fn firstArgumentIsAsyncFunction(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const first = firstArgument(tree, call) orelse return false;
+    return isAsyncFunctionExpression(tree, unwrapTransparent(tree, first));
+}
+
+fn firstArgument(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+    const args = tree.extra(call.arguments);
+    if (args.len == 0) return null;
+    return args[0];
+}
+
+fn isAsyncFunctionExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .arrow_function_expression => |arrow| arrow.async,
+        .function => |function| switch (function.type) {
+            .function_expression => function.async,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn callExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.CallExpression {
+    return switch (tree.data(index)) {
+        .call_expression => |call| call,
+        else => null,
+    };
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn containsIgnoreCase(value: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > value.len) return false;
+
+    var index: usize = 0;
+    while (index + needle.len <= value.len) : (index += 1) {
+        if (std.ascii.eqlIgnoreCase(value[index .. index + needle.len], needle)) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig")
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
+pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
 pub const alipay_ant_prefer_import_from_stdlib = @import("alipay_ant_prefer_import_from_stdlib.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
@@ -419,6 +420,10 @@ pub fn runSemantic(
 
     if (options.alipay_ant_no_spread_params) {
         try alipay_ant_no_spread_params.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.alipay_ant_prefer_click_with_debounce) {
+        try alipay_ant_prefer_click_with_debounce.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.alipay_ant_prefer_import_from_stdlib) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -67,6 +67,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_click_with_debounce.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_spmlint_use_labeled_spm.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_click_with_debounce.zig
+++ b/tests/rules/alipay_ant_prefer_click_with_debounce.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_click_with_debounce = true;
+    options.parser_semantic_errors = false;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-click-with-debounce for async onClick handlers" {
+    const source =
+        \\async function submit() {}
+        \\const save = async () => {};
+        \\const memo = useCallback(async () => {}, []);
+        \\const view = (
+        \\  <>
+        \\    <Button onClick={submit} />
+        \\    <Button onClick={save} />
+        \\    <Button onClick={memo} />
+        \\    <Button onClick={async () => {}} />
+        \\  </>
+        \\);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.alipay_ant_prefer_click_with_debounce.id));
+    try std.testing.expectEqualStrings("异步点击事件(async function)必须防抖处理.", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "reports @alipay/ant/prefer-click-with-debounce for DDD prefixed async definitions" {
+    const source =
+        \\async function DDDSubmit() {}
+        \\const DDDSave = async () => {};
+        \\const DDDMemo = useMemoizedFn(async function () {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.alipay_ant_prefer_click_with_debounce.id));
+}
+
+test "allows @alipay/ant/prefer-click-with-debounce debounced and sync handlers" {
+    const source =
+        \\const debounced = useDebounceFn(async () => {});
+        \\const locked = useLockFn(async () => {});
+        \\const memoDebounced = useCallback(useDebounceFn(async () => {}), []);
+        \\const sync = () => {};
+        \\const view = (
+        \\  <>
+        \\    <Button onClick={debounced} />
+        \\    <Button onClick={locked} />
+        \\    <Button onClick={memoDebounced} />
+        \\    <Button onClick={sync} />
+        \\  </>
+        \\);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_click_with_debounce.id));
+}
+
+test "can disable @alipay/ant/prefer-click-with-debounce" {
+    const source =
+        \\const save = async () => {};
+        \\const view = <Button onClick={save} />;
+    ;
+    var options = optionsOnly();
+    options.alipay_ant_prefer_click_with_debounce = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_click_with_debounce.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-click-with-debounce diagnostics for the Smallfish app default rule
- resolve onClick identifier handlers through semantic symbols and report async handlers that are not debounced
- cover inline async onClick handlers, DDD-prefixed async definitions, useCallback/useMemoizedFn async wrappers, and debounced allow cases

## Verification
- zig fmt src/rules/alipay_ant_prefer_click_with_debounce.zig tests/rules/alipay_ant_prefer_click_with_debounce.zig src/core.zig src/root.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check