### PR TITLE
fix: anchor flat config file patterns

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -654,7 +654,7 @@ function configAppliesToFile(config, filePath, cwd) {
 
   const normalized = normalizeIgnoredPath(filePath, cwd ?? process.cwd());
   const files = normalizeConfigPatterns(config.files);
-  if (files.length > 0 && !files.some((pattern) => matchesIgnorePattern(normalized, normalizeIgnoredPattern(pattern)))) {
+  if (files.length > 0 && !files.some((pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern)))) {
     return false;
   }
 
@@ -805,13 +805,18 @@ function reportToESLintResults(report, textOptions = {}) {
 }
 
 function normalizeReportDiagnostics(diagnostics, options = {}) {
+  const filterUnconfiguredRules = hasRuleConfigSource(options);
   return (diagnostics ?? []).flatMap((diagnostic) => {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
 
     const filePath = normalizeESLintFilePath(diagnostic.filePath, options.cwd);
-    const severity = ruleSeverityMapForOptions(options, filePath)?.get(diagnostic.ruleId);
+    const ruleSeverities = ruleSeverityMapForOptions(options, filePath);
+    const severity = ruleSeverities?.get(diagnostic.ruleId);
+    if (filterUnconfiguredRules && !ruleSeverities?.has(diagnostic.ruleId)) {
+      return [];
+    }
     if (severity === 0) {
       return [];
     }
@@ -831,6 +836,13 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
     ...diagnostic,
     filePath: normalizeESLintFilePath(diagnostic.filePath, options.cwd)
   }));
+}
+
+function hasRuleConfigSource(options = {}) {
+  if (options.baseConfig || options.overrideConfig) {
+    return true;
+  }
+  return !options.noConfig && Boolean(configPathForOptions(options));
 }
 
 function exitCodeForDiagnostics(diagnostics) {
@@ -1210,6 +1222,11 @@ function matchesIgnorePattern(target, pattern) {
   }
 
   const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
+  return expression.test(target);
+}
+
+function matchesConfigFilePattern(target, pattern) {
+  const expression = new RegExp(`^${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -657,7 +657,7 @@ function configAppliesToFile(config, filePath, cwd) {
 
   const normalized = normalizeIgnoredPath(filePath, cwd ?? process.cwd());
   const files = normalizeConfigPatterns(config.files);
-  if (files.length > 0 && !files.some((pattern) => matchesIgnorePattern(normalized, normalizeIgnoredPattern(pattern)))) {
+  if (files.length > 0 && !files.some((pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern)))) {
     return false;
   }
 
@@ -808,13 +808,18 @@ function reportToESLintResults(report, textOptions = {}) {
 }
 
 function normalizeReportDiagnostics(diagnostics, options = {}) {
+  const filterUnconfiguredRules = hasRuleConfigSource(options);
   return (diagnostics ?? []).flatMap((diagnostic) => {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
 
     const filePath = normalizeESLintFilePath(diagnostic.filePath, options.cwd);
-    const severity = ruleSeverityMapForOptions(options, filePath)?.get(diagnostic.ruleId);
+    const ruleSeverities = ruleSeverityMapForOptions(options, filePath);
+    const severity = ruleSeverities?.get(diagnostic.ruleId);
+    if (filterUnconfiguredRules && !ruleSeverities?.has(diagnostic.ruleId)) {
+      return [];
+    }
     if (severity === 0) {
       return [];
     }
@@ -834,6 +839,13 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
     ...diagnostic,
     filePath: normalizeESLintFilePath(diagnostic.filePath, options.cwd)
   }));
+}
+
+function hasRuleConfigSource(options = {}) {
+  if (options.baseConfig || options.overrideConfig) {
+    return true;
+  }
+  return !options.noConfig && Boolean(configPathForOptions(options));
 }
 
 function exitCodeForDiagnostics(diagnostics) {
@@ -1213,6 +1225,11 @@ function matchesIgnorePattern(target, pattern) {
   }
 
   const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
+  return expression.test(target);
+}
+
+function matchesConfigFilePattern(target, pattern) {
+  const expression = new RegExp(`^${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 


### PR DESCRIPTION
## Summary
- match flat config `files` patterns with anchored glob semantics instead of ignore-style basename semantics
- filter native default diagnostics for rules that are not enabled by the matched config

## Why
ESLint flat config `files: ['*.js']` matches a root file such as `a.js`, but not `nested/a.js`. The JS API reused the ignore matcher, so `*.js` also matched nested files. After anchoring the file matcher, unmatched files still leaked native default warnings, so this also filters unconfigured rules when an explicit rule config source is present.

## Validation
- compared against ESLint 10.5.0 in a temp project for `files: ['*.js']`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS `ESLint` and raw `lintFiles` with `files: ['*.js']` only report root files
- smoke: `files: ['**/*.js']` still reports root and nested files
- smoke: empty `utoo.json` filters native default diagnostics
