### PR TITLE
fix: find config from file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ utoo-lint --format=json src
 
 By default, `utoo-lint` reads `utoo.json`, `utoo-lint.json`, or
 `eslint.config.js`/`eslint.config.mjs`/`eslint.config.cjs` from the current
-directory. Use `--config=path/to/utoo.json` for an explicit file or
+directory or its ancestors. Use `--config=path/to/utoo.json` for an explicit file or
 `--no-config` to ignore local config. JavaScript flat config files are supported
 by the JavaScript API for JSON-serializable `rules`, `files`, and `ignores`
 entries.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,17 @@
 # Configuration
 
-`utoo-lint` reads a JSON config file from the current working directory before applying CLI flags.
+`utoo-lint` reads a config file from the current working directory or its ancestors before applying CLI flags.
 
 Supported config file names:
 
 - `utoo.json`
 - `utoo-lint.json`
+- `eslint.config.js`
+- `eslint.config.mjs`
+- `eslint.config.cjs`
 
 Use `--config=path/to/utoo.json` to select a config explicitly, or `--no-config` to ignore local config.
+JavaScript flat config files are supported by the JavaScript API for JSON-serializable `rules`, `files`, and `ignores` entries.
 
 ## Frontend Project Config
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -41,7 +41,7 @@ Minimal config:
 }
 ```
 
-`utoo-lint` also reads `utoo-lint.json`. Use `--config=path/to/file.json` to select a file explicitly, or `--no-config` to ignore local config.
+`utoo-lint` also reads `utoo-lint.json` and `eslint.config.js`/`eslint.config.mjs`/`eslint.config.cjs` from the current directory or its ancestors. Use `--config=path/to/file.json` to select a file explicitly, or `--no-config` to ignore local config.
 
 Rule values support the common ESLint forms:
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -2,7 +2,7 @@ const { spawnSync } = require("node:child_process");
 const { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } = require("node:fs");
 const { writeFile: writeFileAsync } = require("node:fs/promises");
 const { tmpdir } = require("node:os");
-const { extname, isAbsolute, join, resolve: resolvePath } = require("node:path");
+const { dirname, extname, isAbsolute, join, resolve: resolvePath } = require("node:path");
 
 const { platformPackageName, resolveBinary } = require("./lib/binary.cjs");
 
@@ -392,10 +392,13 @@ class UtooLint {
     return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
-  async findConfigFile(_filePath) {
+  async findConfigFile(filePath) {
     const options = eslintConstructorOptions(this.options);
     if (options.noConfig) {
       return undefined;
+    }
+    if (filePath) {
+      return configPathForFile(options, filePath);
     }
     return configPathForOptions(options);
   }
@@ -1027,13 +1030,43 @@ function configPathForOptions(options) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  for (const candidate of CONFIG_FILENAMES) {
-    const path = resolvePath(cwd, candidate);
-    if (existsSync(path)) {
-      return path;
-    }
+  return configPathFromDirectory(cwd);
+}
+
+function configPathForFile(options, filePath) {
+  if (options.config) {
+    return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
-  return undefined;
+  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd));
+}
+
+function configSearchDirectoryForFile(filePath, cwd) {
+  const absolute = normalizeESLintFilePath(filePath, cwd);
+  try {
+    if (statSync(absolute).isDirectory()) {
+      return absolute;
+    }
+  } catch {
+    // Non-existent filenames are common for editor integrations.
+  }
+  return dirname(absolute);
+}
+
+function configPathFromDirectory(directory) {
+  let current = resolvePath(directory);
+  while (true) {
+    for (const candidate of CONFIG_FILENAMES) {
+      const path = resolvePath(current, candidate);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
 }
 
 function readConfig(path, cwd) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { writeFile as writeFileAsync } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { extname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { dirname, extname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveBinary } from "./lib/binary.js";
@@ -395,10 +395,13 @@ export class UtooLint {
     return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
   }
 
-  async findConfigFile(_filePath) {
+  async findConfigFile(filePath) {
     const options = eslintConstructorOptions(this.options);
     if (options.noConfig) {
       return undefined;
+    }
+    if (filePath) {
+      return configPathForFile(options, filePath);
     }
     return configPathForOptions(options);
   }
@@ -1611,13 +1614,43 @@ function configPathForOptions(options) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  for (const candidate of CONFIG_FILENAMES) {
-    const path = resolvePath(cwd, candidate);
-    if (existsSync(path)) {
-      return path;
-    }
+  return configPathFromDirectory(cwd);
+}
+
+function configPathForFile(options, filePath) {
+  if (options.config) {
+    return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
-  return undefined;
+  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd));
+}
+
+function configSearchDirectoryForFile(filePath, cwd) {
+  const absolute = normalizeESLintFilePath(filePath, cwd);
+  try {
+    if (statSync(absolute).isDirectory()) {
+      return absolute;
+    }
+  } catch {
+    // Non-existent filenames are common for editor integrations.
+  }
+  return dirname(absolute);
+}
+
+function configPathFromDirectory(directory) {
+  let current = resolvePath(directory);
+  while (true) {
+    for (const candidate of CONFIG_FILENAMES) {
+      const path = resolvePath(current, candidate);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
 }
 
 function readConfig(path, cwd) {


### PR DESCRIPTION
## Summary
- make ESLint#findConfigFile(filePath) search from the provided file directory
- search config candidates upward from cwd or file path, matching monorepo-style ESLint config discovery
- keep explicit config and noConfig behavior unchanged
- update config docs to describe ancestor lookup and JavaScript config candidates

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- JS API smoke tests for ESM and CJS findConfigFile(filePath) with parent eslint.config.* files
- zig build
- zig build test
- git diff --check