### PR TITLE
feat: calculate eslint api config

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -70,7 +70,10 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
 `isPathIgnored()` reads default `.eslintignore` entries plus `ignorePath`,
-`ignorePatterns`, and `noIgnore` constructor options. The `CLIEngine` export
+`ignorePatterns`, and `noIgnore` constructor options.
+`calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
+`baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
+`overrideConfigFile`, and `overrideConfig` rules. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -108,9 +108,7 @@ class UtooLint {
   }
 
   async calculateConfigForFile() {
-    return {
-      rules: this.options.overrideConfig?.rules ?? {}
-    };
+    return calculatedConfig(eslintConstructorOptions(this.options));
   }
 
   getRulesMetaForResults(results) {
@@ -213,9 +211,7 @@ class CLIEngine {
   }
 
   getConfigForFile() {
-    return {
-      rules: this.options.overrideConfig?.rules ?? this.options.baseConfig?.rules ?? {}
-    };
+    return calculatedConfig(eslintConstructorOptions(this.options));
   }
 }
 
@@ -522,7 +518,9 @@ function eslintConstructorOptions(options) {
     extraArgs: options.extraArgs,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
-    noIgnore: options.noIgnore ?? options.ignore === false
+    noIgnore: options.noIgnore ?? options.ignore === false,
+    baseConfig: options.baseConfig,
+    noConfig: options.noConfig
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -536,6 +534,57 @@ function eslintConstructorOptions(options) {
     mapped.overrideConfig = { rules };
   }
   return mapped;
+}
+
+function calculatedConfig(options = {}) {
+  return {
+    rules: {
+      ...rulesFromConfig(options.baseConfig),
+      ...rulesFromFileConfig(options),
+      ...rulesFromConfig(options.overrideConfig)
+    }
+  };
+}
+
+function rulesFromConfig(config) {
+  return config?.rules && typeof config.rules === "object" ? config.rules : {};
+}
+
+function rulesFromFileConfig(options) {
+  if (options.noConfig) {
+    return {};
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return {};
+  }
+
+  const config = readJsonConfig(configPath);
+  return rulesFromConfig(config);
+}
+
+function configPathForOptions(options) {
+  if (options.config) {
+    return resolvePath(options.cwd ?? process.cwd(), options.config);
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  for (const candidate of ["utoo.json", "utoo-lint.json"]) {
+    const path = resolvePath(cwd, candidate);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  return undefined;
+}
+
+function readJsonConfig(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`utoo-lint unable to read config ${path}: ${error.message}`);
+  }
 }
 
 function withTemporaryConfig(options, callback) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -110,9 +110,7 @@ export class UtooLint {
   }
 
   async calculateConfigForFile() {
-    return {
-      rules: this.options.overrideConfig?.rules ?? {}
-    };
+    return calculatedConfig(eslintConstructorOptions(this.options));
   }
 
   getRulesMetaForResults(results) {
@@ -217,9 +215,7 @@ export class CLIEngine {
   }
 
   getConfigForFile() {
-    return {
-      rules: this.options.overrideConfig?.rules ?? this.options.baseConfig?.rules ?? {}
-    };
+    return calculatedConfig(eslintConstructorOptions(this.options));
   }
 }
 
@@ -526,7 +522,9 @@ function eslintConstructorOptions(options) {
     extraArgs: options.extraArgs,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
-    noIgnore: options.noIgnore ?? options.ignore === false
+    noIgnore: options.noIgnore ?? options.ignore === false,
+    baseConfig: options.baseConfig,
+    noConfig: options.noConfig
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -540,6 +538,57 @@ function eslintConstructorOptions(options) {
     mapped.overrideConfig = { rules };
   }
   return mapped;
+}
+
+function calculatedConfig(options = {}) {
+  return {
+    rules: {
+      ...rulesFromConfig(options.baseConfig),
+      ...rulesFromFileConfig(options),
+      ...rulesFromConfig(options.overrideConfig)
+    }
+  };
+}
+
+function rulesFromConfig(config) {
+  return config?.rules && typeof config.rules === "object" ? config.rules : {};
+}
+
+function rulesFromFileConfig(options) {
+  if (options.noConfig) {
+    return {};
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return {};
+  }
+
+  const config = readJsonConfig(configPath);
+  return rulesFromConfig(config);
+}
+
+function configPathForOptions(options) {
+  if (options.config) {
+    return resolvePath(options.cwd ?? process.cwd(), options.config);
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  for (const candidate of ["utoo.json", "utoo-lint.json"]) {
+    const path = resolvePath(cwd, candidate);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  return undefined;
+}
+
+function readJsonConfig(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`utoo-lint unable to read config ${path}: ${error.message}`);
+  }
 }
 
 function withTemporaryConfig(options, callback) {


### PR DESCRIPTION
## Summary
- make `ESLint#calculateConfigForFile()` return merged rule config instead of only inline override rules
- make `CLIEngine#getConfigForFile()` use the same config calculation path
- merge `baseConfig`, default `utoo.json` / `utoo-lint.json`, explicit `overrideConfigFile`, and `overrideConfig` rule maps
- respect config disabling via `noConfig`, `useEslintrc: false`, and `overrideConfigFile: true`
- document config introspection behavior in the npm README

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for base/default/override rule merge order
- ESM smoke for explicit `overrideConfigFile`
- ESM smoke for `useEslintrc: false` ignoring default config
- CommonJS smoke for `ESLint#calculateConfigForFile()`
- CommonJS smoke for `CLIEngine#getConfigForFile()`
- git diff --check
- zig build test
- zig build