### PR TITLE
feat: match child rule selectors

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1663,28 +1663,28 @@ function runCustomLinterRules(ruleEntries, sourceCode, options) {
   return messages;
 }
 
-function traverseCustomRuleAst(node, listeners, context, visitorKeys, seen = new Set()) {
+function traverseCustomRuleAst(node, listeners, context, visitorKeys, seen = new Set(), ancestors = []) {
   if (!node || typeof node !== "object" || typeof node.type !== "string" || seen.has(node)) {
     return;
   }
   seen.add(node);
-  for (const listener of customRuleMatchingListeners(listeners, node, false)) {
+  for (const listener of customRuleMatchingListeners(listeners, node, false, ancestors)) {
     context.setCurrentNode(node);
     listener(node);
   }
   for (const child of customRuleChildNodes(node, visitorKeys)) {
-    traverseCustomRuleAst(child, listeners, context, visitorKeys, seen);
+    traverseCustomRuleAst(child, listeners, context, visitorKeys, seen, [...ancestors, node]);
   }
-  for (const listener of customRuleMatchingListeners(listeners, node, true)) {
+  for (const listener of customRuleMatchingListeners(listeners, node, true, ancestors)) {
     context.setCurrentNode(node);
     listener(node);
   }
 }
 
-function customRuleMatchingListeners(listeners, node, exit) {
+function customRuleMatchingListeners(listeners, node, exit, ancestors = []) {
   const matches = [];
   for (const [selector, listener] of Object.entries(listeners)) {
-    if (typeof listener !== "function" || !customRuleSelectorMatches(selector, node, exit)) {
+    if (typeof listener !== "function" || !customRuleSelectorMatches(selector, node, exit, ancestors)) {
       continue;
     }
     matches.push(listener);
@@ -1692,13 +1692,24 @@ function customRuleMatchingListeners(listeners, node, exit) {
   return matches;
 }
 
-function customRuleSelectorMatches(selector, node, exit) {
+function customRuleSelectorMatches(selector, node, exit, ancestors = []) {
   const suffix = ":exit";
   const isExit = selector.endsWith(suffix);
   if (isExit !== exit) {
     return false;
   }
   const expression = isExit ? selector.slice(0, -suffix.length) : selector;
+  const childSelector = expression.match(/^(.+?)\s*>\s*(.+)$/u);
+  if (childSelector) {
+    const parent = ancestors.at(-1);
+    return Boolean(parent)
+      && customRuleSimpleSelectorMatches(childSelector[1].trim(), parent)
+      && customRuleSimpleSelectorMatches(childSelector[2].trim(), node);
+  }
+  return customRuleSimpleSelectorMatches(expression, node);
+}
+
+function customRuleSimpleSelectorMatches(expression, node) {
   if (expression === node.type) {
     return true;
   }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -811,28 +811,28 @@ function runCustomLinterRules(ruleEntries, sourceCode, options) {
   return messages;
 }
 
-function traverseCustomRuleAst(node, listeners, context, visitorKeys, seen = new Set()) {
+function traverseCustomRuleAst(node, listeners, context, visitorKeys, seen = new Set(), ancestors = []) {
   if (!node || typeof node !== "object" || typeof node.type !== "string" || seen.has(node)) {
     return;
   }
   seen.add(node);
-  for (const listener of customRuleMatchingListeners(listeners, node, false)) {
+  for (const listener of customRuleMatchingListeners(listeners, node, false, ancestors)) {
     context.setCurrentNode(node);
     listener(node);
   }
   for (const child of customRuleChildNodes(node, visitorKeys)) {
-    traverseCustomRuleAst(child, listeners, context, visitorKeys, seen);
+    traverseCustomRuleAst(child, listeners, context, visitorKeys, seen, [...ancestors, node]);
   }
-  for (const listener of customRuleMatchingListeners(listeners, node, true)) {
+  for (const listener of customRuleMatchingListeners(listeners, node, true, ancestors)) {
     context.setCurrentNode(node);
     listener(node);
   }
 }
 
-function customRuleMatchingListeners(listeners, node, exit) {
+function customRuleMatchingListeners(listeners, node, exit, ancestors = []) {
   const matches = [];
   for (const [selector, listener] of Object.entries(listeners)) {
-    if (typeof listener !== "function" || !customRuleSelectorMatches(selector, node, exit)) {
+    if (typeof listener !== "function" || !customRuleSelectorMatches(selector, node, exit, ancestors)) {
       continue;
     }
     matches.push(listener);
@@ -840,13 +840,24 @@ function customRuleMatchingListeners(listeners, node, exit) {
   return matches;
 }
 
-function customRuleSelectorMatches(selector, node, exit) {
+function customRuleSelectorMatches(selector, node, exit, ancestors = []) {
   const suffix = ":exit";
   const isExit = selector.endsWith(suffix);
   if (isExit !== exit) {
     return false;
   }
   const expression = isExit ? selector.slice(0, -suffix.length) : selector;
+  const childSelector = expression.match(/^(.+?)\s*>\s*(.+)$/u);
+  if (childSelector) {
+    const parent = ancestors.at(-1);
+    return Boolean(parent)
+      && customRuleSimpleSelectorMatches(childSelector[1].trim(), parent)
+      && customRuleSimpleSelectorMatches(childSelector[2].trim(), node);
+  }
+  return customRuleSimpleSelectorMatches(expression, node);
+}
+
+function customRuleSimpleSelectorMatches(expression, node) {
   if (expression === node.type) {
     return true;
   }


### PR DESCRIPTION
Summary:
- match direct child selectors such as Parent > Child for custom rule listeners
- allow child selector parts to reuse node type and attribute selector matching
- keep existing node type and attribute selector behavior intact

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for direct child selectors with attributes and :exit
- CJS smoke for MemberExpression > Identifier selector
- zig build
- zig build test
- git diff --check