### PR TITLE
fix: accept lint reports in formatters

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -2632,9 +2632,10 @@ function formatESLintResults(results) {
   return lines.join("\n");
 }
 
-function formatResultsByName(results, name = "stylish") {
+function formatResultsByName(input, name = "stylish") {
+  const results = formatterResults(input);
   if (name === "json") {
-    return JSON.stringify(results);
+    return JSON.stringify(input);
   }
   if (name === "json-with-metadata") {
     return JSON.stringify({
@@ -2651,6 +2652,21 @@ function formatResultsByName(results, name = "stylish") {
     return formatUnixResults(results);
   }
   return formatESLintResults(results);
+}
+
+function formatterResults(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input && typeof input === "object" && Array.isArray(input.results)) {
+    return input.results;
+  }
+  if (input && typeof input === "object" && Array.isArray(input.diagnostics)) {
+    return reportToESLintResults(input, {
+      filePaths: (input.filePaths ?? []).map((filePath) => normalizeESLintFilePath(filePath))
+    });
+  }
+  throw new Error("'results' must be an array or lint report");
 }
 
 function formatCompactResults(results) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -2635,9 +2635,10 @@ function formatESLintResults(results) {
   return lines.join("\n");
 }
 
-function formatResultsByName(results, name = "stylish") {
+function formatResultsByName(input, name = "stylish") {
+  const results = formatterResults(input);
   if (name === "json") {
-    return JSON.stringify(results);
+    return JSON.stringify(input);
   }
   if (name === "json-with-metadata") {
     return JSON.stringify({
@@ -2654,6 +2655,21 @@ function formatResultsByName(results, name = "stylish") {
     return formatUnixResults(results);
   }
   return formatESLintResults(results);
+}
+
+function formatterResults(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input && typeof input === "object" && Array.isArray(input.results)) {
+    return input.results;
+  }
+  if (input && typeof input === "object" && Array.isArray(input.diagnostics)) {
+    return reportToESLintResults(input, {
+      filePaths: (input.filePaths ?? []).map((filePath) => normalizeESLintFilePath(filePath))
+    });
+  }
+  throw new Error("'results' must be an array or lint report");
 }
 
 function formatCompactResults(results) {


### PR DESCRIPTION
## Summary
- normalize formatter inputs so ESLint result arrays, CLIEngine report objects, and native lint reports are accepted
- keep json formatter preserving the original input shape
- reuse the existing native report to ESLint results conversion for text formatters and metadata

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- formatter report input smoke for ESM and CJS
- zig build
- zig build test
- git diff --check