### PR TITLE
feat: expose eslint plugin rule meta

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -421,7 +421,19 @@ class UtooLint {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
-    return rulesMetaForResults(results);
+    const options = eslintConstructorOptions(this.options);
+    const customRuleConfig = [options.baseConfig, options.overrideConfig].filter(Boolean);
+    const rulesByFilePath = new Map();
+    return rulesMetaForResults(results, (ruleId, result) => {
+      if (customRuleConfig.length === 0 || typeof result.filePath !== "string") {
+        return undefined;
+      }
+      const filePath = normalizeESLintFilePath(result.filePath, options.cwd);
+      if (!rulesByFilePath.has(filePath)) {
+        rulesByFilePath.set(filePath, customRuleMapForConfig(customRuleConfig, new Map(), filePath, options.cwd));
+      }
+      return rulesByFilePath.get(filePath).get(ruleId)?.meta;
+    });
   }
 
   hasFlag(flag) {
@@ -3510,7 +3522,7 @@ function formatUnixResults(results) {
   return lines.join("\n");
 }
 
-function rulesMetaForResults(results) {
+function rulesMetaForResults(results, ruleMetaForMessage) {
   if (!Array.isArray(results)) {
     throw new Error("'results' must be an array");
   }
@@ -3519,7 +3531,7 @@ function rulesMetaForResults(results) {
   for (const result of results) {
     for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
       if (message.ruleId) {
-        meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
+        meta[message.ruleId] = ruleMetaForMessage?.(message.ruleId, result, message) ?? ruleMetaForRuleId(message.ruleId);
       }
     }
   }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -424,7 +424,19 @@ export class UtooLint {
     if (!Array.isArray(results)) {
       throw new Error("'results' must be an array");
     }
-    return rulesMetaForResults(results);
+    const options = eslintConstructorOptions(this.options);
+    const customRuleConfig = [options.baseConfig, options.overrideConfig].filter(Boolean);
+    const rulesByFilePath = new Map();
+    return rulesMetaForResults(results, (ruleId, result) => {
+      if (customRuleConfig.length === 0 || typeof result.filePath !== "string") {
+        return undefined;
+      }
+      const filePath = normalizeESLintFilePath(result.filePath, options.cwd);
+      if (!rulesByFilePath.has(filePath)) {
+        rulesByFilePath.set(filePath, customRuleMapForConfig(customRuleConfig, new Map(), filePath, options.cwd));
+      }
+      return rulesByFilePath.get(filePath).get(ruleId)?.meta;
+    });
   }
 
   hasFlag(flag) {
@@ -3513,7 +3525,7 @@ function formatUnixResults(results) {
   return lines.join("\n");
 }
 
-function rulesMetaForResults(results) {
+function rulesMetaForResults(results, ruleMetaForMessage) {
   if (!Array.isArray(results)) {
     throw new Error("'results' must be an array");
   }
@@ -3522,7 +3534,7 @@ function rulesMetaForResults(results) {
   for (const result of results) {
     for (const message of [...(result.messages ?? []), ...(result.suppressedMessages ?? [])]) {
       if (message.ruleId) {
-        meta[message.ruleId] = ruleMetaForRuleId(message.ruleId);
+        meta[message.ruleId] = ruleMetaForMessage?.(message.ruleId, result, message) ?? ruleMetaForRuleId(message.ruleId);
       }
     }
   }


### PR DESCRIPTION
Summary:
- return inline plugin rule meta from ESLint#getRulesMetaForResults
- keep generated docs metadata fallback for builtin and unknown rules

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for plugin rule meta and builtin fallback
- CJS smoke for plugin rule meta and builtin fallback
- zig build
- zig build test
- git diff --check