### PR TITLE
feat: add source code split lines

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1273,6 +1273,13 @@ class Linter {
 }
 
 class SourceCode {
+  static splitLines(text) {
+    if (typeof text !== "string") {
+      throw new TypeError("SourceCode.splitLines requires source text");
+    }
+    return text.split(/\r\n|\r|\n/u);
+  }
+
   constructor(textOrConfig, astIfNoConfig = null) {
     if (typeof textOrConfig === "string") {
       this.text = textOrConfig;
@@ -1291,7 +1298,7 @@ class SourceCode {
     } else {
       throw new TypeError("SourceCode requires source text");
     }
-    this.lines = this.text.split(/\r\n|\r|\n/);
+    this.lines = SourceCode.splitLines(this.text);
     this.comments = Array.isArray(this.ast?.comments) ? this.ast.comments : [];
     this.tokens = Array.isArray(this.ast?.tokens) ? this.ast.tokens : [];
     this.lineStartIndices = sourceLineStartIndices(this.text);

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -102,6 +102,7 @@ export interface SourceRange {
 }
 
 export class SourceCode {
+  static splitLines(text: string): string[];
   constructor(text: string, ast?: SourceRange | null);
   constructor(config: {
     text: string;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -525,6 +525,13 @@ export class Linter {
 }
 
 export class SourceCode {
+  static splitLines(text) {
+    if (typeof text !== "string") {
+      throw new TypeError("SourceCode.splitLines requires source text");
+    }
+    return text.split(/\r\n|\r|\n/u);
+  }
+
   constructor(textOrConfig, astIfNoConfig = null) {
     if (typeof textOrConfig === "string") {
       this.text = textOrConfig;
@@ -543,7 +550,7 @@ export class SourceCode {
     } else {
       throw new TypeError("SourceCode requires source text");
     }
-    this.lines = this.text.split(/\r\n|\r|\n/);
+    this.lines = SourceCode.splitLines(this.text);
     this.comments = Array.isArray(this.ast?.comments) ? this.ast.comments : [];
     this.tokens = Array.isArray(this.ast?.tokens) ? this.ast.tokens : [];
     this.lineStartIndices = sourceLineStartIndices(this.text);


### PR DESCRIPTION
## Summary
- add SourceCode.splitLines(text) to the ESLint-compatible SourceCode surface
- reuse the static helper when initializing SourceCode#lines
- update TypeScript declarations for the new static method

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- JS API smoke tests for ESM and CJS SourceCode.splitLines
- zig build
- zig build test
- git diff --check