### PR TITLE
feat: rerun linter fixes

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -9,6 +9,7 @@ const { platformPackageName, resolveBinary } = require("./lib/binary.cjs");
 const version = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")).version;
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const MAX_AUTOFIX_PASSES = 10;
 const RULE_TESTER_INITIAL_CONFIG = { rules: {} };
 let ruleTesterDefaultConfig = { rules: {} };
 let ruleTesterDescribe = null;
@@ -1363,10 +1364,28 @@ class Linter {
   }
 
   verifyAndFix(code, config = {}, options = {}) {
-    const messages = this.verify(code, config, options);
-    const output = applyRuleFixes(code, messages.flatMap((message) => ruleFixItems(message.fix)));
+    let output = code;
+    let fixed = false;
+    let fixPassCount = 0;
+    for (let pass = 0; pass < MAX_AUTOFIX_PASSES; pass += 1) {
+      const messages = this.verify(output, config, options);
+      const fixedOutput = applyRuleFixes(output, messages.flatMap((message) => ruleFixItems(message.fix)));
+      if (fixedOutput === output) {
+        this.fixPassCount = fixPassCount;
+        return {
+          fixed,
+          messages,
+          output
+        };
+      }
+      fixed = true;
+      fixPassCount += 1;
+      output = fixedOutput;
+    }
+    const messages = this.verify(output, config, options);
+    this.fixPassCount = fixPassCount;
     return {
-      fixed: output !== code,
+      fixed,
       messages,
       output
     };

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -12,6 +12,7 @@ export { platformPackageName, resolveBinary } from "./lib/binary.js";
 export const version = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version;
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const MAX_AUTOFIX_PASSES = 10;
 const RULE_TESTER_INITIAL_CONFIG = { rules: {} };
 let ruleTesterDefaultConfig = { rules: {} };
 let ruleTesterDescribe = null;
@@ -511,10 +512,28 @@ export class Linter {
   }
 
   verifyAndFix(code, config = {}, options = {}) {
-    const messages = this.verify(code, config, options);
-    const output = applyRuleFixes(code, messages.flatMap((message) => ruleFixItems(message.fix)));
+    let output = code;
+    let fixed = false;
+    let fixPassCount = 0;
+    for (let pass = 0; pass < MAX_AUTOFIX_PASSES; pass += 1) {
+      const messages = this.verify(output, config, options);
+      const fixedOutput = applyRuleFixes(output, messages.flatMap((message) => ruleFixItems(message.fix)));
+      if (fixedOutput === output) {
+        this.fixPassCount = fixPassCount;
+        return {
+          fixed,
+          messages,
+          output
+        };
+      }
+      fixed = true;
+      fixPassCount += 1;
+      output = fixedOutput;
+    }
+    const messages = this.verify(output, config, options);
+    this.fixPassCount = fixPassCount;
     return {
-      fixed: output !== code,
+      fixed,
       messages,
       output
     };


### PR DESCRIPTION
Summary:
- rerun Linter#verifyAndFix after applying fixes so messages reflect the final output
- track fix pass count and cap automatic fix loops at 10 passes

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for verifyAndFix final messages and fix pass count
- CJS smoke for verifyAndFix final messages and fix pass count
- zig build
- zig build test
- git diff --check