### PR TITLE
fix: preserve fishlint ext value during unmatched filtering

### DIFF
--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -14,6 +14,7 @@ const TARGET_VALUE_FLAGS = new Set([
   "--cache-strategy",
   "--config",
   "--env",
+  "--ext",
   "--fix-type",
   "--format",
   "--global",


### PR DESCRIPTION
## Summary
- treat `--ext` as a value-taking flag during fishlint target pre-filtering
- preserve `--ext .js` before `translateFishlintArgs()` consumes it
- avoid shifting real lint targets into the `--ext` value slot when unmatched paths are skipped

## Why
`--no-error-on-unmatched-pattern --ext .js missing.js` removed `.js` as if it were a missing lint target before argument translation. In mixed cases, the next real file could become the `--ext` value, so the wrapper ended up linting nothing.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `--no-error-on-unmatched-pattern --ext .js missing.js` returns an empty report
- smoke with current binary: `--no-error-on-unmatched-pattern --ext .js missing.js present.js` still lints `present.js`
- smoke with current binary: `--no-error-on-unmatched-pattern --ext .js present.js` lints `present.js`
- `git diff --check`
- `zig build test`
- `zig build`
