### PR TITLE
fix: use file config for js api lookups

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -987,7 +987,7 @@ function rulesFromFileConfig(options, filePath) {
     return {};
   }
 
-  const configPath = configPathForOptions(options);
+  const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
     return {};
   }
@@ -2182,7 +2182,7 @@ function isPathIgnored(filePath, options = {}) {
 
   const cwd = options.cwd ?? process.cwd();
   const normalized = normalizeIgnoredPath(filePath, cwd);
-  const patterns = ignorePatternsForOptions(options, cwd);
+  const patterns = ignorePatternsForOptions(options, cwd, filePath);
   return pathIgnoredByPatterns(normalized, patterns);
 }
 
@@ -2190,7 +2190,7 @@ function ignoreDisabled(options = {}) {
   return options.noIgnore || options.ignore === false;
 }
 
-function ignorePatternsForOptions(options, cwd) {
+function ignorePatternsForOptions(options, cwd, filePath) {
   const patterns = [];
   for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
     patterns.push(pattern);
@@ -2201,17 +2201,17 @@ function ignorePatternsForOptions(options, cwd) {
   if (ignorePath) {
     patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
   }
-  patterns.push(...ignorePatternsFromFileConfig(options));
+  patterns.push(...ignorePatternsFromFileConfig(options, filePath));
   patterns.push(...ignorePatternsFromConfig(options.overrideConfig));
   return patterns;
 }
 
-function ignorePatternsFromFileConfig(options) {
+function ignorePatternsFromFileConfig(options, filePath) {
   if (options.noConfig) {
     return [];
   }
 
-  const configPath = configPathForOptions(options);
+  const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
     return [];
   }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1592,7 +1592,7 @@ function rulesFromFileConfig(options, filePath) {
     return {};
   }
 
-  const configPath = configPathForOptions(options);
+  const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
     return {};
   }
@@ -2185,7 +2185,7 @@ function isPathIgnored(filePath, options = {}) {
 
   const cwd = options.cwd ?? process.cwd();
   const normalized = normalizeIgnoredPath(filePath, cwd);
-  const patterns = ignorePatternsForOptions(options, cwd);
+  const patterns = ignorePatternsForOptions(options, cwd, filePath);
   return pathIgnoredByPatterns(normalized, patterns);
 }
 
@@ -2193,7 +2193,7 @@ function ignoreDisabled(options = {}) {
   return options.noIgnore || options.ignore === false;
 }
 
-function ignorePatternsForOptions(options, cwd) {
+function ignorePatternsForOptions(options, cwd, filePath) {
   const patterns = [];
   for (const pattern of normalizeIgnorePatterns(options.ignorePatterns)) {
     patterns.push(pattern);
@@ -2204,17 +2204,17 @@ function ignorePatternsForOptions(options, cwd) {
   if (ignorePath) {
     patterns.push(...readIgnoreFile(resolvePath(cwd, ignorePath)));
   }
-  patterns.push(...ignorePatternsFromFileConfig(options));
+  patterns.push(...ignorePatternsFromFileConfig(options, filePath));
   patterns.push(...ignorePatternsFromConfig(options.overrideConfig));
   return patterns;
 }
 
-function ignorePatternsFromFileConfig(options) {
+function ignorePatternsFromFileConfig(options, filePath) {
   if (options.noConfig) {
     return [];
   }
 
-  const configPath = configPathForOptions(options);
+  const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
     return [];
   }


### PR DESCRIPTION
## Summary
- resolve file config from the requested file path for calculateConfigForFile and CLIEngine#getConfigForFile
- reuse the same file-aware config lookup for isPathIgnored so nested flat config ignores apply to JS API calls
- keep cwd-level behavior for callers that do not pass a file path

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- path-aware config JS API smoke for ESM and CJS
- zig build
- zig build test
- git diff --check