### PR TITLE
feat: add eslint compatibility bin

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -86,8 +86,13 @@ from standard input, and `--stdin-filename` controls the path shown in output.
 `--print-config` prints the selected utoo-lint JSON configuration for migration
 debugging.
 
+The package also exposes an `eslint` compatibility bin that routes directly
+through the same wrapper, so package scripts such as `eslint src -f json` can be
+tested without adding the `fishlint eslint` prefix.
+
 ```bash
 npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
+npx eslint --config utoo.json --ext .js,.ts src
 ```
 
 For programmatic replacements, `runFishlint()` applies the same argument

--- a/npm/utoo-lint/bin/eslint.js
+++ b/npm/utoo-lint/bin/eslint.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const fishlint = fileURLToPath(new URL("./fishlint.js", import.meta.url));
+const result = spawnSync(process.execPath, [fishlint, "eslint", ...process.argv.slice(2)], {
+  stdio: "inherit"
+});
+
+if (result.error) {
+  console.error(`utoo-lint: failed to run eslint compatibility wrapper: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -20,6 +20,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
+    "eslint": "./bin/eslint.js",
     "fishlint": "./bin/fishlint.js",
     "fishlint-lint-staged": "./bin/fishlint-lint-staged.js",
     "utoo-lint": "./bin/utoo-lint.js"


### PR DESCRIPTION
## Summary
- add an `eslint` bin to the npm package for lower-friction package script replacement
- route the new bin through the existing `fishlint eslint` compatibility wrapper
- document direct `npx eslint ...` usage through `@utoo/lint`

## Validation
- node --check npm/utoo-lint/bin/eslint.js
- node --check npm/utoo-lint/bin/fishlint.js
- node --check npm/utoo-lint/index.js
- eslint compatibility bin smoke test with JSON output
- eslint compatibility bin stdin smoke test
- eslint compatibility bin output-file smoke test
- zig build test
- zig build
- git diff --check