### PR TITLE
feat: port alipay no deprecated dependence

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -88,6 +88,8 @@ pub const Options = struct {
     alipay_ant_disallow_typos: bool = true,
     alipay_ant_exhaustive_deps: bool = true,
     alipay_ant_jsx_handler_names: bool = true,
+    alipay_ant_no_deprecated_dependence: bool = true,
+    alipay_ant_no_deprecated_dependence_profile: DeprecatedDependenceProfile = .default,
     alipay_ant_no_deprecated_variable: bool = true,
     alipay_ant_no_import_files_from_pages_in_common: bool = true,
     alipay_ant_no_negative_conditionals: bool = true,
@@ -390,6 +392,9 @@ pub const Options = struct {
     pub fn setByRuleConfigValue(self: *Options, cli_name: []const u8, value: std.json.Value) RuleConfigError!void {
         const enabled = try ruleConfigValueToBool(value);
         if (!self.setByCliName(cli_name, enabled)) return error.UnknownRule;
+        if (std.mem.eql(u8, cli_name, "@alipay/ant/no-deprecated-dependence")) {
+            self.alipay_ant_no_deprecated_dependence_profile = deprecatedDependenceProfileFromConfig(value);
+        }
     }
 
     pub const RuleConfigError = error{
@@ -429,6 +434,36 @@ pub const Options = struct {
         return null;
     }
 
+    fn deprecatedDependenceProfileFromConfig(value: std.json.Value) DeprecatedDependenceProfile {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .default,
+        };
+        if (items.len < 2) return .default;
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return .default,
+        };
+        const external_packages = switch (config.get("externalPackages") orelse return .default) {
+            .object => |object| object,
+            else => return .default,
+        };
+
+        if (external_packages.get("@alipay/dp-anyshare-react") != null or
+            external_packages.get("@alipay/yuyan-monitor-web") != null or
+            external_packages.get("moment") != null)
+        {
+            return .ivy;
+        }
+        if (external_packages.get("@alipay/one-bridge") != null or
+            external_packages.get("@alipay/bx-rpc") != null or
+            external_packages.get("hooxjs") != null)
+        {
+            return .insurance;
+        }
+        return .default;
+    }
+
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
         inline for (@typeInfo(Options).@"struct".fields) |field| {
             if (field.type == bool) {
@@ -464,6 +499,12 @@ pub const Options = struct {
         }
         return true;
     }
+};
+
+pub const DeprecatedDependenceProfile = enum {
+    default,
+    ivy,
+    insurance,
 };
 
 pub const Diagnostic = struct {
@@ -749,6 +790,26 @@ test "Options can apply ESLint-style rule config values" {
     try array.append(.{ .string = "warn" });
     try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
     try std.testing.expect(options.jsx_a11y_aria_props);
+
+    var ivy_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"externalPackages\":{\"moment\":\"dayjs\"}}]",
+        .{},
+    );
+    defer ivy_config.deinit();
+    try options.setByRuleConfigValue("@alipay/ant/no-deprecated-dependence", ivy_config.value);
+    try std.testing.expectEqual(DeprecatedDependenceProfile.ivy, options.alipay_ant_no_deprecated_dependence_profile);
+
+    var insurance_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"externalPackages\":{\"@alipay/one-bridge\":\"babyfish\"}}]",
+        .{},
+    );
+    defer insurance_config.deinit();
+    try options.setByRuleConfigValue("@alipay/ant/no-deprecated-dependence", insurance_config.value);
+    try std.testing.expectEqual(DeprecatedDependenceProfile.insurance, options.alipay_ant_no_deprecated_dependence_profile);
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -243,6 +243,8 @@ pub fn main(init: std.process.Init) !void {
             options.alipay_ant_exhaustive_deps = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-jsx-handler-names=off")) {
             options.alipay_ant_jsx_handler_names = false;
+        } else if (std.mem.eql(u8, arg, "--alipay-ant-no-deprecated-dependence=off")) {
+            options.alipay_ant_no_deprecated_dependence = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-deprecated-variable=off")) {
             options.alipay_ant_no_deprecated_variable = false;
         } else if (std.mem.eql(u8, arg, "--alipay-ant-no-import-files-from-pages-in-common=off")) {
@@ -1267,6 +1269,7 @@ fn printHelp() void {
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos
         \\  --alipay-ant-exhaustive-deps=off Disable @alipay/ant/exhaustive-deps
         \\  --alipay-ant-jsx-handler-names=off Disable @alipay/ant/jsx-handler-names
+        \\  --alipay-ant-no-deprecated-dependence=off Disable @alipay/ant/no-deprecated-dependence
         \\  --alipay-ant-no-deprecated-variable=off Disable @alipay/ant/no-deprecated-variable
         \\  --alipay-ant-no-import-files-from-pages-in-common=off Disable @alipay/ant/no-import-files-from-pages-in-common
         \\  --alipay-ant-no-negative-conditionals=off Disable @alipay/ant/no-negative-conditionals

--- a/src/rules/alipay_ant_no_deprecated_dependence.zig
+++ b/src/rules/alipay_ant_no_deprecated_dependence.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@alipay/ant/no-deprecated-dependence";
+
+const Dep = struct {
+    deprecated: []const u8,
+    recommend: []const u8,
+};
+
+const default_deps = [_]Dep{
+    .{ .deprecated = "@alipay/qiaozhi/utils", .recommend = "@alipay/shandie-utils" },
+    .{ .deprecated = "@alipay/ivy-utils", .recommend = "@alipay/shandie-utils" },
+    .{ .deprecated = "@alipay/qiaozhi/hooks", .recommend = "@alipay/shandie-hooks" },
+    .{ .deprecated = "@alipay/ivy-hooks", .recommend = "@alipay/shandie-hooks" },
+    .{ .deprecated = "@alipay/alipayjsapi", .recommend = "smallfish:jsapi" },
+};
+
+const ivy_deps = [_]Dep{
+    .{ .deprecated = "@alipay/dp-anyshare-react", .recommend = "jsapi easyShare(原依赖包已不维护，体积也较大)" },
+    .{ .deprecated = "@alipay/yuyan-monitor-web", .recommend = "window.yuyanMonitor(smallfish 框架下，html 会默认注入 yuyanMonitor 全局实例，无需安装额外依赖)" },
+    .{ .deprecated = "@alipay/anylog", .recommend = "window.Tracert(原依赖包已不维护)" },
+    .{ .deprecated = "@alipay/tracert", .recommend = "window.Tracert(smallfish 框架下，html 会默认注入 Tracert 全局实例，无需安装额外依赖)" },
+    .{ .deprecated = "moment", .recommend = "dayjs(原依赖包体积过大)" },
+    .{ .deprecated = "lodash", .recommend = "smallfish:stdlib/lodash 或 lodash-es" },
+};
+
+const insurance_deps = [_]Dep{
+    .{ .deprecated = "@alipay/one-bridge", .recommend = "babyfish" },
+    .{ .deprecated = "@alipay/insiop-comp-request", .recommend = "@smallfish:request/h5" },
+    .{ .deprecated = "@alipay/bx-util", .recommend = "@alipay/bx-utils-next" },
+    .{ .deprecated = "@alipay/bx-util-mp", .recommend = "@alipay/bx-utils-next" },
+    .{ .deprecated = "@alipay/bx-rpc", .recommend = "@smallfish:request/h5" },
+    .{ .deprecated = "@alipay/bx-react-hooks", .recommend = "ahooks" },
+    .{ .deprecated = "@alipay/bx-store", .recommend = "smallfish:stdlib/zustand" },
+    .{ .deprecated = "@alipay/bx-load", .recommend = "babyfish" },
+    .{ .deprecated = "hooxjs", .recommend = "smallfish:stdlib/zustand" },
+    .{ .deprecated = "@alipay/bx-mobile", .recommend = "antd-mobile" },
+    .{ .deprecated = "@alipay/bx-bikini", .recommend = "@alipay/bikini" },
+};
+
+pub fn checkImportDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    index: ast.NodeIndex,
+    profile: core.DeprecatedDependenceProfile,
+) Allocator.Error!void {
+    const source = importSource(tree, declaration) orelse return;
+    const dep = deprecatedDependency(source, profile) orelse return;
+    if (allSpecifiersWhitelisted(tree, declaration, dep.deprecated, profile)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "{s} 工具库不推荐使用，请使用 {s}",
+        .{ dep.deprecated, dep.recommend },
+    );
+}
+
+fn deprecatedDependency(source: []const u8, profile: core.DeprecatedDependenceProfile) ?Dep {
+    if (findDeprecated(source, &default_deps)) |dep| return dep;
+
+    switch (profile) {
+        .default => return null,
+        .ivy => return findDeprecated(source, &ivy_deps),
+        .insurance => return findDeprecated(source, &insurance_deps),
+    }
+}
+
+fn findDeprecated(source: []const u8, deps: []const Dep) ?Dep {
+    for (deps) |dep| {
+        if (std.mem.eql(u8, source, dep.deprecated)) return dep;
+        if (std.mem.startsWith(u8, source, dep.deprecated) and
+            source.len > dep.deprecated.len and
+            source[dep.deprecated.len] == '/')
+        {
+            return dep;
+        }
+    }
+    return null;
+}
+
+fn allSpecifiersWhitelisted(
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    deprecated_dep: []const u8,
+    profile: core.DeprecatedDependenceProfile,
+) bool {
+    const specifiers = tree.extra(declaration.specifiers);
+    if (specifiers.len == 0) return true;
+
+    for (specifiers) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .import_specifier => |specifier| specifier,
+            else => return false,
+        };
+        const name = importedName(tree, specifier.imported) orelse return false;
+        if (!isWhitelisted(deprecated_dep, name, profile)) return false;
+    }
+    return true;
+}
+
+fn isWhitelisted(deprecated_dep: []const u8, imported: []const u8, profile: core.DeprecatedDependenceProfile) bool {
+    return profile == .ivy and
+        std.mem.eql(u8, deprecated_dep, "@alipay/qiaozhi/utils") and
+        std.mem.eql(u8, imported, "AError");
+}
+
+fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
+    return stringLiteralValue(tree, declaration.source);
+}
+
+fn importedName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -27,6 +27,7 @@ pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
+pub const alipay_ant_no_deprecated_dependence = @import("alipay_ant_no_deprecated_dependence.zig");
 pub const alipay_ant_no_deprecated_variable = @import("alipay_ant_no_deprecated_variable.zig");
 pub const alipay_ant_no_import_files_from_pages_in_common = @import("alipay_ant_no_import_files_from_pages_in_common.zig");
 pub const alipay_ant_no_negative_conditionals = @import("alipay_ant_no_negative_conditionals.zig");
