### PR TITLE
fix: accept fishlint setup commands

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -73,6 +73,8 @@ project-local tools when they are installed: `fishlint format` runs `prettier`,
 `fishlint stylelint` runs `stylelint`, `fishlint commitlint` runs `commitlint`,
 and `fishlint projectlint` runs `projectlint`. This keeps existing scripts
 working without treating those tools as native `utoo-lint` checks.
+`fishlint setup` and `fishlint setuplint` are accepted as no-ops so existing
+install hooks do not fail after replacing the package.
 
 `fishlint-lint-staged` is also provided for generated fishlint pre-commit hooks.
 If a project has its own `lint-staged` install, the wrapper delegates to it.

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -9,6 +9,11 @@ import { translateFishlintArgs } from "../index.js";
 const values = process.argv.slice(2);
 const command = values[0];
 
+if (command === "setup" || command === "setuplint") {
+  console.warn(`utoo-lint: fishlint ${command} is treated as a no-op; configure utoo-lint with utoo.json.`);
+  process.exit(0);
+}
+
 if (command && command !== "eslint") {
   runDelegatedCommand(command, values.slice(1));
 }


### PR DESCRIPTION
## Summary
- accept `fishlint setup` and `fishlint setuplint` as compatibility no-ops
- keep existing install/prepare hooks from failing after replacing fishlint with @utoo/lint
- document the no-op behavior in the npm README

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/bin/fishlint-lint-staged.js`
- `node --check npm/utoo-lint/index.js`
- `node npm/utoo-lint/bin/fishlint.js setup` exits 0
- `node npm/utoo-lint/bin/fishlint.js setuplint --preset smallfish` exits 0
- existing fishlint eslint and delegated command smoke tests
- `zig build test`
- `zig build`
- `git diff --check`
