### PR TITLE
fix: match root glob flat configs

### DIFF
--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -746,9 +746,11 @@ function matchesIgnorePattern(target, pattern) {
   }
   if (pattern.startsWith("**/")) {
     const suffix = pattern.slice(3);
-    return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    if (!hasGlobSyntax(suffix)) {
+      return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    }
   }
-  if (!pattern.includes("*")) {
+  if (!hasGlobSyntax(pattern)) {
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1201,14 +1201,20 @@ function matchesIgnorePattern(target, pattern) {
   }
   if (pattern.startsWith("**/")) {
     const suffix = pattern.slice(3);
-    return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    if (!hasGlobSyntax(suffix)) {
+      return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    }
   }
-  if (!pattern.includes("*")) {
+  if (!hasGlobSyntax(pattern)) {
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
   const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
+}
+
+function hasGlobSyntax(pattern) {
+  return /[*?[\]{}]/.test(pattern);
 }
 
 function normalizePath(path) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1204,14 +1204,20 @@ function matchesIgnorePattern(target, pattern) {
   }
   if (pattern.startsWith("**/")) {
     const suffix = pattern.slice(3);
-    return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    if (!hasGlobSyntax(suffix)) {
+      return target.endsWith(suffix) || target.includes(`/${suffix}`);
+    }
   }
-  if (!pattern.includes("*")) {
+  if (!hasGlobSyntax(pattern)) {
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
   const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
+}
+
+function hasGlobSyntax(pattern) {
+  return /[*?[\]{}]/.test(pattern);
 }
 
 function normalizePath(path) {


### PR DESCRIPTION
## Summary
- make `**/` glob patterns with remaining wildcard syntax fall through to the full glob matcher
- apply the same matcher fix to the ESM API, CJS API, and fishlint wrapper ignore filtering

## Why
Common flat config entries like `files: ['**/*.js']` should match files at the project root as well as nested files. The compatibility matcher treated every `**/` pattern as a plain suffix check, so `**/*.js` never matched `a.js`. That left per-file config rules unapplied and produced native default warning severities instead of the configured ESLint severity.

## Validation
- `node --check npm/utoo-lint/bin/fishlint.js && node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: `ESLint({ overrideConfig: [{ files: ['**/*.[jt]s'], rules: { 'no-debugger': 'error' } }] })` reports root and nested files as errors
- smoke: fishlint `--ignore-pattern '**/*.{js,ts}'` filters root and nested targets
