### PR TITLE
fix: normalize public config rules

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -128,7 +128,7 @@ class UtooLint {
   }
 
   async calculateConfigForFile(filePath) {
-    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
   getRulesMetaForResults(results) {
@@ -227,7 +227,7 @@ class CLIEngine {
   }
 
   getConfigForFile(filePath) {
-    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 }
 
@@ -636,6 +636,24 @@ function calculatedConfig(options = {}, filePath) {
   };
 }
 
+function publicCalculatedConfig(options = {}, filePath) {
+  const config = calculatedConfig(options, filePath);
+  return {
+    ...config,
+    rules: Object.fromEntries(
+      Object.entries(config.rules ?? {}).map(([rule, value]) => [rule, publicRuleConfigValue(value)])
+    )
+  };
+}
+
+function publicRuleConfigValue(value) {
+  if (Array.isArray(value)) {
+    const [severity, ...rest] = value;
+    return [ruleConfigSeverity(severity), ...rest];
+  }
+  return [ruleConfigSeverity(value)];
+}
+
 function rulesFromNativeRuleList(rules) {
   if (!rules) {
     return {};
@@ -741,7 +759,7 @@ function withTemporaryConfig(options, callback) {
     return callback(options);
   }
 
-  const rules = calculatedConfig(options).rules;
+  const rules = runtimeRulesFromConfigs(options.baseConfig, options.overrideConfig);
   const enabledRules = enabledRuleNamesFromConfigs(options.baseConfig, options.overrideConfig);
   if (!hasRuleOptions(rules)) {
     return callback({
@@ -769,6 +787,34 @@ function enabledRuleNames(rules) {
   return Object.entries(rules)
     .filter(([, value]) => ruleConfigSeverity(value) > 0)
     .map(([rule]) => rule);
+}
+
+function runtimeRulesFromConfigs(...configs) {
+  const rules = {};
+  for (const config of configs) {
+    Object.assign(rules, runtimeRulesFromConfig(config));
+  }
+  return rules;
+}
+
+function runtimeRulesFromConfig(config) {
+  if (!config) {
+    return {};
+  }
+  if (Array.isArray(config)) {
+    return config.reduce((rules, entry) => ({
+      ...rules,
+      ...runtimeRulesFromConfig(entry)
+    }), {});
+  }
+
+  const rules = {};
+  for (const [rule, value] of Object.entries(rulesFromConfig(config))) {
+    if (ruleConfigSeverity(value) > 0) {
+      rules[rule] = value;
+    }
+  }
+  return rules;
 }
 
 function enabledRuleNamesFromConfigs(...configs) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -131,7 +131,7 @@ export class UtooLint {
   }
 
   async calculateConfigForFile(filePath) {
-    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
   getRulesMetaForResults(results) {
@@ -306,7 +306,7 @@ export class CLIEngine {
   }
 
   getConfigForFile(filePath) {
-    return calculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 }
 
@@ -715,6 +715,24 @@ function calculatedConfig(options = {}, filePath) {
   };
 }
 
+function publicCalculatedConfig(options = {}, filePath) {
+  const config = calculatedConfig(options, filePath);
+  return {
+    ...config,
+    rules: Object.fromEntries(
+      Object.entries(config.rules ?? {}).map(([rule, value]) => [rule, publicRuleConfigValue(value)])
+    )
+  };
+}
+
+function publicRuleConfigValue(value) {
+  if (Array.isArray(value)) {
+    const [severity, ...rest] = value;
+    return [ruleConfigSeverity(severity), ...rest];
+  }
+  return [ruleConfigSeverity(value)];
+}
+
 function rulesFromNativeRuleList(rules) {
   if (!rules) {
     return {};
@@ -820,7 +838,7 @@ function withTemporaryConfig(options, callback) {
     return callback(options);
   }
 
-  const rules = calculatedConfig(options).rules;
+  const rules = runtimeRulesFromConfigs(options.baseConfig, options.overrideConfig);
   const enabledRules = enabledRuleNamesFromConfigs(options.baseConfig, options.overrideConfig);
   if (!hasRuleOptions(rules)) {
     return callback({
@@ -848,6 +866,34 @@ function enabledRuleNames(rules) {
   return Object.entries(rules)
     .filter(([, value]) => ruleConfigSeverity(value) > 0)
     .map(([rule]) => rule);
+}
+
+function runtimeRulesFromConfigs(...configs) {
+  const rules = {};
+  for (const config of configs) {
+    Object.assign(rules, runtimeRulesFromConfig(config));
+  }
+  return rules;
+}
+
+function runtimeRulesFromConfig(config) {
+  if (!config) {
+    return {};
+  }
+  if (Array.isArray(config)) {
+    return config.reduce((rules, entry) => ({
+      ...rules,
+      ...runtimeRulesFromConfig(entry)
+    }), {});
+  }
+
+  const rules = {};
+  for (const [rule, value] of Object.entries(rulesFromConfig(config))) {
+    if (ruleConfigSeverity(value) > 0) {
+      rules[rule] = value;
+    }
+  }
+  return rules;
 }
 
 function enabledRuleNamesFromConfigs(...configs) {


### PR DESCRIPTION
## Summary
- normalize public `calculateConfigForFile()` / `CLIEngine#getConfigForFile()` rule values to ESLint-style severity arrays
- keep internal rule config values unchanged for linting/filtering
- preserve rules that are enabled by any flat config entry when materializing the temporary native config for rule options

## Why
ESLint's public config APIs return normalized rule configs such as `[2]`, `[1]`, and `[2, "always"]`. The compatibility API returned raw values like `"error"` and `"warn"`, which can break tooling that reads calculated configs.

While validating that path, a related flat config bug showed up: when an inline flat config had rule options and a later matching entry disabled the same rule for another file, the temporary native config collapsed the rule to `off` globally. That prevented diagnostics for files where the rule should still run. The native run now uses a broad set of rules enabled by any entry, and the existing per-file filtering still decides final severity/output.

## Validation
- compared public config shape against ESLint latest in a temp project
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `zig build test`
- `zig build`
- smoke: ESM/CJS calculated configs return `[2]`, `[1]`, `[0]`, and option arrays
- smoke: flat config with `eqeqeq: ['error', 'always']` plus a later `no-debugger: 'off'` still reports `no-debugger` for the earlier matching file and suppresses it for the later one
