### PR TITLE
feat: support fishlint output file

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -68,7 +68,8 @@ an ESLint-style result cache. ESLint runtime config flags such as `--env`,
 `--global`, `--parser`, `--parser-options`, `--plugin`, and ignore-pattern flags
 are also consumed so existing wrapper scripts do not pass them as file targets.
 Display and reporting controls such as `--color`, `--no-color`, `--stats`, and
-`--no-warn-ignored` are accepted for the same reason.
+`--no-warn-ignored` are accepted for the same reason. `--output-file` and `-o`
+write the native output to the requested report file.
 
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { resolveBinary } from "../lib/binary.js";
@@ -19,8 +19,9 @@ if (command && command !== "eslint") {
 }
 
 let args;
+const output = extractOutputFile(values);
 try {
-  args = translateFishlintArgs(values, {
+  args = translateFishlintArgs(output.args, {
     warn(message) {
       console.warn(message);
     }
@@ -38,14 +39,45 @@ try {
   process.exit(1);
 }
 
-const result = spawnSync(binary, args, { stdio: "inherit" });
+const result = spawnSync(binary, args, output.file ? { encoding: "utf8" } : { stdio: "inherit" });
 
 if (result.error) {
   console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
   process.exit(1);
 }
+if (output.file) {
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  writeFileSync(output.file, result.stdout ?? "");
+}
 
 process.exit(result.status ?? 1);
+
+function extractOutputFile(args) {
+  const values = [];
+  let file;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--output-file" || arg === "-o") {
+      file = args[index + 1];
+      if (!file) {
+        console.error(`utoo-lint: fishlint ${arg} requires a path`);
+        process.exit(2);
+      }
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--output-file=")) {
+      file = arg.slice("--output-file=".length);
+      continue;
+    }
+    values.push(arg);
+  }
+
+  return { args: values, file };
+}
 
 function runDelegatedCommand(command, args) {
   const delegated = delegatedCommand(command, args);

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -37,12 +37,14 @@ const FISHLINT_DROP_VALUE_FLAGS = new Set([
   "--ignore-path",
   "--ignore-pattern",
   "--max-warnings",
+  "--output-file",
   "--parser",
   "--parser-options",
   "--plugin",
   "--resolve-plugins-relative-to",
   "--rule",
-  "--rulesdir"
+  "--rulesdir",
+  "-o"
 ]);
 
 export class UtooLint {


### PR DESCRIPTION
## Summary
- support fishlint eslint `--output-file` and `-o` in the CLI wrapper
- write captured native stdout to the requested report file while preserving native exit status
- prevent programmatic fishlint argument translation from forwarding output-file flags as lint targets
- document output-file compatibility

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/bin/fishlint.js
- translateFishlintArgs smoke test for `--output-file`, `--output-file=`, and `-o`
- fishlint wrapper smoke test writing JSON output to a report file
- zig build test
- zig build
- git diff --check