### PR TITLE
feat: align rule tester default config api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -77,7 +77,7 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 The `Linter` export supports in-memory `verify()` and `verifyAndFix()` calls for
 utoo-lint's built-in ESLint-compatible rules; custom rule definition APIs are
 not implemented. The `RuleTester` export can run basic valid/invalid cases for
-those built-in rules.
+those built-in rules and supports the default-config static helpers.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -9,6 +9,8 @@ const { platformPackageName, resolveBinary } = require("./lib/binary.cjs");
 const version = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")).version;
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const RULE_TESTER_INITIAL_CONFIG = { rules: {} };
+let ruleTesterDefaultConfig = { rules: {} };
 const FISHLINT_DROP_FLAGS = new Set([
   "--cache",
   "--color",
@@ -911,8 +913,28 @@ class RuleTester {
     return version;
   }
 
+  static setDefaultConfig(config) {
+    if (typeof config !== "object" || config === null) {
+      throw new TypeError("RuleTester.setDefaultConfig: config must be an object");
+    }
+    ruleTesterDefaultConfig = config;
+    ruleTesterDefaultConfig.rules = ruleTesterDefaultConfig.rules || {};
+  }
+
+  static getDefaultConfig() {
+    return ruleTesterDefaultConfig;
+  }
+
+  static resetDefaultConfig() {
+    ruleTesterDefaultConfig = {
+      rules: {
+        ...RULE_TESTER_INITIAL_CONFIG.rules
+      }
+    };
+  }
+
   constructor(config = {}) {
-    this.config = config;
+    this.config = mergeRuleTesterConfig(ruleTesterDefaultConfig, config);
   }
 
   run(ruleName, _rule, tests = {}) {
@@ -931,6 +953,17 @@ class RuleTester {
       assertRuleTesterErrors(testCase, messages);
     }
   }
+}
+
+function mergeRuleTesterConfig(baseConfig, overrideConfig) {
+  return {
+    ...baseConfig,
+    ...overrideConfig,
+    rules: {
+      ...(baseConfig.rules ?? {}),
+      ...(overrideConfig.rules ?? {})
+    }
+  };
 }
 
 function normalizeRuleTesterCase(test) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -12,6 +12,8 @@ export { platformPackageName, resolveBinary } from "./lib/binary.js";
 export const version = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version;
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const RULE_TESTER_INITIAL_CONFIG = { rules: {} };
+let ruleTesterDefaultConfig = { rules: {} };
 const FISHLINT_DROP_FLAGS = new Set([
   "--cache",
   "--color",
@@ -222,8 +224,28 @@ export class RuleTester {
     return version;
   }
 
+  static setDefaultConfig(config) {
+    if (typeof config !== "object" || config === null) {
+      throw new TypeError("RuleTester.setDefaultConfig: config must be an object");
+    }
+    ruleTesterDefaultConfig = config;
+    ruleTesterDefaultConfig.rules = ruleTesterDefaultConfig.rules || {};
+  }
+
+  static getDefaultConfig() {
+    return ruleTesterDefaultConfig;
+  }
+
+  static resetDefaultConfig() {
+    ruleTesterDefaultConfig = {
+      rules: {
+        ...RULE_TESTER_INITIAL_CONFIG.rules
+      }
+    };
+  }
+
   constructor(config = {}) {
-    this.config = config;
+    this.config = mergeRuleTesterConfig(ruleTesterDefaultConfig, config);
   }
 
   run(ruleName, _rule, tests = {}) {
@@ -242,6 +264,17 @@ export class RuleTester {
       assertRuleTesterErrors(testCase, messages);
     }
   }
+}
+
+function mergeRuleTesterConfig(baseConfig, overrideConfig) {
+  return {
+    ...baseConfig,
+    ...overrideConfig,
+    rules: {
+      ...(baseConfig.rules ?? {}),
+      ...(overrideConfig.rules ?? {})
+    }
+  };
 }
 
 function normalizeRuleTesterCase(test) {


### PR DESCRIPTION
## Summary
- add RuleTester.setDefaultConfig(), getDefaultConfig(), and resetDefaultConfig() compatibility helpers
- initialize the shared RuleTester default config with `{ rules: {} }` like ESLint
- merge shared defaults into new RuleTester instances while preserving per-instance rule overrides
- document the default-config helper support

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS RuleTester default-config smoke checks