### PR TITLE
fix: support raw ignore false

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -917,7 +917,7 @@ function isLintableFilePath(filePath) {
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
   const cwd = options.cwd ?? process.cwd();
-  const patterns = options.noIgnore ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
@@ -1030,7 +1030,7 @@ function collectGlobFiles(target, cwd, patterns, expression, files) {
 }
 
 function ignoredLintPathDiagnostics(paths, options = {}) {
-  if (options.noIgnore || options.warnIgnored === false) {
+  if (ignoreDisabled(options) || options.warnIgnored === false) {
     return [];
   }
 
@@ -1120,7 +1120,7 @@ function isPathIgnored(filePath, options = {}) {
   if (typeof filePath !== "string") {
     throw new TypeError("filePath must be a string");
   }
-  if (options.noIgnore) {
+  if (ignoreDisabled(options)) {
     return false;
   }
 
@@ -1128,6 +1128,10 @@ function isPathIgnored(filePath, options = {}) {
   const normalized = normalizeIgnoredPath(filePath, cwd);
   const patterns = ignorePatternsForOptions(options, cwd);
   return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function ignoreDisabled(options = {}) {
+  return options.noIgnore || options.ignore === false;
 }
 
 function ignorePatternsForOptions(options, cwd) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -920,7 +920,7 @@ function isLintableFilePath(filePath) {
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
   const cwd = options.cwd ?? process.cwd();
-  const patterns = options.noIgnore ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
@@ -1033,7 +1033,7 @@ function collectGlobFiles(target, cwd, patterns, expression, files) {
 }
 
 function ignoredLintPathDiagnostics(paths, options = {}) {
-  if (options.noIgnore || options.warnIgnored === false) {
+  if (ignoreDisabled(options) || options.warnIgnored === false) {
     return [];
   }
 
@@ -1123,7 +1123,7 @@ function isPathIgnored(filePath, options = {}) {
   if (typeof filePath !== "string") {
     throw new TypeError("filePath must be a string");
   }
-  if (options.noIgnore) {
+  if (ignoreDisabled(options)) {
     return false;
   }
 
@@ -1131,6 +1131,10 @@ function isPathIgnored(filePath, options = {}) {
   const normalized = normalizeIgnoredPath(filePath, cwd);
   const patterns = ignorePatternsForOptions(options, cwd);
   return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function ignoreDisabled(options = {}) {
+  return options.noIgnore || options.ignore === false;
 }
 
 function ignorePatternsForOptions(options, cwd) {


### PR DESCRIPTION
## Summary
- treat raw JS API `ignore: false` the same as `noIgnore: true`
- apply the option consistently to target filtering, ignored-file diagnostics, and `isPathIgnored()`

## Why
The `ESLint` compatibility class already maps constructor `ignore: false` to `noIgnore`. The raw `lintFiles()` / `lintText()` / `isPathIgnored()` helpers still only checked `noIgnore`, so callers using the ESLint option spelling could get ignored-file warnings instead of lint results when switching API entry points.

## Validation
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: raw ESM/CJS `lintFiles()` with `ignore: false` lints `.eslintignore`-matched files
- smoke: raw `lintText()` with `ignore: false` lints ignored `filePath` inputs
- smoke: default ignore warnings and `warnIgnored: false` behavior are unchanged
