### PR TITLE
feat: support fishlint legacy config flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -95,10 +95,11 @@ specific native binary during local development.
 
 The package also installs a `fishlint` compatibility command for projects that
 currently run `fishlint eslint ...`. It supports the common eslint subcommand
-shape, forwards `--config`, maps `--glob` values to native lint targets, and
-normalizes split value flags such as `--format json`, `-f json`, `--threads 4`,
-and `--rules no-debugger`. Non-JSON ESLint formatter names are accepted and use
-native text output. `--rule` accepts JSON objects such as
+shape, forwards `--config` and `-c`, maps `--glob` values to native lint
+targets, and normalizes split value flags such as `--format json`, `-f json`,
+`--threads 4`, and `--rules no-debugger`. `--no-eslintrc` maps to native
+`--no-config`. Non-JSON ESLint formatter names are accepted and use native text
+output. `--rule` accepts JSON objects such as
 `{"no-console":"warn"}` and simple `rule: severity` pairs, merging them into the
 selected utoo-lint config for the run. It ignores fishlint-only setup/debug
 flags. `--ext` is accepted for compatibility; native directory traversal already

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -31,6 +31,7 @@ const TARGET_VALUE_FLAGS = new Set([
   "--rulesdir",
   "--stdin-filename",
   "--threads",
+  "-c",
   "-f",
   "-o"
 ]);
@@ -178,6 +179,10 @@ function extractIgnorePatterns(args) {
     }
     if (arg === "--no-ignore") {
       ignorePathEnabled = false;
+      continue;
+    }
+    if (arg === "--no-eslintrc") {
+      values.push("--no-config");
       continue;
     }
     if (arg === "--ignore-pattern") {
@@ -626,7 +631,12 @@ function materializeRuleOverrideConfig(args, translatedArgs, ruleOverrides) {
 
 function withConfigArg(args, file) {
   const values = [];
-  for (const arg of args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-c") {
+      index += 1;
+      continue;
+    }
     if (arg === "--no-config" || arg.startsWith("--config=")) {
       continue;
     }
@@ -642,15 +652,15 @@ function findConfigPath(args) {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === "--no-config") {
+    if (arg === "--no-config" || arg === "--no-eslintrc") {
       configEnabled = false;
       configPath = undefined;
       continue;
     }
-    if (arg === "--config") {
+    if (arg === "--config" || arg === "-c") {
       configPath = args[index + 1];
       if (!configPath) {
-        console.error("utoo-lint: fishlint --config requires a path");
+        console.error(`utoo-lint: fishlint ${arg} requires a path`);
         process.exit(2);
       }
       index += 1;

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -18,6 +18,7 @@ const FISHLINT_DROP_FLAGS = new Set([
   "--no-cache",
   "--no-color",
   "--no-error-on-unmatched-pattern",
+  "--no-eslintrc",
   "--no-ignore",
   "--no-inline-config",
   "--no-warn-ignored",
@@ -250,6 +251,9 @@ function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (FISHLINT_DROP_FLAGS.has(arg)) {
+      if (arg === "--no-eslintrc") {
+        translated.push("--no-config");
+      }
       index += 1;
       continue;
     }
@@ -331,10 +335,10 @@ function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
-    if (arg === "--config") {
+    if (arg === "--config" || arg === "-c") {
       const value = rest[index + 1];
       if (!value) {
-        throw new Error("utoo-lint: fishlint --config requires a path");
+        throw new Error(`utoo-lint: fishlint ${arg} requires a path`);
       }
       translated.push(`--config=${value}`);
       index += 2;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -20,6 +20,7 @@ const FISHLINT_DROP_FLAGS = new Set([
   "--no-cache",
   "--no-color",
   "--no-error-on-unmatched-pattern",
+  "--no-eslintrc",
   "--no-ignore",
   "--no-inline-config",
   "--no-warn-ignored",
@@ -254,6 +255,9 @@ export function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (FISHLINT_DROP_FLAGS.has(arg)) {
+      if (arg === "--no-eslintrc") {
+        translated.push("--no-config");
+      }
       index += 1;
       continue;
     }
@@ -335,10 +339,10 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
-    if (arg === "--config") {
+    if (arg === "--config" || arg === "-c") {
       const value = rest[index + 1];
       if (!value) {
-        throw new Error("utoo-lint: fishlint --config requires a path");
+        throw new Error(`utoo-lint: fishlint ${arg} requires a path`);
       }
       translated.push(`--config=${value}`);
       index += 2;


### PR DESCRIPTION
## Summary
- map fishlint/eslint `-c <path>` to native `--config=<path>` in the CLI wrapper and JS API translator
- map legacy `--no-eslintrc` to native `--no-config`
- keep printable config and rule override materialization aligned with those legacy flags

## Why
Existing ESLint/fishlint scripts often use `-c` and `--no-eslintrc`. The compatibility wrapper previously forwarded them as lint targets, causing file-not-found diagnostics instead of applying the intended config behavior.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `fishlint eslint -c utoo.json target.js` reads the config and suppresses `no-debugger`
- smoke with current binary: `fishlint eslint --no-eslintrc target.js` does not treat the flag as a target and runs without default config discovery
- smoke: missing `-c` reports `utoo-lint: fishlint -c requires a path` in bin, ESM, and CJS translation paths
- `git diff --check`
- `zig build test`
- `zig build`
