### PR TITLE
feat: support eslint warn ignored option

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -82,6 +82,7 @@ use those calculated rule severities for `messages`, `errorCount`, and
 provides a synchronous legacy facade for older ESLint integrations.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
+`warnIgnored: false` suppresses warnings for explicit ignored file paths, and
 `errorOnUnmatchedPattern: false` skips explicit missing file paths. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -409,9 +409,10 @@ function startsWithFlagValue(arg, flags) {
 
 function lintFiles(paths = ["."], options = {}) {
   return withTemporaryConfig(options, (resolvedOptions) => {
+    const ignoredDiagnostics = ignoredLintPathDiagnostics(paths, resolvedOptions);
     const lintPaths = filteredLintPaths(paths, resolvedOptions);
     if (lintPaths.length === 0) {
-      return { files: 0, filePaths: [], diagnostics: [], exitCode: 0 };
+      return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
     }
 
     const cliArgs = buildLintArgs(lintPaths, resolvedOptions);
@@ -437,6 +438,10 @@ function lintFiles(paths = ["."], options = {}) {
     }
 
     report.exitCode = status;
+    report.diagnostics = [
+      ...(report.diagnostics ?? []),
+      ...ignoredDiagnostics
+    ];
     if (stderr) {
       Object.defineProperty(report, "stderr", {
         value: stderr,
@@ -464,11 +469,12 @@ function lintText(code, options = {}) {
 
   try {
     if (isPathIgnored(requestedPath, options)) {
+      const diagnostics = options.warnIgnored === false ? [] : [ignoredFileDiagnostic(normalizeESLintFilePath(requestedPath, options.cwd))];
       return {
         files: 0,
         filePaths: [],
-        diagnostics: [],
-        exitCode: 0
+        diagnostics,
+        exitCode: diagnostics.length > 0 ? 1 : 0
       };
     }
 
@@ -538,7 +544,8 @@ function eslintConstructorOptions(options) {
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
     quiet: options.quiet,
-    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern
+    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern,
+    warnIgnored: options.warnIgnored
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -782,6 +789,48 @@ function filteredLintPaths(paths, options = {}) {
     }
   }
   return [...filtered];
+}
+
+function ignoredLintPathDiagnostics(paths, options = {}) {
+  if (options.noIgnore || options.warnIgnored === false) {
+    return [];
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const patterns = ignorePatternsForOptions(options, cwd);
+  if (patterns.length === 0) {
+    return [];
+  }
+
+  const diagnostics = [];
+  for (const target of normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths")) {
+    if (hasGlobMagic(target)) continue;
+
+    const filePath = normalizeESLintFilePath(target, cwd);
+    if (!isLintableFilePath(filePath)) continue;
+
+    try {
+      if (!statSync(filePath).isFile()) continue;
+    } catch {
+      continue;
+    }
+
+    if (pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+      diagnostics.push(ignoredFileDiagnostic(filePath));
+    }
+  }
+  return diagnostics;
+}
+
+function ignoredFileDiagnostic(filePath) {
+  return {
+    filePath,
+    line: 0,
+    column: 0,
+    severity: "warning",
+    message: "File ignored because of a matching ignore pattern. Use noIgnore to override.",
+    ruleId: null
+  };
 }
 
 function expandLintTarget(target, cwd, patterns) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -413,9 +413,10 @@ function startsWithFlagValue(arg, flags) {
 
 export function lintFiles(paths = ["."], options = {}) {
   return withTemporaryConfig(options, (resolvedOptions) => {
+    const ignoredDiagnostics = ignoredLintPathDiagnostics(paths, resolvedOptions);
     const lintPaths = filteredLintPaths(paths, resolvedOptions);
     if (lintPaths.length === 0) {
-      return { files: 0, filePaths: [], diagnostics: [], exitCode: 0 };
+      return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
     }
 
     const cliArgs = buildLintArgs(lintPaths, resolvedOptions);
@@ -441,6 +442,10 @@ export function lintFiles(paths = ["."], options = {}) {
     }
 
     report.exitCode = status;
+    report.diagnostics = [
+      ...(report.diagnostics ?? []),
+      ...ignoredDiagnostics
+    ];
     if (stderr) {
       Object.defineProperty(report, "stderr", {
         value: stderr,
@@ -468,11 +473,12 @@ export function lintText(code, options = {}) {
 
   try {
     if (isPathIgnored(requestedPath, options)) {
+      const diagnostics = options.warnIgnored === false ? [] : [ignoredFileDiagnostic(normalizeESLintFilePath(requestedPath, options.cwd))];
       return {
         files: 0,
         filePaths: [],
-        diagnostics: [],
-        exitCode: 0
+        diagnostics,
+        exitCode: diagnostics.length > 0 ? 1 : 0
       };
     }
 
@@ -542,7 +548,8 @@ function eslintConstructorOptions(options) {
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
     quiet: options.quiet,
-    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern
+    errorOnUnmatchedPattern: options.errorOnUnmatchedPattern,
+    warnIgnored: options.warnIgnored
   };
 
   if (options.useEslintrc === false || options.overrideConfigFile === true) {
@@ -789,6 +796,48 @@ function filteredLintPaths(paths, options = {}) {
     }
   }
   return [...filtered];
+}
+
+function ignoredLintPathDiagnostics(paths, options = {}) {
+  if (options.noIgnore || options.warnIgnored === false) {
+    return [];
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const patterns = ignorePatternsForOptions(options, cwd);
+  if (patterns.length === 0) {
+    return [];
+  }
+
+  const diagnostics = [];
+  for (const target of normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths")) {
+    if (hasGlobMagic(target)) continue;
+
+    const filePath = normalizeESLintFilePath(target, cwd);
+    if (!isLintableFilePath(filePath)) continue;
+
+    try {
+      if (!statSync(filePath).isFile()) continue;
+    } catch {
+      continue;
+    }
+
+    if (pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+      diagnostics.push(ignoredFileDiagnostic(filePath));
+    }
+  }
+  return diagnostics;
+}
+
+function ignoredFileDiagnostic(filePath) {
+  return {
+    filePath,
+    line: 0,
+    column: 0,
+    severity: "warning",
+    message: "File ignored because of a matching ignore pattern. Use noIgnore to override.",
+    ruleId: null
+  };
 }
 
 function expandLintTarget(target, cwd, patterns) {


### PR DESCRIPTION
## Summary
- emit ESLint-compatible warnings for explicit ignored file paths in the JS API
- support `warnIgnored: false` across ESLint, CLIEngine, `lintFiles()`, and `lintText()`
- keep `ignore: false` / `noIgnore` behavior linting ignored files as before

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for ignored file warnings, `warnIgnored: false`, and `ignore: false`
- git diff --check && zig build test && zig build