### PR TITLE
fix: respect ignores in eslint lint text

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -69,6 +69,7 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
+`lintText()` applies those ignore rules to the supplied `filePath`.
 `isPathIgnored()` reads default `.eslintignore` entries plus `ignorePath`,
 `ignorePatterns`, and `noIgnore` constructor options.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -459,6 +459,15 @@ function lintText(code, options = {}) {
   const tempFile = join(tmp, `input${extension}`);
 
   try {
+    if (isPathIgnored(requestedPath, options)) {
+      return {
+        files: 0,
+        filePaths: [],
+        diagnostics: [],
+        exitCode: 0
+      };
+    }
+
     writeFileSync(tempFile, code);
     const report = lintFiles([tempFile], {
       ...options,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -463,6 +463,15 @@ export function lintText(code, options = {}) {
   const tempFile = join(tmp, `input${extension}`);
 
   try {
+    if (isPathIgnored(requestedPath, options)) {
+      return {
+        files: 0,
+        filePaths: [],
+        diagnostics: [],
+        exitCode: 0
+      };
+    }
+
     writeFileSync(tempFile, code);
     const report = lintFiles([tempFile], {
       ...options,


### PR DESCRIPTION
## Summary
- make JS API `lintText()` respect ignore rules for the supplied `filePath`
- return an empty lint report when the text path is ignored
- preserve `noIgnore` behavior so callers can force linting ignored text
- document the `lintText()` ignore behavior in the npm README

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM direct `lintText()` ignored file smoke
- ESM direct `lintText()` with `noIgnore` smoke
- ESM `ESLint#lintText()` ignored file smoke
- CommonJS direct `lintText()` ignored file smoke
- CommonJS `ESLint#lintText()` ignored file smoke
- CommonJS `CLIEngine#executeOnText()` ignored file smoke
- git diff --check
- zig build test
- zig build