### PR TITLE
fix: preserve constructor config option

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -887,6 +887,7 @@ function eslintConstructorOptions(options) {
     binary: options.binary,
     env: options.env,
     extraArgs: options.extraArgs,
+    config: options.config ?? options.configFile,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -54,6 +54,7 @@ export interface LintOptions {
   threads?: number;
   rules?: string[] | string;
   config?: string;
+  configFile?: string;
   noConfig?: boolean;
   useEslintrc?: boolean;
   overrideConfigFile?: string | boolean;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1588,6 +1588,7 @@ function eslintConstructorOptions(options) {
     binary: options.binary,
     env: options.env,
     extraArgs: options.extraArgs,
+    config: options.config ?? options.configFile,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,


### PR DESCRIPTION
## Summary
- keep the constructor-level config option when normalizing ESLint and CLIEngine options
- add configFile as a legacy alias for config
- update npm type declarations for configFile

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- constructor config/configFile smoke for ESM and CJS
- zig build
- zig build test
- git diff --check