### PR TITLE
feat: port eslint comments no restricted disable

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,8 @@ pub const Options = struct {
     default_case: bool = true,
     default_case_last: bool = true,
     eol_last: bool = true,
+    eslint_comments_no_restricted_disable: bool = true,
+    eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,
     for_direction: bool = true,
     getter_return: bool = true,
     guard_for_in: bool = true,
@@ -360,6 +362,10 @@ pub const Options = struct {
             return self.setByPrefixedRuleName("import_", cli_name["import/".len..], value);
         }
 
+        if (std.mem.startsWith(u8, cli_name, "eslint-comments/")) {
+            return self.setByPrefixedRuleName("eslint_comments_", cli_name["eslint-comments/".len..], value);
+        }
+
         if (std.mem.startsWith(u8, cli_name, "@alipay/ant/")) {
             return self.setByPrefixedRuleName("alipay_ant_", cli_name["@alipay/ant/".len..], value);
         }
@@ -394,6 +400,9 @@ pub const Options = struct {
         if (!self.setByCliName(cli_name, enabled)) return error.UnknownRule;
         if (std.mem.eql(u8, cli_name, "@alipay/ant/no-deprecated-dependence")) {
             self.alipay_ant_no_deprecated_dependence_profile = deprecatedDependenceProfileFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
+            self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
     }
 
@@ -462,6 +471,22 @@ pub const Options = struct {
             return .insurance;
         }
         return .default;
+    }
+
+    fn noRestrictedDisableRestrictsNoNestedTernary(value: std.json.Value) bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+        for (items[1..]) |item| {
+            const rule = switch (item) {
+                .string => |rule| rule,
+                else => continue,
+            };
+            if (std.mem.eql(u8, rule, "no-nested-ternary")) return true;
+        }
+        return false;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -810,6 +835,17 @@ test "Options can apply ESLint-style rule config values" {
     defer insurance_config.deinit();
     try options.setByRuleConfigValue("@alipay/ant/no-deprecated-dependence", insurance_config.value);
     try std.testing.expectEqual(DeprecatedDependenceProfile.insurance, options.alipay_ant_no_deprecated_dependence_profile);
+
+    var restricted_disable_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"warn\",\"no-nested-ternary\"]",
+        .{},
+    );
+    defer restricted_disable_config.deinit();
+    try options.setByRuleConfigValue("eslint-comments/no-restricted-disable", restricted_disable_config.value);
+    try std.testing.expect(options.eslint_comments_no_restricted_disable);
+    try std.testing.expect(options.eslint_comments_no_restricted_disable_no_nested_ternary);
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -121,6 +121,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case_last = false;
         } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
             options.eol_last = false;
