### PR TITLE
feat: align define config extends

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -115,7 +115,8 @@ It also exposes legacy `getRules()`, `addPlugin()`, and
 `resolveFileGlobPatterns()` facade methods for integrations that probe them
 during startup.
 The `@utoo/lint/config` subpath exposes `defineConfig()` and `globalIgnores()`,
-and `@utoo/lint/universal` exposes `Linter` for browser-oriented integrations.
+including basic flat config `extends` expansion, and `@utoo/lint/universal`
+exposes `Linter` for browser-oriented integrations.
 The `@utoo/lint/use-at-your-own-risk` subpath exposes `builtinRules`,
 `FlatESLint`, `LegacyESLint`, `shouldUseFlatConfig()`, and `FileEnumerator`
 compatibility exports.

--- a/npm/utoo-lint/config.cjs
+++ b/npm/utoo-lint/config.cjs
@@ -4,7 +4,7 @@ function defineConfig(...args) {
   if (args.length === 0) {
     throw new TypeError("Expected one or more arguments.");
   }
-  return flattenConfigArgs(args);
+  return flattenConfigArgs(args).flatMap((config, index) => expandConfigExtends(config, `UserConfig[${index}]`));
 }
 
 function globalIgnores(ignorePatterns, name) {
@@ -33,6 +33,120 @@ function flattenConfigArgs(values) {
     }
   }
   return configs;
