### PR TITLE
feat: check rule tester output

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1693,6 +1693,7 @@ class RuleTester {
           RuleTester[testCase.only ? "itOnly" : "it"](testCase.name ?? testCase.code, () => {
             const messages = linter.verify(testCase.code, ruleTesterConfig(ruleName, this.config, testCase, "error"), ruleTesterOptions(testCase));
             assertRuleTesterErrors(testCase, messages);
+            assertRuleTesterOutput(testCase, testCase.code);
           });
         }
       });
@@ -1781,6 +1782,18 @@ function assertRuleTesterErrors(testCase, messages) {
       throw new Error("RuleTester messageId assertions are not supported by @utoo/lint");
     }
   });
+}
+
+function assertRuleTesterOutput(testCase, actualOutput) {
+  if (!Object.hasOwn(testCase, "output")) {
+    return;
+  }
+  if (testCase.output == null) {
+    return;
+  }
+  if (testCase.output !== actualOutput) {
+    throw new Error(`Output is incorrect. Expected ${JSON.stringify(testCase.output)} but was ${JSON.stringify(actualOutput)}.`);
+  }
 }
 
 function createLinterSourceCode(text) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -190,6 +190,7 @@ export interface RuleTesterValidCase extends ConfigObject {
 
 export interface RuleTesterInvalidCase extends RuleTesterValidCase {
   errors?: number | Array<number | Partial<LintMessage> & { messageId?: string }>;
+  output?: string | null;
 }
 
 export class RuleTester {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -915,6 +915,7 @@ export class RuleTester {
           RuleTester[testCase.only ? "itOnly" : "it"](testCase.name ?? testCase.code, () => {
             const messages = linter.verify(testCase.code, ruleTesterConfig(ruleName, this.config, testCase, "error"), ruleTesterOptions(testCase));
             assertRuleTesterErrors(testCase, messages);
+            assertRuleTesterOutput(testCase, testCase.code);
           });
         }
       });
@@ -1003,6 +1004,18 @@ function assertRuleTesterErrors(testCase, messages) {
       throw new Error("RuleTester messageId assertions are not supported by @utoo/lint");
     }
   });
+}
+
+function assertRuleTesterOutput(testCase, actualOutput) {
+  if (!Object.hasOwn(testCase, "output")) {
+    return;
+  }
+  if (testCase.output == null) {
+    return;
+  }
+  if (testCase.output !== actualOutput) {
+    throw new Error(`Output is incorrect. Expected ${JSON.stringify(testCase.output)} but was ${JSON.stringify(actualOutput)}.`);
+  }
 }
 
 function createLinterSourceCode(text) {


### PR DESCRIPTION
## Summary
- add RuleTester invalid-case output expectation handling
- allow output: null or output equal to the original code for no-fix runs
- fail clearly when a test expects a different fixed output that @utoo/lint cannot produce yet
- update TypeScript declarations for RuleTesterInvalidCase.output

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- JS API smoke tests for ESM and CJS RuleTester output handling
- zig build
- zig build test
- git diff --check