### PR TITLE
feat: port alipay prefer elseif end with else

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -91,6 +91,7 @@ pub const Options = struct {
     alipay_ant_no_negative_conditionals: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
+    alipay_ant_prefer_elseif_end_with_else: bool = true,
     alipay_ant_prefer_click_with_debounce: bool = true,
     alipay_ant_no_spread_params: bool = true,
     alipay_ant_prefer_import_from_stdlib: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
             options.alipay_ant_no_phantom_dependencies = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-elseif-end-with-else=off")) {
+            options.alipay_ant_prefer_elseif_end_with_else = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-click-with-debounce=off")) {
             options.alipay_ant_prefer_click_with_debounce = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
@@ -1254,6 +1256,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
+        \\  --alipay-ant-prefer-elseif-end-with-else=off Disable @alipay/ant/prefer-elseif-end-with-else
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
         \\  --alipay-ant-prefer-import-from-stdlib=off Disable @alipay/ant/prefer-import-from-stdlib

--- a/src/rules/alipay_ant_prefer_elseif_end_with_else.zig
+++ b/src/rules/alipay_ant_prefer_elseif_end_with_else.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-elseif-end-with-else";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (statement.alternate != .null) return;
+    if (!isElseIf(tree, index, ctx)) return;
+    if (allConsequentsEndWithReturn(tree, statement, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Prefer elseif end with else.",
+        tree.span(index),
+    );
+}
+
+fn isElseIf(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.parent() orelse return false;
+    return switch (tree.data(parent)) {
+        .if_statement => |statement| statement.alternate == index,
+        else => false,
+    };
+}
+
+fn allConsequentsEndWithReturn(tree: *const ast.Tree, start: ast.IfStatement, ctx: *traverser.basic.Ctx) bool {
+    var current = start;
+    var ancestor_depth: usize = 1;
+    while (true) : (ancestor_depth += 1) {
+        if (!statementEndsWithReturn(tree, current.consequent)) return false;
+
+        const parent = ctx.path.ancestor(ancestor_depth) orelse return true;
+        current = switch (tree.data(parent)) {
+            .if_statement => |statement| statement,
+            else => return true,
+        };
+    }
+}
+
+fn statementEndsWithReturn(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .return_statement => true,
+        .block_statement => |block| blockEndsWithReturn(tree, block),
+        else => false,
+    };
+}
+
+fn blockEndsWithReturn(tree: *const ast.Tree, block: ast.BlockStatement) bool {
+    const body = tree.extra(block.body);
+    if (body.len == 0) return false;
+    return tree.data(body[body.len - 1]) == .return_statement;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.z
 pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
+pub const alipay_ant_prefer_elseif_end_with_else = @import("alipay_ant_prefer_elseif_end_with_else.zig");
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
 pub const alipay_ant_prefer_import_from_stdlib = @import("alipay_ant_prefer_import_from_stdlib.zig");
@@ -981,6 +982,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_negated_condition) {
             try no_negated_condition.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        if (self.options.alipay_ant_prefer_elseif_end_with_else) {
+            try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_elseif_end_with_else.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_spread_params.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_elseif_end_with_else.zig
+++ b/tests/rules/alipay_ant_prefer_elseif_end_with_else.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_elseif_end_with_else = true;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-elseif-end-with-else for else-if chains without final else" {
+    const source =
+        \\function test() {
+        \\  if (a) {
+        \\    runA();
+        \\  } else if (b) {
+        \\    runB();
+        \\  }
+        \\
+        \\  if (one) {
+        \\    return 1;
+        \\  } else if (two) {
+        \\    return 2;
+        \\  } else if (three) {
+        \\    runThree();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_prefer_elseif_end_with_else.id));
+    try std.testing.expectEqualStrings("Prefer elseif end with else.", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/prefer-elseif-end-with-else when branches return or final else exists" {
+    const source =
+        \\function test() {
+        \\  if (a) {
+        \\    return 1;
+        \\  } else if (b) {
+        \\    return 2;
+        \\  }
+        \\
+        \\  if (one) {
+        \\    runOne();
+        \\  } else if (two) {
+        \\    runTwo();
+        \\  } else {
+        \\    runOther();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_elseif_end_with_else.id));
+}
+
+test "can disable @alipay/ant/prefer-elseif-end-with-else" {
+    const source =
+        \\if (a) {
+        \\  runA();
+        \\} else if (b) {
+        \\  runB();
+        \\}
+    ;
+    var options = optionsOnly();
+    options.alipay_ant_prefer_elseif_end_with_else = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_elseif_end_with_else.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-elseif-end-with-else from the team fishlint config
- report else-if chains without a final else unless all branch consequents end with return
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_prefer_elseif_end_with_else.zig tests/rules/alipay_ant_prefer_elseif_end_with_else.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check