### PR TITLE
fix: support negated js api globs

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -76,8 +76,9 @@ rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.
 `lintFiles()` returns absolute `filePaths` and diagnostic `filePath` values,
 accepts common glob patterns such as `src/**/*.js` and `src/**/*.{js,ts}`,
-includes empty results for checked files with no messages, and filters inputs
-with the same ignore rules.
+supports negated patterns such as `!src/generated.js`, includes empty results
+for checked files with no messages, and filters inputs with the same ignore
+rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the
 same config discovery as file linting unless `noConfig` is set. Raw
 `lintText()` reports use the supplied `filePath` for both `filePaths` and

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -887,9 +887,13 @@ function filteredLintPaths(paths, options = {}) {
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
+  const excludedPatterns = negatedLintPatterns(values);
 
   const filtered = new Set();
   for (const target of values) {
+    if (isNegatedLintPattern(target)) {
+      continue;
+    }
     if (hasGlobMagic(target)) {
       const expanded = expandGlobTarget(target, cwd, patterns);
       if (expanded.length > 0) {
@@ -921,7 +925,18 @@ function filteredLintPaths(paths, options = {}) {
       filtered.add(filePath);
     }
   }
-  return [...filtered];
+  return [...filtered].filter((filePath) => !pathIgnoredByPatterns(normalizeIgnoredPath(filePath, cwd), excludedPatterns));
+}
+
+function negatedLintPatterns(values) {
+  return values
+    .filter(isNegatedLintPattern)
+    .map((value) => value.slice(1))
+    .filter((value) => value.length > 0);
+}
+
+function isNegatedLintPattern(value) {
+  return value.startsWith("!") && value.length > 1;
 }
 
 function expandGlobTarget(target, cwd, patterns) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -890,9 +890,13 @@ function filteredLintPaths(paths, options = {}) {
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
+  const excludedPatterns = negatedLintPatterns(values);
 
   const filtered = new Set();
   for (const target of values) {
+    if (isNegatedLintPattern(target)) {
+      continue;
+    }
     if (hasGlobMagic(target)) {
       const expanded = expandGlobTarget(target, cwd, patterns);
       if (expanded.length > 0) {
@@ -924,7 +928,18 @@ function filteredLintPaths(paths, options = {}) {
       filtered.add(filePath);
     }
   }
-  return [...filtered];
+  return [...filtered].filter((filePath) => !pathIgnoredByPatterns(normalizeIgnoredPath(filePath, cwd), excludedPatterns));
+}
+
+function negatedLintPatterns(values) {
+  return values
+    .filter(isNegatedLintPattern)
+    .map((value) => value.slice(1))
+    .filter((value) => value.length > 0);
+}
+
+function isNegatedLintPattern(value) {
+  return value.startsWith("!") && value.length > 1;
 }
 
 function expandGlobTarget(target, cwd, patterns) {


### PR DESCRIPTION
## Summary
- treat lintFiles() entries starting with ! as exclusion patterns instead of native targets
- apply negated patterns after glob expansion for both raw JS API and ESLint#lintFiles()
- document negated glob support for programmatic replacements

## Validation
- CJS lintFiles(['src/**/*.js', '!src/excluded.js']) smoke
- CJS lintFiles(['src/**/*.js', '!src/generated/**']) smoke
- CJS ESLint#lintFiles() smoke with exact and directory negated patterns
- ESM lintFiles() smoke with a negated pattern
- ESM ESLint#lintFiles() smoke with a negated pattern
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- zig build test
- zig build