### PR TITLE
feat: add source code comments helper

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1477,6 +1477,14 @@ class SourceCode {
     return sourceItemsInRange(this.comments, this.getRange(node));
   }
 
+  getComments(node) {
+    return {
+      before: this.getCommentsBefore(node),
+      after: this.getCommentsAfter(node),
+      inside: this.getCommentsInside(node)
+    };
+  }
+
   getJSDocComment(node) {
     return this.getCommentsBefore(node).findLast((comment) => String(comment.value ?? "").startsWith("*")) ?? null;
   }

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -145,6 +145,7 @@ export class SourceCode {
   getCommentsBefore(nodeOrToken: SourceRange): SourceRange[];
   getCommentsAfter(nodeOrToken: SourceRange): SourceRange[];
   getCommentsInside(node: SourceRange): SourceRange[];
+  getComments(node: SourceRange): { before: SourceRange[]; after: SourceRange[]; inside: SourceRange[] };
   getJSDocComment(node: SourceRange): SourceRange | null;
   commentsExistBetween(left: SourceRange, right: SourceRange): boolean;
   isSpaceBetween(left: SourceRange, right: SourceRange): boolean;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -699,6 +699,14 @@ export class SourceCode {
     return sourceItemsInRange(this.comments, this.getRange(node));
   }
 
+  getComments(node) {
+    return {
+      before: this.getCommentsBefore(node),
+      after: this.getCommentsAfter(node),
+      inside: this.getCommentsInside(node)
+    };
+  }
+
   getJSDocComment(node) {
     return this.getCommentsBefore(node).findLast((comment) => String(comment.value ?? "").startsWith("*")) ?? null;
   }


### PR DESCRIPTION
## Summary
- add legacy SourceCode#getComments(node) helper
- return before/after/inside comments using the existing comment helpers
- update TypeScript declarations for the helper

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- JS API smoke tests for ESM and CJS SourceCode#getComments
- zig build
- zig build test
- git diff --check