### PR TITLE
feat: support fishlint short env flag

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -107,7 +107,7 @@ filters to supported JavaScript and TypeScript extensions. ESLint cache controls
 other cache flags are consumed for compatibility because utoo-lint does not keep
 an ESLint-style result cache. The wrapper applies ESLint-style warning exit-code
 semantics, including `--max-warnings`. ESLint runtime config flags such as
-`--env`, `--global`, `--parser`, `--parser-options`, `--plugin`, and
+`--env`, `-E`, `--global`, `--parser`, `--parser-options`, `--plugin`, and
 ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -32,6 +32,7 @@ const TARGET_VALUE_FLAGS = new Set([
   "--stdin-filename",
   "--threads",
   "-c",
+  "-E",
   "-f",
   "-o"
 ]);

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -47,6 +47,7 @@ const FISHLINT_DROP_VALUE_FLAGS = new Set([
   "--rule",
   "--rulesdir",
   "--stdin-filename",
+  "-E",
   "-o"
 ]);
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -49,6 +49,7 @@ const FISHLINT_DROP_VALUE_FLAGS = new Set([
   "--rule",
   "--rulesdir",
   "--stdin-filename",
+  "-E",
   "-o"
 ]);
 


### PR DESCRIPTION
## Summary
- accept ESLint's short env flag `-E <env>` in fishlint compatibility paths
- drop the `-E` value before invoking native lint so it is not treated as a lint target
- document `-E` alongside the existing `--env` compatibility support

## Why
Legacy ESLint/fishlint scripts commonly use `-E browser`. The wrapper previously forwarded `-E` and its value to native lint, producing file-not-found diagnostics for both values.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `fishlint eslint -E browser target.js` only lints `target.js`
- smoke: missing `-E` reports `utoo-lint: fishlint -E requires a value` in bin, ESM, and CJS translation paths
- `git diff --check`
- `zig build test`
- `zig build`
