### PR TITLE
fix: drop fishlint flag value forms

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -118,10 +118,11 @@ filters warnings from compatibility output. Explicit ignored file paths emit
 ESLint-style warnings unless `--no-warn-ignored` is set.
 Fix controls such as `--fix`, `--fix-dry-run`, and `--fix-type` are accepted
 with a warning because utoo-lint does not apply fixes yet.
-Display and reporting controls such as `--color`, `--no-color`, `--stats`, and
-`--no-warn-ignored` are accepted for the same reason. `--output-file` and `-o`
-write the native output to the requested report file. `--stdin` reads source
-from standard input, and `--stdin-filename` controls the path shown in output.
+Display and reporting controls such as `--color`, `--no-color`, `--stats`,
+`--stats=true`, and `--no-warn-ignored` are accepted for the same reason.
+`--output-file` and `-o` write the native output to the requested report file.
+`--stdin` reads source from standard input, and `--stdin-filename` controls the
+path shown in output.
 `--print-config` prints the selected utoo-lint JSON configuration for migration
 debugging.
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -258,6 +258,10 @@ function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
+    if (startsWithFlagValue(arg, FISHLINT_DROP_FLAGS)) {
+      index += 1;
+      continue;
+    }
     if (FISHLINT_DROP_VALUE_FLAGS.has(arg)) {
       const value = rest[index + 1];
       if (!value) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -262,6 +262,10 @@ export function translateFishlintArgs(args = [], options = {}) {
       index += 1;
       continue;
     }
+    if (startsWithFlagValue(arg, FISHLINT_DROP_FLAGS)) {
+      index += 1;
+      continue;
+    }
     if (FISHLINT_DROP_VALUE_FLAGS.has(arg)) {
       const value = rest[index + 1];
       if (!value) {


### PR DESCRIPTION
## Summary
- drop `--flag=value` forms for fishlint/eslint compatibility flags that utoo-lint intentionally consumes
- cover reporting/cache controls such as `--report-unused-disable-directives=off`, `--cache=true`, and `--stats=true`
- document the accepted reporting flag value form

## Why
The translator already consumed bare flags like `--stats`, but `--stats=true` or `--report-unused-disable-directives=off` were forwarded as native lint targets. Existing ESLint scripts commonly use these value forms, which caused file-not-found diagnostics during migration.

## Validation
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `--report-unused-disable-directives=off target.js` only lints `target.js`
- smoke with current binary: `--cache=true target.js` only lints `target.js`
- smoke with current binary: `--stats=true target.js` only lints `target.js`
- ESM/CJS `translateFishlintArgs()` return only `target.js` for those forms
- `git diff --check`
- `zig build test`
- `zig build`
