### PR TITLE
fix: apply config severity to eslint results

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -75,7 +75,9 @@ same config discovery as file linting unless `noConfig` is set.
 `ignorePatterns`, and `noIgnore` constructor options.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
 `baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
-`overrideConfigFile`, and `overrideConfig` rules. The `CLIEngine` export
+`overrideConfigFile`, and `overrideConfig` rules. ESLint-compatible results use
+those calculated rule severities for `messages`, `errorCount`, and
+`warningCount`. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior. Set

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -85,7 +85,7 @@ class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
 
@@ -99,7 +99,7 @@ class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
 
@@ -174,7 +174,7 @@ class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -192,7 +192,7 @@ class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -1039,6 +1039,10 @@ function ruleSeverityMap(rules) {
     }
   }
   return severities;
+}
+
+function ruleSeverityMapForOptions(options) {
+  return ruleSeverityMap(calculatedConfig(options).rules);
 }
 
 function ruleConfigSeverity(config) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -87,7 +87,7 @@ export class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
 
@@ -101,7 +101,7 @@ export class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
 
@@ -178,7 +178,7 @@ export class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -196,7 +196,7 @@ export class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
-      ruleSeverities: ruleSeverityMap(mergedOptions.overrideConfig?.rules)
+      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -1046,6 +1046,10 @@ function ruleSeverityMap(rules) {
     }
   }
   return severities;
+}
+
+function ruleSeverityMapForOptions(options) {
+  return ruleSeverityMap(calculatedConfig(options).rules);
 }
 
 function ruleConfigSeverity(config) {


### PR DESCRIPTION
## Summary
- derive ESLint-compatible message severities from the calculated JS API config
- make file config, baseConfig, and overrideConfig severities affect `messages`, `errorCount`, and `warningCount`
- document that JS facade results use calculated rule severities

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for config-driven severity in `lintFiles()` and `lintText()`
- git diff --check && zig build test && zig build