### PR TITLE
feat: apply custom linter fixes

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1334,10 +1334,12 @@ class Linter {
   }
 
   verifyAndFix(code, config = {}, options = {}) {
+    const messages = this.verify(code, config, options);
+    const output = applyRuleFixes(code, messages.flatMap((message) => ruleFixItems(message.fix)));
     return {
-      fixed: false,
-      messages: this.verify(code, config, options),
-      output: code
+      fixed: output !== code,
+      messages,
+      output
     };
   }
 
@@ -1547,6 +1549,10 @@ function customRuleMessageFromReport(ruleEntry, sourceCode, args) {
     result.endLine = location.end.line;
     result.endColumn = location.end.column + 1;
   }
+  const fix = customRuleFix(sourceCode, descriptor);
+  if (fix) {
+    result.fix = fix;
+  }
   if (Array.isArray(descriptor.suggest)) {
     result.suggestions = customRuleSuggestions(ruleEntry.rule, sourceCode, descriptor.suggest);
   }
@@ -1622,11 +1628,15 @@ function customRuleSuggestionDescription(rule, suggestion) {
 }
 
 function customRuleSuggestionFix(sourceCode, suggestion) {
-  if (typeof suggestion.fix !== "function") {
+  return customRuleFix(sourceCode, suggestion);
+}
+
+function customRuleFix(sourceCode, descriptor) {
+  if (typeof descriptor.fix !== "function") {
     return null;
   }
-  const value = suggestion.fix(customRuleFixer(sourceCode));
-  const fixes = (Array.isArray(value) ? value : [value]).filter(Boolean);
+  const value = descriptor.fix(customRuleFixer(sourceCode));
+  const fixes = ruleFixItems(value);
   if (fixes.length === 0) {
     return null;
   }
@@ -2210,9 +2220,14 @@ class RuleTester {
         for (const test of tests.invalid ?? []) {
           const testCase = normalizeRuleTesterCase(test);
           RuleTester[testCase.only ? "itOnly" : "it"](testCase.name ?? testCase.code, () => {
-            const messages = linter.verify(testCase.code, ruleTesterConfig(ruleName, this.config, testCase, "error"), ruleTesterOptions(testCase));
+            const config = ruleTesterConfig(ruleName, this.config, testCase, "error");
+            const options = ruleTesterOptions(testCase);
+            const result = Object.hasOwn(testCase, "output")
+              ? linter.verifyAndFix(testCase.code, config, options)
+              : { messages: linter.verify(testCase.code, config, options), output: testCase.code };
+            const messages = result.messages;
             assertRuleTesterErrors(testCase, messages, rule);
-            assertRuleTesterOutput(testCase, testCase.code);
+            assertRuleTesterOutput(testCase, result.output);
           });
         }
       });
@@ -2353,10 +2368,23 @@ function assertRuleTesterSuggestions(errorIndex, actualSuggestions, expectedSugg
 }
 
 function applyRuleTesterSuggestionFixes(code, fix) {
-  const fixes = (Array.isArray(fix) ? fix : [fix]).filter((item) => item?.range);
-  return fixes
+  return applyRuleFixes(code, fix);
+}
+
+function applyRuleFixes(code, fix) {
+  return ruleFixItems(fix)
     .sort((left, right) => right.range[0] - left.range[0])
     .reduce((output, item) => output.slice(0, item.range[0]) + item.text + output.slice(item.range[1]), code);
+}
+
+function ruleFixItems(fix) {
+  if (!fix) {
+    return [];
+  }
+  if (Array.isArray(fix)) {
+    return fix.flatMap((item) => ruleFixItems(item));
+  }
+  return fix.range ? [fix] : [];
 }
 
 function ruleTesterMessageForId(rule, messageId, data = {}) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -7,6 +7,7 @@ export interface LintMessage {
   endLine?: number;
   endColumn?: number;
   nodeType?: string | null;
+  fix?: LintFix | LintFix[];
   suggestions?: LintSuggestion[];
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -483,10 +483,12 @@ export class Linter {
   }
 
   verifyAndFix(code, config = {}, options = {}) {
+    const messages = this.verify(code, config, options);
+    const output = applyRuleFixes(code, messages.flatMap((message) => ruleFixItems(message.fix)));
     return {
-      fixed: false,
-      messages: this.verify(code, config, options),
-      output: code
+      fixed: output !== code,
+      messages,
+      output
     };
   }
 
@@ -696,6 +698,10 @@ function customRuleMessageFromReport(ruleEntry, sourceCode, args) {
     result.endLine = location.end.line;
     result.endColumn = location.end.column + 1;
   }
+  const fix = customRuleFix(sourceCode, descriptor);
+  if (fix) {
+    result.fix = fix;
+  }
   if (Array.isArray(descriptor.suggest)) {
     result.suggestions = customRuleSuggestions(ruleEntry.rule, sourceCode, descriptor.suggest);
   }
@@ -771,11 +777,15 @@ function customRuleSuggestionDescription(rule, suggestion) {
 }
 
 function customRuleSuggestionFix(sourceCode, suggestion) {
-  if (typeof suggestion.fix !== "function") {
+  return customRuleFix(sourceCode, suggestion);
+}
+
+function customRuleFix(sourceCode, descriptor) {
+  if (typeof descriptor.fix !== "function") {
     return null;
   }
-  const value = suggestion.fix(customRuleFixer(sourceCode));
-  const fixes = (Array.isArray(value) ? value : [value]).filter(Boolean);
+  const value = descriptor.fix(customRuleFixer(sourceCode));
+  const fixes = ruleFixItems(value);
   if (fixes.length === 0) {
     return null;
   }
@@ -1359,9 +1369,14 @@ export class RuleTester {
         for (const test of tests.invalid ?? []) {
           const testCase = normalizeRuleTesterCase(test);
           RuleTester[testCase.only ? "itOnly" : "it"](testCase.name ?? testCase.code, () => {
-            const messages = linter.verify(testCase.code, ruleTesterConfig(ruleName, this.config, testCase, "error"), ruleTesterOptions(testCase));
+            const config = ruleTesterConfig(ruleName, this.config, testCase, "error");
+            const options = ruleTesterOptions(testCase);
+            const result = Object.hasOwn(testCase, "output")
+              ? linter.verifyAndFix(testCase.code, config, options)
+              : { messages: linter.verify(testCase.code, config, options), output: testCase.code };
+            const messages = result.messages;
             assertRuleTesterErrors(testCase, messages, rule);
-            assertRuleTesterOutput(testCase, testCase.code);
+            assertRuleTesterOutput(testCase, result.output);
           });
         }
       });
@@ -1502,10 +1517,23 @@ function assertRuleTesterSuggestions(errorIndex, actualSuggestions, expectedSugg
 }
 
 function applyRuleTesterSuggestionFixes(code, fix) {
-  const fixes = (Array.isArray(fix) ? fix : [fix]).filter((item) => item?.range);
-  return fixes
+  return applyRuleFixes(code, fix);
+}
+
+function applyRuleFixes(code, fix) {
+  return ruleFixItems(fix)
     .sort((left, right) => right.range[0] - left.range[0])
     .reduce((output, item) => output.slice(0, item.range[0]) + item.text + output.slice(item.range[1]), code);
+}
+
+function ruleFixItems(fix) {
+  if (!fix) {
+    return [];
+  }
+  if (Array.isArray(fix)) {
+    return fix.flatMap((item) => ruleFixItems(item));
+  }
+  return fix.range ? [fix] : [];
 }
 
 function ruleTesterMessageForId(rule, messageId, data = {}) {


### PR DESCRIPTION
## Summary
- preserve context.report({ fix }) results from custom Linter rules
- apply custom rule fixes in Linter#verifyAndFix()
- make RuleTester use verifyAndFix() for invalid cases with output expectations
- expose fix on LintMessage declarations

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM verify/verifyAndFix/RuleTester autofix smoke tests
- CJS verifyAndFix autofix smoke test
- zig build
- zig build test
- git diff --check