### PR TITLE
fix: accept fishlint formatter aliases

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -71,8 +71,9 @@ The package also installs a `fishlint` compatibility command for projects that
 currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config`, maps `--glob` values to native lint targets, and
 normalizes split value flags such as `--format json`, `-f json`, `--threads 4`,
-and `--rules no-debugger`. It ignores fishlint-only setup/debug flags. `--ext`
-is accepted for compatibility; native directory traversal already filters to
+and `--rules no-debugger`. Non-JSON ESLint formatter names are accepted and use
+native text output. It ignores fishlint-only setup/debug flags. `--ext` is
+accepted for compatibility; native directory traversal already filters to
 supported JavaScript and TypeScript extensions. ESLint cache controls and
 `--max-warnings` are consumed for compatibility because utoo-lint does not keep
 an ESLint-style result cache. ESLint runtime config flags such as `--env`,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -288,12 +288,12 @@ export function translateFishlintArgs(args = [], options = {}) {
       if (!value) {
         throw new Error(`utoo-lint: fishlint ${arg} requires a formatter name`);
       }
-      translated.push(`--format=${translateFishlintFormat(value)}`);
+      translated.push(`--format=${translateFishlintFormat(value, warn)}`);
       index += 2;
       continue;
     }
     if (arg.startsWith("--format=")) {
-      translated.push(`--format=${translateFishlintFormat(arg.slice("--format=".length))}`);
+      translated.push(`--format=${translateFishlintFormat(arg.slice("--format=".length), warn)}`);
       index += 1;
       continue;
     }
@@ -376,8 +376,14 @@ export function translateFishlintArgs(args = [], options = {}) {
   return translated;
 }
 
-function translateFishlintFormat(format) {
-  return format === "stylish" ? "text" : format;
+function translateFishlintFormat(format, warn) {
+  if (format === "json" || format === "text") {
+    return format;
+  }
+  if (format !== "stylish") {
+    warn(`utoo-lint: fishlint formatter '${format}' is not implemented; using native text output.`);
+  }
+  return "text";
 }
 
 function startsWithFlagValue(arg, flags) {


### PR DESCRIPTION
## Summary
- keep `json` and `text` formatter requests mapped to native output formats
- accept other ESLint/fishlint formatter names by falling back to native text output with a warning
- document non-JSON formatter compatibility behavior

## Validation
- node --check npm/utoo-lint/index.js
- translateFishlintArgs smoke test for unix, compact, and json formatters
- fishlint wrapper smoke test with `-f unix`
- zig build test
- zig build
- git diff --check