### PR TITLE
fix: drop delegated fishlint boolean flags

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -145,7 +145,9 @@ For non-eslint fishlint commands, the compatibility command delegates to
 project-local tools when they are installed: `fishlint format` runs `prettier`,
 `fishlint stylelint` runs `stylelint`, `fishlint commitlint` runs `commitlint`,
 and `fishlint projectlint` runs `projectlint`. This keeps existing scripts
-working without treating those tools as native `utoo-lint` checks.
+working without treating those tools as native `utoo-lint` checks. Delegated
+commands also consume fishlint-only setup and verbose flags, including
+`--disable-setup=true` and similar value forms.
 `fishlint setup` and `fishlint setuplint` are accepted as no-ops so existing
 install hooks do not fail after replacing the package.
 

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -37,6 +37,12 @@ const TARGET_VALUE_FLAGS = new Set([
   "-f",
   "-o"
 ]);
+const FISHLINT_PASSTHROUGH_DROP_FLAGS = new Set([
+  "--disable-legacy",
+  "--disable-setup",
+  "--verbose",
+  "-v"
+]);
 
 if (command === "setup" || command === "setuplint") {
   console.warn(`utoo-lint: fishlint ${command} is treated as a no-op; configure utoo-lint with utoo.json.`);
@@ -997,7 +1003,8 @@ function translatePassthroughArgs(args, options = {}) {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--") continue;
-    if (arg === "--disable-setup" || arg === "--disable-legacy" || arg === "--verbose" || arg === "-v") continue;
+    if (FISHLINT_PASSTHROUGH_DROP_FLAGS.has(arg)) continue;
+    if (isBooleanValueFlag(arg, FISHLINT_PASSTHROUGH_DROP_FLAGS)) continue;
     if (arg === "--glob") {
       const value = args[index + 1];
       if (!value) {
@@ -1028,6 +1035,14 @@ function translatePassthroughArgs(args, options = {}) {
 
   translated.push(...targets);
   return translated;
+}
+
+function isBooleanValueFlag(arg, flags) {
+  const separator = arg.indexOf("=");
+  if (separator === -1) {
+    return false;
+  }
+  return flags.has(arg.slice(0, separator));
 }
 
 function translateCommitlintArgs(args) {


### PR DESCRIPTION
## Summary
- consume delegated fishlint-only setup and verbose flags when they use `--flag=value` syntax
- keep existing passthrough behavior for delegated command flags such as `stylelint --quiet` and `projectlint --debug`
- document delegated command support for setup/verbose value forms

## Root cause
The delegated fishlint argument translator dropped bare fishlint-only flags like `--disable-setup`, but did not recognize value forms such as `--disable-setup=true`. Those flags were forwarded to project-local tools like prettier, which can reject or misinterpret them.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- focused delegated-command harness for `format`, `stylelint`, and `projectlint`
- `git diff --check`
- `zig build test`
- `zig build`
