### PR TITLE
fix: pass cli engine text options

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -80,6 +80,8 @@ same config discovery as file linting unless `noConfig` is set.
 use those calculated rule severities for `messages`, `errorCount`, and
 `warningCount`. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
+`CLIEngine#executeOnText()` accepts a string path or an options object with
+`filePath`, `filename`, and text lint options.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
 `warnIgnored: false` suppresses warnings for explicit ignored file paths and

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -181,11 +181,18 @@ class CLIEngine {
   }
 
   executeOnText(code, filePathOrOptions = "input.js") {
+    const textOptions =
+      typeof filePathOrOptions === "object" && filePathOrOptions !== null
+        ? filePathOrOptions
+        : {};
     const filePath =
       typeof filePathOrOptions === "object" && filePathOrOptions !== null
         ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
         : filePathOrOptions;
-    const mergedOptions = eslintConstructorOptions(this.options);
+    const mergedOptions = {
+      ...eslintConstructorOptions(this.options),
+      ...textOptions
+    };
     const report = lintText(code, {
       ...mergedOptions,
       filePath

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -185,11 +185,18 @@ export class CLIEngine {
   }
 
   executeOnText(code, filePathOrOptions = "input.js") {
+    const textOptions =
+      typeof filePathOrOptions === "object" && filePathOrOptions !== null
+        ? filePathOrOptions
+        : {};
     const filePath =
       typeof filePathOrOptions === "object" && filePathOrOptions !== null
         ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
         : filePathOrOptions;
-    const mergedOptions = eslintConstructorOptions(this.options);
+    const mergedOptions = {
+      ...eslintConstructorOptions(this.options),
+      ...textOptions
+    };
     const report = lintText(code, {
       ...mergedOptions,
       filePath


### PR DESCRIPTION
## Summary
- merge `CLIEngine#executeOnText()` object arguments into per-call lint options
- preserve `filePath` and `filename` handling while allowing options such as `warnIgnored` and `overrideConfig`
- document the object argument support in the npm API README

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- CJS smoke test for `executeOnText()` object options with `warnIgnored`, `filename`, and `overrideConfig`
- git diff --check && zig build test && zig build