### PR TITLE
feat: port alipay no too large file

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -91,6 +91,7 @@ pub const Options = struct {
     alipay_ant_no_negative_conditionals: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,
+    alipay_ant_no_too_large_file: bool = true,
     alipay_ant_prefer_elseif_end_with_else: bool = true,
     alipay_ant_prefer_click_with_debounce: bool = true,
     alipay_ant_no_spread_params: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_import_src = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-phantom-dependencies=off")) {
             options.alipay_ant_no_phantom_dependencies = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-too-large-file=off")) {
+            options.alipay_ant_no_too_large_file = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-elseif-end-with-else=off")) {
             options.alipay_ant_prefer_elseif_end_with_else = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-click-with-debounce=off")) {
@@ -1256,6 +1258,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
+        \\  --alipay-ant-no-too-large-file=off Disable @alipay/ant/no-too-large-file
         \\  --alipay-ant-prefer-elseif-end-with-else=off Disable @alipay/ant/prefer-elseif-end-with-else
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params

--- a/src/rules/alipay_ant_no_too_large_file.zig
+++ b/src/rules/alipay_ant_no_too_large_file.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-too-large-file";
+
+const default_lines_limit = 500;
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+) Allocator.Error!void {
+    const lines = lineCount(tree.source);
+    if (lines <= default_lines_limit) return;
+
+    const display_path = try displayPath(allocator, file_path);
+    defer allocator.free(display_path);
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        .{ .start = 0, .end = 0 },
+        "file: `{s}` is too large 😨 ({d} lines)`.",
+        .{ display_path, lines },
+    );
+}
+
+fn lineCount(source: []const u8) usize {
+    var count: usize = 1;
+    var index: usize = 0;
+    while (index < source.len) : (index += 1) {
+        if (source[index] == '\n') {
+            count += 1;
+        } else if (source[index] == '\r') {
+            count += 1;
+            if (index + 1 < source.len and source[index + 1] == '\n') index += 1;
+        }
+    }
+    return count;
+}
+
+fn displayPath(allocator: Allocator, file_path: []const u8) Allocator.Error![]u8 {
+    if (!std.fs.path.isAbsolute(file_path)) {
+        return std.fmt.allocPrint(allocator, "/{s}", .{file_path});
+    }
+
+    const basename = std.fs.path.basename(file_path);
+    return std.fmt.allocPrint(allocator, "/{s}", .{basename});
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -30,6 +30,7 @@ pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.z
 pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
+pub const alipay_ant_no_too_large_file = @import("alipay_ant_no_too_large_file.zig");
 pub const alipay_ant_prefer_elseif_end_with_else = @import("alipay_ant_prefer_elseif_end_with_else.zig");
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
@@ -361,6 +362,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_triple_slash_reference) {
         try typescript_eslint_triple_slash_reference.run(allocator, diagnostics, tree);
+    }
+    if (options.alipay_ant_no_too_large_file) {
+        try alipay_ant_no_too_large_file.run(allocator, diagnostics, tree, file_path);
     }
     if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_too_large_file.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_prefer_elseif_end_with_else.zig");
 }
 

--- a/tests/rules/alipay_ant_no_too_large_file.zig
+++ b/tests/rules/alipay_ant_no_too_large_file.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_too_large_file = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-too-large-file above default line limit" {
+    const source = try repeatedLines(501);
+    defer std.testing.allocator.free(source);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.alipay_ant_no_too_large_file.id));
+    try std.testing.expectEqualStrings("file: `/fixture.js` is too large 😨 (501 lines)`.", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/no-too-large-file at default line limit" {
+    const source = try repeatedLines(500);
+    defer std.testing.allocator.free(source);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_too_large_file.id));
+}
+
+test "can disable @alipay/ant/no-too-large-file" {
+    const source = try repeatedLines(501);
+    defer std.testing.allocator.free(source);
+
+    var options = optionsOnly();
+    options.alipay_ant_no_too_large_file = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_too_large_file.id));
+}
+
+fn repeatedLines(lines: usize) ![]u8 {
+    var source: std.ArrayList(u8) = .empty;
+    errdefer source.deinit(std.testing.allocator);
+    for (0..lines) |_| {
+        try source.appendSlice(std.testing.allocator, "a();");
+        if (lines > 1) try source.append(std.testing.allocator, '\n');
+    }
+    if (source.items.len > 0) _ = source.pop();
+    return source.toOwnedSlice(std.testing.allocator);
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-too-large-file from the team fishlint config
- report files over the default 500-line limit with fishlint-compatible message formatting
- add CLI toggle and focused line-count tests

## Verification
- zig fmt src/rules/alipay_ant_no_too_large_file.zig tests/rules/alipay_ant_no_too_large_file.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check