### PR TITLE
fix: preserve enabled flat config rules

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -84,6 +84,8 @@ provided, flat config `files` and `ignores` entries are applied before merging.
 ESLint-compatible results use those calculated rule severities for `messages`,
 `errorCount`, and `warningCount`, including per-file flat config matches. The
 JS API filters diagnostics for rules disabled by the matched file config. The
+native run keeps rules enabled when any matched flat config entry may need them,
+so later `off` entries do not suppress diagnostics for other files. The
 `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -699,8 +699,8 @@ function withTemporaryConfig(options, callback) {
   }
 
   const rules = calculatedConfig(options).rules;
-  const enabledRules = enabledRuleNames(rules);
-  if (!hasRuleOptions(rules) && !hasDisabledRules(rules)) {
+  const enabledRules = enabledRuleNamesFromConfigs(options.baseConfig, options.overrideConfig);
+  if (!hasRuleOptions(rules)) {
     return callback({
       ...options,
       noConfig: options.noConfig ?? true,
@@ -728,12 +728,28 @@ function enabledRuleNames(rules) {
     .map(([rule]) => rule);
 }
 
-function hasRuleOptions(rules) {
-  return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+function enabledRuleNamesFromConfigs(...configs) {
+  const rules = new Set();
+  for (const config of configs) {
+    for (const rule of enabledRuleNamesFromConfig(config)) {
+      rules.add(rule);
+    }
+  }
+  return [...rules];
 }
 
-function hasDisabledRules(rules) {
-  return Object.values(rules).some((value) => ruleConfigSeverity(value) === 0);
+function enabledRuleNamesFromConfig(config) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => enabledRuleNamesFromConfig(entry));
+  }
+  return enabledRuleNames(rulesFromConfig(config));
+}
+
+function hasRuleOptions(rules) {
+  return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
 }
 
 function normalizeStringArray(values, name) {


### PR DESCRIPTION
## Summary
- keep native lint rules enabled when any flat config entry may need them
- rely on the JS API per-file result filtering for entries that disable those rules
- document that later `off` flat config entries no longer suppress diagnostics for other files

## Root cause
For pure severity configs, `withTemporaryConfig()` used a file-agnostic merged rule map. If a later flat config entry disabled a rule for one file set, the temporary native config could disable that rule globally, preventing diagnostics for other files where the rule was still enabled.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused JS API script covering flat config `src/**/*.js: error` followed by `test/**/*.js: off`, plus the reverse order
- `git diff --check`
- `zig build test`
- `zig build`