+        } else if (std.mem.eql(u8, arg, "--eslint-comments-no-restricted-disable=off")) {
+            options.eslint_comments_no_restricted_disable = false;
         } else if (std.mem.eql(u8, arg, "--for-direction=off")) {
             options.for_direction = false;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
@@ -1208,6 +1210,7 @@ fn printHelp() void {
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
         \\  --eol-last=off            Disable eol-last
+        \\  --eslint-comments-no-restricted-disable=off Disable eslint-comments/no-restricted-disable
         \\  --for-direction=off       Disable for-direction
         \\  --getter-return=off       Disable getter-return
         \\  --guard-for-in=off        Disable guard-for-in

--- a/src/rules/eslint_comments_no_restricted_disable.zig
+++ b/src/rules/eslint_comments_no_restricted_disable.zig
@@ -1,0 +1,92 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "eslint-comments/no-restricted-disable";
+
+const restricted_rule = "no-nested-ternary";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    restrict_no_nested_ternary: bool,
+) Allocator.Error!void {
+    if (!restrict_no_nested_ternary) return;
+
+    for (tree.comments) |comment| {
+        if (!disablesRestrictedRule(tree.string(comment.value))) continue;
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Disabling 'no-nested-ternary' is not allowed.",
+            .{ .start = comment.start, .end = comment.end },
+        );
+    }
+}
+
+fn disablesRestrictedRule(comment: []const u8) bool {
+    const trimmed = trimLeftWhitespace(comment);
+    const tail = disableDirectiveTail(trimmed) orelse return false;
+    const rules = trimDescription(trimWhitespace(tail));
+    if (rules.len == 0) return true;
+
+    var cursor: usize = 0;
+    while (cursor < rules.len) {
+        while (cursor < rules.len and isRuleSeparator(rules[cursor])) : (cursor += 1) {}
+        const start = cursor;
+        while (cursor < rules.len and !isRuleSeparator(rules[cursor])) : (cursor += 1) {}
+        if (start < cursor and std.mem.eql(u8, rules[start..cursor], restricted_rule)) return true;
+    }
+    return false;
+}
+
+fn disableDirectiveTail(value: []const u8) ?[]const u8 {
+    const directives = [_][]const u8{
+        "eslint-disable-next-line",
+        "eslint-disable-line",
+        "eslint-disable",
+    };
+
+    for (directives) |directive| {
+        if (!std.mem.startsWith(u8, value, directive)) continue;
+        if (value.len == directive.len) return value[directive.len..];
+        if (isWhitespace(value[directive.len])) return value[directive.len..];
+    }
+    return null;
+}
+
+fn trimDescription(value: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, value, "--")) return "";
+    if (std.mem.indexOf(u8, value, " -- ")) |index| return trimWhitespace(value[0..index]);
+    return value;
+}
+
+fn trimWhitespace(value: []const u8) []const u8 {
+    return trimRightWhitespace(trimLeftWhitespace(value));
+}
+
+fn trimLeftWhitespace(value: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index < value.len and isWhitespace(value[index])) : (index += 1) {}
+    return value[index..];
+}
+
+fn trimRightWhitespace(value: []const u8) []const u8 {
+    var end = value.len;
+    while (end > 0 and isWhitespace(value[end - 1])) : (end -= 1) {}
+    return value[0..end];
+}
+
+fn isRuleSeparator(char: u8) bool {
+    return char == ',' or isWhitespace(char);
+}
+
+fn isWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -21,6 +21,7 @@ pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
+pub const eslint_comments_no_restricted_disable = @import("eslint_comments_no_restricted_disable.zig");
 pub const for_direction = @import("for_direction.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
@@ -333,6 +334,9 @@ pub fn runBasic(
     }
     if (options.eol_last) {
         try eol_last.run(allocator, diagnostics, tree);
+    }
+    if (options.eslint_comments_no_restricted_disable) {
+        try eslint_comments_no_restricted_disable.run(allocator, diagnostics, tree, options.eslint_comments_no_restricted_disable_no_nested_ternary);
     }
     if (options.unicode_bom) {
         try unicode_bom.run(allocator, diagnostics, tree);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -31,6 +31,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/eslint_comments_no_restricted_disable.zig");
+}
+
+comptime {
     _ = @import("rules/for_direction.zig");
 }
 

--- a/tests/rules/eslint_comments_no_restricted_disable.zig
+++ b/tests/rules/eslint_comments_no_restricted_disable.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.eslint_comments_no_restricted_disable = true;
+    options.eslint_comments_no_restricted_disable_no_nested_ternary = true;
+    return options;
+}
+
+test "reports eslint-comments/no-restricted-disable for restricted disable comments" {
+    const source =
+        \\/* eslint-disable no-nested-ternary */
+        \\// eslint-disable-next-line no-console, no-nested-ternary
+        \\const value = foo ? bar ? 1 : 2 : 3;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.eslint_comments_no_restricted_disable.id));
+    try std.testing.expectEqualStrings("Disabling 'no-nested-ternary' is not allowed.", result.diagnostics[0].message);
+    try std.testing.expectEqual(.warning, result.diagnostics[0].severity);
+}
+
+test "reports eslint-comments/no-restricted-disable for disable all comments" {
+    const source =
+        \\// eslint-disable-next-line -- reason
+        \\const value = foo ? bar ? 1 : 2 : 3;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.eslint_comments_no_restricted_disable.id));
+}
+
+test "allows eslint-comments/no-restricted-disable for unrestricted comments" {
+    const source =
+        \\/* eslint-disable no-console */
+        \\// eslint-enable no-nested-ternary
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.eslint_comments_no_restricted_disable.id));
+}
+
+test "can disable eslint-comments/no-restricted-disable" {
+    const source = "/* eslint-disable no-nested-ternary */\n";
+    var options = optionsOnly();
+    options.eslint_comments_no_restricted_disable = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.eslint_comments_no_restricted_disable.id));
+}


### PR DESCRIPTION
## Summary
- port eslint-comments/no-restricted-disable for no-nested-ternary disables
- wire config option parsing for the fishlint ivy rule shape
- add CLI disable flag and focused comment tests

## Verification
- zig build test
- zig build
- git diff --check