### PR TITLE
fix: map eslint result severity by file

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -82,7 +82,8 @@ same config discovery as file linting unless `noConfig` is set.
 `overrideConfig` may be objects or flat config arrays; when a file path is
 provided, flat config `files` and `ignores` entries are applied before merging.
 ESLint-compatible results use those calculated rule severities for `messages`,
-`errorCount`, and `warningCount`. The `CLIEngine` export
+`errorCount`, and `warningCount`, including per-file flat config matches. The
+`CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with
 `filePath`, `filename`, and text lint options.

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -89,7 +89,7 @@ export class UtooLint {
     return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
   }
 
@@ -104,7 +104,7 @@ export class UtooLint {
       source: code,
       filePath: normalizeESLintFilePath(options.filePath ?? "<text>", mergedOptions.cwd),
       includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
-      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
   }
 
@@ -169,7 +169,7 @@ export class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -195,7 +195,7 @@ export class CLIEngine {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
       includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
-      ruleSeverities: ruleSeverityMapForOptions(mergedOptions)
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
   }
@@ -744,7 +744,8 @@ function reportToESLintResults(report, textOptions = {}) {
     if (!byFile.has(filePath)) {
       byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
     }
-    byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, textOptions.ruleSeverities));
+    const ruleSeverities = textOptions.ruleSeverityForFile?.(filePath) ?? textOptions.ruleSeverities;
+    byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
   if (textOptions.filePath && textOptions.includeEmptyTextResult !== false && !byFile.has(textOptions.filePath)) {
@@ -1309,8 +1310,8 @@ function ruleSeverityMap(rules) {
   return severities;
 }
 
-function ruleSeverityMapForOptions(options) {
-  return ruleSeverityMap(calculatedConfig(options).rules);
+function ruleSeverityMapForOptions(options, filePath) {
+  return ruleSeverityMap(calculatedConfig(options, filePath).rules);
 }
 
 function ruleConfigSeverity(config) {


### PR DESCRIPTION
## Summary
- compute ESLint-compatible message severity per result file path
- make `lintFiles()`, `lintText()`, and `CLIEngine` counts respect flat config `files` matches
- document per-file flat config severity mapping in the JS API README

## Root cause
After native linting, the JS API restored ESLint numeric severities from one global calculated config. Flat config can assign the same rule different severities for different file globs, so results for `src/**/*.js` and `test/**/*.js` could both be counted as warnings even when one path configured the rule as an error.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused JS API script covering `ESLint#lintFiles()`, `ESLint#lintText()`, and `CLIEngine#executeOnFiles()` with per-file flat config severities
- `git diff --check`
- `zig build test`
- `zig build`
