### PR TITLE
feat: add npm type declarations

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -120,6 +120,9 @@ exposes `Linter` for browser-oriented integrations.
 The `@utoo/lint/use-at-your-own-risk` subpath exposes `builtinRules`,
 `FlatESLint`, `LegacyESLint`, `shouldUseFlatConfig()`, and `FileEnumerator`
 compatibility exports.
+The package ships TypeScript declarations for the main entrypoint and
+compatibility subpaths, so typed ESLint integrations do not need a separate
+`@types` package.
 `ESLint` and `CLIEngine` constructor options also accept `quiet: true` to return
 only error messages, matching ESLint's warning filtering behavior.
 `warnIgnored: false` suppresses warnings for explicit ignored file paths and

--- a/npm/utoo-lint/config.d.ts
+++ b/npm/utoo-lint/config.d.ts
@@ -1,0 +1,4 @@
+import type { ConfigObject } from "./index.js";
+
+export function defineConfig(...configs: Array<ConfigObject | ConfigObject[]>): ConfigObject[];
+export function globalIgnores(ignorePatterns: string[], name?: string): ConfigObject;

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -1,0 +1,267 @@
+export interface LintMessage {
+  ruleId: string | null;
+  severity: 0 | 1 | 2;
+  message: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+  nodeType?: string | null;
+}
+
+export interface LintResult {
+  filePath: string;
+  messages: LintMessage[];
+  suppressedMessages: LintMessage[];
+  errorCount: number;
+  warningCount: number;
+  fixableErrorCount: number;
+  fixableWarningCount: number;
+  source?: string;
+  output?: string;
+}
+
+export interface LintReport {
+  files: number;
+  filePaths: string[];
+  diagnostics: LintMessage[];
+  exitCode: number;
+  stderr?: string;
+}
+
+export interface Formatter {
+  format(results: LintResult[] | LintReport): string;
+}
+
+export type RuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | false | true;
+export type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]];
+
+export interface ConfigObject {
+  name?: string;
+  files?: Array<string | string[]>;
+  ignores?: string[];
+  rules?: Record<string, RuleConfig>;
+  plugins?: Record<string, unknown>;
+  extends?: Array<string | ConfigObject | ConfigObject[]>;
+  basePath?: string;
+  [key: string]: unknown;
+}
+
+export interface LintOptions {
+  cwd?: string;
+  binary?: string;
+  env?: Record<string, string | undefined>;
+  threads?: number;
+  rules?: string[] | string;
+  config?: string;
+  noConfig?: boolean;
+  useEslintrc?: boolean;
+  overrideConfigFile?: string | boolean;
+  baseConfig?: ConfigObject | ConfigObject[];
+  overrideConfig?: ConfigObject | ConfigObject[];
+  ignore?: boolean;
+  noIgnore?: boolean;
+  ignorePath?: string;
+  ignorePatterns?: string[];
+  quiet?: boolean;
+  warnIgnored?: boolean;
+  errorOnUnmatchedPattern?: boolean;
+  extraArgs?: string[];
+  flags?: string[];
+}
+
+export interface TextLintOptions extends LintOptions {
+  filePath?: string;
+  filename?: string;
+}
+
+export interface VerifyOptions {
+  filename?: string;
+  filePath?: string;
+  cwd?: string;
+}
+
+export interface VerifyAndFixResult {
+  fixed: boolean;
+  messages: LintMessage[];
+  output: string;
+}
+
+export interface SourceLocation {
+  line: number;
+  column: number;
+}
+
+export interface SourceRange {
+  range?: [number, number];
+  loc?: {
+    start: SourceLocation;
+    end: SourceLocation;
+  };
+  [key: string]: unknown;
+}
+
+export class SourceCode {
+  constructor(text: string, ast?: SourceRange | null);
+  constructor(config: {
+    text: string;
+    ast?: SourceRange | null;
+    hasBOM?: boolean;
+    parserServices?: unknown;
+    scopeManager?: unknown;
+    visitorKeys?: unknown;
+  });
+  text: string;
+  ast: SourceRange | null;
+  lines: string[];
+  comments: SourceRange[];
+  tokens: SourceRange[];
+  getText(node?: SourceRange, beforeCount?: number, afterCount?: number): string;
+  getLines(): string[];
+  getAllComments(): SourceRange[];
+  getIndexFromLoc(loc: SourceLocation): number;
+  getLocFromIndex(index: number): SourceLocation;
+  getRange(node?: SourceRange): [number, number];
+  getLoc(node?: SourceRange): { start: SourceLocation; end: SourceLocation };
+  getAllTokens(): SourceRange[];
+  getTokens(node?: SourceRange, beforeCount?: number, afterCount?: number): SourceRange[];
+  getFirstToken(node?: SourceRange): SourceRange | null;
+  getFirstTokens(node?: SourceRange, count?: number): SourceRange[];
+  getLastToken(node?: SourceRange): SourceRange | null;
+  getLastTokens(node?: SourceRange, count?: number): SourceRange[];
+  getTokenBefore(nodeOrToken: SourceRange): SourceRange | null;
+  getTokensBefore(nodeOrToken: SourceRange, count?: number): SourceRange[];
+  getTokenAfter(nodeOrToken: SourceRange): SourceRange | null;
+  getTokensAfter(nodeOrToken: SourceRange, count?: number): SourceRange[];
+  getTokensBetween(left: SourceRange, right: SourceRange): SourceRange[];
+  getFirstTokenBetween(left: SourceRange, right: SourceRange): SourceRange | null;
+  getFirstTokensBetween(left: SourceRange, right: SourceRange, count?: number): SourceRange[];
+  getLastTokenBetween(left: SourceRange, right: SourceRange): SourceRange | null;
+  getLastTokensBetween(left: SourceRange, right: SourceRange, count?: number): SourceRange[];
+  getTokenByRangeStart(index: number): SourceRange | null;
+  getTokenOrCommentBefore(nodeOrToken: SourceRange): SourceRange | null;
+  getTokenOrCommentAfter(nodeOrToken: SourceRange): SourceRange | null;
+  getCommentsBefore(nodeOrToken: SourceRange): SourceRange[];
+  getCommentsAfter(nodeOrToken: SourceRange): SourceRange[];
+  getCommentsInside(node: SourceRange): SourceRange[];
+  getJSDocComment(node: SourceRange): SourceRange | null;
+  commentsExistBetween(left: SourceRange, right: SourceRange): boolean;
+  isSpaceBetween(left: SourceRange, right: SourceRange): boolean;
+  isSpaceBetweenTokens(left: SourceRange, right: SourceRange): boolean;
+  getNodeByRangeIndex(index: number): SourceRange | null;
+  getAncestors(): SourceRange[];
+  getDeclaredVariables(): unknown[];
+  getScope(): unknown;
+  markVariableAsUsed(name: string): boolean;
+  getDisableDirectives(): unknown[];
+  getInlineConfigNodes(): unknown[];
+  applyInlineConfig(): undefined;
+  applyLanguageOptions(): undefined;
+  finalize(): undefined;
+  traverse(): unknown[];
+  isGlobalReference(): boolean;
+}
+
+export class Linter {
+  static readonly version: string;
+  constructor(options?: { flags?: string[] });
+  verify(code: string, config?: ConfigObject, options?: VerifyOptions | string): LintMessage[];
+  verifyAndFix(code: string, config?: ConfigObject, options?: VerifyOptions | string): VerifyAndFixResult;
+  getSourceCode(): SourceCode | null;
+  getSuppressedMessages(): LintMessage[];
+  getTimes(): { passes: unknown[] };
+  getFixPassCount(): number;
+  hasFlag(flag: string): boolean;
+  getRules(): Map<string, unknown>;
+  defineRule(): never;
+  defineRules(): never;
+  defineParser(): never;
+}
+
+export interface RuleTesterValidCase extends ConfigObject {
+  code: string;
+  name?: string;
+  filename?: string;
+  filePath?: string;
+  options?: unknown[];
+  only?: boolean;
+}
+
+export interface RuleTesterInvalidCase extends RuleTesterValidCase {
+  errors?: number | Array<number | Partial<LintMessage> & { messageId?: string }>;
+}
+
+export class RuleTester {
+  static readonly version: string;
+  static setDefaultConfig(config: ConfigObject): void;
+  static getDefaultConfig(): ConfigObject;
+  static resetDefaultConfig(): void;
+  static describe: ((name: string, fn: () => void) => unknown) | null;
+  static it: ((name: string, fn: () => void) => unknown) | null;
+  static itOnly: ((name: string, fn: () => void) => unknown) | null;
+  static only<T extends string | RuleTesterValidCase | RuleTesterInvalidCase>(item: T): T extends string ? RuleTesterValidCase : T & { only: true };
+  constructor(config?: ConfigObject);
+  run(ruleName: string, rule: unknown, tests?: {
+    valid?: Array<string | RuleTesterValidCase>;
+    invalid?: RuleTesterInvalidCase[];
+  }): void;
+}
+
+export class UtooLint {
+  static readonly version: string;
+  static readonly configType: "flat";
+  static readonly defaultConfig: ConfigObject[];
+  static fromOptionsModule(optionsURL: URL): Promise<UtooLint>;
+  static outputFixes(results: LintResult[]): Promise<void>;
+  static getErrorResults(results: LintResult[]): LintResult[];
+  constructor(options?: LintOptions);
+  lintFiles(patterns?: string | string[], options?: LintOptions): Promise<LintResult[]>;
+  lintText(code: string, options?: TextLintOptions): Promise<LintResult[]>;
+  isPathIgnored(filePath: string): Promise<boolean>;
+  calculateConfigForFile(filePath: string): Promise<ConfigObject>;
+  findConfigFile(filePath?: string): Promise<string | undefined>;
+  getRulesMetaForResults(results: LintResult[]): Record<string, unknown>;
+  hasFlag(flag: string): boolean;
+  loadFormatter(name?: string): Promise<Formatter>;
+}
+
+export { UtooLint as ESLint };
+
+export class CLIEngine {
+  static readonly version: string;
+  static outputFixes(report: { results?: LintResult[] } | LintResult[]): void;
+  static getErrorResults(results: LintResult[]): LintResult[];
+  constructor(options?: LintOptions);
+  executeOnFiles(patterns: string | string[]): {
+    results: LintResult[];
+    errorCount: number;
+    warningCount: number;
+    fixableErrorCount: number;
+    fixableWarningCount: number;
+  };
+  executeOnText(code: string, filePathOrOptions?: string | TextLintOptions): {
+    results: LintResult[];
+    errorCount: number;
+    warningCount: number;
+    fixableErrorCount: number;
+    fixableWarningCount: number;
+  };
+  getFormatter(name?: string): (results: LintResult[]) => string;
+  getRules(): Map<string, unknown>;
+  addPlugin(name: string, pluginObject: unknown): void;
+  resolveFileGlobPatterns(patterns: string | string[]): string[];
+  isPathIgnored(filePath: string): boolean;
+  getConfigForFile(filePath: string): ConfigObject;
+}
+
+export function loadESLint(options?: { useFlatConfig?: boolean; cwd?: string }): Promise<typeof UtooLint>;
+export function lintFiles(patterns?: string | string[], options?: LintOptions): LintReport;
+export function lintText(code: string, options?: TextLintOptions): LintReport;
+export function run(args?: string[], options?: LintOptions): unknown;
+export function runFishlint(args?: string[], options?: LintOptions): unknown;
+export function translateFishlintArgs(args?: string[], options?: { command?: string; warn?: (message: string) => void }): string[];
+export function resolveBinary(options?: { env?: Record<string, string | undefined>; platform?: string; arch?: string }): string;
+export function platformPackageName(platform?: string, arch?: string): string | undefined;
+
+export const version: string;
+export default UtooLint;

