### PR TITLE
fix: preserve fishlint format check mode

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -165,6 +165,9 @@ and `fishlint projectlint` runs `projectlint`. This keeps existing scripts
 working without treating those tools as native `utoo-lint` checks. Delegated
 commands also consume fishlint-only setup and verbose flags, including
 `--disable-setup=true` and similar value forms.
+`fishlint format` defaults to `prettier --write`, but keeps explicit prettier
+mode flags such as `--check`, `--list-different`, and `--debug-check` instead
+of adding `--write`.
 `fishlint commitlint -E=GIT_PARAMS` is normalized like `--env GIT_PARAMS`,
 falling back to `--edit` when the environment variable is not set.
 Default delegated targets are still added when the command only contains

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -1077,12 +1077,13 @@ function delegatedCommand(command, args) {
     case "format":
       return {
         bin: "prettier",
-        args: [
-          "--write",
-          ...withDefaultTargets(translatePassthroughArgs(args), ["**/*.{js,jsx,ts,tsx,less,css,vue}"], {
+        args: withDefaultTargets(
+          withDefaultPrettierWrite(translatePassthroughArgs(args)),
+          ["**/*.{js,jsx,ts,tsx,less,css,vue}"],
+          {
             valueFlags: FORMAT_VALUE_FLAGS
-          })
-        ]
+          }
+        )
       };
     case "commitlint":
       return {
@@ -1097,6 +1098,22 @@ function delegatedCommand(command, args) {
     default:
       return null;
   }
+}
+
+function withDefaultPrettierWrite(args) {
+  if (hasPrettierMode(args)) {
+    return args;
+  }
+  return ["--write", ...args];
+}
+
+function hasPrettierMode(args) {
+  return args.some((arg) =>
+    arg === "--write" ||
+    arg === "--check" ||
+    arg === "--list-different" ||
+    arg === "--debug-check"
+  );
 }
 
 function withDefaultTargets(args, defaults, options = {}) {


### PR DESCRIPTION
## Summary
- avoid adding prettier --write when fishlint format receives explicit prettier mode flags
- keep default fishlint format behavior as prettier --write when no mode is provided
- document the delegated format mode behavior

## Validation
- fake prettier delegation smoke covering default, default targets, --check, --list-different, --debug-check, and explicit --write
- node --check npm/utoo-lint/bin/fishlint.js
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build test
- zig build