### PR TITLE
fix: normalize raw lint file paths

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -71,8 +71,9 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.
-`lintFiles()` returns absolute `filePath` values, includes empty results for
-checked files with no messages, and filters inputs with the same ignore rules.
+`lintFiles()` returns absolute `filePaths` and diagnostic `filePath` values,
+includes empty results for checked files with no messages, and filters inputs
+with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the
 same config discovery as file linting unless `noConfig` is set. Raw
 `lintText()` reports use the supplied `filePath` for both `filePaths` and

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -476,6 +476,8 @@ export function lintFiles(paths = ["."], options = {}) {
       ...ignoredDiagnostics
     ];
     if (!resolvedOptions.deferDiagnosticConfigFiltering) {
+      report.filePaths = normalizeReportFilePaths(report.filePaths, resolvedOptions);
+      report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, resolvedOptions);
       report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
     }
     if (stderr) {
@@ -817,6 +819,17 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
     }
     return [diagnostic];
   });
+}
+
+function normalizeReportFilePaths(filePaths, options = {}) {
+  return (filePaths ?? []).map((filePath) => normalizeESLintFilePath(filePath, options.cwd));
+}
+
+function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
+  return (diagnostics ?? []).map((diagnostic) => ({
+    ...diagnostic,
+    filePath: normalizeESLintFilePath(diagnostic.filePath, options.cwd)
+  }));
 }
 
 function normalizeESLintFilePath(filePath, cwd) {


### PR DESCRIPTION
## Summary
- normalize raw `lintFiles()` report `filePaths` to absolute paths
- normalize raw diagnostics `filePath` values for `lintFiles()` reports
- keep raw `lintText()` reports using the caller-provided inline path

## Root cause
The README and ESLint-compatible API surface promise absolute file paths for file linting, but the lower-level raw `lintFiles()` report still returned the native relative paths when callers passed relative patterns.

## Validation
- `node --check npm/utoo-lint/index.js`
- focused raw JS API script covering `lintFiles()` absolute paths and `lintText()` supplied-path preservation
- `git diff --check`
- `zig build test`
- `zig build`
