### PR TITLE
fix: recalculate filtered js api exit code

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -66,7 +66,8 @@ the fishlint wrapper and per-file flat config handling.
 `lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
 `diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
 `column`, `severity`, `message`, and `ruleId`, with disabled per-file rules
-filtered from the diagnostics. The `ESLint` export is an alias for `UtooLint`
+filtered from the diagnostics. `exitCode` is recalculated from the filtered
+diagnostics. The `ESLint` export is an alias for `UtooLint`
 and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -478,6 +478,7 @@ function lintFiles(paths = ["."], options = {}) {
       report.filePaths = normalizeReportFilePaths(report.filePaths, resolvedOptions);
       report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, resolvedOptions);
       report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
+      report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     }
     if (stderr) {
       Object.defineProperty(report, "stderr", {
@@ -529,6 +530,7 @@ function lintText(code, options = {}) {
       filePath: requestedPath
     }));
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     return report;
   } finally {
     rmSync(tmp, { recursive: true, force: true });
@@ -829,6 +831,10 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
     ...diagnostic,
     filePath: normalizeESLintFilePath(diagnostic.filePath, options.cwd)
   }));
+}
+
+function exitCodeForDiagnostics(diagnostics) {
+  return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
 }
 
 function normalizeESLintFilePath(filePath, cwd) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -481,6 +481,7 @@ export function lintFiles(paths = ["."], options = {}) {
       report.filePaths = normalizeReportFilePaths(report.filePaths, resolvedOptions);
       report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, resolvedOptions);
       report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
+      report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     }
     if (stderr) {
       Object.defineProperty(report, "stderr", {
@@ -532,6 +533,7 @@ export function lintText(code, options = {}) {
       filePath: requestedPath
     }));
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     return report;
   } finally {
     rmSync(tmp, { recursive: true, force: true });
@@ -832,6 +834,10 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
     ...diagnostic,
     filePath: normalizeESLintFilePath(diagnostic.filePath, options.cwd)
   }));
+}
+
+function exitCodeForDiagnostics(diagnostics) {
+  return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
 }
 
 function normalizeESLintFilePath(filePath, cwd) {


### PR DESCRIPTION
## Summary
- recalculate raw JS API exitCode after per-file config filtering removes diagnostics
- keep lintFiles() and lintText() exitCode aligned with the diagnostics returned to callers
- document that exitCode is based on filtered diagnostics

## Validation
- CJS lintText() smoke where flat config keeps no-debugger enabled
- CJS lintText() smoke where flat config disables no-debugger and diagnostics are empty
- CJS lintFiles() smoke for enabled and disabled per-file rules
- ESM lintText() smoke for disabled per-file rules
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- zig build test
- zig build