### PR TITLE
fix: preserve fishlint flag values during ignore filtering

### DIFF
--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -384,6 +384,14 @@ function filterIgnoredTargets(args, patterns, warnIgnored) {
   let removedTarget = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (TARGET_VALUE_FLAGS.has(arg)) {
+      values.push(arg);
+      if (index + 1 < args.length) {
+        values.push(args[index + 1]);
+        index += 1;
+      }
+      continue;
+    }
     if (arg === "--glob") {
       const value = args[index + 1];
       if (!value) {


### PR DESCRIPTION
## Summary
- preserve split value flags while applying fishlint ignore pre-filtering
- prevent ignored patterns from deleting values for flags like `--config` and `--ext`
- keep missing split value errors intact after the pre-filtering pass

## Why
The wrapper's ignore pre-filter only knew about lint targets and `--glob`. If an ignore pattern matched a split flag value, for example `--config config/utoo.json` with `--ignore-pattern 'config/**'`, the config path was removed and the next lint target shifted into the config slot. That could silently lint nothing or use the wrong config.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `--ignore-pattern 'config/**' --config config/utoo.json target.js` keeps the config value and lints `target.js`
- smoke with current binary: `--ignore-pattern '.js' --ext .js target.js` keeps the `--ext` value and lints `target.js`
- smoke: missing `--config` still reports `utoo-lint: fishlint --config requires a path`
- `git diff --check`
- `zig build test`
- `zig build`
