### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,153 @@
+# Contributing
+
+This guide covers local development, rule implementation, packaging, benchmark
+charts, and publishing for `utoo-lint`.
+
+## Prerequisites
+
+Yuku currently tracks Zig nightly. Use a Zig version compatible with the
+vendored Yuku commit:
+
+```bash
+zig version
+```
+
+The vendored Yuku `build.zig.zon` currently asks for
+`0.17.0-dev.224+c166c49b1` or newer.
+
+Initialize submodules before building:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Development
+
+Run the test suite:
+
+```bash
+zig build test -Doptimize=ReleaseFast -j1
+```
+
+Build the CLI:
+
+```bash
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/utoo-lint src test
+```
+
+Run the CLI against the fixture:
+
+```bash
+zig build run -Doptimize=ReleaseFast -j1 -- test/fixtures/bad.ts
+```
+
+## Adding a Rule
+
+Add a new file under `src/rules`, then register it in `src/rules/root.zig`.
+
+For a structural rule, add a check function in the rule file and call it from
+the matching visitor hook in `BasicVisitor`.
+
+For a scope or symbol rule, add a `run` function in the rule file and call it
+from `runSemantic`.
+
+Add focused tests under `tests/rules`, then include the test module from
+`tests/all.zig`.
+
+## Benchmarks
+
+The benchmark workspace compares the local `utoo-lint` binary with Oxlint,
+Biome, and ESLint on a generated TypeScript corpus using a shared rule set.
+
+```bash
+zig build -Doptimize=ReleaseFast
+cd benchmarks
+npm install
+npm run generate
+npm run bench
+```
+
+The benchmark runner writes machine-readable results to
+`benchmarks/results/latest.json`.
+
+Render a shareable chart from the latest benchmark results:
+
+```bash
+cd benchmarks
+npm run chart
+```
+
+`benchmarks/results` is ignored by git, so generated charts do not need to be
+cleaned up before committing.
+
+## Packaging
+
+Build and stage the npm CLI packages:
+
+```bash
+./scripts/package-npm.sh
+node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts
+```
+
+Local npm install test:
+
+```bash
+npm install -g ./npm/@utoo/lint-darwin-arm64
+npm install -g ./npm/utoo-lint
+utoo-lint test/fixtures/bad.ts
+```
+
+The npm package layout is:
+
+- `npm/utoo-lint` is the public CLI wrapper published as `@utoo/lint`.
+- `npm/@utoo/lint-darwin-arm64` is published as
+  `@utoo/lint-darwin-arm64`.
+- `npm/@utoo/lint-darwin-x64` is published as `@utoo/lint-darwin-x64`.
+- `npm/@utoo/lint-linux-arm64` is published as `@utoo/lint-linux-arm64`.
+- `npm/@utoo/lint-linux-x64` is published as `@utoo/lint-linux-x64`.
+- `npm/@utoo/lint-win32-x64` is published as `@utoo/lint-win32-x64`.
+
+## Publishing
+
+GitHub Releases publish binary archives for:
+
+- `utoo-lint-darwin-arm64.tar.gz`
+- `utoo-lint-darwin-x64.tar.gz`
+- `utoo-lint-linux-arm64.tar.gz`
+- `utoo-lint-linux-x64.tar.gz`
+- `utoo-lint-windows-x64.zip`
+
+Each archive is uploaded with a matching `.sha256` file.
+
+The release workflow builds all release archives, stages all native npm
+packages from the same binaries, uploads the archives to the GitHub Release,
+and publishes the native packages before the CLI wrapper.
+
+Required GitHub repository secret:
+
+```text
+NPM_TOKEN
+```
+
+Create it from npm as an automation token, then add it in GitHub under
+`Settings -> Secrets and variables -> Actions`.
+
+Publish from GitHub:
+
+1. Create a new GitHub Release whose tag starts with `v`, for example `v0.1.0`.
+2. Publish the release.
+
+The release workflow updates npm package versions from the release tag and
+publishes the npm packages.
+
+For a manual run, open the `Release` workflow in GitHub Actions and set
+`release_tag` to a `v`-prefixed tag. Enable `publish_npm` when the npm packages
+should be published.
+
+After the workflow succeeds:
+
+```bash
+npm install -g @utoo/lint
+utoo-lint test/fixtures/bad.ts
+```

