### PR TITLE
feat: add linter custom api surface

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -76,11 +76,11 @@ low-friction replacements. It also provides ESLint-compatible `version`,
 `hasFlag()` surfaces. The top-level
 `loadESLint()` helper resolves to the compatibility `ESLint` class.
 The `Linter` export supports in-memory `verify()` and `verifyAndFix()` calls for
-utoo-lint's built-in ESLint-compatible rules; custom rule definition APIs are
-not implemented. The `RuleTester` export can run basic valid/invalid cases for
-those built-in rules and supports the default-config and test-framework static
-helpers. The `SourceCode` export provides basic source text access helpers used
-by `Linter#getSourceCode()`.
+utoo-lint's built-in ESLint-compatible rules, plus `getRules()` and explicit
+unsupported custom rule definition methods. The `RuleTester` export can run
+basic valid/invalid cases for those built-in rules and supports the
+default-config and test-framework static helpers. The `SourceCode` export
+provides basic source text access helpers used by `Linter#getSourceCode()`.
 Rule meta includes best-effort `docs.url` values for common ESLint-compatible
 rule IDs. `loadFormatter()` and `CLIEngine#getFormatter()` support `json`,
 `json-with-metadata`, `compact`, `unix`, and the native text formatter shape.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -934,6 +934,22 @@ class Linter {
   hasFlag(flag) {
     return this.flags.includes(flag);
   }
+
+  getRules() {
+    return new Map();
+  }
+
+  defineRule() {
+    throw new Error("Linter#defineRule is not implemented by @utoo/lint");
+  }
+
+  defineRules() {
+    throw new Error("Linter#defineRules is not implemented by @utoo/lint");
+  }
+
+  defineParser() {
+    throw new Error("Linter#defineParser is not implemented by @utoo/lint");
+  }
 }
 
 class SourceCode {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -237,6 +237,22 @@ export class Linter {
   hasFlag(flag) {
     return this.flags.includes(flag);
   }
+
+  getRules() {
+    return new Map();
+  }
+
+  defineRule() {
+    throw new Error("Linter#defineRule is not implemented by @utoo/lint");
+  }
+
+  defineRules() {
+    throw new Error("Linter#defineRules is not implemented by @utoo/lint");
+  }
+
+  defineParser() {
+    throw new Error("Linter#defineParser is not implemented by @utoo/lint");
+  }
 }
 
 export class SourceCode {


### PR DESCRIPTION
## Summary
- add Linter#getRules() compatibility surface returning an empty Map
- add explicit unsupported defineRule(), defineRules(), and defineParser() methods
- document that custom rule definition APIs are surfaced but not implemented

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS Linter custom API smoke checks