### PR TITLE
feat: port alipay prefer resource from huamei

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -99,6 +99,7 @@ pub const Options = struct {
     alipay_ant_prefer_click_with_debounce: bool = true,
     alipay_ant_prefer_import_as_required: bool = true,
     alipay_ant_no_spread_params: bool = true,
+    alipay_ant_prefer_resource_from_huamei: bool = true,
     alipay_ant_prefer_import_from_stdlib: bool = true,
     alipay_spmlint_use_labeled_spm: bool = true,
     alipay_spmlint_valid_manual_click: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -265,6 +265,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_prefer_import_as_required = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-spread-params=off")) {
             options.alipay_ant_no_spread_params = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-resource-from-huamei=off")) {
+            options.alipay_ant_prefer_resource_from_huamei = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-prefer-import-from-stdlib=off")) {
             options.alipay_ant_prefer_import_from_stdlib = false;
         } else if (std.mem.eql(u8, arg, "--alipay-spmlint-use-labeled-spm=off")) {
@@ -1274,6 +1276,7 @@ fn printHelp() void {
         \\  --alipay-ant-prefer-click-with-debounce=off Disable @alipay/ant/prefer-click-with-debounce
         \\  --alipay-ant-prefer-import-as-required=off Disable @alipay/ant/prefer-import-as-required
         \\  --alipay-ant-no-spread-params=off Disable @alipay/ant/no-spread-params
+        \\  --alipay-ant-prefer-resource-from-huamei=off Disable @alipay/ant/prefer-resource-from-huamei
         \\  --alipay-ant-prefer-import-from-stdlib=off Disable @alipay/ant/prefer-import-from-stdlib
         \\  --alipay-spmlint-use-labeled-spm=off Disable @alipay/spmLint/use-labeled-spm
         \\  --alipay-spmlint-valid-manual-click=off Disable @alipay/spmLint/valid-manual-click

--- a/src/rules/alipay_ant_prefer_resource_from_huamei.zig
+++ b/src/rules/alipay_ant_prefer_resource_from_huamei.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/prefer-resource-from-huamei";
+
+const allow_keywords = [_][]const u8{
+    "huamei",
+    "mars",
+    "marketing",
+    "/graph_jupiter/afts/img",
+    "fecodex_image",
+};
+
+pub fn checkStringLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.StringLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const value = tree.string(literal.value);
+    if (!isResourceUrl(value)) return;
+    if (hasAllowedKeyword(value)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "静态资源({s})推荐使用画眉平台进行上传使用(https://huamei.antgroup-inc.cn/my/space).",
+        .{value},
+    );
+}
+
+fn isResourceUrl(value: []const u8) bool {
+    if (!std.mem.startsWith(u8, value, "http://") and !std.mem.startsWith(u8, value, "https://")) return false;
+    return std.mem.indexOf(u8, value, "/afts/img") != null or
+        std.mem.indexOf(u8, value, ".png") != null or
+        std.mem.indexOf(u8, value, ".jpeg") != null or
+        std.mem.indexOf(u8, value, ".webp") != null or
+        std.mem.indexOf(u8, value, ".avif") != null;
+}
+
+fn hasAllowedKeyword(value: []const u8) bool {
+    for (allow_keywords) |keyword| {
+        if (std.mem.indexOf(u8, value, keyword) != null) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -38,6 +38,7 @@ pub const alipay_ant_prefer_catch_unsafe_func_call = @import("alipay_ant_prefer_
 pub const alipay_ant_prefer_click_with_debounce = @import("alipay_ant_prefer_click_with_debounce.zig");
 pub const alipay_ant_prefer_import_as_required = @import("alipay_ant_prefer_import_as_required.zig");
 pub const alipay_ant_no_spread_params = @import("alipay_ant_no_spread_params.zig");
+pub const alipay_ant_prefer_resource_from_huamei = @import("alipay_ant_prefer_resource_from_huamei.zig");
 pub const alipay_ant_prefer_import_from_stdlib = @import("alipay_ant_prefer_import_from_stdlib.zig");
 pub const alipay_spmlint_use_labeled_spm = @import("alipay_spmlint_use_labeled_spm.zig");
 pub const alipay_spmlint_valid_manual_click = @import("alipay_spmlint_valid_manual_click.zig");
@@ -1725,6 +1726,9 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_ant_disallow_typos) {
             try alipay_ant_disallow_typos.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.alipay_ant_prefer_resource_from_huamei) {
+            try alipay_ant_prefer_resource_from_huamei.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.no_useless_escape) {
             try no_useless_escape.checkStringLiteral(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -95,6 +95,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_prefer_resource_from_huamei.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_prefer_click_with_debounce.zig");
 }
 

--- a/tests/rules/alipay_ant_prefer_resource_from_huamei.zig
+++ b/tests/rules/alipay_ant_prefer_resource_from_huamei.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_prefer_resource_from_huamei = true;
+    return options;
+}
+
+test "reports @alipay/ant/prefer-resource-from-huamei for external resource urls" {
+    const source =
+        \\const png = "https://cdn.example.com/assets/banner.png";
+        \\const afts = "https://cdn.example.com/afts/img/abc";
+        \\const webp = "http://cdn.example.com/static/icon.webp?x=1";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.alipay_ant_prefer_resource_from_huamei.id));
+    try std.testing.expectEqualStrings(
+        "静态资源(https://cdn.example.com/assets/banner.png)推荐使用画眉平台进行上传使用(https://huamei.antgroup-inc.cn/my/space).",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "allows @alipay/ant/prefer-resource-from-huamei allowed keywords and non resource urls" {
+    const source =
+        \\const huamei = "https://huamei.example.com/assets/banner.png";
+        \\const mars = "https://cdn.example.com/mars/banner.png";
+        \\const graph = "https://gw.alipayobjects.com/graph_jupiter/afts/img/foo";
+        \\const jpg = "https://cdn.example.com/assets/banner.jpg";
+        \\const local = "/assets/banner.png";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_resource_from_huamei.id));
+}
+
+test "can disable @alipay/ant/prefer-resource-from-huamei" {
+    const source = "const png = \"https://cdn.example.com/assets/banner.png\";\n";
+    var options = optionsOnly();
+    options.alipay_ant_prefer_resource_from_huamei = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_prefer_resource_from_huamei.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/prefer-resource-from-huamei from the team fishlint config
- report external static resource URLs that are not covered by the default allow keywords
- add CLI toggle and focused parity tests

## Verification
- zig fmt src/rules/alipay_ant_prefer_resource_from_huamei.zig tests/rules/alipay_ant_prefer_resource_from_huamei.zig src/core.zig src/main.zig src/rules/root.zig tests/all.zig
- zig build test
- fishlint ESLint sample parity check
- zig build
- git diff --check