### PR TITLE
feat: add cli engine legacy methods

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -111,6 +111,9 @@ so later `off` entries do not suppress diagnostics for other files. Raw
 provides a synchronous legacy facade for older ESLint integrations.
 `CLIEngine#executeOnText()` accepts a string path or an options object with
 `filePath`, `filename`, and text lint options.
+It also exposes legacy `getRules()`, `addPlugin()`, and
+`resolveFileGlobPatterns()` facade methods for integrations that probe them
+during startup.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
 `warnIgnored: false` suppresses warnings for explicit ignored file paths and

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -193,6 +193,7 @@ class CLIEngine {
 
   constructor(options = {}) {
     this.options = { ...options };
+    this.plugins = new Map();
   }
 
   executeOnFiles(patterns) {
@@ -237,6 +238,18 @@ class CLIEngine {
     return (results) => {
       return formatResultsByName(results, name);
     };
+  }
+
+  getRules() {
+    return new Linter().getRules();
+  }
+
+  addPlugin(name, pluginObject) {
+    this.plugins.set(name, pluginObject);
+  }
+
+  resolveFileGlobPatterns(patterns) {
+    return normalizeStringArray(Array.isArray(patterns) ? patterns : [patterns], "patterns");
   }
 
   isPathIgnored(filePath) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -756,6 +756,7 @@ export class CLIEngine {
 
   constructor(options = {}) {
     this.options = { ...options };
+    this.plugins = new Map();
   }
 
   executeOnFiles(patterns) {
@@ -800,6 +801,18 @@ export class CLIEngine {
     return (results) => {
       return formatResultsByName(results, name);
     };
+  }
+
+  getRules() {
+    return new Linter().getRules();
+  }
+
+  addPlugin(name, pluginObject) {
+    this.plugins.set(name, pluginObject);
+  }
+
+  resolveFileGlobPatterns(patterns) {
+    return normalizeStringArray(Array.isArray(patterns) ? patterns : [patterns], "patterns");
   }
 
   isPathIgnored(filePath) {


### PR DESCRIPTION
## Summary
- add CLIEngine#getRules() compatibility facade
- add CLIEngine#addPlugin() storage for integrations that register plugins during startup
- add CLIEngine#resolveFileGlobPatterns() string/array normalization facade
- document the added legacy CLIEngine methods

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS CLIEngine legacy method smoke checks