### PR TITLE
feat: add consistent return rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -7,6 +7,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for fishlint's `allowImplicit: true, checkForEach: false, allowVoid: false` configuration |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
+| [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value and bare return statements |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -83,6 +83,7 @@ process.stdout.write(json);
 const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "block-scoped-var",
+  "consistent-return",
   "constructor-super",
   "curly",
   "default-case",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -86,6 +86,7 @@ process.stdout.write(json);
 const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "block-scoped-var",
+  "consistent-return",
   "constructor-super",
   "curly",
   "default-case",

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const Options = struct {
     array_callback_return: bool = true,
     block_scoped_var: bool = true,
+    consistent_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,
     dot_notation: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -106,6 +106,8 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
             options = lint.Options.allDisabled();
             parseEnabledRules(arg["--rules=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--consistent-return=off")) {
+            options.consistent_return = false;
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
             options.constructor_super = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
@@ -1206,6 +1208,7 @@ fn printHelp() void {
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --array-callback-return=off Disable array-callback-return
         \\  --block-scoped-var=off   Disable block-scoped-var
+        \\  --consistent-return=off  Disable consistent-return
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly
         \\  --dot-notation=off       Disable dot-notation

--- a/src/rules/consistent_return.zig
+++ b/src/rules/consistent_return.zig
@@ -1,0 +1,126 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "consistent-return";
+
+const ReturnKind = enum {
+    value,
+    bare,
+};
+
+const ScanState = struct {
+    expected: ?ReturnKind = null,
+    reported: bool = false,
+};
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    if (function.body == .null) return;
+
+    var state = ScanState{};
+    try scanNode(allocator, diagnostics, tree, function.body, &state);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+) Allocator.Error!void {
+    if (expression.expression) return;
+
+    var state = ScanState{};
+    try scanNode(allocator, diagnostics, tree, expression.body, &state);
+}
+
+fn scanNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: *ScanState,
+) Allocator.Error!void {
+    if (index == .null or state.reported) return;
+
+    switch (tree.data(index)) {
+        .function,
+        .arrow_function_expression,
+        => return,
+        .function_body => |body| try scanRange(allocator, diagnostics, tree, body.body, state),
+        .block_statement => |block| try scanRange(allocator, diagnostics, tree, block.body, state),
+        .return_statement => |statement| try checkReturn(allocator, diagnostics, tree, statement, index, state),
+        .if_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.consequent, state);
+            try scanNode(allocator, diagnostics, tree, statement.alternate, state);
+        },
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                try scanNode(allocator, diagnostics, tree, case_index, state);
+            }
+        },
+        .switch_case => |case| try scanRange(allocator, diagnostics, tree, case.consequent, state),
+        .try_statement => |statement| {
+            try scanNode(allocator, diagnostics, tree, statement.block, state);
+            if (statement.handler != .null) {
+                switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| try scanNode(allocator, diagnostics, tree, handler.body, state),
+                    else => {},
+                }
+            }
+            try scanNode(allocator, diagnostics, tree, statement.finalizer, state);
+        },
+        .while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .do_while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .for_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .for_in_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .for_of_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .labeled_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        .with_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body, state),
+        else => {},
+    }
+}
+
+fn scanRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    state: *ScanState,
+) Allocator.Error!void {
+    for (tree.extra(range)) |statement| {
+        try scanNode(allocator, diagnostics, tree, statement, state);
+        if (state.reported) return;
+    }
+}
+
+fn checkReturn(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ReturnStatement,
+    index: ast.NodeIndex,
+    state: *ScanState,
+) Allocator.Error!void {
+    const kind: ReturnKind = if (statement.argument == .null) .bare else .value;
+    if (state.expected) |expected| {
+        if (expected == kind) return;
+        state.reported = true;
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            if (kind == .value) "Expected no return value." else "Expected a return value.",
+            tree.span(index),
+        );
+        return;
+    }
+    state.expected = kind;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -16,6 +16,7 @@ const symbol_checks = @import("symbol_checks.zig");
 pub const curly = @import("curly.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
+pub const consistent_return = @import("consistent_return.zig");
 pub const constructor_super = @import("constructor_super.zig");
 pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
@@ -887,6 +888,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.consistent_return) {
+            try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
         }
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
@@ -1792,6 +1796,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, expression.body);
+        }
+        if (self.options.consistent_return) {
+            try consistent_return.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -7,6 +7,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/consistent_return.zig");
+}
+
+comptime {
     _ = @import("rules/constructor_super.zig");
 }
 

--- a/tests/rules/consistent_return.zig
+++ b/tests/rules/consistent_return.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports consistent-return for mixed return values" {
+    const source =
+        "function valueThenBare(flag) {\n" ++
+        "  if (flag) return 1;\n" ++
+        "  return;\n" ++
+        "}\n" ++
+        "const bareThenValue = (flag) => {\n" ++
+        "  if (flag) return;\n" ++
+        "  return 1;\n" ++
+        "};\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .no_unused_vars = false,
+        .no_unused_expressions = false,
+        .no_useless_return = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.consistent_return.id));
+    try std.testing.expectEqualStrings("Expected a return value.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Expected no return value.", result.diagnostics[1].message);
+}
+
+test "scopes nested functions separately" {
+    const source =
+        "function values(flag) {\n" ++
+        "  if (flag) return 1;\n" ++
+        "  return 2;\n" ++
+        "}\n" ++
+        "function bare(flag) {\n" ++
+        "  if (flag) return;\n" ++
+        "  return;\n" ++
+        "}\n" ++
+        "function outer() {\n" ++
+        "  function inner(flag) {\n" ++
+        "    if (flag) return 1;\n" ++
+        "    return;\n" ++
+        "  }\n" ++
+        "  return 1;\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.consistent_return.id));
+}
+
+test "can disable consistent-return" {
+    const source =
+        "function mixed(flag) {\n" ++
+        "  if (flag) return 1;\n" ++
+        "  return;\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .consistent_return = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.consistent_return.id));
+}


### PR DESCRIPTION
Summary:
- add native `consistent-return` lint rule for mixed explicit value and bare return statements
- wire the rule through options, CLI disable flag, JS built-in rule metadata, and rule status docs
- add coverage for mixed return values, nested function scoping, and disabling the rule

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=consistent-return --format=json`
- git diff --check