### PR TITLE
fix: ignore fishlint eslint config flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -64,7 +64,9 @@ and `--rules no-debugger`. It ignores fishlint-only setup/debug flags. `--ext`
 is accepted for compatibility; native directory traversal already filters to
 supported JavaScript and TypeScript extensions. ESLint cache controls and
 `--max-warnings` are consumed for compatibility because utoo-lint does not keep
-an ESLint-style result cache.
+an ESLint-style result cache. ESLint runtime config flags such as `--env`,
+`--global`, `--parser`, `--parser-options`, `--plugin`, and ignore-pattern flags
+are also consumed so existing wrapper scripts do not pass them as file targets.
 
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -11,6 +11,34 @@ export { platformPackageName, resolveBinary } from "./lib/binary.js";
 export const version = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version;
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const FISHLINT_DROP_FLAGS = new Set([
+  "--cache",
+  "--debug",
+  "--disable-legacy",
+  "--disable-setup",
+  "--no-cache",
+  "--no-error-on-unmatched-pattern",
+  "--no-inline-config",
+  "--quiet",
+  "--report-unused-disable-directives",
+  "--verbose",
+  "-v"
+]);
+const FISHLINT_DROP_VALUE_FLAGS = new Set([
+  "--cache-location",
+  "--cache-strategy",
+  "--env",
+  "--global",
+  "--ignore-path",
+  "--ignore-pattern",
+  "--max-warnings",
+  "--parser",
+  "--parser-options",
+  "--plugin",
+  "--resolve-plugins-relative-to",
+  "--rule",
+  "--rulesdir"
+]);
 
 export class UtooLint {
   static get version() {
@@ -146,21 +174,11 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
-    if (
-      arg === "--disable-setup" ||
-      arg === "--disable-legacy" ||
-      arg === "--debug" ||
-      arg === "--verbose" ||
-      arg === "-v" ||
-      arg === "--quiet" ||
-      arg === "--no-error-on-unmatched-pattern" ||
-      arg === "--cache" ||
-      arg === "--no-cache"
-    ) {
+    if (FISHLINT_DROP_FLAGS.has(arg)) {
       index += 1;
       continue;
     }
-    if (arg === "--cache-location" || arg === "--cache-strategy" || arg === "--max-warnings") {
+    if (FISHLINT_DROP_VALUE_FLAGS.has(arg)) {
       const value = rest[index + 1];
       if (!value) {
         throw new Error(`utoo-lint: fishlint ${arg} requires a value`);
@@ -168,11 +186,7 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 2;
       continue;
     }
-    if (
-      arg.startsWith("--cache-location=") ||
-      arg.startsWith("--cache-strategy=") ||
-      arg.startsWith("--max-warnings=")
-    ) {
+    if (startsWithFlagValue(arg, FISHLINT_DROP_VALUE_FLAGS)) {
       index += 1;
       continue;
     }
@@ -276,6 +290,15 @@ export function translateFishlintArgs(args = [], options = {}) {
 
 function translateFishlintFormat(format) {
   return format === "stylish" ? "text" : format;
+}
+
+function startsWithFlagValue(arg, flags) {
+  for (const flag of flags) {
+    if (arg.startsWith(`${flag}=`)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function lintFiles(paths = ["."], options = {}) {


### PR DESCRIPTION
## Summary
- centralize fishlint compatibility-only dropped flags
- consume common ESLint runtime config flags such as `--env`, `--global`, `--parser`, `--parser-options`, and `--plugin`
- consume ignore-pattern and rulesdir-style options so existing scripts do not pass them to the native binary as file targets
- document the compatibility behavior

## Validation
- node --check npm/utoo-lint/index.js
- translateFishlintArgs smoke test for ESLint config flags
- fishlint wrapper smoke test with config flags and a clean JS file
- zig build test
- zig build
- git diff --check