### PR TITLE
feat: port alipay prefer import as required

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -95,6 +95,7 @@ pub const Options = struct {
     alipay_ant_no_too_large_file: bool = true,
     alipay_ant_prefer_elseif_end_with_else: bool = true,
     alipay_ant_prefer_click_with_debounce: bool = true,
+    alipay_ant_prefer_import_as_required: bool = true,
     alipay_ant_no_spread_params: bool = true,
     alipay_ant_prefer_import_from_stdlib: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -257,6 +257,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_prefer_elseif_end_with_else = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-click-with-debounce=off")) {
             options.alipay_ant_prefer_click_with_debounce = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-as-required=off")) {
+            options.alipay_ant_prefer_import_as_required = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
             options.alipay_ant_no_spread_params = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-from-stdlib=off")) {
@@ -1264,6 +1266,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-too-large-file=off Disable @alipay/ant/no-too-large-file
         \\  --alipay-ant-prefer-elseif-end-with-else=off Disable @alipay/ant/prefer-elseif-end-with-else
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
+        \\  --alipay-ant-prefer-import-as-required=off Disable @alipay/ant/prefer-import-as-required
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
         \\  --alipay-ant-prefer-import-from-stdlib=off Disable @alipay/ant/prefer-import-from-stdlib
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm

--- a/src/rules/alipay_ant_prefer_import_as_required.zig
+++ b/src/rules/alipay_ant_prefer_import_as_required.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-import-as-required";
+
+const default_check_deps = [_][]const u8{
+    "lodash-es",
+    "@alipay/content-components",
+    "@alipay/cdk-components",
+    "@alipay/content-utils",
+    "@alipay/cdk-utils",
+    "@alipay/shandie-utils",
+    "@alipay/shandie-hooks",
+    "smallfish:stdlib/lodash",
+    "@alipay/stdlib",
+};
+
+pub fn checkImportDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const source = importSource(tree, declaration) orelse return;
+    if (!isDefaultOrNamespaceImport(tree, declaration)) return;
+    if (!isCheckedDependency(source)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "使用按需引入以减小构建包体积: {s}.",
+        .{source},
+    );
+}
+
+fn isDefaultOrNamespaceImport(tree: *const ast.Tree, declaration: ast.ImportDeclaration) bool {
+    for (tree.extra(declaration.specifiers)) |specifier| {
+        switch (tree.data(specifier)) {
+            .import_default_specifier, .import_namespace_specifier => return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn isCheckedDependency(source: []const u8) bool {
+    for (default_check_deps) |dependency| {
+        if (std.mem.eql(u8, source, dependency)) return true;
+    }
+    return false;
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_de
 pub const alipay_ant_no_too_large_file = @import("alipay_ant_no_too_large_file.zig");
 pub const alipay_ant_prefer_elseif_end_with_else = @import("alipay_ant_prefer_elseif_end_with_else.zig");
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
+pub const alipay_ant_prefer_import_as_required = @import("alipay_ant_prefer_import_as_required.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
 pub const alipay_ant_prefer_import_from_stdlib = @import("alipay_ant_prefer_import_from_stdlib.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
@@ -990,6 +991,18 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
             try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_import_declaration(
+        self: *BasicVisitor,
+        declaration: ast.ImportDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.alipay_ant_prefer_import_as_required) {
+            try alipay_ant_prefer_import_as_required.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -83,6 +83,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_import_as_required.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_prefer_click_with_debounce.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_import_as_required.zig
+++ b/tests/rules/alipay_ant_prefer_import_as_required.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_import_as_required = true;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-import-as-required for default and namespace checked imports" {
+    const source =
+        \\import lodashEs from 'lodash-es';
+        \\import * as stdlib from '@alipay/stdlib';
+        \\import components, { Button } from '@alipay/content-components';
+        \\import { debounce } from 'lodash-es';
+        \\import other from 'other-package';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.alipay_ant_prefer_import_as_required.id));
+    try std.testing.expectEqualStrings("使用按需引入以减小构建包体积: lodash-es.", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/prefer-import-as-required named and unchecked imports" {
+    const source =
+        \\import { debounce } from 'lodash-es';
+        \\import { Button } from '@alipay/content-components';
+        \\import other from 'other-package';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_import_as_required.id));
+}
+
+test "can disable @alipay/ant/prefer-import-as-required" {
+    const source = "import lodashEs from 'lodash-es';\n";
+    var options = optionsOnly();
+    options.alipay_ant_prefer_import_as_required = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_import_as_required.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-import-as-required from the team fishlint config
- report default and namespace imports from the default checked dependency list
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_prefer_import_as_required.zig tests/rules/alipay_ant_prefer_import_as_required.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check