### PR TITLE
feat: delegate fishlint helper commands

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -68,6 +68,12 @@ npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 For programmatic replacements, `runFishlint()` applies the same argument
 translation before invoking the native binary.
 
+For non-eslint fishlint commands, the compatibility command delegates to
+project-local tools when they are installed: `fishlint format` runs `prettier`,
+`fishlint stylelint` runs `stylelint`, `fishlint commitlint` runs `commitlint`,
+and `fishlint projectlint` runs `projectlint`. This keeps existing scripts
+working without treating those tools as native `utoo-lint` checks.
+
 `fishlint-lint-staged` is also provided for generated fishlint pre-commit hooks.
 If a project has its own `lint-staged` install, the wrapper delegates to it.
 Otherwise it lints staged JavaScript and TypeScript files directly with

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import { resolveBinary } from "../lib/binary.js";
 import { translateFishlintArgs } from "../index.js";
 
-let binary;
-try {
-  binary = resolveBinary();
-} catch (error) {
-  console.error(error.message);
-  process.exit(1);
+const values = process.argv.slice(2);
+const command = values[0];
+
+if (command && command !== "eslint") {
+  runDelegatedCommand(command, values.slice(1));
 }
 
 let args;
 try {
-  args = translateFishlintArgs(process.argv.slice(2), {
+  args = translateFishlintArgs(values, {
     warn(message) {
       console.warn(message);
     }
@@ -22,6 +23,14 @@ try {
 } catch (error) {
   console.error(error.message);
   process.exit(2);
+}
+
+let binary;
+try {
+  binary = resolveBinary();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
 }
 
 const result = spawnSync(binary, args, { stdio: "inherit" });
@@ -32,3 +41,155 @@ if (result.error) {
 }
 
 process.exit(result.status ?? 1);
+
+function runDelegatedCommand(command, args) {
+  const delegated = delegatedCommand(command, args);
+  if (!delegated) {
+    console.error(`utoo-lint fishlint compatibility only supports the eslint command, received: ${command}`);
+    process.exit(2);
+  }
+
+  const bin = localBin(delegated.bin);
+  if (!bin) {
+    console.error(`utoo-lint: fishlint ${command} requires a project-local ${delegated.bin} binary`);
+    process.exit(2);
+  }
+
+  const result = spawnSync(bin, delegated.args, { stdio: "inherit" });
+  if (result.error) {
+    console.error(`utoo-lint: failed to run ${delegated.bin}: ${result.error.message}`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
+}
+
+function delegatedCommand(command, args) {
+  switch (command) {
+    case "stylelint":
+      return {
+        bin: "stylelint",
+        args: withDefaultTargets(
+          translatePassthroughArgs(args, {
+            passthroughFlags: new Set(["--fix", "--quiet"])
+          }),
+          ["**/*.{less,css,acss}"]
+        )
+      };
+    case "format":
+      return {
+        bin: "prettier",
+        args: ["--write", ...withDefaultTargets(translatePassthroughArgs(args), ["**/*.{js,jsx,ts,tsx,less,css,vue}"])]
+      };
+    case "commitlint":
+      return {
+        bin: "commitlint",
+        args: translateCommitlintArgs(args)
+      };
+    case "projectlint":
+      return {
+        bin: "projectlint",
+        args: ["lint", "./", ...translatePassthroughArgs(args, { passthroughFlags: new Set(["--debug"]) })]
+      };
+    default:
+      return null;
+  }
+}
+
+function withDefaultTargets(args, defaults) {
+  if (args.some((arg) => !arg.startsWith("-"))) {
+    return args;
+  }
+  return [...args, ...defaults];
+}
+
+function translatePassthroughArgs(args, options = {}) {
+  const passthroughFlags = options.passthroughFlags ?? new Set();
+  const dropValueFlags = options.dropValueFlags ?? new Set();
+  const translated = [];
+  const targets = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--disable-setup" || arg === "--disable-legacy" || arg === "--verbose" || arg === "-v") continue;
+    if (arg === "--glob") {
+      const value = args[index + 1];
+      if (!value) {
+        console.error("utoo-lint: fishlint --glob requires a path");
+        process.exit(2);
+      }
+      targets.push(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--glob=")) {
+      targets.push(arg.slice("--glob=".length));
+      continue;
+    }
+    if (dropValueFlags.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if ([...dropValueFlags].some((flag) => arg.startsWith(`${flag}=`))) {
+      continue;
+    }
+    if (passthroughFlags.has(arg) || [...passthroughFlags].some((flag) => arg.startsWith(`${flag}=`))) {
+      translated.push(arg);
+      continue;
+    }
+    translated.push(arg);
+  }
+
+  translated.push(...targets);
+  return translated;
+}
+
+function translateCommitlintArgs(args) {
+  const translated = [];
+  let hasMessageSource = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--quiet") {
+      translated.push(arg);
+      continue;
+    }
+    if (arg === "-E" || arg === "--env") {
+      const envKey = args[index + 1];
+      if (!envKey) {
+        console.error(`utoo-lint: fishlint ${arg} requires an environment variable name`);
+        process.exit(2);
+      }
+      if (process.env[envKey]) {
+        translated.push("--env", envKey);
+      } else {
+        translated.push("--edit");
+      }
+      hasMessageSource = true;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--env=")) {
+      const envKey = arg.slice("--env=".length);
+      if (process.env[envKey]) {
+        translated.push("--env", envKey);
+      } else {
+        translated.push("--edit");
+      }
+      hasMessageSource = true;
+      continue;
+    }
+    translated.push(arg);
+  }
+
+  if (!hasMessageSource) {
+    translated.push("--edit");
+  }
+  return translated;
+}
+
+function localBin(name) {
+  const executable = process.platform === "win32" ? `${name}.cmd` : name;
+  const path = join(process.cwd(), "node_modules", ".bin", executable);
+  return existsSync(path) ? path : null;
+}


### PR DESCRIPTION
## Summary
- delegate `fishlint format`, `fishlint stylelint`, `fishlint commitlint`, and `fishlint projectlint` to project-local tools when installed
- keep `fishlint eslint` on the native `utoo-lint` compatibility path
- document that non-eslint fishlint commands are compatibility delegation, not native checks

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/bin/fishlint-lint-staged.js`
- `node --check npm/utoo-lint/index.js`
- temp project fake-bin smoke for `format`, `stylelint`, `commitlint`, and `projectlint` argument translation
- `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint node npm/utoo-lint/bin/fishlint.js eslint --disable-setup --ext .ts,.tsx --glob test/fixtures/bad.ts --rules=no-debugger` (expected status 1)
- `zig build test`
- `zig build`
- `git diff --check`
