### PR TITLE
fix: pass stdin input to fishlint wrapper

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -156,7 +156,8 @@ npx eslint --config utoo.json --ext .js,.ts src
 
 For programmatic replacements, `runFishlint()` invokes the same compatibility
 wrapper as the `fishlint` bin, including wrapper-side ignore filtering, quiet
-output, max-warning exit semantics, stdin handling, and delegated commands.
+output, max-warning exit semantics, stdin handling through `options.input`, and
+delegated commands.
 
 For non-eslint fishlint commands, the compatibility command delegates to
 project-local tools when they are installed: `fishlint format` runs `prettier`,

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -222,6 +222,7 @@ function run(args = [], options = {}) {
     cwd: options.cwd,
     env,
     encoding: options.encoding ?? "utf8",
+    input: options.input,
     stdio: options.stdio
   });
 }
@@ -237,6 +238,7 @@ function runFishlint(args = [], options = {}) {
     cwd: options.cwd,
     env,
     encoding: options.encoding ?? "utf8",
+    input: options.input,
     stdio: options.stdio
   });
 }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -225,6 +225,7 @@ export function run(args = [], options = {}) {
     cwd: options.cwd,
     env,
     encoding: options.encoding ?? "utf8",
+    input: options.input,
     stdio: options.stdio
   });
 }
@@ -240,6 +241,7 @@ export function runFishlint(args = [], options = {}) {
     cwd: options.cwd,
     env,
     encoding: options.encoding ?? "utf8",
+    input: options.input,
     stdio: options.stdio
   });
 }


### PR DESCRIPTION
## Summary
- pass options.input through run() and runFishlint() spawn calls
- make programmatic runFishlint --stdin calls behave like the fishlint bin
- document that runFishlint stdin handling uses options.input

## Validation
- CJS runFishlint stdin smoke with --stdin-filename and no-debugger
- ESM runFishlint stdin smoke with --stdin-filename and no-debugger
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- zig build test
- zig build