### PR TITLE
feat: add source code ancestors lookup

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1517,8 +1517,8 @@ class SourceCode {
     return sourceNodeByRangeIndex(this.ast, index);
   }
 
-  getAncestors() {
-    return [];
+  getAncestors(node) {
+    return node ? sourceAncestorsForNode(this.ast, node) ?? [] : [];
   }
 
   getDeclaredVariables() {
@@ -1689,6 +1689,30 @@ function sourceNodeByRangeIndex(node, index, seen = new Set()) {
     }
   }
   return node;
+}
+
+function sourceAncestorsForNode(root, target, ancestors = [], seen = new Set()) {
+  if (!root || typeof root !== "object" || seen.has(root)) {
+    return null;
+  }
+  if (root === target) {
+    return ancestors;
+  }
+  seen.add(root);
+
+  for (const value of Object.values(root)) {
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (!child || typeof child !== "object") {
+        continue;
+      }
+      const result = sourceAncestorsForNode(child, target, [...ancestors, root], seen);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  return null;
 }
 
 class RuleTester {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -164,7 +164,7 @@ export class SourceCode {
   isSpaceBetween(left: SourceRange, right: SourceRange): boolean;
   isSpaceBetweenTokens(left: SourceRange, right: SourceRange): boolean;
   getNodeByRangeIndex(index: number): SourceRange | null;
-  getAncestors(): SourceRange[];
+  getAncestors(node?: SourceRange): SourceRange[];
   getDeclaredVariables(): unknown[];
   getScope(): unknown;
   markVariableAsUsed(name: string): boolean;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -738,8 +738,8 @@ export class SourceCode {
     return sourceNodeByRangeIndex(this.ast, index);
   }
 
-  getAncestors() {
-    return [];
+  getAncestors(node) {
+    return node ? sourceAncestorsForNode(this.ast, node) ?? [] : [];
   }
 
   getDeclaredVariables() {
@@ -910,6 +910,30 @@ function sourceNodeByRangeIndex(node, index, seen = new Set()) {
     }
   }
   return node;
+}
+
+function sourceAncestorsForNode(root, target, ancestors = [], seen = new Set()) {
+  if (!root || typeof root !== "object" || seen.has(root)) {
+    return null;
+  }
+  if (root === target) {
+    return ancestors;
+  }
+  seen.add(root);
+
+  for (const value of Object.values(root)) {
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (!child || typeof child !== "object") {
+        continue;
+      }
+      const result = sourceAncestorsForNode(child, target, [...ancestors, root], seen);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  return null;
 }
 
 export class RuleTester {


### PR DESCRIPTION
## Summary
- implement SourceCode#getAncestors(node) by walking the stored AST
- preserve the previous empty-array behavior when no node is provided or the node is not found
- update npm type declarations for the optional node argument

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode ancestors smoke for ESM and CJS
- zig build
- zig build test
- git diff --check