### PR TITLE
ci: fix release asset upload repo resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
-          gh release view "${RELEASE_TAG}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --generate-notes
-          gh release upload "${RELEASE_TAG}" dist/release-assets/* --clobber
+          gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --generate-notes
+          gh release upload "${RELEASE_TAG}" dist/release-assets/* --clobber --repo "${GITHUB_REPOSITORY}"
 
   publish-npm:
     name: Publish npm packages


### PR DESCRIPTION
## Summary

Fix the release workflow's GitHub Release asset upload step by passing the repository explicitly to `gh release` commands.

## Root Cause

The `publish-github-release` job downloads artifacts but does not check out the repository, so `gh release` cannot infer the current repository from `.git` and fails with `fatal: not a git repository`.

## Validation

- Inspected the workflow diff to confirm only `.github/workflows/release.yml` changed.
- This should be validated by rerunning the `Release` workflow for a tag such as `v0.0.2`.
