### PR TITLE
feat: add eslint cli engine facade

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -145,3 +145,22 @@ const [result] = await eslint.lintText("debugger;\n", {
   filePath: "inline.js"
 });
 ```
+
+Older integrations that still use ESLint's legacy `CLIEngine` can import a
+small synchronous facade:
+
+```js
+import { CLIEngine } from "@utoo/lint";
+
+const cli = new CLIEngine({
+  useEslintrc: false,
+  baseConfig: {
+    rules: {
+      "no-debugger": "error"
+    }
+  }
+});
+
+const report = cli.executeOnFiles(["src"]);
+console.log(cli.getFormatter("stylish")(report.results));
+```

--- a/npm/README.md
+++ b/npm/README.md
@@ -12,7 +12,7 @@ This directory contains the npm CLI wrapper for `@utoo/lint` and the native plat
 The CLI package also exposes a small ESM API:
 
 ```js
-import { ESLint, lintFiles, lintText, resolveBinary, run, runFishlint } from "@utoo/lint";
+import { CLIEngine, ESLint, lintFiles, lintText, resolveBinary, run, runFishlint } from "@utoo/lint";
 
 const report = lintFiles(["src", "test"], {
   config: "utoo.json",
@@ -42,6 +42,16 @@ const results = await eslint.lintText("debugger;\n", { filePath: "inline.js" });
 console.log(results[0].messages);
 console.log(ESLint.version);
 console.log(ESLint.getErrorResults(results));
+
+const cli = new CLIEngine({
+  useEslintrc: false,
+  baseConfig: {
+    rules: {
+      "no-debugger": "error"
+    }
+  }
+});
+console.log(cli.executeOnFiles(["src"]).results);
 ```
 
 `lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
@@ -52,7 +62,8 @@ for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
 low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 `lintFiles()` returns absolute `filePath` values and includes empty results for
-checked files with no messages. Set
+checked files with no messages. The `CLIEngine` export provides a synchronous
+legacy facade for older ESLint integrations. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -143,6 +143,84 @@ export class UtooLint {
 
 export { UtooLint as ESLint };
 
+export class CLIEngine {
+  static get version() {
+    return version;
+  }
+
+  static outputFixes(report) {
+    const results = Array.isArray(report) ? report : report?.results;
+    if (!Array.isArray(results)) {
+      throw new Error("'report' must be an ESLint report or result array");
+    }
+
+    for (const result of results) {
+      if (typeof result !== "object" || result === null) {
+        throw new Error("'report' must include only result objects");
+      }
+      if (typeof result.output === "string" && isAbsolute(result.filePath)) {
+        writeFileSync(result.filePath, result.output);
+      }
+    }
+  }
+
+  static getErrorResults(results) {
+    return getErrorResults(results);
+  }
+
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  executeOnFiles(patterns) {
+    const mergedOptions = eslintConstructorOptions(this.options);
+    const report = lintFiles(patterns, mergedOptions);
+    const results = reportToESLintResults(report, {
+      cwd: mergedOptions.cwd,
+      filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(patterns, mergedOptions.cwd)),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+    return resultsToCLIEngineReport(results);
+  }
+
+  executeOnText(code, filePathOrOptions = "input.js") {
+    const filePath =
+      typeof filePathOrOptions === "object" && filePathOrOptions !== null
+        ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
+        : filePathOrOptions;
+    const mergedOptions = eslintConstructorOptions(this.options);
+    const report = lintText(code, {
+      ...mergedOptions,
+      filePath
+    });
+    const results = reportToESLintResults(report, {
+      source: code,
+      filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+    return resultsToCLIEngineReport(results);
+  }
+
+  getFormatter(name = "stylish") {
+    return (results) => {
+      if (name === "json") {
+        return JSON.stringify(results);
+      }
+      return formatESLintResults(results);
+    };
+  }
+
+  isPathIgnored() {
+    return false;
+  }
+
+  getConfigForFile() {
+    return {
+      rules: this.options.overrideConfig?.rules ?? this.options.baseConfig?.rules ?? {}
+    };
+  }
+}
+
 export function run(args = [], options = {}) {
   const cliArgs = normalizeStringArray(args, "args");
   const env = options.env ? { ...process.env, ...options.env } : process.env;
@@ -422,8 +500,9 @@ function eslintConstructorOptions(options) {
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
   }
-  if (options.overrideConfig?.rules) {
-    mapped.overrideConfig = { rules: options.overrideConfig.rules };
+  const rules = options.overrideConfig?.rules ?? options.baseConfig?.rules;
+  if (rules) {
+    mapped.overrideConfig = { rules };
   }
   return mapped;
 }
@@ -573,6 +652,28 @@ function getErrorResults(results) {
     });
   }
   return filtered;
+}
+
+function resultsToCLIEngineReport(results) {
+  const report = {
+    results,
+    errorCount: 0,
+    fatalErrorCount: 0,
+    warningCount: 0,
+    fixableErrorCount: 0,
+    fixableWarningCount: 0,
+    usedDeprecatedRules: []
+  };
+
+  for (const result of results) {
+    report.errorCount += result.errorCount ?? 0;
+    report.fatalErrorCount += result.fatalErrorCount ?? 0;
+    report.warningCount += result.warningCount ?? 0;
+    report.fixableErrorCount += result.fixableErrorCount ?? 0;
+    report.fixableWarningCount += result.fixableWarningCount ?? 0;
+  }
+
+  return report;
 }
 
 function emptyESLintResult(filePath, source) {


### PR DESCRIPTION
## Summary
- add a synchronous `CLIEngine` export for legacy ESLint Node API integrations
- support `executeOnFiles`, `executeOnText`, formatter loading, config lookup, ignored-path checks, and report helpers
- map `baseConfig.rules` into the existing override rule path
- document the legacy facade in npm and migration docs

## Validation
- node --check npm/utoo-lint/index.js
- CLIEngine smoke test for clean and dirty file results
- CLIEngine lintText/formatter/config smoke test
- zig build test
- zig build
- git diff --check