--- a/README.md
+++ b/README.md
@@ -3,103 +3,34 @@
 ![utoo-lint logo](assets/utoo-lint-logo.svg)
 
 `@utoo/lint` is an experimental JavaScript and TypeScript linter written in Zig.
-It uses [`yuku`](https://github.com/yuku-toolchain/yuku) (GitHub: https://github.com/yuku-toolchain/yuku) for parsing, AST traversal, scope tracking, and symbol resolution.
+It uses [`yuku`](https://github.com/yuku-toolchain/yuku) for parsing, AST
+traversal, scope tracking, and symbol resolution.
 
 ## Status
 
 This repo is a working scaffold, not a production linter yet.
 
-See [Rule status](docs/rule-status.md) for the current rule list and the corresponding ESLint documentation links.
-See [Configuration](docs/configuration.md) for `utoo.json` files that can be used in frontend projects.
-See [Migrating from ESLint](docs/eslint-migration.md) for the current migration path.
+Useful docs:
 
-## Prerequisites
+- [Rule status](docs/rule-status.md) lists implemented rules and their ESLint
+  documentation links.
+- [Configuration](docs/configuration.md) describes `utoo.json` files for
+  frontend projects.
+- [Migrating from ESLint](docs/eslint-migration.md) covers the current migration
+  path.
+- [Contributing](CONTRIBUTING.md) covers local development, rule work,
+  packaging, and publishing.
 
-Yuku currently tracks Zig nightly. Use a Zig version compatible with the vendored Yuku commit:
-
-```bash
-zig version
-```
-
-The vendored Yuku `build.zig.zon` currently asks for `0.17.0-dev.224+c166c49b1` or newer.
-
-## Setup
+## Install
 
 ```bash
-git submodule update --init --recursive
-zig build test -Doptimize=ReleaseFast -j1
-zig build run -Doptimize=ReleaseFast -j1 -- test/fixtures/bad.ts
+npm install -D @utoo/lint
 ```
 
-Build the binary:
+Run it with:
 
 ```bash
-zig build -Doptimize=ReleaseFast
-./zig-out/bin/utoo-lint src test
-```
-
-Build and stage the npm CLI packages:
-
-```bash
-./scripts/package-npm.sh
-node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts
-```
-
-Local npm install test:
-
-```bash
-npm install -g ./npm/@utoo/lint-darwin-arm64
-npm install -g ./npm/utoo-lint
-utoo-lint test/fixtures/bad.ts
-```
-
-## Publishing
-
-GitHub Releases publish binary archives for:
-
-- `utoo-lint-darwin-arm64.tar.gz`
-- `utoo-lint-darwin-x64.tar.gz`
-- `utoo-lint-linux-arm64.tar.gz`
-- `utoo-lint-linux-x64.tar.gz`
-- `utoo-lint-windows-x64.zip`
-
-Each archive is uploaded with a matching `.sha256` file.
-
-The npm publishing setup supports the same native platforms:
-
-- `npm/utoo-lint` is the public CLI wrapper published as `@utoo/lint`.
-- `npm/@utoo/lint-darwin-arm64` is published as `@utoo/lint-darwin-arm64`.
-- `npm/@utoo/lint-darwin-x64` is published as `@utoo/lint-darwin-x64`.
-- `npm/@utoo/lint-linux-arm64` is published as `@utoo/lint-linux-arm64`.
-- `npm/@utoo/lint-linux-x64` is published as `@utoo/lint-linux-x64`.
-- `npm/@utoo/lint-win32-x64` is published as `@utoo/lint-win32-x64`.
-- `.github/workflows/release.yml` builds all release archives, stages all native npm packages from the same binaries, uploads the archives to the GitHub Release, and publishes the native packages before the CLI wrapper.
-
-Required GitHub repository secret:
-
-```text
-NPM_TOKEN
-```
-
-Create it from npm as an automation token, then add it in GitHub under `Settings -> Secrets and variables -> Actions`.
-
-Publish from GitHub:
-
-1. Create a new GitHub Release whose tag starts with `v`, for example `v0.1.0`.
-2. Publish the release.
-
-The release workflow builds the binary archives, uploads them to the GitHub Release,
-updates the npm package versions from the release tag, and publishes the npm packages.
-
-For a manual run, open the `Release` workflow in GitHub Actions and set
-`release_tag` to a `v`-prefixed tag. Enable `publish_npm` when the npm packages
-should be published.
-
-After the workflow succeeds:
-
-```bash
-npm install -g @utoo/lint
-utoo-lint test/fixtures/bad.ts
+npx utoo-lint src
 ```
 
 ## CLI
@@ -108,9 +39,39 @@ utoo-lint test/fixtures/bad.ts
 utoo-lint [options] [file-or-directory ...]
 ```
 
-If no target is provided, `utoo-lint` scans the current directory. It skips `.git`, `.zig-cache`, `node_modules`, `vendor`, and `zig-out`.
+If no target is provided, `utoo-lint` scans the current directory. It skips
+`.git`, `.zig-cache`, `node_modules`, `vendor`, and `zig-out`.
 
-Configuration files:
+Start a frontend project from the packaged template:
+
+```bash
+cp node_modules/@utoo/lint/configs/frontend.json utoo.json
+npx utoo-lint src
+```
+
+Run only a focused rule set:
+
+```bash
+utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
+```
+
+Disable a rule from the command line:
+
+```bash
+utoo-lint --no-console=off src
+```
+
+Use machine-readable output:
+
+```bash
+utoo-lint --format=json src
+```
+
+## Configuration
+
+By default, `utoo-lint` reads `utoo.json` or `utoo-lint.json` from the current
+directory. Use `--config=path/to/utoo.json` for an explicit file or
+`--no-config` to ignore local config.
 
 ```json
 {
@@ -123,34 +84,10 @@ Configuration files:
 }
 ```
 
-By default, `utoo-lint` reads `utoo.json` or `utoo-lint.json` from the current directory. Use `--config=path/to/utoo.json` for an explicit file or `--no-config` to ignore local config. Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an ESLint-style array whose first item is the severity.
+Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an
+ESLint-style array whose first item is the severity.
 
-Start a frontend project from the packaged template:
-
-```bash
-cp node_modules/@utoo/lint/configs/frontend.json utoo.json
-npx utoo-lint src
-```
-
-Rule toggles:
-
-```bash
-utoo-lint --no-console=off --no-unused-vars=off src
-```
-
-Run only a focused rule set:
-
-```bash
-utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
-```
-
-Machine-readable output:
-
-```bash
-utoo-lint --format=json src
-```
-
-JavaScript API:
+## JavaScript API
 
 ```js
 import { lintFiles } from "@utoo/lint";
@@ -170,12 +107,6 @@ const report = lintFiles(["src"], {
 - `src/main.zig` owns CLI argument parsing, file discovery, and terminal output.
 - `vendor/yuku` is pinned as a git submodule so the parser API is reproducible.
 
-The current rule engine deliberately uses Yuku's native flat AST and semantic traverser instead of converting to ESTree. That keeps the first version small and avoids a JS runtime dependency.
-
-## Adding a Rule
-
-Add a new file under `src/rules`, then register it in `src/rules/root.zig`.
-
-For a structural rule, add a check function in the rule file and call it from the matching visitor hook in `BasicVisitor`.
-
-For a scope/symbol rule, add a `run` function in the rule file and call it from `runSemantic`.
+The current rule engine deliberately uses Yuku's native flat AST and semantic
+traverser instead of converting to ESTree. That keeps the first version small
+and avoids a JS runtime dependency.


### PR DESCRIPTION
## Summary

- Rework the README into a user-facing project overview with install, CLI, config, API, and architecture sections.
- Add `CONTRIBUTING.md` for local development, adding rules, benchmarks, packaging, and publishing.
- Move release and npm publishing details out of the README.

## Validation

- Not run; docs-only change.
