### PR TITLE
feat: port alipay no negative conditionals

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_exhaustive_deps: bool = true,
     alipay_ant_jsx_handler_names: bool = true,
+    alipay_ant_no_negative_conditionals: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
     alipay_ant_prefer_click_with_debounce: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -243,6 +243,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_exhaustive_deps = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-jsx-handler-names=off")) {
             options.alipay_ant_jsx_handler_names = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-negative-conditionals=off")) {
+            options.alipay_ant_no_negative_conditionals = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
@@ -1249,6 +1251,7 @@ fn printHelp() void {
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
         \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
+        \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce

--- a/src/rules/alipay_ant_no_negative_conditionals.zig
+++ b/src/rules/alipay_ant_no_negative_conditionals.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-negative-conditionals";
+
+pub fn checkNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    data: ast.NodeData,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = identifierName(tree, data) orelse return;
+    if (!isNegativeConditionalName(name)) return;
+
+    const instead = try replacementName(allocator, name);
+    defer allocator.free(instead);
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "use `{s}` instead `{s}`.",
+        .{ instead, name },
+    );
+}
+
+fn identifierName(tree: *const ast.Tree, data: ast.NodeData) ?[]const u8 {
+    return switch (data) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isNegativeConditionalName(name: []const u8) bool {
+    if (!std.mem.startsWith(u8, name, "is") and !std.mem.startsWith(u8, name, "IS")) return false;
+
+    var index: usize = 0;
+    while (index < name.len) : (index += 1) {
+        if (std.mem.startsWith(u8, name[index..], "Not")) {
+            const after = index + "Not".len;
+            return after >= name.len or !std.ascii.isLower(name[after]);
+        }
+        if (std.mem.startsWith(u8, name[index..], "NOT")) {
+            const after = index + "NOT".len;
+            return after >= name.len or !std.ascii.isUpper(name[after]);
+        }
+    }
+    return false;
+}
+
+fn replacementName(allocator: Allocator, name: []const u8) Allocator.Error![]u8 {
+    const index = caseInsensitiveIndexOf(name, "not") orelse return allocator.dupe(u8, name);
+    const start = if (index > 0 and name[index - 1] == '_') index - 1 else index;
+
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(allocator);
+    try result.appendSlice(allocator, name[0..start]);
+    try result.appendSlice(allocator, name[index + "not".len ..]);
+    return result.toOwnedSlice(allocator);
+}
+
+fn caseInsensitiveIndexOf(value: []const u8, needle: []const u8) ?usize {
+    if (needle.len == 0) return 0;
+    if (needle.len > value.len) return null;
+
+    var index: usize = 0;
+    while (index + needle.len <= value.len) : (index += 1) {
+        if (std.ascii.eqlIgnoreCase(value[index .. index + needle.len], needle)) return index;
+    }
+    return null;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -27,6 +27,7 @@ pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
+pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
@@ -766,6 +767,18 @@ const BasicVisitor = struct {
     react_no_unused_state_state: react_no_unused_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
+
+    pub fn enter_node(
+        self: *BasicVisitor,
+        data: ast.NodeData,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.alipay_ant_no_negative_conditionals) {
+            try alipay_ant_no_negative_conditionals.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index);
+        }
+        return .proceed;
+    }
 
     pub fn enter_program(
         self: *BasicVisitor,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_negative_conditionals.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_spread_params.zig");
 }
 

--- a/tests/rules/alipay_ant_no_negative_conditionals.zig
+++ b/tests/rules/alipay_ant_no_negative_conditionals.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_negative_conditionals = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-negative-conditionals for negative is identifiers" {
+    const source =
+        \\const isNotReady = isNotAllowed;
+        \\const obj = { isNotReady };
+        \\foo.isNotReady;
+        \\const isNotification = true;
+        \\const isNOT_READY = true;
+        \\const isNOTReady = true;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.alipay_ant_no_negative_conditionals.id));
+    try std.testing.expectEqualStrings("use `isReady` instead `isNotReady`.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("use `is_READY` instead `isNOT_READY`.", result.diagnostics[5].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/no-negative-conditionals non matching names" {
+    const source =
+        \\const isNotification = true;
+        \\const isnotReady = true;
+        \\const wasNotReady = true;
+        \\const isNOTReady = true;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_negative_conditionals.id));
+}
+
+test "can disable @alipay/ant/no-negative-conditionals" {
+    const source = "const isNotReady = true;\n";
+    var options = optionsOnly();
+    options.alipay_ant_no_negative_conditionals = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_negative_conditionals.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-negative-conditionals from the team fishlint config
- scan binding, reference, and property identifiers for is*/IS* negative conditional names
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_no_negative_conditionals.zig tests/rules/alipay_ant_no_negative_conditionals.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check