### PR TITLE
feat: support eslint text formatters

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -69,7 +69,7 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
-`json-with-metadata`, and the native text formatter shape.
+`json-with-metadata`, `compact`, `unix`, and the native text formatter shape.
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1167,7 +1167,33 @@ function formatResultsByName(results, name = "stylish") {
       }
     });
   }
+  if (name === "compact") {
+    return formatCompactResults(results);
+  }
+  if (name === "unix") {
+    return formatUnixResults(results);
+  }
   return formatESLintResults(results);
+}
+
+function formatCompactResults(results) {
+  const lines = [];
+  for (const result of results) {
+    for (const message of result.messages ?? []) {
+      lines.push(`${result.filePath}: line ${message.line}, col ${message.column}, ${message.severity === 2 ? "Error" : "Warning"} - ${message.message} (${message.ruleId ?? ""})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatUnixResults(results) {
+  const lines = [];
+  for (const result of results) {
+    for (const message of result.messages ?? []) {
+      lines.push(`${result.filePath}:${message.line}:${message.column}: ${message.message} [${message.severity === 2 ? "Error" : "Warning"}/${message.ruleId ?? ""}]`);
+    }
+  }
+  return lines.join("\n");
 }
 
 function rulesMetaForResults(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1174,7 +1174,33 @@ function formatResultsByName(results, name = "stylish") {
       }
     });
   }
+  if (name === "compact") {
+    return formatCompactResults(results);
+  }
+  if (name === "unix") {
+    return formatUnixResults(results);
+  }
   return formatESLintResults(results);
+}
+
+function formatCompactResults(results) {
+  const lines = [];
+  for (const result of results) {
+    for (const message of result.messages ?? []) {
+      lines.push(`${result.filePath}: line ${message.line}, col ${message.column}, ${message.severity === 2 ? "Error" : "Warning"} - ${message.message} (${message.ruleId ?? ""})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatUnixResults(results) {
+  const lines = [];
+  for (const result of results) {
+    for (const message of result.messages ?? []) {
+      lines.push(`${result.filePath}:${message.line}:${message.column}: ${message.message} [${message.severity === 2 ? "Error" : "Warning"}/${message.ruleId ?? ""}]`);
+    }
+  }
+  return lines.join("\n");
 }
 
 function rulesMetaForResults(results) {


### PR DESCRIPTION
## Summary
- add `compact` formatter support for ESLint-compatible JS API formatters
- add `unix` formatter support for ESLint-compatible JS API formatters
- document the formatter names in the npm API README

## Validation
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs
- ESM/CJS smoke tests for `compact`, `unix`, and empty formatter output
- git diff --check && zig build test && zig build