### PR TITLE
fix: support fishlint globstar ignores

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -115,7 +115,8 @@ semantics, including `--max-warnings`. ESLint runtime config flags such as
 ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
-targets before invoking native lint, including `!pattern` negation entries.
+targets before invoking native lint, including `**/*.js` globstar patterns and
+`!pattern` negation entries.
 `--no-ignore` and `--no-ignore=true` disable those wrapper-side ignore filters.
 `--no-error-on-unmatched-pattern` and `--no-error-on-unmatched-pattern=true` skip
 missing explicit and `--glob` targets before invoking native lint. `--quiet`

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -579,12 +579,35 @@ function matchesIgnorePattern(target, pattern) {
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
-  const expression = new RegExp(`(^|/)${escapeRegExp(pattern).replaceAll("\\*\\*", ".*").replaceAll("\\*", "[^/]*")}$`);
+  const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 
 function normalizePath(path) {
   return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function globPatternRegExpSource(pattern) {
+  let source = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        if (pattern[index + 2] === "/") {
+          source += "(?:.*/)?";
+          index += 2;
+        } else {
+          source += ".*";
+          index += 1;
+        }
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+  return source;
 }
 
 function escapeRegExp(value) {


### PR DESCRIPTION
## Summary
- fix fishlint wrapper ignore matching for globstar patterns such as `src/**/*.js`
- support both zero-level and nested matches for `**/` segments
- document globstar ignore-pattern compatibility

## Root cause
The wrapper converted wildcard ignore patterns by applying string replacements that expected escaped `*` characters. Patterns like `src/**/*.js` kept raw `*` tokens in the generated regular expression, causing the wrapper to crash before invoking the native linter.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js`
- focused fishlint wrapper reproduction for `--ignore-pattern 'src/**/*.js'` against zero-level and nested files
- focused `.eslintignore` reproduction with `src/**/*.js`
- `git diff --check`
- `zig build test`
- `zig build`
