### PR TITLE
fix: support glob character classes

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -76,9 +76,9 @@ rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.
 `lintFiles()` returns absolute `filePaths` and diagnostic `filePath` values,
 accepts common glob patterns such as `src/**/*.js` and `src/**/*.{js,ts}`,
-supports negated patterns such as `!src/generated.js`, includes empty results
-for checked files with no messages, and filters inputs with the same ignore
-rules.
+supports character classes such as `src/**/*.[jt]s` and negated patterns such
+as `!src/generated.js`, includes empty results for checked files with no
+messages, and filters inputs with the same ignore rules.
 `lintText()` applies those ignore rules to the supplied `filePath` and uses the
 same config discovery as file linting unless `noConfig` is set. Raw
 `lintText()` reports use the supplied `filePath` for both `filePaths` and
@@ -112,7 +112,8 @@ The package also installs a `fishlint` compatibility command for projects that
 currently run `fishlint eslint ...`. It supports the common eslint subcommand
 shape, forwards `--config` and `-c`, maps `--glob` values to native lint
 targets, expands common `--glob` patterns such as `src/**/*.js` and
-`src/**/*.{js,ts}`, and normalizes split value flags such as `--format json`, `-f json`,
+`src/**/*.{js,ts}` or `src/**/*.[jt]s`, and normalizes split value flags such
+as `--format json`, `-f json`,
 `--threads 4`, and `--rules no-debugger`. `--no-eslintrc` maps to native
 `--no-config`, and `--no-eslintrc=true` is accepted for compatibility.
 `json-with-metadata` emits the native JSON report with a `metadata.rulesMeta`

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -710,6 +710,21 @@ function globPatternRegExpSource(pattern) {
         continue;
       }
     }
+    if (char === "[") {
+      const end = pattern.indexOf("]", index + 1);
+      if (end !== -1) {
+        const raw = pattern.slice(index + 1, end);
+        if (raw.length > 0) {
+          const negated = raw[0] === "!" || raw[0] === "^";
+          const body = raw.slice(negated ? 1 : 0);
+          if (body.length > 0) {
+            source += `[${negated ? "^" : ""}${escapeCharacterClass(body)}]`;
+            index = end;
+            continue;
+          }
+        }
+      }
+    }
     source += escapeRegExp(char);
   }
   return source;
@@ -717,6 +732,10 @@ function globPatternRegExpSource(pattern) {
 
 function escapeRegExp(value) {
   return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function escapeCharacterClass(value) {
+  return value.replace(/[\\\]]/g, "\\$&");
 }
 
 function emptyLintOutput(args) {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1240,6 +1240,21 @@ function globPatternRegExpSource(pattern) {
         continue;
       }
     }
+    if (char === "[") {
+      const end = pattern.indexOf("]", index + 1);
+      if (end !== -1) {
+        const raw = pattern.slice(index + 1, end);
+        if (raw.length > 0) {
+          const negated = raw[0] === "!" || raw[0] === "^";
+          const body = raw.slice(negated ? 1 : 0);
+          if (body.length > 0) {
+            source += `[${negated ? "^" : ""}${escapeCharacterClass(body)}]`;
+            index = end;
+            continue;
+          }
+        }
+      }
+    }
     source += escapeRegExp(char);
   }
   return source;
@@ -1247,6 +1262,10 @@ function globPatternRegExpSource(pattern) {
 
 function escapeRegExp(value) {
   return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function escapeCharacterClass(value) {
+  return value.replace(/[\\\]]/g, "\\$&");
 }
 
 function getErrorResults(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1243,6 +1243,21 @@ function globPatternRegExpSource(pattern) {
         continue;
       }
     }
+    if (char === "[") {
+      const end = pattern.indexOf("]", index + 1);
+      if (end !== -1) {
+        const raw = pattern.slice(index + 1, end);
+        if (raw.length > 0) {
+          const negated = raw[0] === "!" || raw[0] === "^";
+          const body = raw.slice(negated ? 1 : 0);
+          if (body.length > 0) {
+            source += `[${negated ? "^" : ""}${escapeCharacterClass(body)}]`;
+            index = end;
+            continue;
+          }
+        }
+      }
+    }
     source += escapeRegExp(char);
   }
   return source;
@@ -1250,6 +1265,10 @@ function globPatternRegExpSource(pattern) {
 
 function escapeRegExp(value) {
   return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function escapeCharacterClass(value) {
+  return value.replace(/[\\\]]/g, "\\$&");
 }
 
 function getErrorResults(results) {


### PR DESCRIPTION
## Summary
- support glob character classes such as src/**/*.[jt]s in JS API glob expansion
- support the same character classes in the fishlint --glob compatibility wrapper
- document character-class glob support for programmatic and fishlint replacements

## Validation
- CJS lintFiles(['src/**/*.[jt]s']) smoke with JS and TS files
- CJS ESLint#lintFiles(['src/**/*.[jt]s', '!src/b.ts']) smoke
- ESM lintFiles(['src/**/*.[jt]s']) smoke
- ESM ESLint#lintFiles(['src/**/*.[jt]s']) smoke
- fishlint eslint --glob 'src/**/*.[jt]s' smoke
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- zig build test
- zig build