### PR TITLE
feat: support range token comment lookup

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1465,8 +1465,8 @@ class SourceCode {
     return sourceBackwardTokens(sourceTokensBetween(this, left, right, options), options);
   }
 
-  getTokenByRangeStart(index) {
-    return this.tokens.find((token) => token.range?.[0] === index) ?? null;
+  getTokenByRangeStart(index, options = {}) {
+    return sourceTokenItems(this, sourceTokenOptions(options, "skip")).find((token) => token.range?.[0] === index) ?? null;
   }
 
   getTokenOrCommentBefore(nodeOrToken) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -152,7 +152,7 @@ export class SourceCode {
   getFirstTokensBetween(left: SourceRange, right: SourceRange, countOrOptions?: SourceCodeTokenCountOrOptions): SourceRange[];
   getLastTokenBetween(left: SourceRange, right: SourceRange, skipOrOptions?: SourceCodeTokenCountOrOptions): SourceRange | null;
   getLastTokensBetween(left: SourceRange, right: SourceRange, countOrOptions?: SourceCodeTokenCountOrOptions): SourceRange[];
-  getTokenByRangeStart(index: number): SourceRange | null;
+  getTokenByRangeStart(index: number, options?: Pick<SourceCodeTokenOptions, "includeComments">): SourceRange | null;
   getTokenOrCommentBefore(nodeOrToken: SourceRange): SourceRange | null;
   getTokenOrCommentAfter(nodeOrToken: SourceRange): SourceRange | null;
   getCommentsBefore(nodeOrToken: SourceRange): SourceRange[];

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -686,8 +686,8 @@ export class SourceCode {
     return sourceBackwardTokens(sourceTokensBetween(this, left, right, options), options);
   }
 
-  getTokenByRangeStart(index) {
-    return this.tokens.find((token) => token.range?.[0] === index) ?? null;
+  getTokenByRangeStart(index, options = {}) {
+    return sourceTokenItems(this, sourceTokenOptions(options, "skip")).find((token) => token.range?.[0] === index) ?? null;
   }
 
   getTokenOrCommentBefore(nodeOrToken) {


### PR DESCRIPTION
## Summary
- add getTokenByRangeStart(index, { includeComments: true }) support to SourceCode
- preserve the default token-only lookup behavior
- update npm type declarations for the added option

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode range token option smoke for ESM and CJS
- zig build
- zig build test
- git diff --check