### PR TITLE
feat: add prefer object spread rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -155,6 +155,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for fishlint's `destructuring: any, ignoreReadBeforeAssign: true` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for fishlint's object variable declarator configuration |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
+| [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Implemented |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Implemented |
 | [`prefer-rest-params`](https://eslint.org/docs/latest/rules/prefer-rest-params) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -231,6 +231,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",
   "prefer-rest-params",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -234,6 +234,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",
   "prefer-rest-params",

--- a/src/core.zig
+++ b/src/core.zig
@@ -230,6 +230,7 @@ pub const Options = struct {
     prefer_destructuring: bool = true,
     prefer_regex_literals: bool = true,
     prefer_rest_params: bool = true,
+    prefer_object_spread: bool = true,
     prefer_spread: bool = true,
     prefer_template: bool = true,
     react_default_props_match_prop_types: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -520,6 +520,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_destructuring = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-object-spread=off")) {
+            options.prefer_object_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-rest-params=off")) {
             options.prefer_rest_params = false;
         } else if (std.mem.eql(u8, arg, "--prefer-spread=off")) {
@@ -1412,6 +1414,7 @@ fn printHelp() void {
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
         \\  --prefer-destructuring=off Disable prefer-destructuring
+        \\  --prefer-object-spread=off Disable prefer-object-spread
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params
         \\  --prefer-spread=off       Disable prefer-spread

--- a/src/root.zig
+++ b/src/root.zig
@@ -166,6 +166,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_use_before_define or
         options.prefer_const or
         options.prefer_exponentiation_operator or
+        options.prefer_object_spread or
         options.prefer_promise_reject_errors or
         options.prefer_regex_literals or
         options.radix or

--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-object-spread";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isPreferableObjectAssign(ctx.tree, self.symbol_table, call)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Use an object spread instead of Object.assign.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isPreferableObjectAssign(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    call: ast.CallExpression,
+) bool {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2) return false;
+    if (!isObjectExpression(tree, arguments[0])) return false;
+    for (arguments[1..]) |argument| {
+        if (tree.data(argument) == .spread_element) return false;
+    }
+    return isGlobalObjectAssign(tree, symbol_table, call.callee);
+}
+
+fn isObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .object_expression => true,
+        else => false,
+    };
+}
+
+fn isGlobalObjectAssign(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed or member.optional) return false;
+    if (!isIdentifierName(tree, member.property, "assign")) return false;
+    const object = unwrapTransparent(tree, member.object);
+    if (!isIdentifierReference(tree, object, "Object")) return false;
+    return isUnresolvedReference(symbol_table, object);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn isIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
+        else => false,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
+        else => false,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -216,6 +216,7 @@ pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_const = @import("prefer_const.zig");
 pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
+pub const prefer_object_spread = @import("prefer_object_spread.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_rest_params = @import("prefer_rest_params.zig");
@@ -713,6 +714,10 @@ pub fn runSemantic(
 
     if (options.prefer_regex_literals) {
         try prefer_regex_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_object_spread) {
+        try prefer_object_spread.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.radix) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -807,6 +807,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_object_spread.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_promise_reject_errors.zig");
 }
 

--- a/tests/rules/prefer_object_spread.zig
+++ b/tests/rules/prefer_object_spread.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-object-spread for Object.assign into object literals" {
+    const source =
+        \\const first = Object.assign({}, source);
+        \\const second = Object.assign({ value: 1 }, source, extra);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_object_spread.id));
+    try std.testing.expectEqualStrings("Use an object spread instead of Object.assign.", result.diagnostics[0].message);
+}
+
+test "allows non-object targets shadowed Object and spread arguments" {
+    const source =
+        \\const target = {};
+        \\Object.assign(target, source);
+        \\Object.assign({}, ...sources);
+        \\Object["assign"]({}, source);
+        \\function local(Object) {
+        \\  Object.assign({}, source);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_object_spread.id));
+}
+
+test "can disable prefer-object-spread" {
+    const source = "const value = Object.assign({}, source);\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .prefer_object_spread = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_object_spread.id));
+}


### PR DESCRIPTION
Summary:
- add native `prefer-object-spread` lint rule for `Object.assign` calls into object literals
- verify global `Object.assign` with semantic references to avoid shadowed Object false positives
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=prefer-object-spread --format=json`
- git diff --check