### PR TITLE
feat: support eslint config ignores

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -72,7 +72,7 @@ checked files with no messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the
 same config discovery as file linting unless `noConfig` is set.
 `isPathIgnored()` reads default `.eslintignore` entries plus `ignorePath`,
-`ignorePatterns`, and `noIgnore` constructor options.
+`ignorePatterns`, `noIgnore`, and `baseConfig`/`overrideConfig` ignore entries.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
 `baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
 `overrideConfigFile`, and `overrideConfig` rules. ESLint-compatible results use

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -544,9 +544,13 @@ function eslintConstructorOptions(options) {
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
   }
-  const rules = options.overrideConfig?.rules ?? options.baseConfig?.rules;
-  if (rules) {
-    mapped.overrideConfig = { rules };
+  if (options.overrideConfig) {
+    mapped.overrideConfig = Array.isArray(options.overrideConfig) ? options.overrideConfig : { ...options.overrideConfig };
+    if (!Array.isArray(mapped.overrideConfig) && !mapped.overrideConfig.rules && options.baseConfig?.rules) {
+      mapped.overrideConfig.rules = options.baseConfig.rules;
+    }
+  } else if (options.baseConfig?.rules) {
+    mapped.overrideConfig = { rules: options.baseConfig.rules };
   }
   return mapped;
 }
@@ -824,12 +828,42 @@ function ignorePatternsForOptions(options, cwd) {
   for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
     patterns.push(pattern);
   }
+  patterns.push(...ignorePatternsFromConfig(options.baseConfig));
 
   const ignorePath = options.ignorePath ?? ".eslintignore";
   if (ignorePath) {
     patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
   }
+  patterns.push(...ignorePatternsFromFileConfig(options));
+  patterns.push(...ignorePatternsFromConfig(options.overrideConfig));
   return patterns;
+}
+
+function ignorePatternsFromFileConfig(options) {
+  if (options.noConfig) {
+    return [];
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return [];
+  }
+
+  return ignorePatternsFromConfig(readJsonConfig(configPath));
+}
+
+function ignorePatternsFromConfig(config) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => ignorePatternsFromConfig(entry));
+  }
+
+  return [
+    ...normalizeIgnorePatterns(config.ignorePatterns),
+    ...normalizeIgnorePatterns(config.ignores)
+  ];
 }
 
 function normalizeIgnorePatterns(patterns) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -548,9 +548,13 @@ function eslintConstructorOptions(options) {
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
   }
-  const rules = options.overrideConfig?.rules ?? options.baseConfig?.rules;
-  if (rules) {
-    mapped.overrideConfig = { rules };
+  if (options.overrideConfig) {
+    mapped.overrideConfig = Array.isArray(options.overrideConfig) ? options.overrideConfig : { ...options.overrideConfig };
+    if (!Array.isArray(mapped.overrideConfig) && !mapped.overrideConfig.rules && options.baseConfig?.rules) {
+      mapped.overrideConfig.rules = options.baseConfig.rules;
+    }
+  } else if (options.baseConfig?.rules) {
+    mapped.overrideConfig = { rules: options.baseConfig.rules };
   }
   return mapped;
 }
@@ -831,12 +835,42 @@ function ignorePatternsForOptions(options, cwd) {
   for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
     patterns.push(pattern);
   }
+  patterns.push(...ignorePatternsFromConfig(options.baseConfig));
 
   const ignorePath = options.ignorePath ?? ".eslintignore";
   if (ignorePath) {
     patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
   }
+  patterns.push(...ignorePatternsFromFileConfig(options));
+  patterns.push(...ignorePatternsFromConfig(options.overrideConfig));
   return patterns;
+}
+
+function ignorePatternsFromFileConfig(options) {
+  if (options.noConfig) {
+    return [];
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return [];
+  }
+
+  return ignorePatternsFromConfig(readJsonConfig(configPath));
+}
+
+function ignorePatternsFromConfig(config) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => ignorePatternsFromConfig(entry));
+  }
+
+  return [
+    ...normalizeIgnorePatterns(config.ignorePatterns),
+    ...normalizeIgnorePatterns(config.ignores)
+  ];
 }
 
 function normalizeIgnorePatterns(patterns) {


### PR DESCRIPTION
## Summary
- apply `baseConfig` and `overrideConfig` ignore entries in the ESLint/CLIEngine JS facade
- support both legacy `ignorePatterns` and flat config `ignores`, including flat config arrays
- include ignore entries from discovered project config files when filtering JS API paths

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS JS API smoke tests for config ignores, project config ignores, and `ignore: false`
- git diff --check && zig build test && zig build