### PR TITLE
fix: ignore fishlint fix control flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -85,6 +85,8 @@ supported JavaScript and TypeScript extensions. ESLint cache controls and
 an ESLint-style result cache. ESLint runtime config flags such as `--env`,
 `--global`, `--parser`, `--parser-options`, `--plugin`, and ignore-pattern flags
 are also consumed so existing wrapper scripts do not pass them as file targets.
+Fix controls such as `--fix`, `--fix-dry-run`, and `--fix-type` are accepted
+with a warning because utoo-lint does not apply fixes yet.
 Display and reporting controls such as `--color`, `--no-color`, `--stats`, and
 `--no-warn-ignored` are accepted for the same reason. `--output-file` and `-o`
 write the native output to the requested report file. `--stdin` reads source

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -279,6 +279,25 @@ function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
+    if (arg === "--fix-dry-run") {
+      warn("utoo-lint: fishlint --fix-dry-run is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
+    if (arg === "--fix-type") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --fix-type requires a value");
+      }
+      warn("utoo-lint: fishlint --fix-type is ignored because utoo-lint does not apply fixes yet.");
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--fix-type=")) {
+      warn("utoo-lint: fishlint --fix-type is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
     if (arg === "--format" || arg === "-f") {
       const value = rest[index + 1];
       if (!value) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -283,6 +283,25 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
+    if (arg === "--fix-dry-run") {
+      warn("utoo-lint: fishlint --fix-dry-run is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
+    if (arg === "--fix-type") {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error("utoo-lint: fishlint --fix-type requires a value");
+      }
+      warn("utoo-lint: fishlint --fix-type is ignored because utoo-lint does not apply fixes yet.");
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--fix-type=")) {
+      warn("utoo-lint: fishlint --fix-type is ignored because utoo-lint does not apply fixes yet.");
+      index += 1;
+      continue;
+    }
     if (arg === "--format" || arg === "-f") {
       const value = rest[index + 1];
       if (!value) {


### PR DESCRIPTION
## Summary
- consume `--fix-dry-run` and `--fix-type` in fishlint/ESLint compatibility argument translation
- emit explicit warnings for fix controls because utoo-lint does not apply fixes yet
- keep ESM and CommonJS translation behavior in sync
- document fix control compatibility

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM translateFishlintArgs smoke test for fix controls
- CommonJS translateFishlintArgs smoke test for fix controls
- eslint compatibility bin smoke test with `--fix-dry-run --fix-type problem`
- zig build test
- zig build
- git diff --check