### PR TITLE
feat: add linter verify api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -74,6 +74,9 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `configType`, `defaultConfig`, `fromOptionsModule()`, `outputFixes()`,
 `getErrorResults()`, and `getRulesMetaForResults()` surfaces. The top-level
 `loadESLint()` helper resolves to the compatibility `ESLint` class.
+The `Linter` export supports in-memory `verify()` and `verifyAndFix()` calls for
+utoo-lint's built-in ESLint-compatible rules; custom rule definition APIs are
+not implemented.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -799,6 +799,40 @@ async function loadESLint() {
   return UtooLint;
 }
 
+class Linter {
+  static get version() {
+    return version;
+  }
+
+  verify(code, config = {}, options = {}) {
+    if (typeof code !== "string") {
+      throw new TypeError("code must be a string");
+    }
+
+    const verifyOptions = typeof options === "string" ? { filename: options } : { ...options };
+    const filePath = verifyOptions.filename ?? verifyOptions.filePath ?? "input.js";
+    const lintOptions = {
+      cwd: verifyOptions.cwd,
+      filePath,
+      noConfig: true,
+      noIgnore: true,
+      warnIgnored: false,
+      overrideConfig: config
+    };
+    const report = lintText(code, lintOptions);
+    const ruleSeverities = ruleSeverityMapForOptions(lintOptions, normalizeESLintFilePath(filePath, verifyOptions.cwd));
+    return (report.diagnostics ?? []).map((diagnostic) => diagnosticToESLintMessage(diagnostic, ruleSeverities));
+  }
+
+  verifyAndFix(code, config = {}, options = {}) {
+    return {
+      fixed: false,
+      messages: this.verify(code, config, options),
+      output: code
+    };
+  }
+}
+
 function normalizeStringArray(values, name) {
   if (!Array.isArray(values)) {
     throw new TypeError(`${name} must be an array of strings`);
@@ -1612,6 +1646,7 @@ function ruleConfigSeverity(config) {
 module.exports = {
   CLIEngine,
   ESLint,
+  Linter,
   UtooLint,
   default: UtooLint,
   lintFiles,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -156,6 +156,40 @@ export async function loadESLint() {
   return UtooLint;
 }
 
+export class Linter {
+  static get version() {
+    return version;
+  }
+
+  verify(code, config = {}, options = {}) {
+    if (typeof code !== "string") {
+      throw new TypeError("code must be a string");
+    }
+
+    const verifyOptions = typeof options === "string" ? { filename: options } : { ...options };
+    const filePath = verifyOptions.filename ?? verifyOptions.filePath ?? "input.js";
+    const lintOptions = {
+      cwd: verifyOptions.cwd,
+      filePath,
+      noConfig: true,
+      noIgnore: true,
+      warnIgnored: false,
+      overrideConfig: config
+    };
+    const report = lintText(code, lintOptions);
+    const ruleSeverities = ruleSeverityMapForOptions(lintOptions, normalizeESLintFilePath(filePath, verifyOptions.cwd));
+    return (report.diagnostics ?? []).map((diagnostic) => diagnosticToESLintMessage(diagnostic, ruleSeverities));
+  }
+
+  verifyAndFix(code, config = {}, options = {}) {
+    return {
+      fixed: false,
+      messages: this.verify(code, config, options),
+      output: code
+    };
+  }
+}
+
 export class CLIEngine {
   static get version() {
     return version;


### PR DESCRIPTION
## Summary
- add a top-level `Linter` export for ESM and CJS consumers
- implement `Linter#verify()` through the existing in-memory `lintText()` path for built-in ESLint-compatible rules
- implement `Linter#verifyAndFix()` as a no-fix result wrapper
- document the supported `Linter` scope

## Why
Some ESLint integrations replace the package at the module boundary and use `new Linter().verify(...)` for in-memory code checks instead of the higher-level `ESLint` class. The package did not export `Linter`, so those consumers failed immediately. This adds a concrete built-in-rule path without pretending to support custom rule definition APIs.

## Validation
- compared core `Linter#verify()` shapes against ESLint latest in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS `new Linter().verify('debugger', { rules: { 'no-debugger': 'error' } })`
- smoke: no config returns no messages and project config is ignored
- smoke: flat `files` entries respect the supplied filename
- smoke: `verifyAndFix()` returns `{ fixed: false, messages, output }`
