### PR TITLE
feat: port alipay no import files from pages in common

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -89,6 +89,7 @@ pub const Options = struct {
     alipay_ant_exhaustive_deps: bool = true,
     alipay_ant_jsx_handler_names: bool = true,
     alipay_ant_no_deprecated_variable: bool = true,
+    alipay_ant_no_import_files_from_pages_in_common: bool = true,
     alipay_ant_no_negative_conditionals: bool = true,
     alipay_ant_no_import_src: bool = true,
     alipay_ant_no_phantom_dependencies: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -245,6 +245,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_jsx_handler_names = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-deprecated-variable=off")) {
             options.alipay_ant_no_deprecated_variable = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-files-from-pages-in-common=off")) {
+            options.alipay_ant_no_import_files_from_pages_in_common = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-negative-conditionals=off")) {
             options.alipay_ant_no_negative_conditionals = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-src=off")) {
@@ -1260,6 +1262,7 @@ fn printHelp() void {
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
         \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
         \\  --alipay-ant-no-deprecated-variable=off Disable @alipay/ant/no-deprecated-variable
+        \\  --alipay-ant-no-import-files-from-pages-in-common=off Disable @alipay/ant/no-import-files-from-pages-in-common
         \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals
         \\  --alipay-ant-no-import-src=off Disable @alipay/ant/no-import-src
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies

--- a/src/rules/alipay_ant_no_import_files_from_pages_in_common.zig
+++ b/src/rules/alipay_ant_no_import_files_from_pages_in_common.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-import-files-from-pages-in-common";
+
+pub fn checkImportDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    index: ast.NodeIndex,
+    file_path: []const u8,
+) Allocator.Error!void {
+    if (std.mem.indexOf(u8, file_path, "src/common") == null) return;
+
+    const source = importSource(tree, declaration) orelse return;
+    if (std.mem.indexOf(u8, source, "smallfish") == null or
+        std.mem.indexOf(u8, source, "page-") == null)
+    {
+        return;
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "don't import things from src/pages/ while you're in src/common: reading `{s}` now.",
+        .{source},
+    );
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -28,6 +28,7 @@ pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
 pub const alipay_ant_no_deprecated_variable = @import("alipay_ant_no_deprecated_variable.zig");
+pub const alipay_ant_no_import_files_from_pages_in_common = @import("alipay_ant_no_import_files_from_pages_in_common.zig");
 pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
 pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
@@ -1003,6 +1004,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.alipay_ant_prefer_import_as_required) {
             try alipay_ant_prefer_import_as_required.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        if (self.options.alipay_ant_no_import_files_from_pages_in_common) {
+            try alipay_ant_no_import_files_from_pages_in_common.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.file_path);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_import_files_from_pages_in_common.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_negative_conditionals.zig");
 }
 

--- a/tests/rules/alipay_ant_no_import_files_from_pages_in_common.zig
+++ b/tests/rules/alipay_ant_no_import_files_from_pages_in_common.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_import_files_from_pages_in_common = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-import-files-from-pages-in-common in src common files" {
+    const source =
+        \\import pageA from 'smallfish/page-home';
+        \\import pageB from '@scope/smallfish-mobile/page-detail';
+        \\import ok from 'smallfish/component-card';
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/common/foo.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_no_import_files_from_pages_in_common.id));
+    try std.testing.expectEqualStrings(
+        "don't import things from src/pages/ while you're in src/common: reading `smallfish/page-home` now.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/no-import-files-from-pages-in-common outside src common" {
+    const source = "import pageA from 'smallfish/page-home';\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/pages/foo.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_import_files_from_pages_in_common.id));
+}
+
+test "can disable @alipay/ant/no-import-files-from-pages-in-common" {
+    const source = "import pageA from 'smallfish/page-home';\n";
+    var options = optionsOnly();
+    options.alipay_ant_no_import_files_from_pages_in_common = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "src/common/foo.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_import_files_from_pages_in_common.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-import-files-from-pages-in-common from the team fishlint config
- report smallfish page imports from files under src/common
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_no_import_files_from_pages_in_common.zig tests/rules/alipay_ant_no_import_files_from_pages_in_common.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check