### PR TITLE
feat: add use at your own risk api

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -114,6 +114,9 @@ provides a synchronous legacy facade for older ESLint integrations.
 It also exposes legacy `getRules()`, `addPlugin()`, and
 `resolveFileGlobPatterns()` facade methods for integrations that probe them
 during startup.
+The `@utoo/lint/use-at-your-own-risk` subpath exposes `builtinRules`,
+`FlatESLint`, `LegacyESLint`, `shouldUseFlatConfig()`, and `FileEnumerator`
+compatibility exports.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
 `warnIgnored: false` suppresses warnings for explicit ignored file paths and

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -21,6 +21,10 @@
       "import": "./lib/binary.js",
       "require": "./lib/binary.cjs"
     },
+    "./use-at-your-own-risk": {
+      "import": "./use-at-your-own-risk.js",
+      "require": "./use-at-your-own-risk.cjs"
+    },
     "./configs/frontend": "./configs/frontend.json",
     "./schema": "./schema.json",
     "./package.json": "./package.json"
@@ -37,7 +41,9 @@
     "index.cjs",
     "index.js",
     "lib",
-    "schema.json"
+    "schema.json",
+    "use-at-your-own-risk.cjs",
+    "use-at-your-own-risk.js"
   ],
   "optionalDependencies": {
     "@utoo/lint-darwin-arm64": "0.1.0",

--- a/npm/utoo-lint/use-at-your-own-risk.cjs
+++ b/npm/utoo-lint/use-at-your-own-risk.cjs
@@ -1,0 +1,28 @@
+const { CLIEngine, Linter, UtooLint } = require("./index.cjs");
+
+const builtinRules = new Linter().getRules();
+const FlatESLint = UtooLint;
+const LegacyESLint = UtooLint;
+
+async function shouldUseFlatConfig() {
+  return true;
+}
+
+class FileEnumerator {
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  iterateFiles(patterns = []) {
+    const cli = new CLIEngine(this.options);
+    return cli.resolveFileGlobPatterns(patterns).map((filePath) => ({ filePath }));
+  }
+}
+
+module.exports = {
+  builtinRules,
+  FileEnumerator,
+  FlatESLint,
+  LegacyESLint,
+  shouldUseFlatConfig
+};

--- a/npm/utoo-lint/use-at-your-own-risk.js
+++ b/npm/utoo-lint/use-at-your-own-risk.js
@@ -1,0 +1,20 @@
+import { CLIEngine, Linter, UtooLint } from "./index.js";
+
+export const builtinRules = new Linter().getRules();
+export const FlatESLint = UtooLint;
+export const LegacyESLint = UtooLint;
+
+export async function shouldUseFlatConfig() {
+  return true;
+}
+
+export class FileEnumerator {
+  constructor(options = {}) {
+    this.options = { ...options };
+  }
+
+  iterateFiles(patterns = []) {
+    const cli = new CLIEngine(this.options);
+    return cli.resolveFileGlobPatterns(patterns).map((filePath) => ({ filePath }));
+  }
+}


### PR DESCRIPTION
## Summary
- add @utoo/lint/use-at-your-own-risk ESM and CJS subpath exports
- expose builtinRules, FlatESLint, LegacyESLint, shouldUseFlatConfig(), and FileEnumerator compatibility shims
- add the new subpath to package exports/files
- document the unsupported API compatibility entrypoint

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/use-at-your-own-risk.js && node --check npm/utoo-lint/use-at-your-own-risk.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS use-at-your-own-risk smoke checks
- package exports/files smoke check