### PR TITLE
feat: support eslint unmatched pattern option

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -81,7 +81,8 @@ use those calculated rule severities for `messages`, `errorCount`, and
 `warningCount`. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
-only error messages, matching ESLint's warning filtering behavior. Set
+only error messages, matching ESLint's warning filtering behavior.
+`errorOnUnmatchedPattern: false` skips explicit missing file paths. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -537,7 +537,8 @@ function eslintConstructorOptions(options) {
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
-    quiet: options.quiet
+    quiet: options.quiet,
+    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -751,13 +752,9 @@ function isLintableFilePath(filePath) {
 
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
-  if (options.noIgnore) {
-    return values;
-  }
-
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignorePatternsForOptions(options, cwd);
-  if (patterns.length === 0) {
+  const patterns = options.noIgnore ? [] : ignorePatternsForOptions(options, cwd);
+  if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false) {
     return values;
   }
 
@@ -772,6 +769,9 @@ function filteredLintPaths(paths, options = {}) {
 
     const expanded = expandLintTarget(target, cwd, patterns);
     if (expanded == null) {
+      if (options.errorOnUnmatchedPattern === false) {
+        continue;
+      }
       if (!pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
         filtered.add(target);
       }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -541,7 +541,8 @@ function eslintConstructorOptions(options) {
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
-    quiet: options.quiet
+    quiet: options.quiet,
+    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -758,13 +759,9 @@ function isLintableFilePath(filePath) {
 
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
-  if (options.noIgnore) {
-    return values;
-  }
-
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignorePatternsForOptions(options, cwd);
-  if (patterns.length === 0) {
+  const patterns = options.noIgnore ? [] : ignorePatternsForOptions(options, cwd);
+  if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false) {
     return values;
   }
 
@@ -779,6 +776,9 @@ function filteredLintPaths(paths, options = {}) {
 
     const expanded = expandLintTarget(target, cwd, patterns);
     if (expanded == null) {
+      if (options.errorOnUnmatchedPattern === false) {
+        continue;
+      }
       if (!pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
         filtered.add(target);
       }


### PR DESCRIPTION
## Summary
- thread `errorOnUnmatchedPattern` through the ESLint and CLIEngine JS facade options
- skip explicit missing file paths when `errorOnUnmatchedPattern: false` is set
- document the JS API option in the npm README

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for default unmatched behavior and `errorOnUnmatchedPattern: false`
- git diff --check && zig build test && zig build