### PR TITLE
fix: respect no-config js api

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -610,11 +610,27 @@ function eslintConstructorOptions(options) {
 function calculatedConfig(options = {}, filePath) {
   return {
     rules: {
+      ...rulesFromNativeRuleList(options.rules),
       ...rulesFromConfig(options.baseConfig, filePath, options.cwd),
       ...rulesFromFileConfig(options, filePath),
       ...rulesFromConfig(options.overrideConfig, filePath, options.cwd)
     }
   };
+}
+
+function rulesFromNativeRuleList(rules) {
+  if (!rules) {
+    return {};
+  }
+  const values = Array.isArray(rules) ? rules : String(rules).split(",");
+  const result = {};
+  for (const rule of values) {
+    const name = String(rule).trim();
+    if (name) {
+      result[name] = "warn";
+    }
+  }
+  return result;
 }
 
 function rulesFromConfig(config, filePath, cwd) {
@@ -839,7 +855,7 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
 }
 
 function hasRuleConfigSource(options = {}) {
-  if (options.baseConfig || options.overrideConfig) {
+  if (options.noConfig || options.baseConfig || options.overrideConfig || options.rules) {
     return true;
   }
   return !options.noConfig && Boolean(configPathForOptions(options));

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -613,11 +613,27 @@ function eslintConstructorOptions(options) {
 function calculatedConfig(options = {}, filePath) {
   return {
     rules: {
+      ...rulesFromNativeRuleList(options.rules),
       ...rulesFromConfig(options.baseConfig, filePath, options.cwd),
       ...rulesFromFileConfig(options, filePath),
       ...rulesFromConfig(options.overrideConfig, filePath, options.cwd)
     }
   };
+}
+
+function rulesFromNativeRuleList(rules) {
+  if (!rules) {
+    return {};
+  }
+  const values = Array.isArray(rules) ? rules : String(rules).split(",");
+  const result = {};
+  for (const rule of values) {
+    const name = String(rule).trim();
+    if (name) {
+      result[name] = "warn";
+    }
+  }
+  return result;
 }
 
 function rulesFromConfig(config, filePath, cwd) {
@@ -842,7 +858,7 @@ function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
 }
 
 function hasRuleConfigSource(options = {}) {
-  if (options.baseConfig || options.overrideConfig) {
+  if (options.noConfig || options.baseConfig || options.overrideConfig || options.rules) {
     return true;
   }
   return !options.noConfig && Boolean(configPathForOptions(options));


### PR DESCRIPTION
## Summary
- treat JS API `noConfig` / ESLint `overrideConfigFile: true` as an explicit empty rule config
- keep explicit raw API `rules` enabled while filtering native default diagnostics

## Why
ESLint API callers use `overrideConfigFile: true` and legacy `useEslintrc: false` to run without discovered config. In that mode ESLint reports no rule messages unless rules are provided through `overrideConfig`/`baseConfig`. The compatibility API skipped config discovery but still allowed native default rule diagnostics to leak through as warnings.

## Validation
- compared `overrideConfigFile: true` against ESLint 10.5.0 in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS `ESLint({ overrideConfigFile: true })` and `CLIEngine({ useEslintrc: false })` return no messages
- smoke: explicit `overrideConfig`, `baseConfig`, and raw `rules` still report diagnostics
