### PR TITLE
feat: add fishlint compat js entry

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -95,6 +95,20 @@ npx utoo-lint --config=utoo.json src test
 
 Once diagnostics match your expectations, replace the ESLint job for that rule set or keep both while expanding rule coverage.
 
+## Replace Fishlint Commands
+
+`@utoo/lint` installs a `fishlint` compatibility command for scripts that already
+call the eslint subcommand:
+
+```bash
+npx fishlint eslint --disable-setup --config utoo.json --glob src
+```
+
+The wrapper invokes `utoo-lint` after translating common fishlint eslint flags.
+It forwards `--config`, maps `--glob` values to lint targets, and ignores
+fishlint-only setup/debug flags. `--fix` is accepted with a warning because
+`utoo-lint` does not apply fixes yet.
+
 ## Replace ESLint API Calls
 
 For scripts that already use ESLint's Node API, import `ESLint` from `@utoo/lint`

--- a/npm/README.md
+++ b/npm/README.md
@@ -12,7 +12,7 @@ This directory contains the npm CLI wrapper for `@utoo/lint` and the native plat
 The CLI package also exposes a small ESM API:
 
 ```js
-import { ESLint, lintFiles, lintText, resolveBinary, run } from "@utoo/lint";
+import { ESLint, lintFiles, lintText, resolveBinary, run, runFishlint } from "@utoo/lint";
 
 const report = lintFiles(["src", "test"], {
   config: "utoo.json",
@@ -22,6 +22,7 @@ const report = lintFiles(["src", "test"], {
 console.log(report.diagnostics);
 console.log(resolveBinary());
 console.log(run(["--help"]).stdout);
+console.log(runFishlint(["eslint", "--disable-setup", "--glob", "src"]).status);
 
 const textReport = lintText("debugger;\n", {
   filePath: "inline.js",
@@ -48,6 +49,18 @@ diagnostic includes `filePath`, `line`, `column`, `severity`, `message`, and
 `calculateConfigForFile()` methods for low-friction replacements. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
+
+The package also installs a `fishlint` compatibility command for projects that
+currently run `fishlint eslint ...`. It supports the common eslint subcommand
+shape, forwards `--config`, maps `--glob` values to native lint targets, and
+ignores fishlint-only setup/debug flags:
+
+```bash
+npx fishlint eslint --disable-setup --config utoo.json --glob src
+```
+
+For programmatic replacements, `runFishlint()` applies the same argument
+translation before invoking the native binary.
 
 Use the packaged frontend config in an app:
 

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+import { resolveBinary } from "../lib/binary.js";
+import { translateFishlintArgs } from "../index.js";
+
+let binary;
+try {
+  binary = resolveBinary();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+let args;
+try {
+  args = translateFishlintArgs(process.argv.slice(2), {
+    warn(message) {
+      console.warn(message);
+    }
+  });
+} catch (error) {
+  console.error(error.message);
+  process.exit(2);
+}
+
+const result = spawnSync(binary, args, { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -66,6 +66,81 @@ export function run(args = [], options = {}) {
   });
 }
 
+export function runFishlint(args = [], options = {}) {
+  return run(translateFishlintArgs(args, options), options);
+}
+
+export function translateFishlintArgs(args = [], options = {}) {
+  const values = normalizeStringArray(args, "args");
+  const warn = options.warn ?? (() => {});
+
+  if (values.length === 0) {
+    return ["--help"];
+  }
+
+  const [command, ...rest] = values;
+  if (command !== "eslint") {
+    throw new Error(`utoo-lint fishlint compatibility only supports the eslint command, received: ${command}`);
+  }
+
+  const translated = [];
+  const globTargets = [];
+  let index = 0;
+
+  while (index < rest.length) {
+    const arg = rest[index];
+    if (arg === "--") {
+      index += 1;
+      continue;
+    }
+    if (arg === "--disable-setup" || arg === "--disable-legacy" || arg === "--debug" || arg === "--verbose" || arg === "-v" || arg === "--quiet") {
+      index += 1;
+      continue;
+    }
+    if (arg === "--fix") {
+      warn("utoo-lint: fishlint --fix is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
+    if (arg === "--config") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --config requires a path");
+      }
+      translated.push(`--config=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--glob") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --glob requires a path");
+      }
+      globTargets.push(value);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--glob=")) {
+      globTargets.push(arg.slice("--glob=".length));
+      index += 1;
+      continue;
+    }
+    translated.push(arg);
+    index += 1;
+  }
+
+  if (globTargets.length > 0) {
+    translated.push(...globTargets);
+  }
+
+  return translated;
+}
+
 export function lintFiles(paths = ["."], options = {}) {
   return withTemporaryConfig(options, (resolvedOptions) => {
     const cliArgs = buildLintArgs(paths, resolvedOptions);

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -20,6 +20,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
+    "fishlint": "./bin/fishlint.js",
     "utoo-lint": "./bin/utoo-lint.js"
   },
   "files": [


### PR DESCRIPTION
## Summary
- add a `fishlint` npm bin that translates common `fishlint eslint ...` invocations to the native `utoo-lint` binary
- export `runFishlint()` and `translateFishlintArgs()` for programmatic replacements
- document fishlint command compatibility in the npm and ESLint migration docs

## Validation
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/bin/fishlint.js`
- `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node --input-type=module ...`
- `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node npm/utoo-lint/bin/fishlint.js eslint --disable-setup --glob test/fixtures/bad.ts --rules=no-debugger`
- `zig build test`
- `zig build`
- `git diff --check`
