### PR TITLE
fix: ignore fishlint report control flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -67,6 +67,8 @@ supported JavaScript and TypeScript extensions. ESLint cache controls and
 an ESLint-style result cache. ESLint runtime config flags such as `--env`,
 `--global`, `--parser`, `--parser-options`, `--plugin`, and ignore-pattern flags
 are also consumed so existing wrapper scripts do not pass them as file targets.
+Display and reporting controls such as `--color`, `--no-color`, `--stats`, and
+`--no-warn-ignored` are accepted for the same reason.
 
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -13,14 +13,19 @@ export const version = JSON.parse(readFileSync(new URL("./package.json", import.
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const FISHLINT_DROP_FLAGS = new Set([
   "--cache",
+  "--color",
   "--debug",
   "--disable-legacy",
   "--disable-setup",
   "--no-cache",
+  "--no-color",
   "--no-error-on-unmatched-pattern",
   "--no-inline-config",
+  "--no-warn-ignored",
+  "--pass-on-no-patterns",
   "--quiet",
   "--report-unused-disable-directives",
+  "--stats",
   "--verbose",
   "-v"
 ]);


### PR DESCRIPTION
## Summary
- consume fishlint/ESLint display and reporting flags before invoking the native CLI
- prevent `--color`, `--no-color`, `--stats`, `--no-warn-ignored`, and `--pass-on-no-patterns` from being treated as lint targets
- document the compatibility behavior

## Validation
- node --check npm/utoo-lint/index.js
- translateFishlintArgs smoke test for report/control flags
- fishlint wrapper smoke test with `--format json --rules no-debugger --color --stats --no-warn-ignored`
- zig build test
- zig build
- git diff --check