### PR TITLE
fix: skip ignored lint text when warnings disabled

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -82,8 +82,9 @@ use those calculated rule severities for `messages`, `errorCount`, and
 provides a synchronous legacy facade for older ESLint integrations.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
-`warnIgnored: false` suppresses warnings for explicit ignored file paths, and
-`errorOnUnmatchedPattern: false` skips explicit missing file paths. Set
+`warnIgnored: false` suppresses warnings for explicit ignored file paths and
+skips ignored `lintText()` inputs. `errorOnUnmatchedPattern: false` skips
+explicit missing file paths. Set
 `UTOO_LINT_BIN=/path/to/utoo-lint` to force the JS API and CLI wrapper to use a
 specific native binary during local development.
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -99,6 +99,7 @@ class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
       ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
@@ -192,6 +193,7 @@ class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
       ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
@@ -695,7 +697,7 @@ function reportToESLintResults(report, textOptions = {}) {
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, textOptions.ruleSeverities));
   }
 
-  if (textOptions.filePath && !byFile.has(textOptions.filePath)) {
+  if (textOptions.filePath && textOptions.includeEmptyTextResult !== false && !byFile.has(textOptions.filePath)) {
     byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
   }
   for (const filePath of textOptions.filePaths ?? []) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -101,6 +101,7 @@ export class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
       ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
   }
@@ -196,6 +197,7 @@ export class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
       ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
@@ -699,7 +701,7 @@ function reportToESLintResults(report, textOptions = {}) {
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, textOptions.ruleSeverities));
   }
 
-  if (textOptions.filePath && !byFile.has(textOptions.filePath)) {
+  if (textOptions.filePath && textOptions.includeEmptyTextResult !== false && !byFile.has(textOptions.filePath)) {
     byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
   }
   for (const filePath of textOptions.filePaths ?? []) {


### PR DESCRIPTION
## Summary
- return no ESLint result for ignored `lintText()` inputs when `warnIgnored: false` is set
- keep normal clean `lintText()` inputs returning an empty-message result with source
- document the ignored `lintText()` behavior

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for ignored `lintText()` with and without `warnIgnored: false`
- git diff --check && zig build test && zig build