### PR TITLE
fix: support fishlint ignore negation

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -111,7 +111,8 @@ semantics, including `--max-warnings`. ESLint runtime config flags such as
 ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
-targets before invoking native lint. `--no-error-on-unmatched-pattern` skips
+targets before invoking native lint, including `!pattern` negation entries.
+`--no-error-on-unmatched-pattern` skips
 missing explicit and `--glob` targets before invoking native lint. `--quiet`
 filters warnings from compatibility output. Explicit ignored file paths emit
 ESLint-style warnings unless `--no-warn-ignored` is set.

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -495,7 +495,18 @@ function hasLintTarget(args) {
 
 function isIgnoredTarget(target, patterns) {
   const normalized = normalizePath(target);
-  return patterns.some((pattern) => matchesIgnorePattern(normalized, normalizePath(pattern)));
+  let ignored = false;
+  for (const pattern of patterns) {
+    const negated = pattern.startsWith("!");
+    if (matchesIgnorePattern(normalized, normalizeIgnoredPattern(pattern))) {
+      ignored = !negated;
+    }
+  }
+  return ignored;
+}
+
+function normalizeIgnoredPattern(pattern) {
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
 }
 
 function matchesIgnorePattern(target, pattern) {


### PR DESCRIPTION
## Summary
- make fishlint wrapper ignore filtering honor `!pattern` negation entries
- apply the same order-sensitive ignore semantics used by the JS API helpers
- document negated ignore pattern support for fishlint compatibility

## Why
The wrapper previously used `patterns.some(...)`, so once a target matched an earlier ignore pattern it could not be re-included by a later `!pattern`. Existing ESLint/fishlint projects commonly use `.eslintignore` patterns such as `*.js` followed by `!keep.js`.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `.eslintignore` with `*.js` and `!keep.js` ignores `skip.js` but lints `keep.js`
- smoke with current binary: `--ignore-pattern '*.js' --ignore-pattern '!keep.js'` has the same behavior
- JS API comparison: `ESLint#isPathIgnored()` returns `true` for `skip.js` and `false` for `keep.js`
- `git diff --check`
- `zig build test`
- `zig build`
