### PR TITLE
feat: include clean eslint api file results

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -50,7 +50,9 @@ diagnostic includes `filePath`, `line`, `column`, `severity`, `message`, and
 `lintFiles()`, `lintText()`, `loadFormatter()`, `isPathIgnored()`, and
 `calculateConfigForFile()` methods for low-friction replacements. It also
 provides ESLint-compatible `version`, `outputFixes()`, `getErrorResults()`, and
-`getRulesMetaForResults()` surfaces. Set
+`getRulesMetaForResults()` surfaces. `lintFiles()` returns absolute `filePath`
+values and includes empty results for explicitly provided files with no
+messages. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { writeFile as writeFileAsync } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, isAbsolute, join, resolve as resolvePath } from "node:path";
@@ -9,6 +9,8 @@ import { resolveBinary } from "./lib/binary.js";
 export { platformPackageName, resolveBinary } from "./lib/binary.js";
 
 export const version = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version;
+
+const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 
 export class UtooLint {
   static get version() {
@@ -45,6 +47,7 @@ export class UtooLint {
     const report = lintFiles(patterns, mergedOptions);
     return reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
+      filePaths: explicitLintFilePaths(patterns, mergedOptions.cwd),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
     });
   }
@@ -393,6 +396,11 @@ function reportToESLintResults(report, textOptions = {}) {
   if (textOptions.filePath && !byFile.has(textOptions.filePath)) {
     byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
   }
+  for (const filePath of textOptions.filePaths ?? []) {
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath));
+    }
+  }
 
   for (const result of byFile.values()) {
     finalizeESLintResult(result);
@@ -405,6 +413,34 @@ function normalizeESLintFilePath(filePath, cwd) {
   if (filePath === "<text>") return filePath;
   if (isAbsolute(filePath)) return filePath;
   return resolvePath(cwd ?? process.cwd(), filePath);
+}
+
+function explicitLintFilePaths(patterns, cwd) {
+  const files = [];
+  for (const pattern of normalizeStringArray(Array.isArray(patterns) ? patterns : [patterns], "patterns")) {
+    if (hasGlobMagic(pattern)) continue;
+
+    const filePath = normalizeESLintFilePath(pattern, cwd);
+    if (!isLintableFilePath(filePath)) continue;
+
+    try {
+      if (statSync(filePath).isFile()) {
+        files.push(filePath);
+      }
+    } catch {
+      // Let the native binary report missing paths. This helper only fills in
+      // empty ESLint results for files that were checked successfully.
+    }
+  }
+  return files;
+}
+
+function hasGlobMagic(pattern) {
+  return /[*?[\]{}()!+@]/.test(pattern);
+}
+
+function isLintableFilePath(filePath) {
+  return LINTABLE_EXTENSIONS.has(extname(filePath));
 }
 
 function getErrorResults(results) {


### PR DESCRIPTION
## Summary
- include empty ESLint-compatible results for explicit clean file inputs
- keep dirty file diagnostics grouped by absolute file path
- document clean result behavior for JS API replacements

## Validation
- node --check npm/utoo-lint/index.js
- JS API smoke test for clean and dirty explicit files
- zig build test
- zig build
- git diff --check