### PR TITLE
feat: run linter plugin rules

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1307,8 +1307,10 @@ class Linter {
     const filePath = verifyOptions.filename ?? verifyOptions.filePath ?? "input.js";
     const sourceCode = createLinterSourceCode(code);
     const normalizedFilePath = normalizeESLintFilePath(filePath, verifyOptions.cwd);
-    const customRules = customRuleEntriesForConfig(config, this.rules, normalizedFilePath, verifyOptions.cwd);
-    const nativeConfig = configWithoutCustomRules(config, this.rules);
+    const customRuleMap = customRuleMapForConfig(config, this.rules, normalizedFilePath, verifyOptions.cwd);
+    const customRuleFilterMap = customRuleMapForConfig(config, this.rules);
+    const customRules = customRuleEntriesForConfig(config, customRuleMap, normalizedFilePath, verifyOptions.cwd);
+    const nativeConfig = configWithoutCustomRules(config, customRuleFilterMap);
     const lintOptions = {
       cwd: verifyOptions.cwd,
       filePath,
@@ -1410,6 +1412,44 @@ function customRuleEntriesForConfig(config, rules, filePath, cwd) {
     });
   }
   return [...entries.values()];
+}
+
+function customRuleMapForConfig(config, definedRules, filePath, cwd) {
+  return new Map([
+    ...pluginRulesForConfig(config, filePath, cwd),
+    ...definedRules
+  ]);
+}
+
+function pluginRulesForConfig(config, filePath, cwd) {
+  const rules = new Map();
+  for (const entry of matchingConfigEntries(config, filePath, cwd)) {
+    if (!entry.plugins || typeof entry.plugins !== "object") {
+      continue;
+    }
+    for (const [pluginName, plugin] of Object.entries(entry.plugins)) {
+      if (!plugin?.rules || typeof plugin.rules !== "object") {
+        continue;
+      }
+      for (const [ruleName, rule] of Object.entries(plugin.rules)) {
+        rules.set(`${pluginName}/${ruleName}`, rule);
+      }
+    }
+  }
+  return rules;
+}
+
+function matchingConfigEntries(config, filePath = undefined, cwd = undefined) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => matchingConfigEntries(entry, filePath, cwd));
+  }
+  if (typeof config !== "object" || !configAppliesToFile(config, filePath, cwd)) {
+    return [];
+  }
+  return [config];
 }
 
 function ruleConfigEntries(config, filePath = undefined, cwd = undefined) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -49,12 +49,17 @@ export interface Formatter {
 export type RuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | false | true;
 export type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]];
 
+export interface PluginObject {
+  rules?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export interface ConfigObject {
   name?: string;
   files?: Array<string | string[]>;
   ignores?: string[];
   rules?: Record<string, RuleConfig>;
-  plugins?: Record<string, unknown>;
+  plugins?: Record<string, PluginObject>;
   settings?: Record<string, unknown>;
   languageOptions?: {
     parser?: unknown;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -456,8 +456,10 @@ export class Linter {
     const filePath = verifyOptions.filename ?? verifyOptions.filePath ?? "input.js";
     const sourceCode = createLinterSourceCode(code);
     const normalizedFilePath = normalizeESLintFilePath(filePath, verifyOptions.cwd);
-    const customRules = customRuleEntriesForConfig(config, this.rules, normalizedFilePath, verifyOptions.cwd);
-    const nativeConfig = configWithoutCustomRules(config, this.rules);
+    const customRuleMap = customRuleMapForConfig(config, this.rules, normalizedFilePath, verifyOptions.cwd);
+    const customRuleFilterMap = customRuleMapForConfig(config, this.rules);
+    const customRules = customRuleEntriesForConfig(config, customRuleMap, normalizedFilePath, verifyOptions.cwd);
+    const nativeConfig = configWithoutCustomRules(config, customRuleFilterMap);
     const lintOptions = {
       cwd: verifyOptions.cwd,
       filePath,
@@ -559,6 +561,44 @@ function customRuleEntriesForConfig(config, rules, filePath, cwd) {
     });
   }
   return [...entries.values()];
+}
+
+function customRuleMapForConfig(config, definedRules, filePath, cwd) {
+  return new Map([
+    ...pluginRulesForConfig(config, filePath, cwd),
+    ...definedRules
+  ]);
+}
+
+function pluginRulesForConfig(config, filePath, cwd) {
+  const rules = new Map();
+  for (const entry of matchingConfigEntries(config, filePath, cwd)) {
+    if (!entry.plugins || typeof entry.plugins !== "object") {
+      continue;
+    }
+    for (const [pluginName, plugin] of Object.entries(entry.plugins)) {
+      if (!plugin?.rules || typeof plugin.rules !== "object") {
+        continue;
+      }
+      for (const [ruleName, rule] of Object.entries(plugin.rules)) {
+        rules.set(`${pluginName}/${ruleName}`, rule);
+      }
+    }
+  }
+  return rules;
+}
+
+function matchingConfigEntries(config, filePath = undefined, cwd = undefined) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => matchingConfigEntries(entry, filePath, cwd));
+  }
+  if (typeof config !== "object" || !configAppliesToFile(config, filePath, cwd)) {
+    return [];
+  }
+  return [config];
 }
 
 function ruleConfigEntries(config, filePath = undefined, cwd = undefined) {


### PR DESCRIPTION
## Summary
- run flat config plugin rules from Linter#verify()
- filter plugin rule IDs before native lint so plugin rules do not fail as unknown rules
- respect flat config files/ignores matching for plugin rule execution
- expose a basic PluginObject type in npm declarations

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM flat config plugin rule smoke test
- CJS flat config plugin rule smoke test
- zig build
- zig build test
- git diff --check