### PR TITLE
feat: support json metadata formatter

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -68,7 +68,8 @@ for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
 low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
-rule IDs.
+rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
+`json-with-metadata`, and the native text formatter shape.
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -116,25 +116,13 @@ class UtooLint {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
-
-    const meta = {};
-    for (const result of results) {
-      for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
-        if (message.ruleId) {
-          meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
-        }
-      }
-    }
-    return meta;
+    return rulesMetaForResults(results);
   }
 
   async loadFormatter(name = "stylish") {
     return {
       format(results) {
-        if (name === "json") {
-          return JSON.stringify(results);
-        }
-        return formatESLintResults(results);
+        return formatResultsByName(results, name);
       }
     };
   }
@@ -208,10 +196,7 @@ class CLIEngine {
 
   getFormatter(name = "stylish") {
     return (results) => {
-      if (name === "json") {
-        return JSON.stringify(results);
-      }
-      return formatESLintResults(results);
+      return formatResultsByName(results, name);
     };
   }
 
@@ -1168,6 +1153,37 @@ function formatESLintResults(results) {
   }
 
   return lines.join("\n");
+}
+
+function formatResultsByName(results, name = "stylish") {
+  if (name === "json") {
+    return JSON.stringify(results);
+  }
+  if (name === "json-with-metadata") {
+    return JSON.stringify({
+      results,
+      metadata: {
+        rulesMeta: rulesMetaForResults(results)
+      }
+    });
+  }
+  return formatESLintResults(results);
+}
+
+function rulesMetaForResults(results) {
+  if (!Array.isArray(results)) {
+    throw new Error("'results' must be an array");
+  }
+
+  const meta = {};
+  for (const result of results) {
+    for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
+      if (message.ruleId) {
+        meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
+      }
+    }
+  }
+  return meta;
 }
 
 function ruleSeverityMap(rules) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -118,25 +118,13 @@ export class UtooLint {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
-
-    const meta = {};
-    for (const result of results) {
-      for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
-        if (message.ruleId) {
-          meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
-        }
-      }
-    }
-    return meta;
+    return rulesMetaForResults(results);
   }
 
   async loadFormatter(name = "stylish") {
     return {
       format(results) {
-        if (name === "json") {
-          return JSON.stringify(results);
-        }
-        return formatESLintResults(results);
+        return formatResultsByName(results, name);
       }
     };
   }
@@ -212,10 +200,7 @@ export class CLIEngine {
 
   getFormatter(name = "stylish") {
     return (results) => {
-      if (name === "json") {
-        return JSON.stringify(results);
-      }
-      return formatESLintResults(results);
+      return formatResultsByName(results, name);
     };
   }
 
@@ -1175,6 +1160,37 @@ function formatESLintResults(results) {
   }
 
   return lines.join("\n");
+}
+
+function formatResultsByName(results, name = "stylish") {
+  if (name === "json") {
+    return JSON.stringify(results);
+  }
+  if (name === "json-with-metadata") {
+    return JSON.stringify({
+      results,
+      metadata: {
+        rulesMeta: rulesMetaForResults(results)
+      }
+    });
+  }
+  return formatESLintResults(results);
+}
+
+function rulesMetaForResults(results) {
+  if (!Array.isArray(results)) {
+    throw new Error("'results' must be an array");
+  }
+
+  const meta = {};
+  for (const result of results) {
+    for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
+      if (message.ruleId) {
+        meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
+      }
+    }
+  }
+  return meta;
 }
 
 function ruleSeverityMap(rules) {


### PR DESCRIPTION
## Summary
- add `json-with-metadata` support to `ESLint#loadFormatter()` and `CLIEngine#getFormatter()`
- include `metadata.rulesMeta` using the existing best-effort rule meta helper
- keep the existing `json` formatter array shape unchanged

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for `json`, `json-with-metadata`, and metadata rule URLs
- git diff --check && zig build test && zig build