@@ -1007,6 +1008,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.alipay_ant_prefer_import_as_required) {
             try alipay_ant_prefer_import_as_required.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        if (self.options.alipay_ant_no_deprecated_dependence) {
+            try alipay_ant_no_deprecated_dependence.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.options.alipay_ant_no_deprecated_dependence_profile);
         }
         if (self.options.alipay_ant_no_import_files_from_pages_in_common) {
             try alipay_ant_no_import_files_from_pages_in_common.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.file_path);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -103,6 +103,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/alipay_ant_no_deprecated_dependence.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_prefer_click_with_debounce.zig");
 }
 

--- a/tests/rules/alipay_ant_no_deprecated_dependence.zig
+++ b/tests/rules/alipay_ant_no_deprecated_dependence.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.alipay_ant_no_deprecated_dependence = true;
+    return options;
+}
+
+test "reports @alipay/ant/no-deprecated-dependence for default deprecated imports" {
+    const source =
+        \\import { foo } from "@alipay/qiaozhi/utils";
+        \\import hooks from "@alipay/ivy-hooks/useFoo";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_no_deprecated_dependence.id));
+    try std.testing.expectEqualStrings("@alipay/qiaozhi/utils 工具库不推荐使用，请使用 @alipay/shandie-utils", result.diagnostics[0].message);
+    try std.testing.expectEqual(.@"error", result.diagnostics[0].severity);
+}
+
+test "matches fishlint side-effect-only skip for @alipay/ant/no-deprecated-dependence" {
+    const source = "import \"@alipay/qiaozhi/utils\";\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_deprecated_dependence.id));
+}
+
+test "supports ivy @alipay/ant/no-deprecated-dependence packages and whitelist" {
+    const source =
+        \\import { AError as AErrorAlias } from "@alipay/qiaozhi/utils";
+        \\import { Other } from "@alipay/qiaozhi/utils";
+        \\import moment from "moment";
+    ;
+    var options = optionsOnly();
+    options.alipay_ant_no_deprecated_dependence_profile = .ivy;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_no_deprecated_dependence.id));
+    try std.testing.expectEqualStrings("@alipay/qiaozhi/utils 工具库不推荐使用，请使用 @alipay/shandie-utils", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("moment 工具库不推荐使用，请使用 dayjs(原依赖包体积过大)", result.diagnostics[1].message);
+}
+
+test "supports insurance @alipay/ant/no-deprecated-dependence packages" {
+    const source =
+        \\import bridge from "@alipay/one-bridge";
+        \\import { request } from "@alipay/bx-rpc/path";
+    ;
+    var options = optionsOnly();
+    options.alipay_ant_no_deprecated_dependence_profile = .insurance;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_no_deprecated_dependence.id));
+    try std.testing.expectEqualStrings("@alipay/one-bridge 工具库不推荐使用，请使用 babyfish", result.diagnostics[0].message);
+}
+
+test "can disable @alipay/ant/no-deprecated-dependence" {
+    const source = "import { foo } from \"@alipay/qiaozhi/utils\";\n";
+    var options = optionsOnly();
+    options.alipay_ant_no_deprecated_dependence = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_no_deprecated_dependence.id));
+}


### PR DESCRIPTION
## Summary
- port @alipay/ant/no-deprecated-dependence import checks
- support default, ivy, and insurance fishlint package profiles
- add CLI disable flag and focused tests

## Verification
- zig build test
- zig build
- git diff --check