### PR TITLE
feat: add eslint-compatible js api

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -94,3 +94,36 @@ npx utoo-lint --config=utoo.json src test
 ```
 
 Once diagnostics match your expectations, replace the ESLint job for that rule set or keep both while expanding rule coverage.
+
+## Replace ESLint API Calls
+
+For scripts that already use ESLint's Node API, import `ESLint` from `@utoo/lint`
+and keep the high-level call shape:
+
+```js
+import { ESLint } from "@utoo/lint";
+
+const eslint = new ESLint({
+  useEslintrc: false,
+  overrideConfig: {
+    rules: {
+      "no-debugger": "warn",
+      "no-console": "warn"
+    }
+  }
+});
+
+const results = await eslint.lintFiles(["src"]);
+const formatter = await eslint.loadFormatter("stylish");
+console.log(formatter.format(results));
+```
+
+`ESLint#lintText()` is also supported. It writes the text to a temporary file and
+maps diagnostics back to the provided `filePath`, which is useful for editor,
+pre-commit, and codemod integrations:
+
+```js
+const [result] = await eslint.lintText("debugger;\n", {
+  filePath: "inline.js"
+});
+```

--- a/npm/README.md
+++ b/npm/README.md
@@ -12,7 +12,7 @@ This directory contains the npm CLI wrapper for `@utoo/lint` and the native plat
 The CLI package also exposes a small ESM API:
 
 ```js
-import { lintFiles, resolveBinary, run } from "@utoo/lint";
+import { ESLint, lintFiles, lintText, resolveBinary, run } from "@utoo/lint";
 
 const report = lintFiles(["src", "test"], {
   config: "utoo.json",
@@ -22,10 +22,30 @@ const report = lintFiles(["src", "test"], {
 console.log(report.diagnostics);
 console.log(resolveBinary());
 console.log(run(["--help"]).stdout);
+
+const textReport = lintText("debugger;\n", {
+  filePath: "inline.js",
+  rules: ["no-debugger"]
+});
+console.log(textReport.diagnostics);
+
+const eslint = new ESLint({
+  useEslintrc: false,
+  overrideConfig: {
+    rules: {
+      "no-debugger": "warn"
+    }
+  }
+});
+const results = await eslint.lintText("debugger;\n", { filePath: "inline.js" });
+console.log(results[0].messages);
 ```
 
-`lintFiles()` returns `{ files, diagnostics, exitCode }`. Each diagnostic includes
-`filePath`, `line`, `column`, `severity`, `message`, and `ruleId`. Set
+`lintFiles()` and `lintText()` return `{ files, diagnostics, exitCode }`. Each
+diagnostic includes `filePath`, `line`, `column`, `severity`, `message`, and
+`ruleId`. The `ESLint` export is an alias for `UtooLint` and supports the common
+`lintFiles()`, `lintText()`, `loadFormatter()`, `isPathIgnored()`, and
+`calculateConfigForFile()` methods for low-friction replacements. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1,8 +1,57 @@
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
 
 import { resolveBinary } from "./lib/binary.js";
 
 export { platformPackageName, resolveBinary } from "./lib/binary.js";
