### PR TITLE
feat: add linter registration api

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -942,6 +942,8 @@ class Linter {
 
   constructor(options = {}) {
     this.flags = flagsFromOptions(options);
+    this.rules = new Map();
+    this.parsers = new Map();
     this.sourceCode = null;
     this.suppressedMessages = [];
     this.times = { passes: [] };
@@ -1001,19 +1003,30 @@ class Linter {
   }
 
   getRules() {
-    return new Map();
+    return new Map(this.rules);
   }
 
-  defineRule() {
-    throw new Error("Linter#defineRule is not implemented by @utoo/lint");
+  defineRule(ruleId, rule) {
+    if (typeof ruleId !== "string" || ruleId.length === 0) {
+      throw new TypeError("Linter#defineRule requires a rule id string");
+    }
+    this.rules.set(ruleId, rule);
   }
 
-  defineRules() {
-    throw new Error("Linter#defineRules is not implemented by @utoo/lint");
+  defineRules(rules) {
+    if (typeof rules !== "object" || rules === null) {
+      throw new TypeError("Linter#defineRules requires a rules object");
+    }
+    for (const [ruleId, rule] of Object.entries(rules)) {
+      this.defineRule(ruleId, rule);
+    }
   }
 
-  defineParser() {
-    throw new Error("Linter#defineParser is not implemented by @utoo/lint");
+  defineParser(parserId, parser) {
+    if (typeof parserId !== "string" || parserId.length === 0) {
+      throw new TypeError("Linter#defineParser requires a parser id string");
+    }
+    this.parsers.set(parserId, parser);
   }
 }
 
@@ -1376,8 +1389,9 @@ class RuleTester {
     this.config = mergeRuleTesterConfig(ruleTesterDefaultConfig, config);
   }
 
-  run(ruleName, _rule, tests = {}) {
+  run(ruleName, rule, tests = {}) {
     const linter = new Linter();
+    linter.defineRule(ruleName, rule);
     RuleTester.describe(ruleName, () => {
       RuleTester.describe("valid", () => {
         for (const test of tests.valid ?? []) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -173,9 +173,9 @@ export class Linter {
   getFixPassCount(): number;
   hasFlag(flag: string): boolean;
   getRules(): Map<string, unknown>;
-  defineRule(): never;
-  defineRules(): never;
-  defineParser(): never;
+  defineRule(ruleId: string, rule: unknown): void;
+  defineRules(rules: Record<string, unknown>): void;
+  defineParser(parserId: string, parser: unknown): void;
 }
 
 export interface RuleTesterValidCase extends ConfigObject {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -194,6 +194,8 @@ export class Linter {
 
   constructor(options = {}) {
     this.flags = flagsFromOptions(options);
+    this.rules = new Map();
+    this.parsers = new Map();
     this.sourceCode = null;
     this.suppressedMessages = [];
     this.times = { passes: [] };
@@ -253,19 +255,30 @@ export class Linter {
   }
 
   getRules() {
-    return new Map();
+    return new Map(this.rules);
   }
 
-  defineRule() {
-    throw new Error("Linter#defineRule is not implemented by @utoo/lint");
+  defineRule(ruleId, rule) {
+    if (typeof ruleId !== "string" || ruleId.length === 0) {
+      throw new TypeError("Linter#defineRule requires a rule id string");
+    }
+    this.rules.set(ruleId, rule);
   }
 
-  defineRules() {
-    throw new Error("Linter#defineRules is not implemented by @utoo/lint");
+  defineRules(rules) {
+    if (typeof rules !== "object" || rules === null) {
+      throw new TypeError("Linter#defineRules requires a rules object");
+    }
+    for (const [ruleId, rule] of Object.entries(rules)) {
+      this.defineRule(ruleId, rule);
+    }
   }
 
-  defineParser() {
-    throw new Error("Linter#defineParser is not implemented by @utoo/lint");
+  defineParser(parserId, parser) {
+    if (typeof parserId !== "string" || parserId.length === 0) {
+      throw new TypeError("Linter#defineParser requires a parser id string");
+    }
+    this.parsers.set(parserId, parser);
   }
 }
 
@@ -628,8 +641,9 @@ export class RuleTester {
     this.config = mergeRuleTesterConfig(ruleTesterDefaultConfig, config);
   }
 
-  run(ruleName, _rule, tests = {}) {
+  run(ruleName, rule, tests = {}) {
     const linter = new Linter();
+    linter.defineRule(ruleName, rule);
     RuleTester.describe(ruleName, () => {
       RuleTester.describe("valid", () => {
         for (const test of tests.valid ?? []) {


### PR DESCRIPTION
## Summary
- add instance-level Linter rule and parser registries
- make defineRule, defineRules, defineParser, and getRules behave like registration APIs instead of throwing
- register the rule passed to RuleTester.run on its internal Linter
- update TypeScript declarations for the registration methods

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- JS API smoke tests for ESM and CJS Linter registration
- zig build
- zig build test
- git diff --check