### PR TITLE
feat: port alipay no deprecated variable

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_exhaustive_deps: bool = true,
     alipay_ant_jsx_handler_names: bool = true,
+    alipay_ant_no_deprecated_variable: bool = true,
     alipay_ant_no_negative_conditionals: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -243,6 +243,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_exhaustive_deps = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-jsx-handler-names=off")) {
             options.alipay_ant_jsx_handler_names = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-deprecated-variable=off")) {
+            options.alipay_ant_no_deprecated_variable = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-negative-conditionals=off")) {
             options.alipay_ant_no_negative_conditionals = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
@@ -1255,6 +1257,7 @@ fn printHelp() void {
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
         \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
+        \\  --alipay-ant-no-deprecated-variable=off Disable @alipay/ant/no-deprecated-variable
         \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies

--- a/src/rules/alipay_ant_no_deprecated_variable.zig
+++ b/src/rules/alipay_ant_no_deprecated_variable.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-deprecated-variable";
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (!isDeprecatedIdentifier(tree, member.object) and !isDeprecatedIdentifier(tree, member.property)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "ap 不推荐使用。强烈建议 使用 my 替代。",
+        tree.span(index),
+    );
+}
+
+fn isDeprecatedIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, "ap") or std.mem.eql(u8, name, "AlipayJSBridge");
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -27,6 +27,7 @@ pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
+pub const alipay_ant_no_deprecated_variable = @import("alipay_ant_no_deprecated_variable.zig");
 pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
@@ -2099,6 +2100,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_env) {
             try no_process_env.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.alipay_ant_no_deprecated_variable) {
+            try alipay_ant_no_deprecated_variable.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_deprecated_variable.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_negative_conditionals.zig");
 }
 

--- a/tests/rules/alipay_ant_no_deprecated_variable.zig
+++ b/tests/rules/alipay_ant_no_deprecated_variable.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_deprecated_variable = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-deprecated-variable for ap and AlipayJSBridge member usage" {
+    const source =
+        \\ap.alert();
+        \\AlipayJSBridge.call("toast");
+        \\bridge[ap]();
+        \\bridge.AlipayJSBridge();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.alipay_ant_no_deprecated_variable.id));
+    try std.testing.expectEqualStrings("ap 不推荐使用。强烈建议 使用 my 替代。", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/no-deprecated-variable ordinary members and identifiers" {
+    const source =
+        \\const ap = createBridge();
+        \\my.alert();
+        \\bridge.call("toast");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_deprecated_variable.id));
+}
+
+test "can disable @alipay/ant/no-deprecated-variable" {
+    const source = "ap.alert();\n";
+    var options = optionsOnly();
+    options.alipay_ant_no_deprecated_variable = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_deprecated_variable.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-deprecated-variable from the team fishlint config
- report member expressions that use deprecated ap or AlipayJSBridge globals
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_no_deprecated_variable.zig tests/rules/alipay_ant_no_deprecated_variable.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check