### PR TITLE
fix: support fishlint boolean flag values

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -98,8 +98,9 @@ currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config` and `-c`, maps `--glob` values to native lint
 targets, and normalizes split value flags such as `--format json`, `-f json`,
 `--threads 4`, and `--rules no-debugger`. `--no-eslintrc` maps to native
-`--no-config`. Non-JSON ESLint formatter names are accepted and use native text
-output. `--rule` accepts JSON objects such as
+`--no-config`, and `--no-eslintrc=true` is accepted for compatibility. Non-JSON
+ESLint formatter names are accepted and use native text output. `--rule`
+accepts JSON objects such as
 `{"no-console":"warn"}` and simple `rule: severity` pairs, merging them into the
 selected utoo-lint config for the run. It ignores fishlint-only setup/debug
 flags. `--ext` is accepted for compatibility; native directory traversal already
@@ -112,7 +113,7 @@ ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
 targets before invoking native lint, including `!pattern` negation entries.
-`--no-ignore` disables those wrapper-side ignore filters.
+`--no-ignore` and `--no-ignore=true` disable those wrapper-side ignore filters.
 `--no-error-on-unmatched-pattern` skips
 missing explicit and `--glob` targets before invoking native lint. `--quiet`
 filters warnings from compatibility output. Explicit ignored file paths emit

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -183,8 +183,18 @@ function extractIgnorePatterns(args) {
       ignorePathEnabled = false;
       continue;
     }
+    if (arg.startsWith("--no-ignore=")) {
+      ignorePathEnabled = booleanFlagValue(arg) === false;
+      continue;
+    }
     if (arg === "--no-eslintrc") {
       values.push("--no-config");
+      continue;
+    }
+    if (arg.startsWith("--no-eslintrc=")) {
+      if (booleanFlagValue(arg) !== false) {
+        values.push("--no-config");
+      }
       continue;
     }
     if (arg === "--ignore-pattern") {
@@ -362,6 +372,14 @@ function parseMaxWarnings(value) {
     process.exit(2);
   }
   return parsed;
+}
+
+function booleanFlagValue(arg) {
+  const value = arg.slice(arg.indexOf("=") + 1).trim().toLowerCase();
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return true;
 }
 
 function readIgnoreFile(path) {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -259,6 +259,9 @@ function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (startsWithFlagValue(arg, FISHLINT_DROP_FLAGS)) {
+      if (arg.startsWith("--no-eslintrc=") && booleanFlagValue(arg) !== false) {
+        translated.push("--no-config");
+      }
       index += 1;
       continue;
     }
@@ -408,6 +411,14 @@ function startsWithFlagValue(arg, flags) {
     }
   }
   return false;
+}
+
+function booleanFlagValue(arg) {
+  const value = arg.slice(arg.indexOf("=") + 1).trim().toLowerCase();
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return true;
 }
 
 function lintFiles(paths = ["."], options = {}) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -263,6 +263,9 @@ export function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (startsWithFlagValue(arg, FISHLINT_DROP_FLAGS)) {
+      if (arg.startsWith("--no-eslintrc=") && booleanFlagValue(arg) !== false) {
+        translated.push("--no-config");
+      }
       index += 1;
       continue;
     }
@@ -412,6 +415,14 @@ function startsWithFlagValue(arg, flags) {
     }
   }
   return false;
+}
+
+function booleanFlagValue(arg) {
+  const value = arg.slice(arg.indexOf("=") + 1).trim().toLowerCase();
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return true;
 }
 
 export function lintFiles(paths = ["."], options = {}) {


### PR DESCRIPTION
## Summary
- support boolean value forms for fishlint compatibility flags
- treat `--no-ignore=true` like `--no-ignore`, while `--no-ignore=false` keeps ignore filtering enabled
- map `--no-eslintrc=true` to native `--no-config` in the wrapper and ESM/CJS translator, while `false` keeps config discovery enabled

## Why
Some migrated ESLint/fishlint scripts pass boolean options as `--flag=true`. The compatibility layer previously consumed those arguments as generic drop flags, but did not apply behavior for `--no-ignore=true` or `--no-eslintrc=true`, so files could stay ignored or config discovery could remain enabled unexpectedly.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- smoke with `UTOO_LINT_BIN=/Users/zoomdong/utoo-lint/zig-out/bin/utoo-lint`: `--no-ignore=true target.js` lints a file listed in `.eslintignore`
- smoke with current binary: `--no-ignore=false target.js` keeps the file ignored
- smoke with current binary: `--no-eslintrc=true target.js` disables default config discovery and reports `no-debugger`
- smoke with current binary: `--no-eslintrc=false target.js` keeps default config discovery enabled
- ESM/CJS `translateFishlintArgs()` map `--no-eslintrc=true` to `--no-config`
- `git diff --check`
- `zig build test`
- `zig build`
