### PR TITLE
feat: add eslint instance helpers

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -72,7 +72,8 @@ and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,
 `configType`, `defaultConfig`, `fromOptionsModule()`, `outputFixes()`,
-`getErrorResults()`, and `getRulesMetaForResults()` surfaces. The top-level
+`getErrorResults()`, `getRulesMetaForResults()`, `findConfigFile()`, and
+`hasFlag()` surfaces. The top-level
 `loadESLint()` helper resolves to the compatibility `ESLint` class.
 The `Linter` export supports in-memory `verify()` and `verifyAndFix()` calls for
 utoo-lint's built-in ESLint-compatible rules; custom rule definition APIs are

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -136,11 +136,23 @@ class UtooLint {
     return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
+  async findConfigFile(_filePath) {
+    const options = eslintConstructorOptions(this.options);
+    if (options.noConfig) {
+      return undefined;
+    }
+    return configPathForOptions(options);
+  }
+
   getRulesMetaForResults(results) {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
     return rulesMetaForResults(results);
+  }
+
+  hasFlag(flag) {
+    return hasFlagInOptions(this.options, flag);
   }
 
   async loadFormatter(name = "stylish") {
@@ -630,6 +642,14 @@ function eslintConstructorOptions(options) {
   return mapped;
 }
 
+function flagsFromOptions(options = {}) {
+  return Array.isArray(options.flags) ? [...options.flags] : [];
+}
+
+function hasFlagInOptions(options, flag) {
+  return flagsFromOptions(options).includes(flag);
+}
+
 function calculatedConfig(options = {}, filePath) {
   return {
     rules: {
@@ -855,7 +875,8 @@ class Linter {
     return version;
   }
 
-  constructor() {
+  constructor(options = {}) {
+    this.flags = flagsFromOptions(options);
     this.sourceCode = null;
     this.suppressedMessages = [];
     this.times = { passes: [] };
@@ -908,6 +929,10 @@ class Linter {
 
   getFixPassCount() {
     return this.fixPassCount;
+  }
+
+  hasFlag(flag) {
+    return this.flags.includes(flag);
   }
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -139,11 +139,23 @@ export class UtooLint {
     return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
+  async findConfigFile(_filePath) {
+    const options = eslintConstructorOptions(this.options);
+    if (options.noConfig) {
+      return undefined;
+    }
+    return configPathForOptions(options);
+  }
+
   getRulesMetaForResults(results) {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
     return rulesMetaForResults(results);
+  }
+
+  hasFlag(flag) {
+    return hasFlagInOptions(this.options, flag);
   }
 
   async loadFormatter(name = "stylish") {
@@ -166,7 +178,8 @@ export class Linter {
     return version;
   }
 
-  constructor() {
+  constructor(options = {}) {
+    this.flags = flagsFromOptions(options);
     this.sourceCode = null;
     this.suppressedMessages = [];
     this.times = { passes: [] };
@@ -219,6 +232,10 @@ export class Linter {
 
   getFixPassCount() {
     return this.fixPassCount;
+  }
+
+  hasFlag(flag) {
+    return this.flags.includes(flag);
   }
 }
 
@@ -913,6 +930,14 @@ function eslintConstructorOptions(options) {
     mapped.overrideConfig = { rules: options.baseConfig.rules };
   }
   return mapped;
+}
+
+function flagsFromOptions(options = {}) {
+  return Array.isArray(options.flags) ? [...options.flags] : [];
+}
+
+function hasFlagInOptions(options, flag) {
+  return flagsFromOptions(options).includes(flag);
 }
 
 function calculatedConfig(options = {}, filePath) {


### PR DESCRIPTION
## Summary
- add ESLint/UtooLint findConfigFile() compatibility helper
- add hasFlag() to ESLint/UtooLint and Linter instances
- allow Linter construction with a flags option while preserving existing defaults
- document the new instance helper surfaces

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS findConfigFile() and hasFlag() smoke checks