### PR TITLE
feat: mark source code variables as used

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1532,8 +1532,8 @@ class SourceCode {
     return this.scopeManager?.globalScope ?? null;
   }
 
-  markVariableAsUsed() {
-    return false;
+  markVariableAsUsed(name, node) {
+    return markScopeVariableAsUsed(this.getScope(node), name);
   }
 
   getDisableDirectives() {
@@ -1714,6 +1714,29 @@ function sourceAncestorsForNode(root, target, ancestors = [], seen = new Set()) 
         return result;
       }
     }
+  }
+  return null;
+}
+
+function markScopeVariableAsUsed(scope, name) {
+  let current = scope;
+  while (current) {
+    const variable = scopeVariableByName(current, name);
+    if (variable) {
+      variable.eslintUsed = true;
+      return true;
+    }
+    current = current.upper ?? null;
+  }
+  return false;
+}
+
+function scopeVariableByName(scope, name) {
+  if (scope?.set instanceof Map && scope.set.has(name)) {
+    return scope.set.get(name);
+  }
+  if (Array.isArray(scope?.variables)) {
+    return scope.variables.find((variable) => variable?.name === name) ?? null;
   }
   return null;
 }

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -167,7 +167,7 @@ export class SourceCode {
   getAncestors(node?: SourceRange): SourceRange[];
   getDeclaredVariables(node?: SourceRange): unknown[];
   getScope(node?: SourceRange): unknown;
-  markVariableAsUsed(name: string): boolean;
+  markVariableAsUsed(name: string, node?: SourceRange): boolean;
   getDisableDirectives(): unknown[];
   getInlineConfigNodes(): unknown[];
   applyInlineConfig(): undefined;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -753,8 +753,8 @@ export class SourceCode {
     return this.scopeManager?.globalScope ?? null;
   }
 
-  markVariableAsUsed() {
-    return false;
+  markVariableAsUsed(name, node) {
+    return markScopeVariableAsUsed(this.getScope(node), name);
   }
 
   getDisableDirectives() {
@@ -935,6 +935,29 @@ function sourceAncestorsForNode(root, target, ancestors = [], seen = new Set()) 
         return result;
       }
     }
+  }
+  return null;
+}
+
+function markScopeVariableAsUsed(scope, name) {
+  let current = scope;
+  while (current) {
+    const variable = scopeVariableByName(current, name);
+    if (variable) {
+      variable.eslintUsed = true;
+      return true;
+    }
+    current = current.upper ?? null;
+  }
+  return false;
+}
+
+function scopeVariableByName(scope, name) {
+  if (scope?.set instanceof Map && scope.set.has(name)) {
+    return scope.set.get(name);
+  }
+  if (Array.isArray(scope?.variables)) {
+    return scope.variables.find((variable) => variable?.name === name) ?? null;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- implement SourceCode#markVariableAsUsed(name, node) with scope-chain lookup
- support eslint-scope style scope.set maps and scope.variables arrays
- keep false fallback when no matching variable or scope exists

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode mark variable smoke for ESM and CJS
- zig build
- zig build test
- git diff --check