### PR TITLE
fix: match eslint unmatched file errors

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -84,6 +84,7 @@ class UtooLint {
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintFiles(patterns, mergedOptions);
+    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
@@ -164,6 +165,7 @@ class CLIEngine {
   executeOnFiles(patterns) {
     const mergedOptions = eslintConstructorOptions(this.options);
     const report = lintFiles(patterns, mergedOptions);
+    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
@@ -826,6 +828,9 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
+    if (diagnostic.ruleId === "io") {
+      return [diagnostic];
+    }
 
     const filePath = normalizeESLintFilePath(diagnostic.filePath, options.cwd);
     const ruleSeverities = ruleSeverityMapForOptions(options, filePath);
@@ -863,6 +868,24 @@ function hasRuleConfigSource(options = {}) {
 
 function exitCodeForDiagnostics(diagnostics) {
   return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
+}
+
+function throwOnUnmatchedPatternDiagnostics(report, options = {}) {
+  if (options.errorOnUnmatchedPattern === false) {
+    return;
+  }
+  const diagnostic = (report.diagnostics ?? []).find((item) => item?.ruleId === "io" && /unable to stat path/i.test(item.message ?? ""));
+  if (diagnostic) {
+    throw new Error(`No files matching '${unmatchedPatternDisplayPath(diagnostic.filePath, options.cwd)}' were found.`);
+  }
+}
+
+function unmatchedPatternDisplayPath(filePath, cwd) {
+  const root = resolvePath(cwd ?? process.cwd());
+  if (typeof filePath === "string" && filePath.startsWith(`${root}/`)) {
+    return filePath.slice(root.length + 1);
+  }
+  return filePath;
 }
 
 function normalizeESLintFilePath(filePath, cwd) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -87,6 +87,7 @@ export class UtooLint {
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const report = lintFiles(patterns, mergedOptions);
+    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     return maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
@@ -167,6 +168,7 @@ export class CLIEngine {
   executeOnFiles(patterns) {
     const mergedOptions = eslintConstructorOptions(this.options);
     const report = lintFiles(patterns, mergedOptions);
+    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
@@ -829,6 +831,9 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
+    if (diagnostic.ruleId === "io") {
+      return [diagnostic];
+    }
 
     const filePath = normalizeESLintFilePath(diagnostic.filePath, options.cwd);
     const ruleSeverities = ruleSeverityMapForOptions(options, filePath);
@@ -866,6 +871,24 @@ function hasRuleConfigSource(options = {}) {
 
 function exitCodeForDiagnostics(diagnostics) {
   return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
+}
+
+function throwOnUnmatchedPatternDiagnostics(report, options = {}) {
+  if (options.errorOnUnmatchedPattern === false) {
+    return;
+  }
+  const diagnostic = (report.diagnostics ?? []).find((item) => item?.ruleId === "io" && /unable to stat path/i.test(item.message ?? ""));
+  if (diagnostic) {
+    throw new Error(`No files matching '${unmatchedPatternDisplayPath(diagnostic.filePath, options.cwd)}' were found.`);
+  }
+}
+
+function unmatchedPatternDisplayPath(filePath, cwd) {
+  const root = resolvePath(cwd ?? process.cwd());
+  if (typeof filePath === "string" && filePath.startsWith(`${root}/`)) {
+    return filePath.slice(root.length + 1);
+  }
+  return filePath;
 }
 
 function normalizeESLintFilePath(filePath, cwd) {


### PR DESCRIPTION
## Summary
- preserve native `io` diagnostics in raw JS API reports
- make `ESLint#lintFiles()` and `CLIEngine#executeOnFiles()` throw ESLint-style unmatched file errors by default
- keep `errorOnUnmatchedPattern: false` returning empty results

## Why
Real ESLint throws `No files matching 'missing.js' were found.` for unmatched file inputs unless `errorOnUnmatchedPattern: false` is set. The compatibility API was returning empty results because config filtering dropped the native `io` diagnostic. This made missing paths look like successful lint runs.

## Validation
- compared against ESLint latest in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS `ESLint#lintFiles(['missing.js'])` and `CLIEngine#executeOnFiles(['missing.js'])` throw matching errors
- smoke: `errorOnUnmatchedPattern: false` returns empty results
- smoke: raw `lintFiles()` keeps the native `io` diagnostic and exit code
