### PR TITLE
fix: ignore fishlint cache control flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -62,7 +62,9 @@ shape, forwards `--config`, maps `--glob` values to native lint targets, and
 normalizes split value flags such as `--format json`, `-f json`, `--threads 4`,
 and `--rules no-debugger`. It ignores fishlint-only setup/debug flags. `--ext`
 is accepted for compatibility; native directory traversal already filters to
-supported JavaScript and TypeScript extensions.
+supported JavaScript and TypeScript extensions. ESLint cache controls and
+`--max-warnings` are consumed for compatibility because utoo-lint does not keep
+an ESLint-style result cache.
 
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -153,7 +153,25 @@ export function translateFishlintArgs(args = [], options = {}) {
       arg === "--verbose" ||
       arg === "-v" ||
       arg === "--quiet" ||
-      arg === "--no-error-on-unmatched-pattern"
+      arg === "--no-error-on-unmatched-pattern" ||
+      arg === "--cache" ||
+      arg === "--no-cache"
+    ) {
+      index += 1;
+      continue;
+    }
+    if (arg === "--cache-location" || arg === "--cache-strategy" || arg === "--max-warnings") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: fishlint ${arg} requires a value`);
+      }
+      index += 2;
+      continue;
+    }
+    if (
+      arg.startsWith("--cache-location=") ||
+      arg.startsWith("--cache-strategy=") ||
+      arg.startsWith("--max-warnings=")
     ) {
       index += 1;
       continue;


### PR DESCRIPTION
## Summary
- consume fishlint/ESLint cache flags instead of forwarding them as native targets
- consume `--max-warnings` values for compatibility
- document that cache controls are accepted but utoo-lint does not keep an ESLint-style cache

## Validation
- node --check npm/utoo-lint/index.js
- translateFishlintArgs smoke test for cache/max-warnings flags
- fishlint wrapper smoke test with `--format json --rules no-debugger --max-warnings 0 --cache --cache-location .eslintcache --cache-strategy content`
- zig build test
- zig build
- git diff --check