### PR TITLE
feat: add eslint loading api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -71,7 +71,9 @@ diagnostics. The `ESLint` export is an alias for `UtooLint`
 and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,
-`outputFixes()`, `getErrorResults()`, and `getRulesMetaForResults()` surfaces.
+`configType`, `defaultConfig`, `fromOptionsModule()`, `outputFixes()`,
+`getErrorResults()`, and `getRulesMetaForResults()` surfaces. The top-level
+`loadESLint()` helper resolves to the compatibility `ESLint` class.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -56,6 +56,22 @@ class UtooLint {
     return version;
   }
 
+  static get configType() {
+    return "flat";
+  }
+
+  static get defaultConfig() {
+    return [];
+  }
+
+  static async fromOptionsModule(optionsURL) {
+    if (!(optionsURL instanceof URL)) {
+      throw new TypeError("Argument must be a URL object");
+    }
+    const loaded = await import(optionsURL.href);
+    return new UtooLint(loaded.default ?? loaded);
+  }
+
   static async outputFixes(results) {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
@@ -777,6 +793,10 @@ function enabledRuleNamesFromConfig(config) {
 
 function hasRuleOptions(rules) {
   return Object.values(rules).some((value) => Array.isArray(value) && value.length > 1);
+}
+
+async function loadESLint() {
+  return UtooLint;
 }
 
 function normalizeStringArray(values, name) {
@@ -1596,6 +1616,7 @@ module.exports = {
   default: UtooLint,
   lintFiles,
   lintText,
+  loadESLint,
   platformPackageName,
   resolveBinary,
   run,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -59,6 +59,22 @@ export class UtooLint {
     return version;
   }
 
+  static get configType() {
+    return "flat";
+  }
+
+  static get defaultConfig() {
+    return [];
+  }
+
+  static async fromOptionsModule(optionsURL) {
+    if (!(optionsURL instanceof URL)) {
+      throw new TypeError("Argument must be a URL object");
+    }
+    const loaded = await import(optionsURL.href);
+    return new UtooLint(loaded.default ?? loaded);
+  }
+
   static async outputFixes(results) {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
@@ -135,6 +151,10 @@ export class UtooLint {
 }
 
 export { UtooLint as ESLint };
+
+export async function loadESLint() {
+  return UtooLint;
+}
 
 export class CLIEngine {
   static get version() {


### PR DESCRIPTION
## Summary
- add ESLint-compatible static loading surfaces: `ESLint.configType`, `ESLint.defaultConfig`, and `ESLint.fromOptionsModule()`
- add top-level `loadESLint()` for package-level ESLint replacement feature detection
- document the new JS API surfaces

## Why
Modern ESLint exposes `loadESLint()` and static metadata/loading helpers that tooling can use for feature detection and dynamic options-module loading. The compatibility API already supports the core linting methods, but these missing surfaces can break consumers that replace `eslint` with `@utoo/lint` at the package boundary.

## Validation
- compared static API shape against ESLint latest and ESLint 8 in temp projects
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS `loadESLint()` resolves to the compatibility `ESLint` class
- smoke: ESM/CJS `ESLint.fromOptionsModule(new URL(...))` loads options and lints with the configured rule
- smoke: non-URL `fromOptionsModule()` arguments throw the ESLint-style type error
