### PR TITLE
feat: support eslint api quiet option

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -75,7 +75,9 @@ checked files with no messages, and filters inputs with the same ignore rules.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
 `baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
 `overrideConfigFile`, and `overrideConfig` rules. The `CLIEngine` export
-provides a synchronous legacy facade for older ESLint integrations. Set
+provides a synchronous legacy facade for older ESLint integrations.
+`ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
+only error messages, matching ESLint's warning filtering behavior. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -82,11 +82,11 @@ class UtooLint {
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintFiles(patterns, mergedOptions);
-    return reportToESLintResults(report, {
+    return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
   }
 
   async lintText(code, options = {}) {
@@ -96,11 +96,11 @@ class UtooLint {
 
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintText(code, mergedOptions);
-    return reportToESLintResults(report, {
+    return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
   }
 
   async isPathIgnored(filePath) {
@@ -171,11 +171,11 @@ class CLIEngine {
   executeOnFiles(patterns) {
     const mergedOptions = eslintConstructorOptions(this.options);
     const report = lintFiles(patterns, mergedOptions);
-    const results = reportToESLintResults(report, {
+    const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
 
@@ -189,11 +189,11 @@ class CLIEngine {
       ...mergedOptions,
       filePath
     });
-    const results = reportToESLintResults(report, {
+    const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
 
@@ -529,7 +529,8 @@ function eslintConstructorOptions(options) {
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
-    noConfig: options.noConfig
+    noConfig: options.noConfig,
+    quiet: options.quiet
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -973,6 +974,8 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 }
 
 function finalizeESLintResult(result) {
+  result.errorCount = 0;
+  result.warningCount = 0;
   for (const message of result.messages) {
     if (message.severity === 2) {
       result.errorCount += 1;
@@ -980,6 +983,20 @@ function finalizeESLintResult(result) {
       result.warningCount += 1;
     }
   }
+}
+
+function maybeFilterQuietResults(results, options = {}) {
+  if (!options.quiet) {
+    return results;
+  }
+
+  for (const result of results) {
+    result.messages = (result.messages ?? []).filter((message) => message.severity === 2);
+    result.suppressedMessages = (result.suppressedMessages ?? []).filter((message) => message.severity === 2);
+    result.fixableWarningCount = 0;
+    finalizeESLintResult(result);
+  }
+  return results;
 }
 
 function formatESLintResults(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -84,11 +84,11 @@ export class UtooLint {
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintFiles(patterns, mergedOptions);
-    return reportToESLintResults(report, {
+    return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
   }
 
   async lintText(code, options = {}) {
@@ -98,11 +98,11 @@ export class UtooLint {
 
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintText(code, mergedOptions);
-    return reportToESLintResults(report, {
+    return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
   }
 
   async isPathIgnored(filePath) {
@@ -175,11 +175,11 @@ export class CLIEngine {
   executeOnFiles(patterns) {
     const mergedOptions = eslintConstructorOptions(this.options);
     const report = lintFiles(patterns, mergedOptions);
-    const results = reportToESLintResults(report, {
+    const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
 
@@ -193,11 +193,11 @@ export class CLIEngine {
       ...mergedOptions,
       filePath
     });
-    const results = reportToESLintResults(report, {
+    const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
       ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
-    });
+    }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
 
@@ -533,7 +533,8 @@ function eslintConstructorOptions(options) {
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
-    noConfig: options.noConfig
+    noConfig: options.noConfig,
+    quiet: options.quiet
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -980,6 +981,8 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 }
 
 function finalizeESLintResult(result) {
+  result.errorCount = 0;
+  result.warningCount = 0;
   for (const message of result.messages) {
     if (message.severity === 2) {
       result.errorCount += 1;
@@ -987,6 +990,20 @@ function finalizeESLintResult(result) {
       result.warningCount += 1;
     }
   }
+}
+
+function maybeFilterQuietResults(results, options = {}) {
+  if (!options.quiet) {
+    return results;
+  }
+
+  for (const result of results) {
+    result.messages = (result.messages ?? []).filter((message) => message.severity === 2);
+    result.suppressedMessages = (result.suppressedMessages ?? []).filter((message) => message.severity === 2);
+    result.fixableWarningCount = 0;
+    finalizeESLintResult(result);
+  }
+  return results;
 }
 
 function formatESLintResults(results) {


### PR DESCRIPTION
## Summary
- thread `quiet` through the ESLint and CLIEngine JS facade options
- filter warning messages from ESLint-compatible results when `quiet: true` is set
- document the constructor option in the npm API README

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS JS API smoke tests for quiet warning filtering and preserved parse errors with the local native binary
- git diff --check && zig build test && zig build