### PR TITLE
fix: match eslint config by file

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -79,9 +79,10 @@ same config discovery as file linting unless `noConfig` is set.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge
 `baseConfig`, default `utoo.json` or `utoo-lint.json` files, explicit
 `overrideConfigFile`, and `overrideConfig` rules. `baseConfig` and
-`overrideConfig` may be objects or flat config arrays. ESLint-compatible results
-use those calculated rule severities for `messages`, `errorCount`, and
-`warningCount`. The `CLIEngine` export
+`overrideConfig` may be objects or flat config arrays; when a file path is
+provided, flat config `files` and `ignores` entries are applied before merging.
+ESLint-compatible results use those calculated rule severities for `messages`,
+`errorCount`, and `warningCount`. The `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with
 `filePath`, `filename`, and text lint options.

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -112,8 +112,8 @@ export class UtooLint {
     return isPathIgnored(filePath, mergeLintOptions(this.options, {}));
   }
 
-  async calculateConfigForFile() {
-    return calculatedConfig(eslintConstructorOptions(this.options));
+  async calculateConfigForFile(filePath) {
+    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
   getRulesMetaForResults(results) {
@@ -210,8 +210,8 @@ export class CLIEngine {
     return isPathIgnored(filePath, eslintConstructorOptions(this.options));
   }
 
-  getConfigForFile() {
-    return calculatedConfig(eslintConstructorOptions(this.options));
+  getConfigForFile(filePath) {
+    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 }
 
@@ -583,30 +583,33 @@ function eslintConstructorOptions(options) {
   return mapped;
 }
 
-function calculatedConfig(options = {}) {
+function calculatedConfig(options = {}, filePath) {
   return {
     rules: {
-      ...rulesFromConfig(options.baseConfig),
-      ...rulesFromFileConfig(options),
-      ...rulesFromConfig(options.overrideConfig)
+      ...rulesFromConfig(options.baseConfig, filePath, options.cwd),
+      ...rulesFromFileConfig(options, filePath),
+      ...rulesFromConfig(options.overrideConfig, filePath, options.cwd)
     }
   };
 }
 
-function rulesFromConfig(config) {
+function rulesFromConfig(config, filePath, cwd) {
   if (!config) {
     return {};
   }
   if (Array.isArray(config)) {
     return config.reduce((rules, entry) => ({
       ...rules,
-      ...rulesFromConfig(entry)
+      ...rulesFromConfig(entry, filePath, cwd)
     }), {});
+  }
+  if (!configAppliesToFile(config, filePath, cwd)) {
+    return {};
   }
   return config.rules && typeof config.rules === "object" ? config.rules : {};
 }
 
-function rulesFromFileConfig(options) {
+function rulesFromFileConfig(options, filePath) {
   if (options.noConfig) {
     return {};
   }
@@ -617,7 +620,35 @@ function rulesFromFileConfig(options) {
   }
 
   const config = readJsonConfig(configPath);
-  return rulesFromConfig(config);
+  return rulesFromConfig(config, filePath, options.cwd);
+}
+
+function configAppliesToFile(config, filePath, cwd) {
+  if (!filePath) {
+    return true;
+  }
+
+  const normalized = normalizeIgnoredPath(filePath, cwd ?? process.cwd());
+  const files = normalizeConfigPatterns(config.files);
+  if (files.length > 0 && !files.some((pattern) => matchesIgnorePattern(normalized, normalizeIgnoredPattern(pattern)))) {
+    return false;
+  }
+
+  const ignores = normalizeIgnorePatterns(config.ignores);
+  return !pathIgnoredByPatterns(normalized, ignores);
+}
+
+function normalizeConfigPatterns(patterns) {
+  if (!patterns) {
+    return [];
+  }
+  const values = Array.isArray(patterns) ? patterns : [patterns];
+  return values.flatMap((value) => {
+    if (typeof value === "string") {
+      return [value];
+    }
+    return [];
+  });
 }
 
 function configPathForOptions(options) {
@@ -1018,12 +1049,35 @@ function matchesIgnorePattern(target, pattern) {
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
-  const expression = new RegExp(`(^|/)${escapeRegExp(pattern).replaceAll("\\*\\*", ".*").replaceAll("\\*", "[^/]*")}$`);
+  const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 
 function normalizePath(path) {
   return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function globPatternRegExpSource(pattern) {
+  let source = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        if (pattern[index + 2] === "/") {
+          source += "(?:.*/)?";
+          index += 2;
+        } else {
+          source += ".*";
+          index += 1;
+        }
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+  return source;
 }
 
 function escapeRegExp(value) {


### PR DESCRIPTION
## Summary
- make `ESLint#calculateConfigForFile(filePath)` and `CLIEngine#getConfigForFile(filePath)` apply flat config `files` and `ignores` entries before merging rules
- fix wildcard matching for common `**/*.js` patterns used by flat config and ignore config
- document file-aware flat config merging in the JS API README

## Root cause
The JS compatibility API merged every rule entry from flat config arrays without considering the requested file path. That made `calculateConfigForFile('src/a.js')` include rules meant for `test/**/*.js`, and wildcard patterns such as `src/**/*.js` could also generate invalid regular expressions.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused JS API script covering `calculateConfigForFile()`, `CLIEngine#getConfigForFile()`, flat config `files`, `ignores`, and `**/*.js` matching
- `git diff --check`
- `zig build test`
- `zig build`
