### PR TITLE
fix: use config for eslint lint text

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -69,7 +69,8 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
-`lintText()` applies those ignore rules to the supplied `filePath`.
+`lintText()` applies those ignore rules to the supplied `filePath` and uses the
+same config discovery as file linting unless `noConfig` is set.
 `isPathIgnored()` reads default `.eslintignore` entries plus `ignorePath`,
 `ignorePatterns`, and `noIgnore` constructor options.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -457,6 +457,10 @@ function lintText(code, options = {}) {
   const requestedPath = options.filePath ?? "text.js";
   const extension = extname(requestedPath) || ".js";
   const tempFile = join(tmp, `input${extension}`);
+  const discoveredConfig =
+    !options.noConfig && !options.config && !options.overrideConfig
+      ? configPathForOptions(options)
+      : undefined;
 
   try {
     if (isPathIgnored(requestedPath, options)) {
@@ -472,7 +476,8 @@ function lintText(code, options = {}) {
     const report = lintFiles([tempFile], {
       ...options,
       cwd: options.cwd,
-      noConfig: options.noConfig ?? !(options.config || options.overrideConfig)
+      config: options.config ?? discoveredConfig,
+      noConfig: options.noConfig
     });
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -461,6 +461,10 @@ export function lintText(code, options = {}) {
   const requestedPath = options.filePath ?? "text.js";
   const extension = extname(requestedPath) || ".js";
   const tempFile = join(tmp, `input${extension}`);
+  const discoveredConfig =
+    !options.noConfig && !options.config && !options.overrideConfig
+      ? configPathForOptions(options)
+      : undefined;
 
   try {
     if (isPathIgnored(requestedPath, options)) {
@@ -476,7 +480,8 @@ export function lintText(code, options = {}) {
     const report = lintFiles([tempFile], {
       ...options,
       cwd: options.cwd,
-      noConfig: options.noConfig ?? !(options.config || options.overrideConfig)
+      config: options.config ?? discoveredConfig,
+      noConfig: options.noConfig
     });
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,


### PR DESCRIPTION
## Summary
- make `lintText()` discover the same default config files as file linting when `noConfig` is not set
- keep explicit `noConfig` behavior intact for callers that want to bypass project config
- document the config discovery behavior for the JS API

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS JS API smoke tests for `lintText()` cwd config discovery and explicit `noConfig`
- git diff --check && zig build test && zig build