### PR TITLE
fix: accept prettier compat rule

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -109,6 +109,10 @@ It forwards `--config`, maps `--glob` values to lint targets, accepts `--ext`
 for compatibility, and ignores fishlint-only setup/debug flags. `--fix` is
 accepted with a warning because `utoo-lint` does not apply fixes yet.
 
+Fishlint presets often include `prettier/prettier`. `utoo-lint` accepts that rule
+in config files for compatibility and ignores it because formatting remains
+outside the native linter.
+
 ## Replace ESLint API Calls
 
 For scripts that already use ESLint's Node API, import `ESLint` from `@utoo/lint`

--- a/src/core.zig
+++ b/src/core.zig
@@ -343,6 +343,10 @@ pub const Options = struct {
             return true;
         }
 
+        if (std.mem.eql(u8, cli_name, "prettier/prettier")) {
+            return true;
+        }
+
         if (std.mem.startsWith(u8, cli_name, "@typescript-eslint/")) {
             const typescript_rule_name = cli_name["@typescript-eslint/".len..];
             inline for (@typeInfo(Options).@"struct".fields) |field| {
@@ -815,6 +819,8 @@ test "Options can apply ESLint-style rule config values" {
     try array.append(.{ .string = "warn" });
     try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
     try std.testing.expect(options.jsx_a11y_aria_props);
+
+    try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
 
     var ivy_config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- accept `prettier/prettier` as a compatibility-only rule in config files
- keep formatting out of the native linter while avoiding config load failures from fishlint presets
- document the compatibility behavior in the migration guide

## Validation
- `zig fmt src/core.zig`
- `zig build test`
- `zig build`
- `./zig-out/bin/utoo-lint --config=<tmp with prettier/prettier> <tmp>/a.js`
- `git diff --check`
