### PR TITLE
fix: support commitlint short env value

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -148,6 +148,8 @@ and `fishlint projectlint` runs `projectlint`. This keeps existing scripts
 working without treating those tools as native `utoo-lint` checks. Delegated
 commands also consume fishlint-only setup and verbose flags, including
 `--disable-setup=true` and similar value forms.
+`fishlint commitlint -E=GIT_PARAMS` is normalized like `--env GIT_PARAMS`,
+falling back to `--edit` when the environment variable is not set.
 `fishlint setup` and `fishlint setuplint` are accepted as no-ops so existing
 install hooks do not fail after replacing the package.
 

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -1080,6 +1080,16 @@ function translateCommitlintArgs(args) {
       hasMessageSource = true;
       continue;
     }
+    if (arg.startsWith("-E=")) {
+      const envKey = arg.slice("-E=".length);
+      if (process.env[envKey]) {
+        translated.push("--env", envKey);
+      } else {
+        translated.push("--edit");
+      }
+      hasMessageSource = true;
+      continue;
+    }
     translated.push(arg);
   }
 


### PR DESCRIPTION
## Summary
- support `fishlint commitlint -E=VAR` in the delegated commitlint translator
- normalize populated env vars to `--env VAR`
- keep the existing `--edit` fallback when the env var is not available

## Root cause
The commitlint delegation handled split `-E VAR` and long `--env=VAR`, but not the short value form `-E=VAR`. That left `-E=VAR` in the forwarded args and also appended the default `--edit` source.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- focused commitlint harness for `-E=COMMIT_MSG` with and without the env var set
- `git diff --check`
- `zig build test`
- `zig build`
