### PR TITLE
feat: format plugin rule metadata

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -452,9 +452,12 @@ class UtooLint {
   }
 
   async loadFormatter(name = "stylish") {
+    const eslint = this;
     return {
       format(results) {
-        return formatResultsByName(results, name);
+        return formatResultsByName(results, name, {
+          rulesMeta: (results) => eslint.getRulesMetaForResults(results)
+        });
       }
     };
   }
@@ -3763,7 +3766,7 @@ function formatESLintResults(results) {
   return lines.join("\n");
 }
 
-function formatResultsByName(input, name = "stylish") {
+function formatResultsByName(input, name = "stylish", metadata = {}) {
   const results = formatterResults(input);
   if (name === "json") {
     return JSON.stringify(input);
@@ -3772,7 +3775,7 @@ function formatResultsByName(input, name = "stylish") {
     return JSON.stringify({
       results,
       metadata: {
-        rulesMeta: rulesMetaForResults(results)
+        rulesMeta: typeof metadata.rulesMeta === "function" ? metadata.rulesMeta(results) : rulesMetaForResults(results)
       }
     });
   }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -455,9 +455,12 @@ export class UtooLint {
   }
 
   async loadFormatter(name = "stylish") {
+    const eslint = this;
     return {
       format(results) {
-        return formatResultsByName(results, name);
+        return formatResultsByName(results, name, {
+          rulesMeta: (results) => eslint.getRulesMetaForResults(results)
+        });
       }
     };
   }
@@ -3766,7 +3769,7 @@ function formatESLintResults(results) {
   return lines.join("\n");
 }
 
-function formatResultsByName(input, name = "stylish") {
+function formatResultsByName(input, name = "stylish", metadata = {}) {
   const results = formatterResults(input);
   if (name === "json") {
     return JSON.stringify(input);
@@ -3775,7 +3778,7 @@ function formatResultsByName(input, name = "stylish") {
     return JSON.stringify({
       results,
       metadata: {
-        rulesMeta: rulesMetaForResults(results)
+        rulesMeta: typeof metadata.rulesMeta === "function" ? metadata.rulesMeta(results) : rulesMetaForResults(results)
       }
     });
   }


### PR DESCRIPTION
Summary:
- make ESLint#loadFormatter bind json-with-metadata rule metadata to the ESLint instance
- return inline plugin rule meta in formatter metadata instead of generated fallback docs URLs
- keep non-instance formatter fallback behavior unchanged

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for json-with-metadata plugin rule meta
- CJS smoke for json-with-metadata plugin rule meta
- zig build
- zig build test
- git diff --check