### PR TITLE
feat: check rule tester error types

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -2125,6 +2125,9 @@ function assertRuleTesterErrors(testCase, messages, rule) {
         throw new Error(`Error ${index + 1} messageId ${JSON.stringify(expectation.messageId)} should resolve to ${JSON.stringify(expectedMessage)} but message was ${JSON.stringify(message.message)}`);
       }
     }
+    if (expectation.type != null && message.nodeType !== expectation.type) {
+      throw new Error(`Error ${index + 1} type should be ${JSON.stringify(expectation.type)} but was ${JSON.stringify(message.nodeType)}`);
+    }
   });
 }
 

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -203,7 +203,7 @@ export interface RuleTesterValidCase extends ConfigObject {
 }
 
 export interface RuleTesterInvalidCase extends RuleTesterValidCase {
-  errors?: number | Array<number | Partial<LintMessage> & { messageId?: string; data?: Record<string, unknown> }>;
+  errors?: number | Array<number | Partial<LintMessage> & { messageId?: string; data?: Record<string, unknown>; type?: string | null }>;
   output?: string | null;
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -1346,6 +1346,9 @@ function assertRuleTesterErrors(testCase, messages, rule) {
         throw new Error(`Error ${index + 1} messageId ${JSON.stringify(expectation.messageId)} should resolve to ${JSON.stringify(expectedMessage)} but message was ${JSON.stringify(message.message)}`);
       }
     }
+    if (expectation.type != null && message.nodeType !== expectation.type) {
+      throw new Error(`Error ${index + 1} type should be ${JSON.stringify(expectation.type)} but was ${JSON.stringify(message.nodeType)}`);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- enforce ESLint-style RuleTester invalid-case errors[].type assertions
- compare expected type against the reported nodeType
- expose type on the RuleTester invalid-case TypeScript declaration

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- RuleTester type assertion smoke test for pass and fail paths
- zig build
- zig build test
- git diff --check