### PR TITLE
fix: let no-ignore disable fishlint patterns

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -112,6 +112,7 @@ ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
 targets before invoking native lint, including `!pattern` negation entries.
+`--no-ignore` disables those wrapper-side ignore filters.
 `--no-error-on-unmatched-pattern` skips
 missing explicit and `--glob` targets before invoking native lint. `--quiet`
 filters warnings from compatibility output. Explicit ignored file paths emit

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -204,10 +204,11 @@ function extractIgnorePatterns(args) {
     values.push(arg);
   }
 
-  if (ignorePathEnabled) {
-    patterns.push(...readIgnoreFile(ignorePath));
+  if (!ignorePathEnabled) {
+    return { args: values, patterns: [] };
   }
 
+  patterns.push(...readIgnoreFile(ignorePath));
   return { args: values, patterns };
 }
 


### PR DESCRIPTION
## Summary
- make fishlint wrapper `--no-ignore` disable `--ignore-pattern` filters as well as `.eslintignore`
- keep consuming ignore flags so they do not become native lint targets
- document the wrapper-side ignore disabling behavior

## Why
`--no-ignore` already disabled `.eslintignore` in the wrapper, but explicit `--ignore-pattern` values still filtered targets. ESLint and the JS API `noIgnore` behavior disable ignore handling entirely, so existing scripts could still skip files unexpectedly after migration.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: default `.eslintignore` still ignores `target.js`
- smoke with current binary: `--no-ignore target.js` lints `target.js`
- smoke with current binary: both `--ignore-pattern target.js --no-ignore target.js` and `--no-ignore --ignore-pattern target.js target.js` lint `target.js`
- JS API comparison: `ESLint#isPathIgnored()` returns false with `noIgnore: true`, even when `ignorePatterns` is set
- `git diff --check`
- `zig build test`
- `zig build`
