### PR TITLE
feat: add config and universal subpaths

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -114,6 +114,8 @@ provides a synchronous legacy facade for older ESLint integrations.
 It also exposes legacy `getRules()`, `addPlugin()`, and
 `resolveFileGlobPatterns()` facade methods for integrations that probe them
 during startup.
+The `@utoo/lint/config` subpath exposes `defineConfig()` and `globalIgnores()`,
+and `@utoo/lint/universal` exposes `Linter` for browser-oriented integrations.
 The `@utoo/lint/use-at-your-own-risk` subpath exposes `builtinRules`,
 `FlatESLint`, `LegacyESLint`, `shouldUseFlatConfig()`, and `FileEnumerator`
 compatibility exports.

--- a/npm/utoo-lint/config.cjs
+++ b/npm/utoo-lint/config.cjs
@@ -1,0 +1,41 @@
+let globalIgnoreCount = 0;
+
+function defineConfig(...args) {
+  if (args.length === 0) {
+    throw new TypeError("Expected one or more arguments.");
+  }
+  return flattenConfigArgs(args);
+}
+
+function globalIgnores(ignorePatterns, name) {
+  if (!Array.isArray(ignorePatterns)) {
+    throw new TypeError("ignorePatterns must be an array");
+  }
+  if (ignorePatterns.length === 0) {
+    throw new TypeError("ignorePatterns must contain at least one pattern");
+  }
+  const id = globalIgnoreCount++;
+  return {
+    name: name || `globalIgnores ${id}`,
+    ignores: ignorePatterns
+  };
+}
+
+function flattenConfigArgs(values) {
+  const configs = [];
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      configs.push(...flattenConfigArgs(value));
+    } else if (typeof value === "object" && value !== null) {
+      configs.push(value);
+    } else {
+      throw new TypeError(`Expected an object but received ${String(value)}.`);
+    }
+  }
+  return configs;
+}
+
+module.exports = {
+  defineConfig,
+  globalIgnores
+};

--- a/npm/utoo-lint/config.js
+++ b/npm/utoo-lint/config.js
@@ -1,0 +1,36 @@
+let globalIgnoreCount = 0;
+
+export function defineConfig(...args) {
+  if (args.length === 0) {
+    throw new TypeError("Expected one or more arguments.");
+  }
+  return flattenConfigArgs(args);
+}
+
+export function globalIgnores(ignorePatterns, name) {
+  if (!Array.isArray(ignorePatterns)) {
+    throw new TypeError("ignorePatterns must be an array");
+  }
+  if (ignorePatterns.length === 0) {
+    throw new TypeError("ignorePatterns must contain at least one pattern");
+  }
+  const id = globalIgnoreCount++;
+  return {
+    name: name || `globalIgnores ${id}`,
+    ignores: ignorePatterns
+  };
+}
+
+function flattenConfigArgs(values) {
+  const configs = [];
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      configs.push(...flattenConfigArgs(value));
+    } else if (typeof value === "object" && value !== null) {
+      configs.push(value);
+    } else {
+      throw new TypeError(`Expected an object but received ${String(value)}.`);
+    }
+  }
+  return configs;
+}

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -21,9 +21,17 @@
       "import": "./lib/binary.js",
       "require": "./lib/binary.cjs"
     },
+    "./config": {
+      "import": "./config.js",
+      "require": "./config.cjs"
+    },
     "./use-at-your-own-risk": {
       "import": "./use-at-your-own-risk.js",
       "require": "./use-at-your-own-risk.cjs"
+    },
+    "./universal": {
+      "import": "./universal.js",
+      "require": "./universal.cjs"
     },
     "./configs/frontend": "./configs/frontend.json",
     "./schema": "./schema.json",
@@ -37,11 +45,15 @@
   },
   "files": [
     "bin",
+    "config.cjs",
+    "config.js",
     "configs",
     "index.cjs",
     "index.js",
     "lib",
     "schema.json",
+    "universal.cjs",
+    "universal.js",
     "use-at-your-own-risk.cjs",
     "use-at-your-own-risk.js"
   ],

--- a/npm/utoo-lint/universal.cjs
+++ b/npm/utoo-lint/universal.cjs
@@ -1,0 +1,3 @@
+const { Linter } = require("./index.cjs");
+
+module.exports = { Linter };

--- a/npm/utoo-lint/universal.js
+++ b/npm/utoo-lint/universal.js
@@ -1,0 +1,1 @@
+export { Linter } from "./index.js";


### PR DESCRIPTION
## Summary
- add @utoo/lint/config ESM and CJS subpath with defineConfig() and globalIgnores() helpers
- add @utoo/lint/universal ESM and CJS subpath exposing Linter
- include the new subpaths in package exports/files
- document the new compatibility subpaths

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/config.js && node --check npm/utoo-lint/config.cjs && node --check npm/utoo-lint/universal.js && node --check npm/utoo-lint/universal.cjs && node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS config and universal subpath smoke checks
- package exports/files smoke check