### PR TITLE
feat: add commonjs api entry

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -54,6 +54,12 @@ const cli = new CLIEngine({
 console.log(cli.executeOnFiles(["src"]).results);
 ```
 
+CommonJS scripts can use the same surface through `require()`:
+
+```js
+const { ESLint, lintFiles } = require("@utoo/lint");
+```
+
 `lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
 `diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
 `column`, `severity`, `message`, and `ruleId`. The `ESLint` export is an alias

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1,0 +1,792 @@
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } = require("node:fs");
+const { writeFile: writeFileAsync } = require("node:fs/promises");
+const { tmpdir } = require("node:os");
+const { extname, isAbsolute, join, resolve: resolvePath } = require("node:path");
+
+const { platformPackageName, resolveBinary } = require("./lib/binary.cjs");
+
+const version = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")).version;
+
+const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const FISHLINT_DROP_FLAGS = new Set([
+  "--cache",
+  "--color",
+  "--debug",
+  "--disable-legacy",
+  "--disable-setup",
+  "--no-cache",
+  "--no-color",
+  "--no-error-on-unmatched-pattern",
+  "--no-inline-config",
+  "--no-warn-ignored",
+  "--pass-on-no-patterns",
+  "--quiet",
+  "--report-unused-disable-directives",
+  "--stats",
+  "--stdin",
+  "--verbose",
+  "-v"
+]);
+const FISHLINT_DROP_VALUE_FLAGS = new Set([
+  "--cache-location",
+  "--cache-strategy",
+  "--env",
+  "--global",
+  "--ignore-path",
+  "--ignore-pattern",
+  "--max-warnings",
+  "--output-file",
+  "--parser",
+  "--parser-options",
+  "--plugin",
+  "--print-config",
+  "--resolve-plugins-relative-to",
+  "--rule",
+  "--rulesdir",
+  "--stdin-filename",
+  "-o"
+]);
+
+class UtooLint {
+  static get version() {
+    return version;
+  }
+
+  static async outputFixes(results) {
+    if (!Array.isArray(results)) {
+      throw new Error("'results' must be an array");
+    }
+
+    await Promise.all(
+      results
+        .filter((result) => {
+          if (typeof result !== "object" || result === null) {
+            throw new Error("'results' must include only objects");
+          }
+          return typeof result.output === "string" && isAbsolute(result.filePath);
+        })
+        .map((result) => writeFileAsync(result.filePath, result.output))
+    );
+  }
+
+  static getErrorResults(results) {
+    return getErrorResults(results);
+  }
+
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  async lintFiles(patterns = ["."], options = {}) {
+    const mergedOptions = mergeLintOptions(this.options, options);
+    const report = lintFiles(patterns, mergedOptions);
+    return reportToESLintResults(report, {
+      cwd: mergedOptions.cwd,
+      filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(patterns, mergedOptions.cwd)),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+  }
+
+  async lintText(code, options = {}) {
+    if (typeof code !== "string") {
+      throw new TypeError("code must be a string");
+    }
+
+    const mergedOptions = mergeLintOptions(this.options, options);
+    const report = lintText(code, mergedOptions);
+    return reportToESLintResults(report, {
+      source: code,
+      filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+  }
+
+  async isPathIgnored() {
+    return false;
+  }
+
+  async calculateConfigForFile() {
+    return {
+      rules: this.options.overrideConfig?.rules ?? {}
+    };
+  }
+
+  getRulesMetaForResults(results) {
+    if (!Array.isArray(results)) {
+      throw new Error("'results' must be an array");
+    }
+
+    const meta = {};
+    for (const result of results) {
+      for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
+        if (message.ruleId) {
+          meta[message.ruleId] = {};
+        }
+      }
+    }
+    return meta;
+  }
+
+  async loadFormatter(name = "stylish") {
+    return {
+      format(results) {
+        if (name === "json") {
+          return JSON.stringify(results);
+        }
+        return formatESLintResults(results);
+      }
+    };
+  }
+}
+
+class CLIEngine {
+  static get version() {
+    return version;
+  }
+
+  static outputFixes(report) {
+    const results = Array.isArray(report) ? report : report?.results;
+    if (!Array.isArray(results)) {
+      throw new Error("'report' must be an ESLint report or result array");
+    }
+
+    for (const result of results) {
+      if (typeof result !== "object" || result === null) {
+        throw new Error("'report' must include only result objects");
+      }
+      if (typeof result.output === "string" && isAbsolute(result.filePath)) {
+        writeFileSync(result.filePath, result.output);
+      }
+    }
+  }
+
+  static getErrorResults(results) {
+    return getErrorResults(results);
+  }
+
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  executeOnFiles(patterns) {
+    const mergedOptions = eslintConstructorOptions(this.options);
+    const report = lintFiles(patterns, mergedOptions);
+    const results = reportToESLintResults(report, {
+      cwd: mergedOptions.cwd,
+      filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(patterns, mergedOptions.cwd)),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+    return resultsToCLIEngineReport(results);
+  }
+
+  executeOnText(code, filePathOrOptions = "input.js") {
+    const filePath =
+      typeof filePathOrOptions === "object" && filePathOrOptions !== null
+        ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
+        : filePathOrOptions;
+    const mergedOptions = eslintConstructorOptions(this.options);
+    const report = lintText(code, {
+      ...mergedOptions,
+      filePath
+    });
+    const results = reportToESLintResults(report, {
+      source: code,
+      filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
+      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+    });
+    return resultsToCLIEngineReport(results);
+  }
+
+  getFormatter(name = "stylish") {
+    return (results) => {
+      if (name === "json") {
+        return JSON.stringify(results);
+      }
+      return formatESLintResults(results);
+    };
+  }
+
+  isPathIgnored() {
+    return false;
+  }
+
+  getConfigForFile() {
+    return {
+      rules: this.options.overrideConfig?.rules ?? this.options.baseConfig?.rules ?? {}
+    };
+  }
+}
+
+function run(args = [], options = {}) {
+  const cliArgs = normalizeStringArray(args, "args");
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  const binary = options.binary ?? resolveBinary({ env });
+
+  return spawnSync(binary, cliArgs, {
+    cwd: options.cwd,
+    env,
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio
+  });
+}
+
+function runFishlint(args = [], options = {}) {
+  return run(translateFishlintArgs(args, options), options);
+}
+
+function translateFishlintArgs(args = [], options = {}) {
+  const values = normalizeStringArray(args, "args");
+  const warn = options.warn ?? (() => {});
+
+  if (values.length === 0) {
+    return ["--help"];
+  }
+
+  const [command, ...rest] = values;
+  if (command !== "eslint") {
+    throw new Error(`utoo-lint fishlint compatibility only supports the eslint command, received: ${command}`);
+  }
+
+  const translated = [];
+  const globTargets = [];
+  let index = 0;
+
+  while (index < rest.length) {
+    const arg = rest[index];
+    if (arg === "--") {
+      index += 1;
+      continue;
+    }
+    if (FISHLINT_DROP_FLAGS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (FISHLINT_DROP_VALUE_FLAGS.has(arg)) {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: fishlint ${arg} requires a value`);
+      }
+      index += 2;
+      continue;
+    }
+    if (startsWithFlagValue(arg, FISHLINT_DROP_VALUE_FLAGS)) {
+      index += 1;
+      continue;
+    }
+    if (arg === "--fix") {
+      warn("utoo-lint: fishlint --fix is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
+    if (arg === "--format" || arg === "-f") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: fishlint ${arg} requires a formatter name`);
+      }
+      translated.push(`--format=${translateFishlintFormat(value, warn)}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--format=")) {
+      translated.push(`--format=${translateFishlintFormat(arg.slice("--format=".length), warn)}`);
+      index += 1;
+      continue;
+    }
+    if (arg === "--threads") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --threads requires a number");
+      }
+      translated.push(`--threads=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--threads=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--rules") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --rules requires a comma-separated rule list");
+      }
+      translated.push(`--rules=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--rules=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--config") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --config requires a path");
+      }
+      translated.push(`--config=${value}`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      translated.push(arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--ext") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --ext requires an extension list");
+      }
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--ext=")) {
+      index += 1;
+      continue;
+    }
+    if (arg === "--glob") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --glob requires a path");
+      }
+      globTargets.push(value);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--glob=")) {
+      globTargets.push(arg.slice("--glob=".length));
+      index += 1;
+      continue;
+    }
+    translated.push(arg);
+    index += 1;
+  }
+
+  if (globTargets.length > 0) {
+    translated.push(...globTargets);
+  }
+
+  return translated;
+}
+
+function translateFishlintFormat(format, warn) {
+  if (format === "json" || format === "text") {
+    return format;
+  }
+  if (format !== "stylish") {
+    warn(`utoo-lint: fishlint formatter '${format}' is not implemented; using native text output.`);
+  }
+  return "text";
+}
+
+function startsWithFlagValue(arg, flags) {
+  for (const flag of flags) {
+    if (arg.startsWith(`${flag}=`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function lintFiles(paths = ["."], options = {}) {
+  return withTemporaryConfig(options, (resolvedOptions) => {
+    const cliArgs = buildLintArgs(paths, resolvedOptions);
+    const result = run(cliArgs, { ...resolvedOptions, stdio: undefined, encoding: "utf8" });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    const status = result.status ?? 1;
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+
+    if (status !== 0 && status !== 1) {
+      throw new Error(stderr.trim() || `utoo-lint exited with status ${status}`);
+    }
+
+    let report;
+    try {
+      report = JSON.parse(stdout);
+    } catch (error) {
+      throw new Error(`utoo-lint returned invalid JSON: ${error.message}`);
+    }
+
+    report.exitCode = status;
+    if (stderr) {
+      Object.defineProperty(report, "stderr", {
+        value: stderr,
+        enumerable: false
+      });
+    }
+
+    return report;
+  });
+}
+
+function lintText(code, options = {}) {
+  if (typeof code !== "string") {
+    throw new TypeError("code must be a string");
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-"));
+  const requestedPath = options.filePath ?? "text.js";
+  const extension = extname(requestedPath) || ".js";
+  const tempFile = join(tmp, `input${extension}`);
+
+  try {
+    writeFileSync(tempFile, code);
+    const report = lintFiles([tempFile], {
+      ...options,
+      cwd: options.cwd,
+      noConfig: options.noConfig ?? !(options.config || options.overrideConfig)
+    });
+    report.diagnostics = report.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      filePath: requestedPath
+    }));
+    return report;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function buildLintArgs(paths, options) {
+  const cliArgs = [];
+
+  if (options.config) {
+    cliArgs.push(`--config=${options.config}`);
+  }
+  if (options.noConfig) {
+    cliArgs.push("--no-config");
+  }
+  if (options.rules) {
+    const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
+    cliArgs.push(`--rules=${rules}`);
+  }
+  if (options.threads != null) {
+    cliArgs.push(`--threads=${options.threads}`);
+  }
+
+  cliArgs.push("--format=json");
+
+  if (options.extraArgs) {
+    cliArgs.push(...normalizeStringArray(options.extraArgs, "extraArgs"));
+  }
+
+  cliArgs.push(...normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths"));
+  return cliArgs;
+}
+
+function mergeLintOptions(base, override) {
+  return {
+    ...eslintConstructorOptions(base),
+    ...override
+  };
+}
+
+function eslintConstructorOptions(options) {
+  const mapped = {
+    cwd: options.cwd,
+    threads: options.threads,
+    binary: options.binary,
+    env: options.env,
+    extraArgs: options.extraArgs
+  };
+
+  if (options.useEslintrc === false || options.overrideConfigFile === true) {
+    mapped.noConfig = true;
+  }
+  if (typeof options.overrideConfigFile === "string") {
+    mapped.config = options.overrideConfigFile;
+  }
+  const rules = options.overrideConfig?.rules ?? options.baseConfig?.rules;
+  if (rules) {
+    mapped.overrideConfig = { rules };
+  }
+  return mapped;
+}
+
+function withTemporaryConfig(options, callback) {
+  if (!options.overrideConfig?.rules) {
+    return callback(options);
+  }
+
+  const enabledRules = enabledRuleNames(options.overrideConfig.rules);
+  if (!hasRuleOptions(options.overrideConfig.rules)) {
+    return callback({
+      ...options,
+      noConfig: options.noConfig ?? true,
+      rules: options.rules ?? enabledRules
+    });
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
+  const configPath = join(tmp, "utoo.json");
+  try {
+    writeFileSync(configPath, JSON.stringify({ rules: options.overrideConfig.rules }));
+    return callback({
+      ...options,
+      config: options.config ?? configPath,
+      noConfig: false
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function enabledRuleNames(rules) {
+  return Object.entries(rules)
+    .filter(([, value]) => ruleConfigSeverity(value) > 0)
+    .map(([rule]) => rule);
+}
+
+function hasRuleOptions(rules) {
+  return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+}
+
+function normalizeStringArray(values, name) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${name} must be an array of strings`);
+  }
+  for (const value of values) {
+    if (typeof value !== "string") {
+      throw new TypeError(`${name} must be an array of strings`);
+    }
+  }
+  return values;
+}
+
+function reportToESLintResults(report, textOptions = {}) {
+  const byFile = new Map();
+
+  for (const diagnostic of report.diagnostics ?? []) {
+    const filePath = textOptions.filePath ?? normalizeESLintFilePath(diagnostic.filePath, textOptions.cwd);
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, textOptions.ruleSeverities));
+  }
+
+  if (textOptions.filePath && !byFile.has(textOptions.filePath)) {
+    byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
+  }
+  for (const filePath of textOptions.filePaths ?? []) {
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath));
+    }
+  }
+
+  for (const result of byFile.values()) {
+    finalizeESLintResult(result);
+  }
+
+  return [...byFile.values()];
+}
+
+function normalizeESLintFilePath(filePath, cwd) {
+  if (filePath === "<text>") return filePath;
+  if (isAbsolute(filePath)) return filePath;
+  return resolvePath(cwd ?? process.cwd(), filePath);
+}
+
+function reportFilePaths(report, cwd, fallbackFilePaths = []) {
+  const filePaths = new Set();
+  if (Array.isArray(report.filePaths)) {
+    for (const filePath of report.filePaths) {
+      if (typeof filePath === "string") {
+        filePaths.add(normalizeESLintFilePath(filePath, cwd));
+      }
+    }
+  }
+  for (const filePath of fallbackFilePaths) {
+    filePaths.add(filePath);
+  }
+  return [...filePaths];
+}
+
+function explicitLintFilePaths(patterns, cwd) {
+  const files = [];
+  for (const pattern of normalizeStringArray(Array.isArray(patterns) ? patterns : [patterns], "patterns")) {
+    if (hasGlobMagic(pattern)) continue;
+
+    const filePath = normalizeESLintFilePath(pattern, cwd);
+    if (!isLintableFilePath(filePath)) continue;
+
+    try {
+      if (statSync(filePath).isFile()) {
+        files.push(filePath);
+      }
+    } catch {}
+  }
+  return files;
+}
+
+function hasGlobMagic(pattern) {
+  return /[*?[\]{}()!+@]/.test(pattern);
+}
+
+function isLintableFilePath(filePath) {
+  return LINTABLE_EXTENSIONS.has(extname(filePath));
+}
+
+function getErrorResults(results) {
+  if (!Array.isArray(results)) {
+    throw new Error("'results' must be an array");
+  }
+
+  const filtered = [];
+  for (const result of results) {
+    const messages = (result.messages ?? []).filter((message) => message.severity === 2);
+    if (messages.length === 0) continue;
+    filtered.push({
+      ...result,
+      messages,
+      suppressedMessages: (result.suppressedMessages ?? []).filter((message) => message.severity === 2),
+      errorCount: messages.length,
+      warningCount: 0,
+      fixableWarningCount: 0
+    });
+  }
+  return filtered;
+}
+
+function resultsToCLIEngineReport(results) {
+  const report = {
+    results,
+    errorCount: 0,
+    fatalErrorCount: 0,
+    warningCount: 0,
+    fixableErrorCount: 0,
+    fixableWarningCount: 0,
+    usedDeprecatedRules: []
+  };
+
+  for (const result of results) {
+    report.errorCount += result.errorCount ?? 0;
+    report.fatalErrorCount += result.fatalErrorCount ?? 0;
+    report.warningCount += result.warningCount ?? 0;
+    report.fixableErrorCount += result.fixableErrorCount ?? 0;
+    report.fixableWarningCount += result.fixableWarningCount ?? 0;
+  }
+
+  return report;
+}
+
+function emptyESLintResult(filePath, source) {
+  const result = {
+    filePath,
+    messages: [],
+    suppressedMessages: [],
+    errorCount: 0,
+    fatalErrorCount: 0,
+    warningCount: 0,
+    fixableErrorCount: 0,
+    fixableWarningCount: 0,
+    usedDeprecatedRules: []
+  };
+  if (source != null) {
+    result.source = source;
+  }
+  return result;
+}
+
+function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
+  return {
+    ruleId: diagnostic.ruleId,
+    severity: ruleSeverities?.get(diagnostic.ruleId) ?? (diagnostic.severity === "error" ? 2 : 1),
+    message: diagnostic.message,
+    line: diagnostic.line,
+    column: diagnostic.column,
+    nodeType: null
+  };
+}
+
+function finalizeESLintResult(result) {
+  for (const message of result.messages) {
+    if (message.severity === 2) {
+      result.errorCount += 1;
+    } else {
+      result.warningCount += 1;
+    }
+  }
+}
+
+function formatESLintResults(results) {
+  const lines = [];
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const result of results) {
+    if (result.messages.length === 0) continue;
+    lines.push(result.filePath);
+    for (const message of result.messages) {
+      const severity = message.severity === 2 ? "error" : "warning";
+      lines.push(`  ${message.line}:${message.column}  ${severity}  ${message.message}  ${message.ruleId}`);
+    }
+    errorCount += result.errorCount;
+    warningCount += result.warningCount;
+  }
+
+  if (errorCount || warningCount) {
+    lines.push("");
+    lines.push(`x ${errorCount + warningCount} problem${errorCount + warningCount === 1 ? "" : "s"} (${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"})`);
+  }
+
+  return lines.join("\n");
+}
+
+function ruleSeverityMap(rules) {
+  if (!rules) return undefined;
+
+  const severities = new Map();
+  for (const [rule, config] of Object.entries(rules)) {
+    const severity = ruleConfigSeverity(config);
+    if (severity > 0) {
+      severities.set(rule, severity);
+    }
+  }
+  return severities;
+}
+
+function ruleConfigSeverity(config) {
+  const severity = Array.isArray(config) ? config[0] : config;
+  if (severity === false || severity === 0) return 0;
+  if (severity === true || severity === 2) return 2;
+  if (severity === 1) return 1;
+  if (typeof severity === "string") {
+    switch (severity.toLowerCase()) {
+      case "off":
+      case "0":
+        return 0;
+      case "warn":
+      case "warning":
+      case "1":
+        return 1;
+      case "error":
+      case "2":
+        return 2;
+      default:
+        return 1;
+    }
+  }
+  return 1;
+}
+
+module.exports = {
+  CLIEngine,
+  ESLint: UtooLint,
+  UtooLint,
+  default: UtooLint,
+  lintFiles,
+  lintText,
+  platformPackageName,
+  resolveBinary,
+  run,
+  runFishlint,
+  translateFishlintArgs,
+  version
+};

--- a/npm/utoo-lint/lib/binary.cjs
+++ b/npm/utoo-lint/lib/binary.cjs
@@ -1,0 +1,64 @@
+const { existsSync } = require("node:fs");
+const { join } = require("node:path");
+
+const here = __dirname;
+
+const packages = {
+  "darwin-arm64": "@utoo/lint-darwin-arm64",
+  "darwin-x64": "@utoo/lint-darwin-x64",
+  "linux-arm64": "@utoo/lint-linux-arm64",
+  "linux-x64": "@utoo/lint-linux-x64",
+  "win32-x64": "@utoo/lint-win32-x64"
+};
+
+function platformPackageName(platform = process.platform, arch = process.arch) {
+  return packages[`${platform}-${arch}`] ?? null;
+}
+
+function binaryName(platform) {
+  return platform === "win32" ? "utoo-lint.exe" : "utoo-lint";
+}
+
+function resolveBinary(options = {}) {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+
+  if (env.UTOO_LINT_BIN) {
+    if (existsSync(env.UTOO_LINT_BIN)) {
+      return env.UTOO_LINT_BIN;
+    }
+    throw new Error(`utoo-lint: UTOO_LINT_BIN does not exist: ${env.UTOO_LINT_BIN}`);
+  }
+
+  const packageName = platformPackageName(platform, arch);
+  if (!packageName) {
+    throw new Error(`utoo-lint: unsupported platform ${platform}-${arch}`);
+  }
+  const executable = binaryName(platform);
+
+  const candidates = [
+    () => require.resolve(`${packageName}/bin/${executable}`),
+    () => join(here, "..", "..", packageName, "bin", executable),
+    () => join(here, "..", "..", "..", "zig-out", "bin", executable)
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const resolved = candidate();
+      if (existsSync(resolved)) {
+        return resolved;
+      }
+    } catch {}
+  }
+
+  throw new Error(
+    `utoo-lint: missing native package ${packageName}. ` +
+      "Run `./scripts/package-npm.sh` from the repository root, or install the matching optional dependency."
+  );
+}
+
+module.exports = {
+  platformPackageName,
+  resolveBinary
+};

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -13,8 +13,14 @@
   "homepage": "https://github.com/fireairforce/utoo-lint#readme",
   "type": "module",
   "exports": {
-    ".": "./index.js",
-    "./binary": "./lib/binary.js",
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs"
+    },
+    "./binary": {
+      "import": "./lib/binary.js",
+      "require": "./lib/binary.cjs"
+    },
     "./configs/frontend": "./configs/frontend.json",
     "./schema": "./schema.json",
     "./package.json": "./package.json"
@@ -28,6 +34,7 @@
   "files": [
     "bin",
     "configs",
+    "index.cjs",
     "index.js",
     "lib",
     "schema.json"


### PR DESCRIPTION
## Summary
- add a CommonJS `require()` entry for the core `@utoo/lint` JS API
- add a CommonJS binary resolver and conditional exports for `@utoo/lint` and `@utoo/lint/binary`
- keep the ESM entry unchanged while letting legacy ESLint integrations require `ESLint`, `CLIEngine`, `lintFiles`, `lintText`, and fishlint helpers
- document CommonJS usage

## Validation
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/lib/binary.cjs
- node --check npm/utoo-lint/index.js
- CommonJS smoke test for lintFiles, lintText, ESLint, CLIEngine, runFishlint, and resolveBinary
- conditional export smoke test via symlinked `node_modules/@utoo/lint`
- zig build test
- zig build
- git diff --check