### PR TITLE
feat: run eslint lint files plugin rules

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -360,13 +360,18 @@ class UtooLint {
 
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
-    const report = lintFiles(patterns, mergedOptions);
-    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
-    return maybeFilterQuietResults(reportToESLintResults(report, {
+    const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
+    const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
+    const nativeOptions = lintOptionsWithoutCustomRules(mergedOptions, customRuleFilterMap);
+    const report = lintFiles(patterns, nativeOptions);
+    throwOnUnmatchedPatternDiagnostics(report, nativeOptions);
+    const results = reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
-    }), mergedOptions);
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(nativeOptions, filePath)
+    });
+    appendCustomLintFileMessages(results, customRuleConfig, mergedOptions);
+    return maybeFilterQuietResults(results, mergedOptions);
   }
 
   async lintText(code, options = {}) {
@@ -1527,6 +1532,35 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
   }
   result.messages.push(...messages);
   finalizeESLintResult(result);
+  return results;
+}
+
+function appendCustomLintFileMessages(results, config, options) {
+  for (const result of results) {
+    const filePath = result.filePath;
+    const rules = customRuleMapForConfig(config, new Map(), filePath, options.cwd);
+    const customRules = customRuleEntriesForConfig(config, rules, filePath, options.cwd);
+    if (customRules.length === 0) {
+      continue;
+    }
+    let code;
+    try {
+      code = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const sourceCode = createLinterSourceCode(code);
+    const messages = runCustomLinterRules(customRules, sourceCode, {
+      cwd: options.cwd,
+      filename: filePath,
+      config: calculatedConfig({ cwd: options.cwd, noConfig: true, baseConfig: options.baseConfig, overrideConfig: options.overrideConfig }, filePath)
+    });
+    if (messages.length === 0) {
+      continue;
+    }
+    result.messages.push(...messages);
+    finalizeESLintResult(result);
+  }
   return results;
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -363,13 +363,18 @@ export class UtooLint {
 
   async lintFiles(patterns = ["."], options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
-    const report = lintFiles(patterns, mergedOptions);
-    throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
-    return maybeFilterQuietResults(reportToESLintResults(report, {
+    const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
+    const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
+    const nativeOptions = lintOptionsWithoutCustomRules(mergedOptions, customRuleFilterMap);
+    const report = lintFiles(patterns, nativeOptions);
+    throwOnUnmatchedPatternDiagnostics(report, nativeOptions);
+    const results = reportToESLintResults(report, {
       cwd: mergedOptions.cwd,
       filePaths: reportFilePaths(report, mergedOptions.cwd, explicitLintFilePaths(report.filePaths ?? patterns, mergedOptions.cwd)),
-      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
-    }), mergedOptions);
+      ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(nativeOptions, filePath)
+    });
+    appendCustomLintFileMessages(results, customRuleConfig, mergedOptions);
+    return maybeFilterQuietResults(results, mergedOptions);
   }
 
   async lintText(code, options = {}) {
@@ -676,6 +681,35 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
   }
   result.messages.push(...messages);
   finalizeESLintResult(result);
+  return results;
+}
+
+function appendCustomLintFileMessages(results, config, options) {
+  for (const result of results) {
+    const filePath = result.filePath;
+    const rules = customRuleMapForConfig(config, new Map(), filePath, options.cwd);
+    const customRules = customRuleEntriesForConfig(config, rules, filePath, options.cwd);
+    if (customRules.length === 0) {
+      continue;
+    }
+    let code;
+    try {
+      code = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const sourceCode = createLinterSourceCode(code);
+    const messages = runCustomLinterRules(customRules, sourceCode, {
+      cwd: options.cwd,
+      filename: filePath,
+      config: calculatedConfig({ cwd: options.cwd, noConfig: true, baseConfig: options.baseConfig, overrideConfig: options.overrideConfig }, filePath)
+    });
+    if (messages.length === 0) {
+      continue;
+    }
+    result.messages.push(...messages);
+    finalizeESLintResult(result);
+  }
   return results;
 }
 


### PR DESCRIPTION
## Summary
- run inline flat config plugin rules from ESLint#lintFiles()
- filter JS plugin rule IDs from native lint options before invoking native lint
- merge custom plugin rule messages into file results and recompute counts

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM ESLint#lintFiles plugin/native/files smoke test
- CJS ESLint#lintFiles plugin rule smoke test
- zig build
- zig build test
- git diff --check