### PR TITLE
feat: detect source code inline config nodes

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1541,7 +1541,7 @@ class SourceCode {
   }
 
   getInlineConfigNodes() {
-    return [];
+    return this.comments.filter((comment) => isInlineConfigComment(comment));
   }
 
   applyInlineConfig() {
@@ -1739,6 +1739,10 @@ function scopeVariableByName(scope, name) {
     return scope.variables.find((variable) => variable?.name === name) ?? null;
   }
   return null;
+}
+
+function isInlineConfigComment(comment) {
+  return /^(?:eslint(?:-disable|-enable|-disable-next-line|-disable-line|-env)?|global|globals|exported)(?:\s|$)/u.test(String(comment?.value ?? "").trim());
 }
 
 class RuleTester {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -762,7 +762,7 @@ export class SourceCode {
   }
 
   getInlineConfigNodes() {
-    return [];
+    return this.comments.filter((comment) => isInlineConfigComment(comment));
   }
 
   applyInlineConfig() {
@@ -960,6 +960,10 @@ function scopeVariableByName(scope, name) {
     return scope.variables.find((variable) => variable?.name === name) ?? null;
   }
   return null;
+}
+
+function isInlineConfigComment(comment) {
+  return /^(?:eslint(?:-disable|-enable|-disable-next-line|-disable-line|-env)?|global|globals|exported)(?:\s|$)/u.test(String(comment?.value ?? "").trim());
 }
 
 export class RuleTester {


### PR DESCRIPTION
## Summary
- implement SourceCode#getInlineConfigNodes() by returning ESLint inline config comments
- detect eslint, eslint-disable/enable variants, eslint-env, globals/global, and exported comments
- preserve ordinary comments outside the returned list

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- SourceCode inline config nodes smoke for ESM and CJS
- zig build
- zig build test
- git diff --check