### PR TITLE
feat: migrate eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,15 @@ utoo-lint --format=json src
 
 ## Configuration
 
-By default, `utoo-lint` reads `utoo.json`, `utoo-lint.json`, or
-`eslint.config.js`/`eslint.config.mjs`/`eslint.config.cjs` from the current
+By default, `utoo-lint` reads `utoo.json` or `utoo-lint.json` from the current
 directory or its ancestors. Use `--config=path/to/utoo.json` for an explicit file or
-`--no-config` to ignore local config. JavaScript flat config files are supported
-by the JavaScript API for JSON-serializable `rules`, `files`, and `ignores`
-entries.
+`--no-config` to ignore local config.
 
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "files": ["src/**/*.{js,jsx,ts,tsx}"],
+  "ignores": ["dist", "node_modules"],
   "rules": {
     "no-console": "off",
     "no-debugger": "error",
@@ -89,6 +88,12 @@ entries.
 
 Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an
 ESLint-style array whose first item is the severity.
+
+To migrate an existing ESLint config into the native utoo format:
+
+```bash
+npx utoo-lint migrate eslint --from eslint.config.js --output utoo.json
+```
 
 ## JavaScript API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,12 +6,16 @@ Supported config file names:
 
 - `utoo.json`
 - `utoo-lint.json`
-- `eslint.config.js`
-- `eslint.config.mjs`
-- `eslint.config.cjs`
 
 Use `--config=path/to/utoo.json` to select a config explicitly, or `--no-config` to ignore local config.
 JavaScript flat config files are supported by the JavaScript API for JSON-serializable `rules`, `files`, and `ignores` entries.
+
+ESLint config files are a migration input, not the recommended long-term
+configuration format. Generate a native config with:
+
+```bash
+npx utoo-lint migrate eslint --from eslint.config.js --output utoo.json
+```
 
 ## Frontend Project Config
 
@@ -27,6 +31,8 @@ The template includes a `$schema` entry for editor validation and a focused set 
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "files": ["src/**/*.{js,jsx,ts,tsx}"],
+  "ignores": ["dist", "node_modules"],
   "rules": {
     "no-debugger": "error",
     "no-console": "warn",

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -17,6 +17,30 @@ For a focused first pass, run only rules that already exist in both projects:
 npx utoo-lint --rules=no-debugger,no-unused-vars,@typescript-eslint/no-unused-vars src
 ```
 
+## Generate a utoo Config
+
+Use the migration command to turn an existing ESLint config into `utoo.json`:
+
+```bash
+npx utoo-lint migrate eslint --from eslint.config.js --output utoo.json
+```
+
+The generated config is a native `utoo-lint` config, not an ESLint config
+executed through a compatibility layer. The migrator copies supported rule
+severities, keeps `files` and `ignores` patterns, skips formatter-only rules
+such as `prettier/prettier`, and reports unsupported rules that still need a
+native utoo rule or a deliberate replacement.
+
+For a preview without writing a file:
+
+```bash
+npx utoo-lint migrate eslint --print --report=json
+```
+
+Rule-specific ESLint options are not interpreted by `utoo-lint` yet. When a rule
+uses an array config, the migrator keeps the severity and reports that the rule
+options were dropped.
+
 ## Add a Config File
 
 Create `utoo.json` in the project root, or copy the packaged frontend template:
@@ -41,7 +65,9 @@ Minimal config:
 }
 ```
 
-`utoo-lint` also reads `utoo-lint.json` and `eslint.config.js`/`eslint.config.mjs`/`eslint.config.cjs` from the current directory or its ancestors. Use `--config=path/to/file.json` to select a file explicitly, or `--no-config` to ignore local config.
+`utoo-lint` reads native `utoo.json` and `utoo-lint.json` files from the current
+directory or its ancestors. Use `--config=path/to/file.json` to select a file
+explicitly, or `--no-config` to ignore local config.
 
 Rule values support the common ESLint forms:
 
@@ -55,7 +81,7 @@ CLI flags are applied after config files, so command-line toggles override confi
 npx utoo-lint --config=utoo.json --no-console=off src
 ```
 
-## Translate ESLint Rules
+## Translate ESLint Rules Manually
 
 Move rules from `eslint.config.js` or `.eslintrc` into `utoo.json` by keeping the same canonical rule names:
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -120,6 +120,16 @@ exposes `Linter` for browser-oriented integrations.
 The `@utoo/lint/use-at-your-own-risk` subpath exposes `builtinRules`,
 `FlatESLint`, `LegacyESLint`, `shouldUseFlatConfig()`, and `FileEnumerator`
 compatibility exports.
+The CLI includes a native migration path for projects replacing ESLint config
+files:
+
+```bash
+utoo-lint migrate eslint --from eslint.config.js --output utoo.json
+```
+
+The migrator writes a utoo config, reports unsupported rules, skips
+formatter-only rules such as `prettier/prettier`, and keeps supported rule
+severities without treating ESLint as the long-term runtime API.
 The package ships TypeScript declarations for the main entrypoint and
 compatibility subpaths, so typed ESLint integrations do not need a separate
 `@types` package.

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -1,0 +1,361 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, extname, resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { Linter } from "../index.js";
+
+const ESLINT_CONFIG_FILENAMES = [
+  "eslint.config.js",
+  "eslint.config.mjs",
+  "eslint.config.cjs",
+  ".eslintrc.json",
+  ".eslintrc"
+];
+const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
+const IGNORED_RULES = new Map([
+  ["prettier/prettier", "formatting is outside utoo-lint"]
+]);
+const SCHEMA_URL = "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json";
+const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
+import { pathToFileURL } from "node:url";
+
+const loaded = await import(pathToFileURL(process.argv[1]).href);
+const seen = new Set();
+
+function strip(value) {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "undefined") {
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  if (seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const items = value.map(strip).filter((item) => item !== undefined);
+    seen.delete(value);
+    return items;
+  }
+  const object = {};
+  for (const [key, item] of Object.entries(value)) {
+    const stripped = strip(item);
+    if (stripped !== undefined) {
+      object[key] = stripped;
+    }
+  }
+  seen.delete(value);
+  return object;
+}
+
+const json = JSON.stringify(strip(loaded.default ?? loaded));
+if (json === undefined) {
+  throw new TypeError("config did not export a migratable value");
+}
+process.stdout.write(json);
+`;
+
+export async function runMigrate(args) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printMigrateHelp();
+    return 0;
+  }
+
+  const source = args[0];
+  if (source !== "eslint") {
+    console.error(`utoo-lint migrate: unsupported source "${source}"`);
+    console.error("Supported sources: eslint");
+    return 2;
+  }
+
+  let options;
+  try {
+    options = parseEslintMigrateArgs(args.slice(1));
+  } catch (error) {
+    console.error(error.message);
+    return 2;
+  }
+
+  if (options.help) {
+    printEslintMigrateHelp();
+    return 0;
+  }
+
+  let result;
+  try {
+    result = migrateEslintConfig(options);
+  } catch (error) {
+    console.error(error.message);
+    return 2;
+  }
+
+  const configJson = JSON.stringify(result.config, null, 2) + "\n";
+  if (options.print) {
+    process.stdout.write(configJson);
+  } else {
+    if (existsSync(options.output) && !options.force) {
+      console.error(`utoo-lint migrate eslint: ${options.output} already exists; pass --force to overwrite it`);
+      return 2;
+    }
+    writeFileSync(options.output, configJson);
+  }
+
+  writeReport(result.report, options, options.print ? process.stderr : process.stdout);
+  return result.report.unsupportedRules.length > 0 ? 1 : 0;
+}
+
+function parseEslintMigrateArgs(args) {
+  const options = {
+    cwd: process.cwd(),
+    force: false,
+    from: undefined,
+    help: false,
+    output: "utoo.json",
+    print: false,
+    report: "text"
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--force") {
+      options.force = true;
+    } else if (arg === "--print") {
+      options.print = true;
+    } else if (arg === "--from") {
+      options.from = requireValue(args, ++index, "--from");
+    } else if (arg.startsWith("--from=")) {
+      options.from = arg.slice("--from=".length);
+    } else if (arg === "--output" || arg === "-o") {
+      options.output = requireValue(args, ++index, arg);
+    } else if (arg.startsWith("--output=")) {
+      options.output = arg.slice("--output=".length);
+    } else if (arg === "--report") {
+      options.report = parseReportFormat(requireValue(args, ++index, "--report"));
+    } else if (arg.startsWith("--report=")) {
+      options.report = parseReportFormat(arg.slice("--report=".length));
+    } else {
+      throw new Error(`utoo-lint migrate eslint: unknown option ${arg}`);
+    }
+  }
+
+  options.cwd = resolvePath(options.cwd);
+  options.output = resolvePath(options.cwd, options.output);
+  if (options.from) {
+    options.from = resolvePath(options.cwd, options.from);
+  }
+  return options;
+}
+
+function requireValue(args, index, flag) {
+  const value = args[index];
+  if (!value) {
+    throw new Error(`utoo-lint migrate eslint: ${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseReportFormat(value) {
+  if (value === "text" || value === "json") {
+    return value;
+  }
+  throw new Error(`utoo-lint migrate eslint: unsupported --report value ${value}`);
+}
+
+function migrateEslintConfig(options) {
+  const sourcePath = options.from ?? findEslintConfig(options.cwd);
+  if (!sourcePath) {
+    throw new Error("utoo-lint migrate eslint: no ESLint config found; pass --from PATH");
+  }
+
+  const eslintConfig = loadEslintConfig(sourcePath, options.cwd);
+  const supportedRuleIds = new Set(new Linter().getRules().keys());
+  const entries = normalizeConfigEntries(eslintConfig);
+  const rules = {};
+  const files = new Set();
+  const ignores = new Set();
+  const supportedRules = [];
+  const unsupportedRules = [];
+  const ignoredRules = [];
+  const optionDroppedRules = [];
+
+  for (const entry of entries) {
+    addPatterns(files, entry.files);
+    addPatterns(ignores, entry.ignores);
+    if (!entry.rules || typeof entry.rules !== "object") {
+      continue;
+    }
+    for (const [ruleId, ruleConfig] of Object.entries(entry.rules)) {
+      if (IGNORED_RULES.has(ruleId)) {
+        ignoredRules.push({ ruleId, reason: IGNORED_RULES.get(ruleId) });
+        continue;
+      }
+      if (!supportedRuleIds.has(ruleId)) {
+        unsupportedRules.push(ruleId);
+        continue;
+      }
+      rules[ruleId] = severityOnly(ruleConfig);
+      supportedRules.push(ruleId);
+      if (Array.isArray(ruleConfig) && ruleConfig.length > 1) {
+        optionDroppedRules.push(ruleId);
+      }
+    }
+  }
+
+  const config = {
+    $schema: SCHEMA_URL
+  };
+  if (files.size > 0) {
+    config.files = [...files];
+  }
+  if (ignores.size > 0) {
+    config.ignores = [...ignores];
+  }
+  config.rules = sortObjectByKey(rules);
+
+  return {
+    config,
+    report: {
+      source: sourcePath,
+      output: options.print ? null : options.output,
+      supportedRules: uniqueSorted(supportedRules),
+      unsupportedRules: uniqueSorted(unsupportedRules),
+      ignoredRules: uniqueByRuleId(ignoredRules),
+      optionDroppedRules: uniqueSorted(optionDroppedRules)
+    }
+  };
+}
+
+function findEslintConfig(cwd) {
+  let current = cwd;
+  while (true) {
+    for (const filename of ESLINT_CONFIG_FILENAMES) {
+      const candidate = resolvePath(current, filename);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+function loadEslintConfig(path, cwd) {
+  if (JAVASCRIPT_CONFIG_EXTENSIONS.has(extname(path))) {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", JAVASCRIPT_CONFIG_LOADER_SCRIPT, path], {
+      cwd,
+      encoding: "utf8"
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(`utoo-lint migrate eslint: unable to load ${path}: ${(result.stderr ?? "").trim() || "JavaScript config loader failed"}`);
+    }
+    return parseJson(result.stdout, path);
+  }
+  return parseJson(readFileSync(path, "utf8"), path);
+}
+
+function parseJson(source, path) {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error(`utoo-lint migrate eslint: unable to parse ${path}: ${error.message}`);
+  }
+}
+
+function normalizeConfigEntries(config) {
+  if (Array.isArray(config)) {
+    return config.flatMap(normalizeConfigEntries);
+  }
+  if (config && typeof config === "object") {
+    return [config];
+  }
+  return [];
+}
+
+function addPatterns(target, value) {
+  if (!value) {
+    return;
+  }
+  for (const pattern of Array.isArray(value) ? value : [value]) {
+    if (typeof pattern === "string") {
+      target.add(pattern);
+    }
+  }
+}
+
+function severityOnly(ruleConfig) {
+  return Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
+}
+
+function sortObjectByKey(object) {
+  return Object.fromEntries(Object.entries(object).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function uniqueByRuleId(values) {
+  const result = new Map();
+  for (const value of values) {
+    result.set(value.ruleId, value);
+  }
+  return [...result.values()].sort((left, right) => left.ruleId.localeCompare(right.ruleId));
+}
+
+function writeReport(report, options, stream) {
+  if (options.report === "json") {
+    stream.write(JSON.stringify(report, null, 2) + "\n");
+    return;
+  }
+
+  stream.write(`utoo-lint migrate eslint: read ${pathToFileURL(report.source).href}\n`);
+  if (report.output) {
+    stream.write(`utoo-lint migrate eslint: wrote ${report.output}\n`);
+  }
+  stream.write(`utoo-lint migrate eslint: migrated ${report.supportedRules.length} supported rule(s)\n`);
+  if (report.optionDroppedRules.length > 0) {
+    stream.write(`utoo-lint migrate eslint: dropped options for ${report.optionDroppedRules.length} rule(s): ${report.optionDroppedRules.join(", ")}\n`);
+  }
+  if (report.ignoredRules.length > 0) {
+    stream.write(`utoo-lint migrate eslint: ignored ${report.ignoredRules.length} rule(s): ${report.ignoredRules.map((rule) => rule.ruleId).join(", ")}\n`);
+  }
+  if (report.unsupportedRules.length > 0) {
+    stream.write(`utoo-lint migrate eslint: ${report.unsupportedRules.length} unsupported rule(s): ${report.unsupportedRules.join(", ")}\n`);
+  }
+}
+
+function printMigrateHelp() {
+  console.log(`Usage:
+  utoo-lint migrate eslint [options]
+
+Sources:
+  eslint                  Convert an ESLint config into utoo.json
+
+Run "utoo-lint migrate eslint --help" for source-specific options.`);
+}
+
+function printEslintMigrateHelp() {
+  console.log(`Usage:
+  utoo-lint migrate eslint [options]
+
+Options:
+  --from=PATH             Read ESLint config from PATH
+  --output=PATH, -o PATH  Write utoo config to PATH (default: utoo.json)
+  --force                 Overwrite the output file when it exists
+  --print                 Print the generated config instead of writing it
+  --report=text|json      Select migration report format
+  --help, -h              Show this help message`);
+}

--- a/npm/utoo-lint/bin/utoo-lint.js
+++ b/npm/utoo-lint/bin/utoo-lint.js
@@ -3,6 +3,11 @@ import { spawnSync } from "node:child_process";
 
 import { resolveBinary } from "../lib/binary.js";
 
+if (process.argv[2] === "migrate") {
+  const { runMigrate } = await import("./migrate.js");
+  process.exit(await runMigrate(process.argv.slice(3)));
+}
+
 let binary;
 try {
   binary = resolveBinary();

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -66,7 +66,7 @@ const FISHLINT_DROP_VALUE_FLAGS = new Set([
   "-E",
   "-o"
 ]);
-const CONFIG_FILENAMES = ["utoo.json", "utoo-lint.json", "eslint.config.js", "eslint.config.mjs", "eslint.config.cjs"];
+const CONFIG_FILENAMES = ["utoo.json", "utoo-lint.json"];
 const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
 import { pathToFileURL } from "node:url";

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -69,7 +69,7 @@ const FISHLINT_DROP_VALUE_FLAGS = new Set([
   "-E",
   "-o"
 ]);
-const CONFIG_FILENAMES = ["utoo.json", "utoo-lint.json", "eslint.config.js", "eslint.config.mjs", "eslint.config.cjs"];
+const CONFIG_FILENAMES = ["utoo.json", "utoo-lint.json"];
 const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
 import { pathToFileURL } from "node:url";

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -14,6 +14,34 @@
       "additionalProperties": {
         "$ref": "#/definitions/ruleSeverity"
       }
+    },
+    "files": {
+      "description": "File globs this config entry applies to.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "ignores": {
+      "description": "File globs ignored by this config entry.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
   "definitions": {


### PR DESCRIPTION
Summary:
- add `utoo-lint migrate eslint` to generate native `utoo.json` configs from ESLint config files
- report supported, unsupported, ignored, and option-downgraded rules during migration
- make native utoo config discovery prefer `utoo.json` / `utoo-lint.json`, with ESLint configs treated as migration input
- document the migration workflow and schema support for `files` / `ignores`

Validation:
- node --check npm/utoo-lint/bin/utoo-lint.js
- node --check npm/utoo-lint/bin/migrate.js
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- smoke `utoo-lint migrate eslint` with supported, unsupported, ignored, and option-downgraded rules
- smoke JS API default config discovery no longer loads eslint.config.mjs
- zig build
- zig build test
- git diff --check