### PR TITLE
feat: support fishlint ignore path

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -85,8 +85,9 @@ supported JavaScript and TypeScript extensions. ESLint cache controls and
 an ESLint-style result cache. ESLint runtime config flags such as `--env`,
 `--global`, `--parser`, `--parser-options`, `--plugin`, and ignore-pattern flags
 are accepted so existing wrapper scripts do not pass them as file targets. The
-wrapper applies simple `--ignore-pattern` filters such as `dist/**` to explicit
-and `--glob` targets before invoking native lint.
+wrapper applies simple `.eslintignore`, `--ignore-path`, and `--ignore-pattern`
+filters such as `dist/**` to explicit and `--glob` targets before invoking
+native lint.
 Fix controls such as `--fix`, `--fix-dry-run`, and `--fix-type` are accepted
 with a warning because utoo-lint does not apply fixes yet.
 Display and reporting controls such as `--color`, `--no-color`, `--stats`, and

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -108,9 +108,28 @@ function extractOutputFile(args) {
 function extractIgnorePatterns(args) {
   const values = [];
   const patterns = [];
+  let ignorePath = ".eslintignore";
+  let ignorePathEnabled = true;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--ignore-path") {
+      ignorePath = args[index + 1];
+      if (!ignorePath) {
+        console.error("utoo-lint: fishlint --ignore-path requires a path");
+        process.exit(2);
+      }
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--ignore-path=")) {
+      ignorePath = arg.slice("--ignore-path=".length);
+      continue;
+    }
+    if (arg === "--no-ignore") {
+      ignorePathEnabled = false;
+      continue;
+    }
     if (arg === "--ignore-pattern") {
       const value = args[index + 1];
       if (!value) {
@@ -128,7 +147,22 @@ function extractIgnorePatterns(args) {
     values.push(arg);
   }
 
+  if (ignorePathEnabled) {
+    patterns.push(...readIgnoreFile(ignorePath));
+  }
+
   return { args: values, patterns };
+}
+
+function readIgnoreFile(path) {
+  if (!path || !existsSync(path)) {
+    return [];
+  }
+
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
 }
 
 function filterIgnoredTargets(args, patterns) {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -18,6 +18,7 @@ const FISHLINT_DROP_FLAGS = new Set([
   "--no-cache",
   "--no-color",
   "--no-error-on-unmatched-pattern",
+  "--no-ignore",
   "--no-inline-config",
   "--no-warn-ignored",
   "--pass-on-no-patterns",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -20,6 +20,7 @@ const FISHLINT_DROP_FLAGS = new Set([
   "--no-cache",
   "--no-color",
   "--no-error-on-unmatched-pattern",
+  "--no-ignore",
   "--no-inline-config",
   "--no-warn-ignored",
   "--pass-on-no-patterns",


### PR DESCRIPTION
## Summary
- read default `.eslintignore` and explicit `--ignore-path` files in the fishlint/eslint compatibility wrapper
- combine ignore file entries with `--ignore-pattern` values before invoking native lint
- support `--no-ignore` to disable default ignore file loading
- keep ESM and CommonJS argument translation aware of `--no-ignore`

## Validation
- node --check npm/utoo-lint/bin/fishlint.js
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- explicit --ignore-path smoke test
- default .eslintignore smoke test
- --no-ignore smoke test
- zig build test
- zig build
- git diff --check