### PR TITLE
feat: support fishlint json metadata formatter

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -99,8 +99,10 @@ currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config` and `-c`, maps `--glob` values to native lint
 targets, and normalizes split value flags such as `--format json`, `-f json`,
 `--threads 4`, and `--rules no-debugger`. `--no-eslintrc` maps to native
-`--no-config`, and `--no-eslintrc=true` is accepted for compatibility. Non-JSON
-ESLint formatter names are accepted and use native text output. `--rule`
+`--no-config`, and `--no-eslintrc=true` is accepted for compatibility.
+`json-with-metadata` emits the native JSON report with a `metadata.rulesMeta`
+section. Other non-JSON ESLint formatter names are accepted and use native text
+output. `--rule`
 accepts JSON objects such as
 `{"no-console":"warn"}` and simple `rule: severity` pairs, merging them into the
 selected utoo-lint config for the run. It ignores fishlint-only setup/debug

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -115,7 +115,7 @@ try {
 }
 
 const ruleConfig = materializeRuleOverrideConfig(nativeValues, args, ruleOverrides.rules);
-const needsReportOutput = quiet.enabled || ignoredFiltered.diagnostics.length > 0;
+const needsReportOutput = quiet.enabled || ignoredFiltered.diagnostics.length > 0 || usesJsonWithMetadataFormat(nativeValues);
 const result = spawnSync(binary, needsReportOutput ? withJsonFormat(ruleConfig.args) : ruleConfig.args, { encoding: "utf8" });
 
 if (result.error) {
@@ -627,10 +627,29 @@ function ignoredTargetDiagnostic(target) {
 function usesJsonFormat(args) {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === "--json" || arg === "--format=json" || arg === "-f=json") {
+    if (
+      arg === "--json" ||
+      arg === "--format=json" ||
+      arg === "--format=json-with-metadata" ||
+      arg === "-f=json" ||
+      arg === "-f=json-with-metadata"
+    ) {
       return true;
     }
-    if ((arg === "--format" || arg === "-f") && args[index + 1] === "json") {
+    if ((arg === "--format" || arg === "-f") && (args[index + 1] === "json" || args[index + 1] === "json-with-metadata")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function usesJsonWithMetadataFormat(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--format=json-with-metadata" || arg === "-f=json-with-metadata") {
+      return true;
+    }
+    if ((arg === "--format" || arg === "-f") && args[index + 1] === "json-with-metadata") {
       return true;
     }
   }
@@ -930,10 +949,62 @@ function rewriteReportStdinPaths(report, input) {
 }
 
 function formatReportOutput(report, args) {
+  if (usesJsonWithMetadataFormat(args)) {
+    return JSON.stringify(reportWithMetadata(report)) + "\n";
+  }
   if (usesJsonFormat(args)) {
     return JSON.stringify(report) + "\n";
   }
   return formatTextReport(report);
+}
+
+function reportWithMetadata(report) {
+  return {
+    ...report,
+    metadata: {
+      rulesMeta: rulesMetaForReport(report)
+    }
+  };
+}
+
+function rulesMetaForReport(report) {
+  const meta = {};
+  for (const diagnostic of report.diagnostics ?? []) {
+    if (diagnostic?.ruleId && !meta[diagnostic.ruleId]) {
+      meta[diagnostic.ruleId] = ruleMetaForRuleId(diagnostic.ruleId);
+    }
+  }
+  return meta;
+}
+
+function ruleMetaForRuleId(ruleId) {
+  return {
+    docs: {
+      url: ruleDocsUrl(ruleId)
+    }
+  };
+}
+
+function ruleDocsUrl(ruleId) {
+  if (ruleId.startsWith("@typescript-eslint/")) {
+    return `https://typescript-eslint.io/rules/${ruleId.slice("@typescript-eslint/".length)}/`;
+  }
+  if (ruleId.startsWith("eslint-comments/")) {
+    return `https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/${ruleId.slice("eslint-comments/".length)}.html`;
+  }
+  if (ruleId.startsWith("import/")) {
+    return `https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/${ruleId.slice("import/".length)}.md`;
+  }
+  if (ruleId.startsWith("jsx-a11y/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/${ruleId.slice("jsx-a11y/".length)}.md`;
+  }
+  if (ruleId.startsWith("react-hooks/")) {
+    return `https://react.dev/reference/eslint-plugin-react-hooks/lints/${ruleId.slice("react-hooks/".length)}`;
+  }
+  if (ruleId.startsWith("react/")) {
+    return `https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/${ruleId.slice("react/".length)}.md`;
+  }
+  return `https://eslint.org/docs/latest/rules/${ruleId}`;
 }
 
 function formatTextReport(report) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -402,6 +402,9 @@ function translateFishlintFormat(format, warn) {
   if (format === "json" || format === "text") {
     return format;
   }
+  if (format === "json-with-metadata") {
+    return "json";
+  }
   if (format !== "stylish") {
     warn(`utoo-lint: fishlint formatter '${format}' is not implemented; using native text output.`);
   }


### PR DESCRIPTION
## Summary
- support `fishlint eslint -f json-with-metadata` without falling back to text output
- emit the native JSON report with a `metadata.rulesMeta` section for reported rules
- map `json-with-metadata` to native JSON in the JS fishlint argument translator without warning

## Root cause
The fishlint compatibility formatter translation only treated `json` as a JSON formatter. `json-with-metadata` was classified as an unsupported non-JSON formatter, so report-consuming scripts received text output and a compatibility warning instead of parseable JSON.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- `node --check npm/utoo-lint/index.js`
- focused fishlint CLI reproduction for `-f json-with-metadata` with `metadata.rulesMeta.no-debugger`
- focused `translateFishlintArgs()` assertion for `json-with-metadata`
- `git diff --check`
- `zig build test`
- `zig build`
