### PR TITLE
feat: add source code api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -78,7 +78,8 @@ The `Linter` export supports in-memory `verify()` and `verifyAndFix()` calls for
 utoo-lint's built-in ESLint-compatible rules; custom rule definition APIs are
 not implemented. The `RuleTester` export can run basic valid/invalid cases for
 those built-in rules and supports the default-config and test-framework static
-helpers.
+helpers. The `SourceCode` export provides basic source text access helpers used
+by `Linter#getSourceCode()`.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -911,6 +911,36 @@ class Linter {
   }
 }
 
+class SourceCode {
+  constructor(textOrConfig, astIfNoConfig = null) {
+    if (typeof textOrConfig === "string") {
+      this.text = textOrConfig;
+      this.ast = astIfNoConfig;
+    } else if (textOrConfig && typeof textOrConfig === "object" && typeof textOrConfig.text === "string") {
+      this.text = textOrConfig.text;
+      this.ast = textOrConfig.ast ?? null;
+      this.parserServices = textOrConfig.parserServices ?? {};
+      this.scopeManager = textOrConfig.scopeManager ?? null;
+      this.visitorKeys = textOrConfig.visitorKeys ?? null;
+      this.hasBOM = Boolean(textOrConfig.hasBOM);
+    } else {
+      throw new TypeError("SourceCode requires source text");
+    }
+    this.lines = this.text.split(/\r\n|\r|\n/);
+  }
+
+  getText(node, beforeCount = 0, afterCount = 0) {
+    if (node?.range) {
+      return this.text.slice(Math.max(node.range[0] - beforeCount, 0), node.range[1] + afterCount);
+    }
+    return this.text;
+  }
+
+  getLines() {
+    return this.lines;
+  }
+}
+
 class RuleTester {
   static get version() {
     return version;
@@ -1095,14 +1125,7 @@ function assertRuleTesterErrors(testCase, messages) {
 }
 
 function createLinterSourceCode(text) {
-  return {
-    text,
-    ast: null,
-    lines: text.split(/\r\n|\r|\n/),
-    getText() {
-      return text;
-    }
-  };
+  return new SourceCode(text, null);
 }
 
 function normalizeStringArray(values, name) {
@@ -1920,6 +1943,7 @@ module.exports = {
   ESLint,
   Linter,
   RuleTester,
+  SourceCode,
   UtooLint,
   default: UtooLint,
   lintFiles,

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -222,6 +222,36 @@ export class Linter {
   }
 }
 
+export class SourceCode {
+  constructor(textOrConfig, astIfNoConfig = null) {
+    if (typeof textOrConfig === "string") {
+      this.text = textOrConfig;
+      this.ast = astIfNoConfig;
+    } else if (textOrConfig && typeof textOrConfig === "object" && typeof textOrConfig.text === "string") {
+      this.text = textOrConfig.text;
+      this.ast = textOrConfig.ast ?? null;
+      this.parserServices = textOrConfig.parserServices ?? {};
+      this.scopeManager = textOrConfig.scopeManager ?? null;
+      this.visitorKeys = textOrConfig.visitorKeys ?? null;
+      this.hasBOM = Boolean(textOrConfig.hasBOM);
+    } else {
+      throw new TypeError("SourceCode requires source text");
+    }
+    this.lines = this.text.split(/\r\n|\r|\n/);
+  }
+
+  getText(node, beforeCount = 0, afterCount = 0) {
+    if (node?.range) {
+      return this.text.slice(Math.max(node.range[0] - beforeCount, 0), node.range[1] + afterCount);
+    }
+    return this.text;
+  }
+
+  getLines() {
+    return this.lines;
+  }
+}
+
 export class RuleTester {
   static get version() {
     return version;
@@ -406,14 +436,7 @@ function assertRuleTesterErrors(testCase, messages) {
 }
 
 function createLinterSourceCode(text) {
-  return {
-    text,
-    ast: null,
-    lines: text.split(/\r\n|\r|\n/),
-    getText() {
-      return text;
-    }
-  };
+  return new SourceCode(text, null);
 }
 
 export class CLIEngine {


### PR DESCRIPTION
## Summary
- export a basic ESLint-compatible SourceCode class from ESM and CJS entrypoints
- support SourceCode construction from source text or `{ text, ast }` config objects
- add basic getText() and getLines() helpers
- return SourceCode instances from Linter#getSourceCode()

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS SourceCode and Linter#getSourceCode() smoke checks