### PR TITLE
feat: forward source code declared variables

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1521,8 +1521,8 @@ class SourceCode {
     return node ? sourceAncestorsForNode(this.ast, node) ?? [] : [];
   }
 
-  getDeclaredVariables() {
-    return [];
+  getDeclaredVariables(node) {
+    return typeof this.scopeManager?.getDeclaredVariables === "function" ? this.scopeManager.getDeclaredVariables(node) : [];
   }
 
   getScope() {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -165,7 +165,7 @@ export class SourceCode {
   isSpaceBetweenTokens(left: SourceRange, right: SourceRange): boolean;
   getNodeByRangeIndex(index: number): SourceRange | null;
   getAncestors(node?: SourceRange): SourceRange[];
-  getDeclaredVariables(): unknown[];
+  getDeclaredVariables(node?: SourceRange): unknown[];
   getScope(): unknown;
   markVariableAsUsed(name: string): boolean;
   getDisableDirectives(): unknown[];

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -742,8 +742,8 @@ export class SourceCode {
     return node ? sourceAncestorsForNode(this.ast, node) ?? [] : [];
   }
 
-  getDeclaredVariables() {
-    return [];
+  getDeclaredVariables(node) {
+    return typeof this.scopeManager?.getDeclaredVariables === "function" ? this.scopeManager.getDeclaredVariables(node) : [];
   }
 
   getScope() {


### PR DESCRIPTION
## Summary
- forward SourceCode#getDeclaredVariables(node) to scopeManager.getDeclaredVariables when available
- keep the existing [] fallback when no scope manager support exists
- update npm type declarations for the optional node argument

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode declared variables smoke for ESM and CJS
- zig build
- zig build test
- git diff --check