### PR TITLE
fix: support flat config rules in eslint api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -75,8 +75,9 @@ same config discovery as file linting unless `noConfig` is set.
 `ignorePatterns`, `noIgnore`, and `baseConfig`/`overrideConfig` ignore entries.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
 `baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
-`overrideConfigFile`, and `overrideConfig` rules. ESLint-compatible results use
-those calculated rule severities for `messages`, `errorCount`, and
+`overrideConfigFile`, and `overrideConfig` rules. `baseConfig` and
+`overrideConfig` may be objects or flat config arrays. ESLint-compatible results
+use those calculated rule severities for `messages`, `errorCount`, and
 `warningCount`. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -500,7 +500,9 @@ function buildLintArgs(paths, options) {
   }
   if (options.rules) {
     const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
-    cliArgs.push(`--rules=${rules}`);
+    if (rules) {
+      cliArgs.push(`--rules=${rules}`);
+    }
   }
   if (options.threads != null) {
     cliArgs.push(`--threads=${options.threads}`);
@@ -566,7 +568,16 @@ function calculatedConfig(options = {}) {
 }
 
 function rulesFromConfig(config) {
-  return config?.rules && typeof config.rules === "object" ? config.rules : {};
+  if (!config) {
+    return {};
+  }
+  if (Array.isArray(config)) {
+    return config.reduce((rules, entry) => ({
+      ...rules,
+      ...rulesFromConfig(entry)
+    }), {});
+  }
+  return config.rules && typeof config.rules === "object" ? config.rules : {};
 }
 
 function rulesFromFileConfig(options) {
@@ -607,12 +618,17 @@ function readJsonConfig(path) {
 }
 
 function withTemporaryConfig(options, callback) {
-  if (!options.overrideConfig?.rules) {
+  const inlineRules = {
+    ...rulesFromConfig(options.baseConfig),
+    ...rulesFromConfig(options.overrideConfig)
+  };
+  if (Object.keys(inlineRules).length === 0) {
     return callback(options);
   }
 
-  const enabledRules = enabledRuleNames(options.overrideConfig.rules);
-  if (!hasRuleOptions(options.overrideConfig.rules)) {
+  const rules = calculatedConfig(options).rules;
+  const enabledRules = enabledRuleNames(rules);
+  if (!hasRuleOptions(rules) && !hasDisabledRules(rules)) {
     return callback({
       ...options,
       noConfig: options.noConfig ?? true,
@@ -623,7 +639,7 @@ function withTemporaryConfig(options, callback) {
   const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
   const configPath = join(tmp, "utoo.json");
   try {
-    writeFileSync(configPath, JSON.stringify({ rules: options.overrideConfig.rules }));
+    writeFileSync(configPath, JSON.stringify({ rules }));
     return callback({
       ...options,
       config: options.config ?? configPath,
@@ -642,6 +658,10 @@ function enabledRuleNames(rules) {
 
 function hasRuleOptions(rules) {
   return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+}
+
+function hasDisabledRules(rules) {
+  return Object.values(rules).some((value) => ruleConfigSeverity(value) === 0);
 }
 
 function normalizeStringArray(values, name) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -504,7 +504,9 @@ function buildLintArgs(paths, options) {
   }
   if (options.rules) {
     const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
-    cliArgs.push(`--rules=${rules}`);
+    if (rules) {
+      cliArgs.push(`--rules=${rules}`);
+    }
   }
   if (options.threads != null) {
     cliArgs.push(`--threads=${options.threads}`);
@@ -570,7 +572,16 @@ function calculatedConfig(options = {}) {
 }
 
 function rulesFromConfig(config) {
-  return config?.rules && typeof config.rules === "object" ? config.rules : {};
+  if (!config) {
+    return {};
+  }
+  if (Array.isArray(config)) {
+    return config.reduce((rules, entry) => ({
+      ...rules,
+      ...rulesFromConfig(entry)
+    }), {});
+  }
+  return config.rules && typeof config.rules === "object" ? config.rules : {};
 }
 
 function rulesFromFileConfig(options) {
@@ -611,12 +622,17 @@ function readJsonConfig(path) {
 }
 
 function withTemporaryConfig(options, callback) {
-  if (!options.overrideConfig?.rules) {
+  const inlineRules = {
+    ...rulesFromConfig(options.baseConfig),
+    ...rulesFromConfig(options.overrideConfig)
+  };
+  if (Object.keys(inlineRules).length === 0) {
     return callback(options);
   }
 
-  const enabledRules = enabledRuleNames(options.overrideConfig.rules);
-  if (!hasRuleOptions(options.overrideConfig.rules)) {
+  const rules = calculatedConfig(options).rules;
+  const enabledRules = enabledRuleNames(rules);
+  if (!hasRuleOptions(rules) && !hasDisabledRules(rules)) {
     return callback({
       ...options,
       noConfig: options.noConfig ?? true,
@@ -627,7 +643,7 @@ function withTemporaryConfig(options, callback) {
   const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
   const configPath = join(tmp, "utoo.json");
   try {
-    writeFileSync(configPath, JSON.stringify({ rules: options.overrideConfig.rules }));
+    writeFileSync(configPath, JSON.stringify({ rules }));
     return callback({
       ...options,
       config: options.config ?? configPath,
@@ -646,6 +662,10 @@ function enabledRuleNames(rules) {
 
 function hasRuleOptions(rules) {
   return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+}
+
+function hasDisabledRules(rules) {
+  return Object.values(rules).some((value) => ruleConfigSeverity(value) === 0);
 }
 
 function normalizeStringArray(values, name) {


### PR DESCRIPTION
## Summary
- merge `rules` from object and flat config array forms in the JS API config helpers
- avoid passing an empty `--rules=` value for disabled-only rule configs
- write a temporary config when calculated rules include disabled rules, so default rules can be turned off

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for disabled rules and flat config array rules in ESLint/CLIEngine facades
- git diff --check && zig build test && zig build