### PR TITLE
feat: match descendant rule selectors

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1796,6 +1796,11 @@ function customRuleSelectorMatches(selector, node, exit, ancestors = []) {
       && customRuleSimpleSelectorMatches(childSelector[1].trim(), parent)
       && customRuleSimpleSelectorMatches(childSelector[2].trim(), node);
   }
+  const descendantSelector = expression.match(/^(.+?)\s+(.+)$/u);
+  if (descendantSelector) {
+    return ancestors.some((ancestor) => customRuleSimpleSelectorMatches(descendantSelector[1].trim(), ancestor))
+      && customRuleSimpleSelectorMatches(descendantSelector[2].trim(), node);
+  }
   return customRuleSimpleSelectorMatches(expression, node);
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -944,6 +944,11 @@ function customRuleSelectorMatches(selector, node, exit, ancestors = []) {
       && customRuleSimpleSelectorMatches(childSelector[1].trim(), parent)
       && customRuleSimpleSelectorMatches(childSelector[2].trim(), node);
   }
+  const descendantSelector = expression.match(/^(.+?)\s+(.+)$/u);
+  if (descendantSelector) {
+    return ancestors.some((ancestor) => customRuleSimpleSelectorMatches(descendantSelector[1].trim(), ancestor))
+      && customRuleSimpleSelectorMatches(descendantSelector[2].trim(), node);
+  }
   return customRuleSimpleSelectorMatches(expression, node);
 }
 


### PR DESCRIPTION
Summary:
- match descendant selectors such as Ancestor Descendant for custom rule listeners
- allow descendant selector parts to reuse node type and attribute matching
- preserve direct child selector behavior

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- ESM smoke for descendant selectors with attributes and child selector regression
- CJS smoke for Program Identifier descendant selector
- zig build
- zig build test
- git diff --check