### PR TITLE
feat: include docs urls in eslint rule meta

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -67,6 +67,8 @@ for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
+Rule meta includes best-effort `docs.url` values for common ESLint-compatible
+rule IDs.
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -121,7 +121,7 @@ class UtooLint {
     for (const result of results) {
       for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
         if (message.ruleId) {
-          meta[message.ruleId] = {};
+          meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
         }
       }
     }
@@ -1037,6 +1037,36 @@ function getErrorResults(results) {
     });
   }
   return filtered;
+}
+
+function ruleMetaForRuleId(ruleId) {
+  return {
+    docs: {
+      url: ruleDocsUrl(ruleId)
+    }
+  };
+}
+
+function ruleDocsUrl(ruleId) {
+  if (ruleId.startsWith("@typescript-eslint/")) {
+    return `https://typescript-eslint.io/rules/${ruleId.slice("@typescript-eslint/".length)}/`;
+  }
+  if (ruleId.startsWith("eslint-comments/")) {
+    return `https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/${ruleId.slice("eslint-comments/".length)}.html`;
+  }
+  if (ruleId.startsWith("import/")) {
+    return `https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/${ruleId.slice("import/".length)}.md`;
+  }
+  if (ruleId.startsWith("jsx-a11y/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/${ruleId.slice("jsx-a11y/".length)}.md`;
+  }
+  if (ruleId.startsWith("react-hooks/")) {
+    return `https://react.dev/reference/eslint-plugin-react-hooks/lints/${ruleId.slice("react-hooks/".length)}`;
+  }
+  if (ruleId.startsWith("react/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/${ruleId.slice("react/".length)}.md`;
+  }
+  return `https://eslint.org/docs/latest/rules/${ruleId}`;
 }
 
 function resultsToCLIEngineReport(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -123,7 +123,7 @@ export class UtooLint {
     for (const result of results) {
       for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
         if (message.ruleId) {
-          meta[message.ruleId] = {};
+          meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
         }
       }
     }
@@ -1044,6 +1044,36 @@ function getErrorResults(results) {
     });
   }
   return filtered;
+}
+
+function ruleMetaForRuleId(ruleId) {
+  return {
+    docs: {
+      url: ruleDocsUrl(ruleId)
+    }
+  };
+}
+
+function ruleDocsUrl(ruleId) {
+  if (ruleId.startsWith("@typescript-eslint/")) {
+    return `https://typescript-eslint.io/rules/${ruleId.slice("@typescript-eslint/".length)}/`;
+  }
+  if (ruleId.startsWith("eslint-comments/")) {
+    return `https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/${ruleId.slice("eslint-comments/".length)}.html`;
+  }
+  if (ruleId.startsWith("import/")) {
+    return `https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/${ruleId.slice("import/".length)}.md`;
+  }
+  if (ruleId.startsWith("jsx-a11y/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/${ruleId.slice("jsx-a11y/".length)}.md`;
+  }
+  if (ruleId.startsWith("react-hooks/")) {
+    return `https://react.dev/reference/eslint-plugin-react-hooks/lints/${ruleId.slice("react-hooks/".length)}`;
+  }
+  if (ruleId.startsWith("react/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/${ruleId.slice("react/".length)}.md`;
+  }
+  return `https://eslint.org/docs/latest/rules/${ruleId}`;
 }
 
 function resultsToCLIEngineReport(results) {


### PR DESCRIPTION
## Summary
- populate `getRulesMetaForResults()` with best-effort `docs.url` metadata
- support core ESLint, `@typescript-eslint`, and common plugin rule prefixes
- document the rule meta behavior in the npm API README

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for core, TypeScript, suppressed, and plugin rule metadata
- git diff --check && zig build test && zig build