+
+export class UtooLint {
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  async lintFiles(patterns = ["."], options = {}) {
+    const report = lintFiles(patterns, mergeLintOptions(this.options, options));
+    return reportToESLintResults(report);
+  }
+
+  async lintText(code, options = {}) {
+    if (typeof code !== "string") {
+      throw new TypeError("code must be a string");
+    }
+
+    const report = lintText(code, mergeLintOptions(this.options, options));
+    return reportToESLintResults(report, {
+      source: code,
+      filePath: options.filePath ?? "<text>"
+    });
+  }
+
+  async isPathIgnored() {
+    return false;
+  }
+
+  async calculateConfigForFile() {
+    return {
+      rules: this.options.overrideConfig?.rules ?? {}
+    };
+  }
+
+  async loadFormatter(name = "stylish") {
+    return {
+      format(results) {
+        if (name === "json") {
+          return JSON.stringify(results);
+        }
+        return formatESLintResults(results);
+      }
+    };
+  }
+}
+
+export { UtooLint as ESLint };
 
 export function run(args = [], options = {}) {
   const cliArgs = normalizeStringArray(args, "args");
@@ -18,37 +67,66 @@ export function run(args = [], options = {}) {
 }
 
 export function lintFiles(paths = ["."], options = {}) {
-  const cliArgs = buildLintArgs(paths, options);
-  const result = run(cliArgs, { ...options, stdio: undefined, encoding: "utf8" });
+  return withTemporaryConfig(options, (resolvedOptions) => {
+    const cliArgs = buildLintArgs(paths, resolvedOptions);
+    const result = run(cliArgs, { ...resolvedOptions, stdio: undefined, encoding: "utf8" });
 
-  if (result.error) {
-    throw result.error;
+    if (result.error) {
+      throw result.error;
+    }
+
+    const status = result.status ?? 1;
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+
+    if (status !== 0 && status !== 1) {
+      throw new Error(stderr.trim() || `utoo-lint exited with status ${status}`);
+    }
+
+    let report;
+    try {
+      report = JSON.parse(stdout);
+    } catch (error) {
+      throw new Error(`utoo-lint returned invalid JSON: ${error.message}`);
+    }
+
+    report.exitCode = status;
+    if (stderr) {
+      Object.defineProperty(report, "stderr", {
+        value: stderr,
+        enumerable: false
+      });
+    }
+
+    return report;
+  });
+}
+
+export function lintText(code, options = {}) {
+  if (typeof code !== "string") {
+    throw new TypeError("code must be a string");
   }
 
-  const status = result.status ?? 1;
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
+  const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-"));
+  const requestedPath = options.filePath ?? "text.js";
+  const extension = extname(requestedPath) || ".js";
+  const tempFile = join(tmp, `input${extension}`);
 
-  if (status !== 0 && status !== 1) {
-    throw new Error(stderr.trim() || `utoo-lint exited with status ${status}`);
-  }
-
-  let report;
   try {
-    report = JSON.parse(stdout);
-  } catch (error) {
-    throw new Error(`utoo-lint returned invalid JSON: ${error.message}`);
-  }
-
-  report.exitCode = status;
-  if (stderr) {
-    Object.defineProperty(report, "stderr", {
-      value: stderr,
-      enumerable: false
+    writeFileSync(tempFile, code);
+    const report = lintFiles([tempFile], {
+      ...options,
+      cwd: options.cwd,
+      noConfig: options.noConfig ?? !(options.config || options.overrideConfig)
     });
+    report.diagnostics = report.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      filePath: requestedPath
+    }));
+    return report;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
   }
-
-  return report;
 }
 
 function buildLintArgs(paths, options) {
@@ -78,6 +156,81 @@ function buildLintArgs(paths, options) {
   return cliArgs;
 }
 
+function mergeLintOptions(base, override) {
+  return {
+    ...eslintConstructorOptions(base),
+    ...override
+  };
+}
+
+function eslintConstructorOptions(options) {
+  const mapped = {
+    cwd: options.cwd,
+    threads: options.threads,
+    binary: options.binary,
+    env: options.env,
+    extraArgs: options.extraArgs
+  };
+
+  if (options.useEslintrc === false || options.overrideConfigFile === true) {
+    mapped.noConfig = true;
+  }
+  if (typeof options.overrideConfigFile === "string") {
+    mapped.config = options.overrideConfigFile;
+  }
+  if (options.overrideConfig?.rules) {
+    mapped.overrideConfig = { rules: options.overrideConfig.rules };
+  }
+  return mapped;
+}
+
+function withTemporaryConfig(options, callback) {
+  if (!options.overrideConfig?.rules) {
+    return callback(options);
+  }
+
+  const enabledRules = enabledRuleNames(options.overrideConfig.rules);
+  if (!hasRuleOptions(options.overrideConfig.rules)) {
+    return callback({
+      ...options,
+      noConfig: options.noConfig ?? true,
+      rules: options.rules ?? enabledRules
+    });
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
+  const configPath = join(tmp, "utoo.json");
+  try {
+    writeFileSync(configPath, JSON.stringify({ rules: options.overrideConfig.rules }));
+    return callback({
+      ...options,
+      config: options.config ?? configPath,
+      noConfig: false
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function enabledRuleNames(rules) {
+  return Object.entries(rules)
+    .filter(([, value]) => ruleConfigIsEnabled(value))
+    .map(([rule]) => rule);
+}
+
+function hasRuleOptions(rules) {
+  return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+}
+
+function ruleConfigIsEnabled(value) {
+  const severity = Array.isArray(value) ? value[0] : value;
+  if (severity === false || severity === 0) return false;
+  if (typeof severity === "string") {
+    return !["off", "0"].includes(severity.toLowerCase());
+  }
+  return true;
+}
+
 function normalizeStringArray(values, name) {
   if (!Array.isArray(values)) {
     throw new TypeError(`${name} must be an array of strings`);
@@ -88,4 +241,89 @@ function normalizeStringArray(values, name) {
     }
   }
   return values;
+}
+
+function reportToESLintResults(report, textOptions = {}) {
+  const byFile = new Map();
+
+  for (const diagnostic of report.diagnostics ?? []) {
+    const filePath = textOptions.filePath ?? diagnostic.filePath;
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic));
+  }
+
+  if (textOptions.filePath && !byFile.has(textOptions.filePath)) {
+    byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
+  }
+
+  for (const result of byFile.values()) {
+    finalizeESLintResult(result);
+  }
+
+  return [...byFile.values()];
+}
+
+function emptyESLintResult(filePath, source) {
+  const result = {
+    filePath,
+    messages: [],
+    suppressedMessages: [],
+    errorCount: 0,
+    fatalErrorCount: 0,
+    warningCount: 0,
+    fixableErrorCount: 0,
+    fixableWarningCount: 0,
+    usedDeprecatedRules: []
+  };
+  if (source != null) {
+    result.source = source;
+  }
+  return result;
+}
+
+function diagnosticToESLintMessage(diagnostic) {
+  return {
+    ruleId: diagnostic.ruleId,
+    severity: diagnostic.severity === "error" ? 2 : 1,
+    message: diagnostic.message,
+    line: diagnostic.line,
+    column: diagnostic.column,
+    nodeType: null
+  };
+}
+
+function finalizeESLintResult(result) {
+  for (const message of result.messages) {
+    if (message.severity === 2) {
+      result.errorCount += 1;
+    } else {
+      result.warningCount += 1;
+    }
+  }
+}
+
+function formatESLintResults(results) {
+  const lines = [];
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const result of results) {
+    if (result.messages.length === 0) continue;
+    lines.push(result.filePath);
+    for (const message of result.messages) {
+      const severity = message.severity === 2 ? "error" : "warning";
+      lines.push(`  ${message.line}:${message.column}  ${severity}  ${message.message}  ${message.ruleId}`);
+    }
+    errorCount += result.errorCount;
+    warningCount += result.warningCount;
+  }
+
+  if (errorCount || warningCount) {
+    lines.push("");
+    lines.push(`x ${errorCount + warningCount} problem${errorCount + warningCount === 1 ? "" : "s"} (${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"})`);
+  }
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- add UtooLint and ESLint JS API exports with lintFiles, lintText, formatter, config helpers
- add raw lintText() helper backed by temporary files for editor/pre-commit integrations
- document ESLint API replacement path and npm wrapper usage

## Verification
- node --check npm/utoo-lint/index.js
- UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node --input-type=module <API smoke script>
- zig build test
- zig build
- git diff --check
