### PR TITLE
feat: support eslint is path ignored

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -68,8 +68,10 @@ for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
 low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 `lintFiles()` returns absolute `filePath` values and includes empty results for
-checked files with no messages. The `CLIEngine` export provides a synchronous
-legacy facade for older ESLint integrations. Set
+checked files with no messages. `isPathIgnored()` reads default `.eslintignore`
+entries plus `ignorePath`, `ignorePatterns`, and `noIgnore` constructor options.
+The `CLIEngine` export provides a synchronous legacy facade for older ESLint
+integrations. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1,5 +1,5 @@
 const { spawnSync } = require("node:child_process");
-const { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } = require("node:fs");
+const { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } = require("node:fs");
 const { writeFile: writeFileAsync } = require("node:fs/promises");
 const { tmpdir } = require("node:os");
 const { extname, isAbsolute, join, resolve: resolvePath } = require("node:path");
@@ -103,8 +103,8 @@ class UtooLint {
     });
   }
 
-  async isPathIgnored() {
-    return false;
+  async isPathIgnored(filePath) {
+    return isPathIgnored(filePath, mergeLintOptions(this.options, {}));
   }
 
   async calculateConfigForFile() {
@@ -208,8 +208,8 @@ class CLIEngine {
     };
   }
 
-  isPathIgnored() {
-    return false;
+  isPathIgnored(filePath) {
+    return isPathIgnored(filePath, eslintConstructorOptions(this.options));
   }
 
   getConfigForFile() {
@@ -514,7 +514,10 @@ function eslintConstructorOptions(options) {
     threads: options.threads,
     binary: options.binary,
     env: options.env,
-    extraArgs: options.extraArgs
+    extraArgs: options.extraArgs,
+    ignorePath: options.ignorePath,
+    ignorePatterns: options.ignorePatterns,
+    noIgnore: options.noIgnore ?? options.ignore === false
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -651,6 +654,107 @@ function hasGlobMagic(pattern) {
 
 function isLintableFilePath(filePath) {
   return LINTABLE_EXTENSIONS.has(extname(filePath));
+}
+
+function isPathIgnored(filePath, options = {}) {
+  if (typeof filePath !== "string") {
+    throw new TypeError("filePath must be a string");
+  }
+  if (options.noIgnore) {
+    return false;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const normalized = normalizeIgnoredPath(filePath, cwd);
+  const patterns = ignorePatternsForOptions(options, cwd);
+  return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function ignorePatternsForOptions(options, cwd) {
+  const patterns = [];
+  for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
+    patterns.push(pattern);
+  }
+
+  const ignorePath = options.ignorePath ?? ".eslintignore";
+  if (ignorePath) {
+    patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
+  }
+  return patterns;
+}
+
+function normalizeIgnorePatterns(patterns) {
+  if (!patterns) {
+    return [];
+  }
+  const values = Array.isArray(patterns) ? patterns : [patterns];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      throw new TypeError("ignorePatterns must be a string or an array of strings");
+    }
+  }
+  return values;
+}
+
+function readIgnoreFile(path) {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+function normalizeIgnoredPath(filePath, cwd) {
+  const root = resolvePath(cwd);
+  const absolute = normalizeESLintFilePath(filePath, root);
+  const relative =
+    absolute === root || absolute.startsWith(`${root}/`) || absolute.startsWith(`${root}\\`)
+      ? absolute.slice(root.length).replace(/^[/\\]/, "")
+      : absolute;
+  return normalizePath(relative);
+}
+
+function normalizeIgnoredPattern(pattern) {
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
+}
+
+function pathIgnoredByPatterns(target, patterns) {
+  let ignored = false;
+  for (const pattern of patterns) {
+    const negated = pattern.startsWith("!");
+    if (matchesIgnorePattern(target, normalizeIgnoredPattern(pattern))) {
+      ignored = !negated;
+    }
+  }
+  return ignored;
+}
+
+function matchesIgnorePattern(target, pattern) {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3);
+    return target === prefix || target.startsWith(`${prefix}/`) || target.includes(`/${prefix}/`);
+  }
+  if (pattern.startsWith("**/")) {
+    const suffix = pattern.slice(3);
+    return target.endsWith(suffix) || target.includes(`/${suffix}`);
+  }
+  if (!pattern.includes("*")) {
+    return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
+  }
+
+  const expression = new RegExp(`(^|/)${escapeRegExp(pattern).replaceAll("\\*\\*", ".*").replaceAll("\\*", "[^/]*")}$`);
+  return expression.test(target);
+}
+
+function normalizePath(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
 }
 
 function getErrorResults(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { writeFile as writeFileAsync } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, isAbsolute, join, resolve as resolvePath } from "node:path";
@@ -105,8 +105,8 @@ export class UtooLint {
     });
   }
 
-  async isPathIgnored() {
-    return false;
+  async isPathIgnored(filePath) {
+    return isPathIgnored(filePath, mergeLintOptions(this.options, {}));
   }
 
   async calculateConfigForFile() {
@@ -212,8 +212,8 @@ export class CLIEngine {
     };
   }
 
-  isPathIgnored() {
-    return false;
+  isPathIgnored(filePath) {
+    return isPathIgnored(filePath, eslintConstructorOptions(this.options));
   }
 
   getConfigForFile() {
@@ -518,7 +518,10 @@ function eslintConstructorOptions(options) {
     threads: options.threads,
     binary: options.binary,
     env: options.env,
-    extraArgs: options.extraArgs
+    extraArgs: options.extraArgs,
+    ignorePath: options.ignorePath,
+    ignorePatterns: options.ignorePatterns,
+    noIgnore: options.noIgnore ?? options.ignore === false
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -658,6 +661,107 @@ function hasGlobMagic(pattern) {
 
 function isLintableFilePath(filePath) {
   return LINTABLE_EXTENSIONS.has(extname(filePath));
+}
+
+function isPathIgnored(filePath, options = {}) {
+  if (typeof filePath !== "string") {
+    throw new TypeError("filePath must be a string");
+  }
+  if (options.noIgnore) {
+    return false;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const normalized = normalizeIgnoredPath(filePath, cwd);
+  const patterns = ignorePatternsForOptions(options, cwd);
+  return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function ignorePatternsForOptions(options, cwd) {
+  const patterns = [];
+  for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
+    patterns.push(pattern);
+  }
+
+  const ignorePath = options.ignorePath ?? ".eslintignore";
+  if (ignorePath) {
+    patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
+  }
+  return patterns;
+}
+
+function normalizeIgnorePatterns(patterns) {
+  if (!patterns) {
+    return [];
+  }
+  const values = Array.isArray(patterns) ? patterns : [patterns];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      throw new TypeError("ignorePatterns must be a string or an array of strings");
+    }
+  }
+  return values;
+}
+
+function readIgnoreFile(path) {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+function normalizeIgnoredPath(filePath, cwd) {
+  const root = resolvePath(cwd);
+  const absolute = normalizeESLintFilePath(filePath, root);
+  const relative =
+    absolute === root || absolute.startsWith(`${root}/`) || absolute.startsWith(`${root}\\`)
+      ? absolute.slice(root.length).replace(/^[/\\]/, "")
+      : absolute;
+  return normalizePath(relative);
+}
+
+function normalizeIgnoredPattern(pattern) {
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
+}
+
+function pathIgnoredByPatterns(target, patterns) {
+  let ignored = false;
+  for (const pattern of patterns) {
+    const negated = pattern.startsWith("!");
+    if (matchesIgnorePattern(target, normalizeIgnoredPattern(pattern))) {
+      ignored = !negated;
+    }
+  }
+  return ignored;
+}
+
+function matchesIgnorePattern(target, pattern) {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3);
+    return target === prefix || target.startsWith(`${prefix}/`) || target.includes(`/${prefix}/`);
+  }
+  if (pattern.startsWith("**/")) {
+    const suffix = pattern.slice(3);
+    return target.endsWith(suffix) || target.includes(`/${suffix}`);
+  }
+  if (!pattern.includes("*")) {
+    return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
+  }
+
+  const expression = new RegExp(`(^|/)${escapeRegExp(pattern).replaceAll("\\*\\*", ".*").replaceAll("\\*", "[^/]*")}$`);
+  return expression.test(target);
+}
+
+function normalizePath(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
 }
 
 function getErrorResults(results) {


### PR DESCRIPTION
## Summary
- implement `ESLint#isPathIgnored()` and `CLIEngine#isPathIgnored()` in the JS API facade
- read default `.eslintignore` plus `ignorePath`, `ignorePatterns`, and `noIgnore` options
- support simple ordered negation patterns such as `!dist/keep.js`
- document the ignore API behavior for ESLint replacement usage

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for default `.eslintignore`, negation, `noIgnore`, `ignorePatterns`, and `ignorePath`
- CommonJS smoke for `ESLint#isPathIgnored()` and `CLIEngine#isPathIgnored()`
- git diff --check
- zig build test
- zig build