### PR TITLE
fix: accept fishlint eslint ext flag

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -101,13 +101,13 @@ Once diagnostics match your expectations, replace the ESLint job for that rule s
 call the eslint subcommand:
 
 ```bash
-npx fishlint eslint --disable-setup --config utoo.json --glob src
+npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 ```
 
 The wrapper invokes `utoo-lint` after translating common fishlint eslint flags.
-It forwards `--config`, maps `--glob` values to lint targets, and ignores
-fishlint-only setup/debug flags. `--fix` is accepted with a warning because
-`utoo-lint` does not apply fixes yet.
+It forwards `--config`, maps `--glob` values to lint targets, accepts `--ext`
+for compatibility, and ignores fishlint-only setup/debug flags. `--fix` is
+accepted with a warning because `utoo-lint` does not apply fixes yet.
 
 ## Replace ESLint API Calls
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -53,10 +53,12 @@ specific native binary during local development.
 The package also installs a `fishlint` compatibility command for projects that
 currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config`, maps `--glob` values to native lint targets, and
-ignores fishlint-only setup/debug flags:
+ignores fishlint-only setup/debug flags. `--ext` is accepted for compatibility;
+native directory traversal already filters to supported JavaScript and
+TypeScript extensions.
 
 ```bash
-npx fishlint eslint --disable-setup --config utoo.json --glob src
+npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 ```
 
 For programmatic replacements, `runFishlint()` applies the same argument

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -93,7 +93,15 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
-    if (arg === "--disable-setup" || arg === "--disable-legacy" || arg === "--debug" || arg === "--verbose" || arg === "-v" || arg === "--quiet") {
+    if (
+      arg === "--disable-setup" ||
+      arg === "--disable-legacy" ||
+      arg === "--debug" ||
+      arg === "--verbose" ||
+      arg === "-v" ||
+      arg === "--quiet" ||
+      arg === "--no-error-on-unmatched-pattern"
+    ) {
       index += 1;
       continue;
     }
@@ -113,6 +121,18 @@ export function translateFishlintArgs(args = [], options = {}) {
     }
     if (arg.startsWith("--config=")) {
       translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--ext") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --ext requires an extension list");
+      }
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--ext=")) {
       index += 1;
       continue;
     }


### PR DESCRIPTION
## Summary
- accept `fishlint eslint --ext ...` and `--ext=...` in the compatibility argument translator
- ignore `--no-error-on-unmatched-pattern`, matching the flag fishlint passes to eslint internally
- document `--ext` compatibility in the npm and migration docs

## Validation
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/bin/fishlint.js`
- `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node --input-type=module ...`
- `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node npm/utoo-lint/bin/fishlint.js eslint --disable-setup --ext .ts,.tsx --glob test/fixtures/bad.ts --rules=no-debugger` (expected status 1)
- `zig build test`
- `zig build`
- `git diff --check`
