### PR TITLE
fix: preserve lint-staged fallback args

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -185,7 +185,8 @@ install hooks do not fail after replacing the package.
 `fishlint-lint-staged` is also provided for generated fishlint pre-commit hooks.
 If a project has its own `lint-staged` install, the wrapper delegates to it.
 Otherwise it lints staged JavaScript and TypeScript files directly with
-`utoo-lint`.
+the same `fishlint eslint` compatibility wrapper, preserving flags such as
+`--config`, `--rules`, and `--quiet`.
 
 Use the packaged frontend config in an app:
 

--- a/npm/utoo-lint/bin/fishlint-lint-staged.js
+++ b/npm/utoo-lint/bin/fishlint-lint-staged.js
@@ -2,8 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-
-import { resolveBinary } from "../lib/binary.js";
+import { fileURLToPath } from "node:url";
 
 const localLintStaged = join(
   process.cwd(),
@@ -42,18 +41,13 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-let binary;
-try {
-  binary = resolveBinary();
-} catch (error) {
-  console.error(error.message);
-  process.exit(1);
-}
-
-const result = spawnSync(binary, files, { stdio: "inherit" });
+const fishlint = fileURLToPath(new URL("./fishlint.js", import.meta.url));
+const result = spawnSync(process.execPath, [fishlint, "eslint", ...process.argv.slice(2), ...files], {
+  stdio: "inherit"
+});
 
 if (result.error) {
-  console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
+  console.error(`utoo-lint: failed to run fishlint-lint-staged fallback: ${result.error.message}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- route the no-local-lint-staged fallback through the fishlint eslint compatibility wrapper
- preserve user flags such as --config, --rules, and --quiet when linting staged files
- document the fallback behavior

## Validation
- fishlint-lint-staged fallback with --rules no-console on staged debugger file exits cleanly
- fishlint-lint-staged fallback with --rules no-debugger --quiet exits cleanly
- fishlint-lint-staged fallback with --rules no-debugger still reports the staged file
- node --check npm/utoo-lint/bin/fishlint-lint-staged.js
- node --check npm/utoo-lint/bin/fishlint.js
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build test
- zig build