--- a/npm/utoo-lint/lib/binary.d.ts
+++ b/npm/utoo-lint/lib/binary.d.ts
@@ -1,0 +1,2 @@
+export function platformPackageName(platform?: string, arch?: string): string | undefined;
+export function resolveBinary(options?: { env?: Record<string, string | undefined>; platform?: string; arch?: string }): string;

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -12,24 +12,30 @@
   },
   "homepage": "https://github.com/fireairforce/utoo-lint#readme",
   "type": "module",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.js",
       "require": "./index.cjs"
     },
     "./binary": {
+      "types": "./lib/binary.d.ts",
       "import": "./lib/binary.js",
       "require": "./lib/binary.cjs"
     },
     "./config": {
+      "types": "./config.d.ts",
       "import": "./config.js",
       "require": "./config.cjs"
     },
     "./use-at-your-own-risk": {
+      "types": "./use-at-your-own-risk.d.ts",
       "import": "./use-at-your-own-risk.js",
       "require": "./use-at-your-own-risk.cjs"
     },
     "./universal": {
+      "types": "./universal.d.ts",
       "import": "./universal.js",
       "require": "./universal.cjs"
     },
@@ -46,15 +52,19 @@
   "files": [
     "bin",
     "config.cjs",
+    "config.d.ts",
     "config.js",
     "configs",
     "index.cjs",
+    "index.d.ts",
     "index.js",
     "lib",
     "schema.json",
     "universal.cjs",
+    "universal.d.ts",
     "universal.js",
     "use-at-your-own-risk.cjs",
+    "use-at-your-own-risk.d.ts",
     "use-at-your-own-risk.js"
   ],
   "optionalDependencies": {

--- a/npm/utoo-lint/universal.d.ts
+++ b/npm/utoo-lint/universal.d.ts
@@ -1,0 +1,1 @@
+export { Linter } from "./index.js";

--- a/npm/utoo-lint/use-at-your-own-risk.d.ts
+++ b/npm/utoo-lint/use-at-your-own-risk.d.ts
@@ -1,0 +1,12 @@
+import { CLIEngine, Linter, UtooLint } from "./index.js";
+
+export const builtinRules: Map<string, unknown>;
+export const FlatESLint: typeof UtooLint;
+export const LegacyESLint: typeof UtooLint;
+
+export function shouldUseFlatConfig(): Promise<boolean>;
+
+export class FileEnumerator {
+  constructor(options?: ConstructorParameters<typeof CLIEngine>[0]);
+  iterateFiles(patterns?: string | string[]): Array<{ filePath: string }>;
+}


### PR DESCRIPTION
## Summary
- add TypeScript declarations for the main JS API entrypoint
- add declarations for config, universal, use-at-your-own-risk, and binary subpaths
- wire type declarations into package exports and files
- document that the package ships built-in declarations

## Validation
- zig build
- zig build test
- node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs && node --check npm/utoo-lint/config.js && node --check npm/utoo-lint/config.cjs && node --check npm/utoo-lint/universal.js && node --check npm/utoo-lint/universal.cjs && node --check npm/utoo-lint/use-at-your-own-risk.js && node --check npm/utoo-lint/use-at-your-own-risk.cjs && node --check npm/utoo-lint/bin/fishlint.js
- git diff --check
- package exports/files type wiring smoke check
- npm pack --dry-run --json