### PR TITLE
feat: port alipay prefer catch unsafe func call

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -95,6 +95,7 @@ pub const Options = struct {
     alipay_ant_no_phantom_dependencies: bool = true,
     alipay_ant_no_too_large_file: bool = true,
     alipay_ant_prefer_elseif_end_with_else: bool = true,
+    alipay_ant_prefer_catch_unsafe_func_call: bool = true,
     alipay_ant_prefer_click_with_debounce: bool = true,
     alipay_ant_prefer_import_as_required: bool = true,
     alipay_ant_no_spread_params: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -257,6 +257,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_no_too_large_file = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-elseif-end-with-else=off")) {
             options.alipay_ant_prefer_elseif_end_with_else = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-catch-unsafe-func-call=off")) {
+            options.alipay_ant_prefer_catch_unsafe_func_call = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-click-with-debounce=off")) {
             options.alipay_ant_prefer_click_with_debounce = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-as-required=off")) {
@@ -1268,6 +1270,7 @@ fn printHelp() void {
         \\  --alipay-ant-no-phantom-dependencies=off Disable @alipay/ant/no-phantom-dependencies
         \\  --alipay-ant-no-too-large-file=off Disable @alipay/ant/no-too-large-file
         \\  --alipay-ant-prefer-elseif-end-with-else=off Disable @alipay/ant/prefer-elseif-end-with-else
+        \\  --alipay-ant-prefer-catch-unsafe-func-call=off Disable @alipay/ant/prefer-catch-unsafe-func-call
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
         \\  --alipay-ant-prefer-import-as-required=off Disable @alipay/ant/prefer-import-as-required
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params

--- a/src/rules/alipay_ant_prefer_catch_unsafe_func_call.zig
+++ b/src/rules/alipay_ant_prefer_catch_unsafe_func_call.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-catch-unsafe-func-call";
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const message = unsafeCallMessage(tree, call) orelse return;
+    if (isInsideTryBlock(tree, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        message,
+        tree.span(index),
+    );
+}
+
+fn unsafeCallMessage(tree: *const ast.Tree, call: ast.CallExpression) ?[]const u8 {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierName(tree, callee)) |name| {
+        if (std.mem.eql(u8, name, "decodeURIComponent")) {
+            return "`decodeURIComponent`存在无法解析出错可能, 需进行catch处理";
+        }
+        return null;
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    const object_name = identifierName(tree, unwrapTransparent(tree, member.object)) orelse return null;
+    const property_name = identifierName(tree, unwrapTransparent(tree, member.property)) orelse return null;
+    if (std.mem.eql(u8, object_name, "localStorage") and std.mem.eql(u8, property_name, "setItem")) {
+        return "`localStorage.setItem`存在无法写入报错可能, 需进行catch处理";
+    }
+    return null;
+}
+
+fn isInsideTryBlock(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        if (tree.data(ancestor) != .block_statement) continue;
+        const parent = ctx.path.ancestor(depth + 1) orelse continue;
+        const try_statement = switch (tree.data(parent)) {
+            .try_statement => |statement| statement,
+            else => continue,
+        };
+        if (try_statement.block == ancestor) return true;
+    }
+    return false;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -34,6 +34,7 @@ pub const alipay_ant_no_import_src = @import("alipay_ant_no_import_src.zig");
 pub const alipay_ant_no_phantom_dependencies = @import("alipay_ant_no_phantom_dependencies.zig");
 pub const alipay_ant_no_too_large_file = @import("alipay_ant_no_too_large_file.zig");
 pub const alipay_ant_prefer_elseif_end_with_else = @import("alipay_ant_prefer_elseif_end_with_else.zig");
+pub const alipay_ant_prefer_catch_unsafe_func_call = @import("alipay_ant_prefer_catch_unsafe_func_call.zig");
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
 pub const alipay_ant_prefer_import_as_required = @import("alipay_ant_prefer_import_as_required.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
@@ -1970,6 +1971,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_spmlint_valid_manual_pv) {
             try alipay_spmlint_valid_manual_pv.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
+        if (self.options.alipay_ant_prefer_catch_unsafe_func_call) {
+            try alipay_ant_prefer_catch_unsafe_func_call.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, ctx);
         }
         if (self.options.react_no_find_dom_node) {
             try react_no_find_dom_node.check(self.allocator, self.diagnostics, ctx.tree, call);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -79,6 +79,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_catch_unsafe_func_call.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_no_spread_params.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_catch_unsafe_func_call.zig
+++ b/tests/rules/alipay_ant_prefer_catch_unsafe_func_call.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_catch_unsafe_func_call = true;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-catch-unsafe-func-call outside try blocks" {
+    const source =
+        \\decodeURIComponent(value);
+        \\localStorage.setItem("key", value);
+        \\JSON.parse(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_prefer_catch_unsafe_func_call.id));
+    try std.testing.expectEqualStrings("`decodeURIComponent`存在无法解析出错可能, 需进行catch处理", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("`localStorage.setItem`存在无法写入报错可能, 需进行catch处理", result.diagnostics[1].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/prefer-catch-unsafe-func-call inside try block" {
+    const source =
+        \\try {
+        \\  decodeURIComponent(value);
+        \\  localStorage.setItem("key", value);
+        \\} catch (error) {
+        \\  report(error);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_catch_unsafe_func_call.id));
+}
+
+test "can disable @alipay/ant/prefer-catch-unsafe-func-call" {
+    const source = "decodeURIComponent(value);\n";
+    var options = optionsOnly();
+    options.alipay_ant_prefer_catch_unsafe_func_call = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_catch_unsafe_func_call.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-catch-unsafe-func-call from the team fishlint config
- report default unsafe calls outside try blocks
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_prefer_catch_unsafe_func_call.zig tests/rules/alipay_ant_prefer_catch_unsafe_func_call.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check