### PR TITLE
fix: normalize raw js api diagnostics

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -62,8 +62,9 @@ const { ESLint, lintFiles } = require("@utoo/lint");
 
 `lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
 `diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
-`column`, `severity`, `message`, and `ruleId`. The `ESLint` export is an alias
-for `UtooLint` and supports the common `lintFiles()`, `lintText()`,
+`column`, `severity`, `message`, and `ruleId`, with disabled per-file rules
+filtered from the diagnostics. The `ESLint` export is an alias for `UtooLint`
+and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,
 `outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
@@ -85,7 +86,8 @@ ESLint-compatible results use those calculated rule severities for `messages`,
 `errorCount`, and `warningCount`, including per-file flat config matches. The
 JS API filters diagnostics for rules disabled by the matched file config. The
 native run keeps rules enabled when any matched flat config entry may need them,
-so later `off` entries do not suppress diagnostics for other files. The
+so later `off` entries do not suppress diagnostics for other files. Raw
+`diagnostics` use the same per-file severity and disabled-rule filtering. The
 `CLIEngine` export
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -475,6 +475,9 @@ export function lintFiles(paths = ["."], options = {}) {
       ...(report.diagnostics ?? []),
       ...ignoredDiagnostics
     ];
+    if (!resolvedOptions.deferDiagnosticConfigFiltering) {
+      report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
+    }
     if (stderr) {
       Object.defineProperty(report, "stderr", {
         value: stderr,
@@ -516,12 +519,14 @@ export function lintText(code, options = {}) {
       ...options,
       cwd: options.cwd,
       config: options.config ?? discoveredConfig,
-      noConfig: options.noConfig
+      noConfig: options.noConfig,
+      deferDiagnosticConfigFiltering: true
     });
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,
       filePath: requestedPath
     }));
+    report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
     return report;
   } finally {
     rmSync(tmp, { recursive: true, force: true });
@@ -793,6 +798,24 @@ function reportToESLintResults(report, textOptions = {}) {
   }
 
   return [...byFile.values()];
+}
+
+function normalizeReportDiagnostics(diagnostics, options = {}) {
+  return (diagnostics ?? []).flatMap((diagnostic) => {
+    if (!diagnostic?.ruleId) {
+      return [diagnostic];
+    }
+
+    const filePath = normalizeESLintFilePath(diagnostic.filePath, options.cwd);
+    const severity = ruleSeverityMapForOptions(options, filePath)?.get(diagnostic.ruleId);
+    if (severity === 0) {
+      return [];
+    }
+    if (severity === 1 || severity === 2) {
+      return [{ ...diagnostic, severity: severity === 2 ? "error" : "warning" }];
+    }
+    return [diagnostic];
+  });
 }
 
 function normalizeESLintFilePath(filePath, cwd) {


### PR DESCRIPTION
## Summary
- normalize raw `lintFiles()` and `lintText()` diagnostics with the matched file config
- filter diagnostics for per-file disabled rules in the raw report API
- update raw diagnostic severity from per-file rule settings before returning reports

## Root cause
The ESLint-compatible class APIs already applied per-file severity and disabled-rule filtering, but the lower-level `lintFiles()` and `lintText()` report APIs still returned native diagnostics unchanged. That could keep diagnostics for rules disabled by the requested file path and leave configured errors reported as warnings.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused raw JS API script covering `lintFiles()` and `lintText()` with per-file `off` and `error` flat config entries
- `git diff --check`
- `zig build test`
- `zig build`
