### PR TITLE
fix: support negated fishlint globs

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -132,7 +132,8 @@ ignore-pattern flags are accepted so existing wrapper scripts do not pass them
 as file targets. The wrapper applies simple `.eslintignore`, `--ignore-path`,
 and `--ignore-pattern` filters such as `dist/**` to explicit and `--glob`
 targets before invoking native lint, including `**/*.js` globstar patterns and
-`!pattern` negation entries.
+`!pattern` negation entries. Negated `--glob` values such as
+`--glob '!src/generated/**'` exclude files from expanded lint targets.
 `--no-ignore` and `--no-ignore=true` disable those wrapper-side ignore filters.
 `--no-error-on-unmatched-pattern` and `--no-error-on-unmatched-pattern=true` skip
 missing explicit and `--glob` targets before invoking native lint. `--quiet`

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -426,6 +426,7 @@ function readIgnoreFile(path) {
 
 function expandGlobTargets(args) {
   const values = [];
+  const excludedPatterns = [];
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (TARGET_VALUE_FLAGS.has(arg)) {
@@ -442,18 +443,55 @@ function expandGlobTargets(args) {
         console.error("utoo-lint: fishlint --glob requires a path");
         process.exit(2);
       }
+      if (isNegatedGlobTarget(value)) {
+        excludedPatterns.push(value.slice(1));
+        index += 1;
+        continue;
+      }
       values.push(...expandedGlobOrOriginal(value, [arg, value]));
       index += 1;
       continue;
     }
     if (arg.startsWith("--glob=")) {
       const value = arg.slice("--glob=".length);
+      if (isNegatedGlobTarget(value)) {
+        excludedPatterns.push(value.slice(1));
+        continue;
+      }
       values.push(...expandedGlobOrOriginal(value, [arg]));
       continue;
     }
     values.push(arg);
   }
-  return { args: values };
+  return { args: filterExpandedGlobExclusions(values, excludedPatterns) };
+}
+
+function isNegatedGlobTarget(value) {
+  return value.startsWith("!") && value.length > 1;
+}
+
+function filterExpandedGlobExclusions(args, excludedPatterns) {
+  if (excludedPatterns.length === 0) {
+    return args;
+  }
+
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (TARGET_VALUE_FLAGS.has(arg)) {
+      values.push(arg);
+      if (index + 1 < args.length) {
+        values.push(args[index + 1]);
+        index += 1;
+      }
+      continue;
+    }
+    if (index > 0 && !arg.startsWith("-") && isIgnoredTarget(arg, excludedPatterns)) {
+      continue;
+    }
+    values.push(arg);
+  }
+  return values;
 }
 
 function expandedGlobOrOriginal(pattern, original) {


### PR DESCRIPTION
## Summary
- treat negated fishlint --glob values as exclusion patterns instead of native lint targets
- filter expanded glob targets for exact file, directory glob, and character-class glob exclusions
- document negated --glob behavior for fishlint replacements

## Validation
- fishlint eslint --glob 'src/**/*.js' --glob '!src/excluded.js' smoke
- fishlint eslint --glob 'src/**/*.js' --glob '!src/generated/**' smoke
- fishlint eslint --glob 'src/**/*.[jt]s' --glob '!src/b.ts' smoke
- node --check npm/utoo-lint/bin/fishlint.js
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build test
- zig build