### PR TITLE
fix: support fishlint wrapper boolean options

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -114,10 +114,11 @@ as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
 targets before invoking native lint, including `!pattern` negation entries.
 `--no-ignore` and `--no-ignore=true` disable those wrapper-side ignore filters.
-`--no-error-on-unmatched-pattern` skips
+`--no-error-on-unmatched-pattern` and `--no-error-on-unmatched-pattern=true` skip
 missing explicit and `--glob` targets before invoking native lint. `--quiet`
-filters warnings from compatibility output. Explicit ignored file paths emit
-ESLint-style warnings unless `--no-warn-ignored` is set.
+and `--quiet=true` filter warnings from compatibility output. Explicit ignored
+file paths emit ESLint-style warnings unless `--no-warn-ignored` or
+`--no-warn-ignored=true` is set.
 Fix controls such as `--fix`, `--fix-dry-run`, and `--fix-type` are accepted
 with a warning because utoo-lint does not apply fixes yet.
 Display and reporting controls such as `--color`, `--no-color`, `--stats`,

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -257,6 +257,10 @@ function extractQuiet(args) {
       enabled = true;
       continue;
     }
+    if (arg.startsWith("--quiet=")) {
+      enabled = booleanFlagValue(arg) !== false;
+      continue;
+    }
     values.push(arg);
   }
 
@@ -272,6 +276,10 @@ function extractUnmatchedPatternOption(args) {
       enabled = true;
       continue;
     }
+    if (arg.startsWith("--no-error-on-unmatched-pattern=")) {
+      enabled = booleanFlagValue(arg) !== false;
+      continue;
+    }
     values.push(arg);
   }
 
@@ -285,6 +293,10 @@ function extractWarnIgnoredOption(args) {
   for (const arg of args) {
     if (arg === "--no-warn-ignored") {
       enabled = false;
+      continue;
+    }
+    if (arg.startsWith("--no-warn-ignored=")) {
+      enabled = booleanFlagValue(arg) === false;
       continue;
     }
     values.push(arg);


### PR DESCRIPTION
## Summary
- consume `--quiet=value`, `--no-warn-ignored=value`, and `--no-error-on-unmatched-pattern=value` inside the fishlint wrapper
- preserve `=false` behavior so scripts can explicitly leave each boolean option disabled
- document the supported wrapper boolean value forms

## Root cause
The wrapper-owned fishlint options only matched bare boolean flags. When existing scripts passed `--flag=true`, the values were forwarded as lint targets or ignored by the wrapper logic, so quiet filtering, ignored-file warning suppression, and unmatched-pattern skipping did not activate.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- focused fishlint wrapper reproductions for `--quiet=true/false`, `--no-warn-ignored=true/false`, and `--no-error-on-unmatched-pattern=true/false`
- `git diff --check`
- `zig build test`
- `zig build`
