### PR TITLE
feat: add fishlint lint-staged bin

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -68,6 +68,11 @@ npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 For programmatic replacements, `runFishlint()` applies the same argument
 translation before invoking the native binary.
 
+`fishlint-lint-staged` is also provided for generated fishlint pre-commit hooks.
+If a project has its own `lint-staged` install, the wrapper delegates to it.
+Otherwise it lints staged JavaScript and TypeScript files directly with
+`utoo-lint`.
+
 Use the packaged frontend config in an app:
 
 ```bash

--- a/npm/utoo-lint/bin/fishlint-lint-staged.js
+++ b/npm/utoo-lint/bin/fishlint-lint-staged.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveBinary } from "../lib/binary.js";
+
+const localLintStaged = join(
+  process.cwd(),
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "lint-staged.cmd" : "lint-staged"
+);
+
+if (existsSync(localLintStaged)) {
+  const result = spawnSync(localLintStaged, process.argv.slice(2), { stdio: "inherit" });
+  if (result.error) {
+    console.error(`utoo-lint: failed to run lint-staged: ${result.error.message}`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
+}
+
+const staged = spawnSync("git", ["diff", "--name-only", "--cached", "--diff-filter=ACMRTUB"], {
+  encoding: "utf8"
+});
+
+if (staged.error) {
+  console.error(`utoo-lint: failed to read staged files: ${staged.error.message}`);
+  process.exit(1);
+}
+if (staged.status !== 0) {
+  process.stderr.write(staged.stderr ?? "");
+  process.exit(staged.status ?? 1);
+}
+
+const files = staged.stdout
+  .split(/\r?\n/)
+  .filter((file) => file.length > 0 && isLintableScript(file));
+
+if (files.length === 0) {
+  process.exit(0);
+}
+
+let binary;
+try {
+  binary = resolveBinary();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+const result = spawnSync(binary, files, { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);
+
+function isLintableScript(file) {
+  return /\.(?:[cm]?[jt]sx?)$/.test(file);
+}

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -21,6 +21,7 @@
   },
   "bin": {
     "fishlint": "./bin/fishlint.js",
+    "fishlint-lint-staged": "./bin/fishlint-lint-staged.js",
     "utoo-lint": "./bin/utoo-lint.js"
   },
   "files": [


### PR DESCRIPTION
## Summary
- add a `fishlint-lint-staged` npm bin for generated fishlint pre-commit hooks
- delegate to a project-local `lint-staged` install when present
- fall back to linting staged JavaScript and TypeScript files with the native binary

## Validation
- `node --check npm/utoo-lint/bin/fishlint-lint-staged.js`
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/index.js`
- temp git repo smoke with staged `bad.js` expecting no-debugger and status 1
- temp git repo smoke with no staged files expecting status 0
- `zig build test`
- `zig build`
- `git diff --check`
