### PR TITLE
fix: filter disabled eslint file rules

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -83,6 +83,7 @@ same config discovery as file linting unless `noConfig` is set.
 provided, flat config `files` and `ignores` entries are applied before merging.
 ESLint-compatible results use those calculated rule severities for `messages`,
 `errorCount`, and `warningCount`, including per-file flat config matches. The
+JS API filters diagnostics for rules disabled by the matched file config. The
 `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -757,6 +757,9 @@ function reportToESLintResults(report, textOptions = {}) {
       byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
     }
     const ruleSeverities = textOptions.ruleSeverityForFile?.(filePath) ?? textOptions.ruleSeverities;
+    if (diagnostic.ruleId && ruleSeverities?.get(diagnostic.ruleId) === 0) {
+      continue;
+    }
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
@@ -1315,9 +1318,7 @@ function ruleSeverityMap(rules) {
   const severities = new Map();
   for (const [rule, config] of Object.entries(rules)) {
     const severity = ruleConfigSeverity(config);
-    if (severity > 0) {
-      severities.set(rule, severity);
-    }
+    severities.set(rule, severity);
   }
   return severities;
 }


### PR DESCRIPTION
## Summary
- filter ESLint-compatible diagnostics when the matched file config disables the rule
- preserve diagnostics for default rules that are not explicitly configured
- document disabled per-file rule filtering in the JS API README

## Root cause
The JS API now maps rule severities per file, but diagnostics from the native run were still kept even when the matched flat config set that rule to `off` for a specific file. That produced false positives for ESLint replacement users with per-file flat config overrides.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused JS API script covering per-file `no-debugger: off` filtering and default-rule preservation
- `git diff --check`
- `zig build test`
- `zig build`
