### PR TITLE
fix: preserve lint text file paths

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -74,7 +74,9 @@ rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `lintFiles()` returns absolute `filePath` values, includes empty results for
 checked files with no messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the
-same config discovery as file linting unless `noConfig` is set.
+same config discovery as file linting unless `noConfig` is set. Raw
+`lintText()` reports use the supplied `filePath` for both `filePaths` and
+diagnostics.
 `isPathIgnored()` reads default `.eslintignore` entries plus `ignorePath`,
 `ignorePatterns`, `noIgnore`, and `baseConfig`/`overrideConfig` ignore entries.
 `calculateConfigForFile()` and `CLIEngine#getConfigForFile()` merge

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -522,6 +522,7 @@ export function lintText(code, options = {}) {
       noConfig: options.noConfig,
       deferDiagnosticConfigFiltering: true
     });
+    report.filePaths = (report.filePaths ?? []).map((filePath) => (filePath === tempFile ? requestedPath : filePath));
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,
       filePath: requestedPath


### PR DESCRIPTION
## Summary
- remap raw `lintText()` report `filePaths` to the caller-provided `filePath`
- keep raw diagnostics and file path list aligned for inline-source linting
- document the raw `lintText()` path behavior

## Root cause
`lintText()` writes source to a temporary file before invoking the native binary. Diagnostics were remapped back to the requested file path, but the raw report's `filePaths` array still exposed the temporary filesystem path.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused raw `lintText()` script asserting `filePaths` and diagnostics use the supplied `filePath`
- `git diff --check`
- `zig build test`
- `zig build`
