### PR TITLE
feat: add linter state accessors

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -804,6 +804,13 @@ class Linter {
     return version;
   }
 
+  constructor() {
+    this.sourceCode = null;
+    this.suppressedMessages = [];
+    this.times = { passes: [] };
+    this.fixPassCount = 0;
+  }
+
   verify(code, config = {}, options = {}) {
     if (typeof code !== "string") {
       throw new TypeError("code must be a string");
@@ -821,6 +828,10 @@ class Linter {
     };
     const report = lintText(code, lintOptions);
     const ruleSeverities = ruleSeverityMapForOptions(lintOptions, normalizeESLintFilePath(filePath, verifyOptions.cwd));
+    this.sourceCode = createLinterSourceCode(code);
+    this.suppressedMessages = [];
+    this.times = { passes: [] };
+    this.fixPassCount = 0;
     return (report.diagnostics ?? []).map((diagnostic) => diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
@@ -831,6 +842,33 @@ class Linter {
       output: code
     };
   }
+
+  getSourceCode() {
+    return this.sourceCode;
+  }
+
+  getSuppressedMessages() {
+    return this.suppressedMessages;
+  }
+
+  getTimes() {
+    return this.times;
+  }
+
+  getFixPassCount() {
+    return this.fixPassCount;
+  }
+}
+
+function createLinterSourceCode(text) {
+  return {
+    text,
+    ast: null,
+    lines: text.split(/\r\n|\r|\n/),
+    getText() {
+      return text;
+    }
+  };
 }
 
 function normalizeStringArray(values, name) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -161,6 +161,13 @@ export class Linter {
     return version;
   }
 
+  constructor() {
+    this.sourceCode = null;
+    this.suppressedMessages = [];
+    this.times = { passes: [] };
+    this.fixPassCount = 0;
+  }
+
   verify(code, config = {}, options = {}) {
     if (typeof code !== "string") {
       throw new TypeError("code must be a string");
@@ -178,6 +185,10 @@ export class Linter {
     };
     const report = lintText(code, lintOptions);
     const ruleSeverities = ruleSeverityMapForOptions(lintOptions, normalizeESLintFilePath(filePath, verifyOptions.cwd));
+    this.sourceCode = createLinterSourceCode(code);
+    this.suppressedMessages = [];
+    this.times = { passes: [] };
+    this.fixPassCount = 0;
     return (report.diagnostics ?? []).map((diagnostic) => diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
@@ -188,6 +199,33 @@ export class Linter {
       output: code
     };
   }
+
+  getSourceCode() {
+    return this.sourceCode;
+  }
+
+  getSuppressedMessages() {
+    return this.suppressedMessages;
+  }
+
+  getTimes() {
+    return this.times;
+  }
+
+  getFixPassCount() {
+    return this.fixPassCount;
+  }
+}
+
+function createLinterSourceCode(text) {
+  return {
+    text,
+    ast: null,
+    lines: text.split(/\r\n|\r|\n/),
+    getText() {
+      return text;
+    }
+  };
 }
 
 export class CLIEngine {


### PR DESCRIPTION
## Summary
- add `Linter#getSourceCode()` state after `verify()` / `verifyAndFix()`
- add `getSuppressedMessages()`, `getTimes()`, and `getFixPassCount()` compatibility accessors
- keep the source object intentionally lightweight with `text`, `lines`, `ast: null`, and `getText()`

## Why
ESLint's `Linter` keeps state from the most recent verification. Tooling that uses `new Linter().verify(...)` often reads `getSourceCode()` or the timing/suppression accessors afterward. The compatibility `Linter` could verify built-in rules, but did not expose those follow-up methods.

## Validation
- compared accessor shapes against ESLint latest in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS accessors before and after `verify()`
- smoke: `verifyAndFix()` refreshes source state and returns no-fix output