+}
+
+function expandConfigExtends(config, baseConfigName) {
+  if (!("extends" in config)) {
+    return [config];
+  }
+  if (!Array.isArray(config.extends)) {
+    throw new TypeError("The `extends` property must be an array.");
+  }
+
+  const { extends: extendsList, ...baseConfig } = config;
+  const expanded = [];
+  for (const [index, extension] of flattenConfigArgs(resolveConfigExtends(config, extendsList)).entries()) {
+    if ("basePath" in extension) {
+      throw new TypeError("'basePath' in `extends` is not allowed.");
+    }
+    if ("extends" in extension) {
+      throw new TypeError("Nested 'extends' is not allowed.");
+    }
+    expanded.push(extendConfig(baseConfig, extension, baseConfigName, extension.name ?? extension.__utooLintConfigName ?? `ExtendedConfig[${index}]`));
+  }
+  if (!isGlobalIgnores(baseConfig)) {
+    expanded.push(baseConfig);
+  }
+  return expanded;
+}
+
+function resolveConfigExtends(config, extendsList) {
+  return extendsList.map((extension) => {
+    if (typeof extension !== "string") {
+      return extension;
+    }
+    const pluginConfig = pluginConfigForName(config, extension);
+    if (!pluginConfig) {
+      const { namespace, configName } = splitPluginConfigName(extension);
+      throw new TypeError(`Plugin config "${configName}" not found in plugin "${namespace}".`);
+    }
+    return withConfigNames(pluginConfig, extension);
+  });
+}
+
+function pluginConfigForName(config, name) {
+  const { namespace, configName } = splitPluginConfigName(name);
+  const plugin = config.plugins?.[namespace];
+  if (!plugin) {
+    throw new TypeError(`Plugin "${namespace}" not found.`);
+  }
+  return plugin.configs?.[configName] ?? plugin.configs?.[`flat/${configName}`];
+}
+
+function splitPluginConfigName(name) {
+  const slashIndex = name.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === name.length - 1) {
+    throw new TypeError(`Invalid plugin config name "${name}".`);
+  }
+  return {
+    namespace: name.slice(0, slashIndex),
+    configName: name.slice(slashIndex + 1)
+  };
+}
+
+function extendConfig(baseConfig, extension, baseConfigName, extensionName) {
+  const { __utooLintConfigName: _name, ...extensionConfig } = extension;
+  const result = { ...extensionConfig };
+  if (!isGlobalIgnores(extension)) {
+    if (baseConfig.files) {
+      result.files = extendConfigFiles(baseConfig.files, extension.files);
+    }
+    if (baseConfig.ignores) {
+      result.ignores = baseConfig.ignores.concat(extension.ignores ?? []);
+    }
+  }
+  result.name = `${baseConfig.name ?? baseConfigName} > ${extensionName}`;
+  if (baseConfig.basePath) {
+    result.basePath = baseConfig.basePath;
+  }
+  return result;
+}
+
+function extendConfigFiles(baseFiles = [], extensionFiles = []) {
+  if (!extensionFiles.length) {
+    return baseFiles.concat();
+  }
+  if (!baseFiles.length) {
+    return extensionFiles.concat();
+  }
+  const result = [];
+  for (const baseFile of baseFiles) {
+    for (const extensionFile of extensionFiles) {
+      result.push([
+        ...(Array.isArray(baseFile) ? baseFile : [baseFile]),
+        ...(Array.isArray(extensionFile) ? extensionFile : [extensionFile])
+      ]);
+    }
+  }
+  return result;
+}
+
+function isGlobalIgnores(config) {
+  const keys = Object.keys(config);
+  return keys.includes("ignores") && keys.every((key) => key === "name" || key === "ignores");
+}
+
+function withConfigNames(config, name) {
+  if (Array.isArray(config)) {
+    return config.map((entry, index) => ({
+      ...entry,
+      __utooLintConfigName: `${name}[${index}]`
+    }));
+  }
+  return {
+    ...config,
+    __utooLintConfigName: name
+  };
 }
 
 module.exports = {

--- a/npm/utoo-lint/config.js
+++ b/npm/utoo-lint/config.js
@@ -4,7 +4,7 @@ export function defineConfig(...args) {
   if (args.length === 0) {
     throw new TypeError("Expected one or more arguments.");
   }
-  return flattenConfigArgs(args);
+  return flattenConfigArgs(args).flatMap((config, index) => expandConfigExtends(config, `UserConfig[${index}]`));
 }
 
 export function globalIgnores(ignorePatterns, name) {
@@ -33,4 +33,118 @@ function flattenConfigArgs(values) {
     }
   }
   return configs;
+}
+
+function expandConfigExtends(config, baseConfigName) {
+  if (!("extends" in config)) {
+    return [config];
+  }
+  if (!Array.isArray(config.extends)) {
+    throw new TypeError("The `extends` property must be an array.");
+  }
+
+  const { extends: extendsList, ...baseConfig } = config;
+  const expanded = [];
+  for (const [index, extension] of flattenConfigArgs(resolveConfigExtends(config, extendsList)).entries()) {
+    if ("basePath" in extension) {
+      throw new TypeError("'basePath' in `extends` is not allowed.");
+    }
+    if ("extends" in extension) {
+      throw new TypeError("Nested 'extends' is not allowed.");
+    }
+    expanded.push(extendConfig(baseConfig, extension, baseConfigName, extension.name ?? extension.__utooLintConfigName ?? `ExtendedConfig[${index}]`));
+  }
+  if (!isGlobalIgnores(baseConfig)) {
+    expanded.push(baseConfig);
+  }
+  return expanded;
+}
+
+function resolveConfigExtends(config, extendsList) {
+  return extendsList.map((extension) => {
+    if (typeof extension !== "string") {
+      return extension;
+    }
+    const pluginConfig = pluginConfigForName(config, extension);
+    if (!pluginConfig) {
+      const { namespace, configName } = splitPluginConfigName(extension);
+      throw new TypeError(`Plugin config "${configName}" not found in plugin "${namespace}".`);
+    }
+    return withConfigNames(pluginConfig, extension);
+  });
+}
+
+function pluginConfigForName(config, name) {
+  const { namespace, configName } = splitPluginConfigName(name);
+  const plugin = config.plugins?.[namespace];
+  if (!plugin) {
+    throw new TypeError(`Plugin "${namespace}" not found.`);
+  }
+  return plugin.configs?.[configName] ?? plugin.configs?.[`flat/${configName}`];
+}
+
+function splitPluginConfigName(name) {
+  const slashIndex = name.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === name.length - 1) {
+    throw new TypeError(`Invalid plugin config name "${name}".`);
+  }
+  return {
+    namespace: name.slice(0, slashIndex),
+    configName: name.slice(slashIndex + 1)
+  };
+}
+
+function extendConfig(baseConfig, extension, baseConfigName, extensionName) {
+  const { __utooLintConfigName: _name, ...extensionConfig } = extension;
+  const result = { ...extensionConfig };
+  if (!isGlobalIgnores(extension)) {
+    if (baseConfig.files) {
+      result.files = extendConfigFiles(baseConfig.files, extension.files);
+    }
+    if (baseConfig.ignores) {
+      result.ignores = baseConfig.ignores.concat(extension.ignores ?? []);
+    }
+  }
+  result.name = `${baseConfig.name ?? baseConfigName} > ${extensionName}`;
+  if (baseConfig.basePath) {
+    result.basePath = baseConfig.basePath;
+  }
+  return result;
+}
+
+function extendConfigFiles(baseFiles = [], extensionFiles = []) {
+  if (!extensionFiles.length) {
+    return baseFiles.concat();
+  }
+  if (!baseFiles.length) {
+    return extensionFiles.concat();
+  }
+  const result = [];
+  for (const baseFile of baseFiles) {
+    for (const extensionFile of extensionFiles) {
+      result.push([
+        ...(Array.isArray(baseFile) ? baseFile : [baseFile]),
+        ...(Array.isArray(extensionFile) ? extensionFile : [extensionFile])
+      ]);
+    }
+  }
+  return result;
+}
+
+function isGlobalIgnores(config) {
+  const keys = Object.keys(config);
+  return keys.includes("ignores") && keys.every((key) => key === "name" || key === "ignores");
+}
+
+function withConfigNames(config, name) {
+  if (Array.isArray(config)) {
+    return config.map((entry, index) => ({
+      ...entry,
+      __utooLintConfigName: `${name}[${index}]`
+    }));
+  }
+  return {
+    ...config,
+    __utooLintConfigName: name
+  };
 }


### PR DESCRIPTION
## Summary
- expand object, array, and plugin string entries from defineConfig() extends
- inherit files, ignores, basePath, and generated config names for extended entries
- reject nested extends and basePath inside extensions like ESLint config helpers
- document basic flat config extends expansion

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/config.js && node --check npm/utoo-lint/config.cjs && node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- ESM/CJS defineConfig extends smoke checks
- parity smoke against local ESLint config helper for object, array, files, and plugin extends cases