### PR TITLE
feat: apply eslint plugin fixes

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -907,6 +907,7 @@ function eslintConstructorOptions(options) {
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
+    fix: options.fix,
     quiet: options.quiet,
     errorOnUnmatchedPattern: options.errorOnUnmatchedPattern,
     warnIgnored: options.warnIgnored
@@ -1531,6 +1532,7 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
     results.push(result);
   }
   result.messages.push(...messages);
+  applyResultFixes(result, code, options);
   finalizeESLintResult(result);
   return results;
 }
@@ -1559,9 +1561,20 @@ function appendCustomLintFileMessages(results, config, options) {
       continue;
     }
     result.messages.push(...messages);
+    applyResultFixes(result, code, options);
     finalizeESLintResult(result);
   }
   return results;
+}
+
+function applyResultFixes(result, code, options) {
+  if (!options.fix) {
+    return;
+  }
+  const output = applyRuleFixes(code, result.messages.flatMap((message) => ruleFixItems(message.fix)));
+  if (output !== code) {
+    result.output = output;
+  }
 }
 
 function runCustomLinterRules(ruleEntries, sourceCode, options) {
@@ -3385,11 +3398,19 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 function finalizeESLintResult(result) {
   result.errorCount = 0;
   result.warningCount = 0;
+  result.fixableErrorCount = 0;
+  result.fixableWarningCount = 0;
   for (const message of result.messages) {
     if (message.severity === 2) {
       result.errorCount += 1;
+      if (ruleFixItems(message.fix).length > 0) {
+        result.fixableErrorCount += 1;
+      }
     } else {
       result.warningCount += 1;
+      if (ruleFixItems(message.fix).length > 0) {
+        result.fixableWarningCount += 1;
+      }
     }
   }
 }

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -85,6 +85,7 @@ export interface LintOptions {
   config?: string;
   configFile?: string;
   noConfig?: boolean;
+  fix?: boolean;
   useEslintrc?: boolean;
   overrideConfigFile?: string | boolean;
   baseConfig?: ConfigObject | ConfigObject[];

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -680,6 +680,7 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
     results.push(result);
   }
   result.messages.push(...messages);
+  applyResultFixes(result, code, options);
   finalizeESLintResult(result);
   return results;
 }
@@ -708,9 +709,20 @@ function appendCustomLintFileMessages(results, config, options) {
       continue;
     }
     result.messages.push(...messages);
+    applyResultFixes(result, code, options);
     finalizeESLintResult(result);
   }
   return results;
+}
+
+function applyResultFixes(result, code, options) {
+  if (!options.fix) {
+    return;
+  }
+  const output = applyRuleFixes(code, result.messages.flatMap((message) => ruleFixItems(message.fix)));
+  if (output !== code) {
+    result.output = output;
+  }
 }
 
 function runCustomLinterRules(ruleEntries, sourceCode, options) {
@@ -2322,6 +2334,7 @@ function eslintConstructorOptions(options) {
     noIgnore: options.noIgnore ?? options.ignore === false,
     baseConfig: options.baseConfig,
     noConfig: options.noConfig,
+    fix: options.fix,
     quiet: options.quiet,
     errorOnUnmatchedPattern: options.errorOnUnmatchedPattern,
     warnIgnored: options.warnIgnored
@@ -3388,11 +3401,19 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 function finalizeESLintResult(result) {
   result.errorCount = 0;
   result.warningCount = 0;
+  result.fixableErrorCount = 0;
+  result.fixableWarningCount = 0;
   for (const message of result.messages) {
     if (message.severity === 2) {
       result.errorCount += 1;
+      if (ruleFixItems(message.fix).length > 0) {
+        result.fixableErrorCount += 1;
+      }
     } else {
       result.warningCount += 1;
+      if (ruleFixItems(message.fix).length > 0) {
+        result.fixableWarningCount += 1;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- preserve ESLint constructor fix options in the JS API
- apply JS plugin rule fixes to ESLint#lintText() and ESLint#lintFiles() results when fix: true is set
- update fixableErrorCount and fixableWarningCount from messages with fixes

## Validation
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM ESLint#lintText and ESLint#lintFiles plugin fix smoke test
- CJS ESLint#lintFiles plugin fix smoke test
- zig build
- zig build test
- git diff --check