### PR TITLE
fix: accept fishlint split value flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -59,9 +59,10 @@ specific native binary during local development.
 The package also installs a `fishlint` compatibility command for projects that
 currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config`, maps `--glob` values to native lint targets, and
-ignores fishlint-only setup/debug flags. `--ext` is accepted for compatibility;
-native directory traversal already filters to supported JavaScript and
-TypeScript extensions.
+normalizes split value flags such as `--format json`, `-f json`, `--threads 4`,
+and `--rules no-debugger`. It ignores fishlint-only setup/debug flags. `--ext`
+is accepted for compatibility; native directory traversal already filters to
+supported JavaScript and TypeScript extensions.
 
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -163,6 +163,48 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
+    if (arg === "--format" || arg === "-f") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: fishlint ${arg} requires a formatter name`);
+      }
+      translated.push(`--format=${translateFishlintFormat(value)}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--format=")) {
+      translated.push(`--format=${translateFishlintFormat(arg.slice("--format=".length))}`);
+      index += 1;
+      continue;
+    }
+    if (arg === "--threads") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --threads requires a number");
+      }
+      translated.push(`--threads=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--threads=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--rules") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --rules requires a comma-separated rule list");
+      }
+      translated.push(`--rules=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--rules=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
     if (arg === "--config") {
       const value = rest[index + 1];
       if (!value) {
@@ -212,6 +254,10 @@ export function translateFishlintArgs(args = [], options = {}) {
   }
 
   return translated;
+}
+
+function translateFishlintFormat(format) {
+  return format === "stylish" ? "text" : format;
 }
 
 export function lintFiles(paths = ["."], options = {}) {


### PR DESCRIPTION
## Summary
- normalize fishlint `--format value` and `-f value` before invoking the native CLI
- normalize split `--threads` and `--rules` values
- map ESLint/fishlint `stylish` formatter requests to native `text` output
- document the supported split value flags

## Validation
- node --check npm/utoo-lint/index.js
- translateFishlintArgs smoke test for split value flags
- fishlint wrapper smoke test with `--format json --rules no-debugger --glob npm/utoo-lint/index.js`
- zig build test
- zig build
- git diff --check