### PR TITLE
feat: add source code node scope lookup

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1525,7 +1525,10 @@ class SourceCode {
     return typeof this.scopeManager?.getDeclaredVariables === "function" ? this.scopeManager.getDeclaredVariables(node) : [];
   }
 
-  getScope() {
+  getScope(node) {
+    if (node && typeof this.scopeManager?.acquire === "function") {
+      return this.scopeManager.acquire(node, true) ?? this.scopeManager.acquire(node, false) ?? this.scopeManager.globalScope ?? null;
+    }
     return this.scopeManager?.globalScope ?? null;
   }
 

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -166,7 +166,7 @@ export class SourceCode {
   getNodeByRangeIndex(index: number): SourceRange | null;
   getAncestors(node?: SourceRange): SourceRange[];
   getDeclaredVariables(node?: SourceRange): unknown[];
-  getScope(): unknown;
+  getScope(node?: SourceRange): unknown;
   markVariableAsUsed(name: string): boolean;
   getDisableDirectives(): unknown[];
   getInlineConfigNodes(): unknown[];

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -746,7 +746,10 @@ export class SourceCode {
     return typeof this.scopeManager?.getDeclaredVariables === "function" ? this.scopeManager.getDeclaredVariables(node) : [];
   }
 
-  getScope() {
+  getScope(node) {
+    if (node && typeof this.scopeManager?.acquire === "function") {
+      return this.scopeManager.acquire(node, true) ?? this.scopeManager.acquire(node, false) ?? this.scopeManager.globalScope ?? null;
+    }
     return this.scopeManager?.globalScope ?? null;
   }
 


### PR DESCRIPTION
## Summary
- support SourceCode#getScope(node) through scopeManager.acquire when available
- preserve the globalScope fallback for calls without a node or without acquire support
- update npm type declarations for the optional node argument

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode node scope smoke for ESM and CJS
- zig build
- zig build test
- git diff --check