### PR TITLE
fix: run fishlint through wrapper

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -143,8 +143,9 @@ npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 npx eslint --config utoo.json --ext .js,.ts src
 ```
 
-For programmatic replacements, `runFishlint()` applies the same argument
-translation before invoking the native binary.
+For programmatic replacements, `runFishlint()` invokes the same compatibility
+wrapper as the `fishlint` bin, including wrapper-side ignore filtering, quiet
+output, max-warning exit semantics, stdin handling, and delegated commands.
 
 For non-eslint fishlint commands, the compatibility command delegates to
 project-local tools when they are installed: `fishlint format` runs `prettier`,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, w
 import { writeFile as writeFileAsync } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { resolveBinary } from "./lib/binary.js";
 
@@ -229,7 +230,18 @@ export function run(args = [], options = {}) {
 }
 
 export function runFishlint(args = [], options = {}) {
-  return run(translateFishlintArgs(args, options), options);
+  const cliArgs = normalizeStringArray(args, "args");
+  const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
+  if (options.binary) {
+    env.UTOO_LINT_BIN = options.binary;
+  }
+
+  return spawnSync(process.execPath, [fileURLToPath(new URL("./bin/fishlint.js", import.meta.url)), ...cliArgs], {
+    cwd: options.cwd,
+    env,
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio
+  });
 }
 
 export function translateFishlintArgs(args = [], options = {}) {


### PR DESCRIPTION
## Summary
- make `runFishlint()` invoke the same compatibility wrapper as the `fishlint` bin
- preserve `cwd`, `env`, `encoding`, `stdio`, and map `options.binary` to `UTOO_LINT_BIN`
- document that programmatic fishlint replacement now gets wrapper-side behavior

## Root cause
`runFishlint()` only translated fishlint args and then invoked the native binary directly. That bypassed compatibility behavior implemented in `bin/fishlint.js`, including `--quiet`, `--max-warnings`, ignored-file warnings, stdin path rewriting, JSON metadata formatting, and delegated commands.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused `runFishlint()` script covering `--quiet`, `--max-warnings=0`, `-f json-with-metadata`, and `options.binary`
- `git diff --check`
- `zig build test`
- `zig build`
