### PR TITLE
feat: expose json file paths

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -44,15 +44,15 @@ console.log(ESLint.version);
 console.log(ESLint.getErrorResults(results));
 ```
 
-`lintFiles()` and `lintText()` return `{ files, diagnostics, exitCode }`. Each
-diagnostic includes `filePath`, `line`, `column`, `severity`, `message`, and
-`ruleId`. The `ESLint` export is an alias for `UtooLint` and supports the common
-`lintFiles()`, `lintText()`, `loadFormatter()`, `isPathIgnored()`, and
-`calculateConfigForFile()` methods for low-friction replacements. It also
-provides ESLint-compatible `version`, `outputFixes()`, `getErrorResults()`, and
-`getRulesMetaForResults()` surfaces. `lintFiles()` returns absolute `filePath`
-values and includes empty results for explicitly provided files with no
-messages. Set
+`lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
+`diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
+`column`, `severity`, `message`, and `ruleId`. The `ESLint` export is an alias
+for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
+`loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
+low-friction replacements. It also provides ESLint-compatible `version`,
+`outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
+`lintFiles()` returns absolute `filePath` values and includes empty results for
+checked files with no messages. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -47,7 +47,7 @@ export class UtooLint {
     const report = lintFiles(patterns, mergedOptions);
     return reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
-      filePaths: explicitLintFilePaths(patterns, mergedOptions.cwd),
+      filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(patterns, mergedOptions.cwd)),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
     });
   }
@@ -413,6 +413,21 @@ function normalizeESLintFilePath(filePath, cwd) {
   if (filePath === "<text>") return filePath;
   if (isAbsolute(filePath)) return filePath;
   return resolvePath(cwd ?? process.cwd(), filePath);
+}
+
+function reportFilePaths(report, cwd, fallbackFilePaths = []) {
+  const filePaths = new Set();
+  if (Array.isArray(report.filePaths)) {
+    for (const filePath of report.filePaths) {
+      if (typeof filePath === "string") {
+        filePaths.add(normalizeESLintFilePath(filePath, cwd));
+      }
+    }
+  }
+  for (const filePath of fallbackFilePaths) {
+    filePaths.add(filePath);
+  }
+  return [...filePaths];
 }
 
 function explicitLintFilePaths(patterns, cwd) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,7 @@ const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
 
 const JsonReport = struct {
     files: usize,
+    filePaths: []const []const u8,
     diagnostics: []const JsonDiagnostic,
 };
 
@@ -743,7 +744,7 @@ pub fn main(init: std.process.Init) !void {
 
     if (output_format == .json) {
         try lintFilesJson(allocator, io, files.items, options, &stats, &json_diagnostics);
-        try writeJsonReport(io, stats, json_diagnostics.items);
+        try writeJsonReport(io, stats, files.items, json_diagnostics.items);
     } else {
         try lintFiles(allocator, io, files.items, options, thread_count_override, &stats);
 
@@ -1156,13 +1157,14 @@ fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosti
     diagnostics.deinit(allocator);
 }
 
-fn writeJsonReport(io: std.Io, stats: Stats, diagnostics: []const JsonDiagnostic) !void {
+fn writeJsonReport(io: std.Io, stats: Stats, file_paths: []const []const u8, diagnostics: []const JsonDiagnostic) !void {
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
 
     try std.json.Stringify.value(JsonReport{
         .files = stats.files,
+        .filePaths = file_paths,
         .diagnostics = diagnostics,
     }, .{}, stdout);
     try stdout.writeByte('\n');


### PR DESCRIPTION
## Summary
- add `filePaths` to native JSON reports while keeping the existing `files` count
- use native checked file paths in the ESLint facade to include clean directory/glob results
- document the new JS report shape

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js
- native JSON smoke test for `filePaths`
- JS API smoke test for directory input with clean and dirty files
- git diff --check