### PR TITLE
fix: scope flat config ignores

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1194,9 +1194,10 @@ function ignorePatternsFromConfig(config) {
     return config.flatMap((entry) => ignorePatternsFromConfig(entry));
   }
 
+  const flatConfigIgnores = config.files ? [] : normalizeIgnorePatterns(config.ignores);
   return [
     ...normalizeIgnorePatterns(config.ignorePatterns),
-    ...normalizeIgnorePatterns(config.ignores)
+    ...flatConfigIgnores
   ];
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1197,9 +1197,10 @@ function ignorePatternsFromConfig(config) {
     return config.flatMap((entry) => ignorePatternsFromConfig(entry));
   }
 
+  const flatConfigIgnores = config.files ? [] : normalizeIgnorePatterns(config.ignores);
   return [
     ...normalizeIgnorePatterns(config.ignorePatterns),
-    ...normalizeIgnorePatterns(config.ignores)
+    ...flatConfigIgnores
   ];
 }
 


### PR DESCRIPTION
## Summary
- stop treating `ignores` from flat config entries with `files` as global ignore patterns
- keep standalone `{ ignores: [...] }` entries and legacy `ignorePatterns` as global ignores

## Why
In ESLint flat config, `ignores` on an entry with `files` scopes that entry; it should not remove the file from the whole lint run. A later config entry can still match that same file. The compatibility API was extracting every `ignores` value globally, so files such as `src/generated.js` were reported as ignored instead of being linted by a later rule config.

## Validation
- compared against ESLint latest in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: scoped `ignores` with a later matching entry lints the file with the later severity
- smoke: standalone `{ ignores: [...] }` still reports the file as ignored
- smoke: ESM and CJS APIs match
