### PR TITLE
feat: add prefer numeric literals rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -155,6 +155,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for fishlint's `destructuring: any, ignoreReadBeforeAssign: true` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for fishlint's object variable declarator configuration |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
+| [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Implemented |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -231,6 +231,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-numeric-literals",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -234,6 +234,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-numeric-literals",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",

--- a/src/core.zig
+++ b/src/core.zig
@@ -226,6 +226,7 @@ pub const Options = struct {
     no_undef: bool = true,
     prefer_const: bool = true,
     prefer_exponentiation_operator: bool = true,
+    prefer_numeric_literals: bool = true,
     prefer_promise_reject_errors: bool = true,
     prefer_destructuring: bool = true,
     prefer_regex_literals: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -514,6 +514,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_const = false;
         } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
             options.prefer_exponentiation_operator = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-numeric-literals=off")) {
+            options.prefer_numeric_literals = false;
         } else if (std.mem.eql(u8, arg, "--prefer-promise-reject-errors=off")) {
             options.prefer_promise_reject_errors = false;
         } else if (std.mem.eql(u8, arg, "--prefer-destructuring=off")) {
@@ -1412,6 +1414,7 @@ fn printHelp() void {
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-const=off        Disable prefer-const
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
+        \\  --prefer-numeric-literals=off Disable prefer-numeric-literals
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
         \\  --prefer-destructuring=off Disable prefer-destructuring
         \\  --prefer-object-spread=off Disable prefer-object-spread

--- a/src/root.zig
+++ b/src/root.zig
@@ -166,6 +166,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_use_before_define or
         options.prefer_const or
         options.prefer_exponentiation_operator or
+        options.prefer_numeric_literals or
         options.prefer_object_spread or
         options.prefer_promise_reject_errors or
         options.prefer_regex_literals or

--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -1,0 +1,196 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-numeric-literals";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (preferredLiteralKind(ctx.tree, self.symbol_table, call)) |kind| {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                diagnosticMessage(kind),
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+const LiteralKind = enum {
+    binary,
+    octal,
+    hexadecimal,
+};
+
+fn preferredLiteralKind(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    call: ast.CallExpression,
+) ?LiteralKind {
+    if (!isGlobalParseIntCall(tree, symbol_table, call.callee)) return null;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len != 2) return null;
+
+    const source = staticStringValue(tree, arguments[0]) orelse return null;
+    const kind = radixLiteralKind(tree, arguments[1]) orelse return null;
+    return if (isValidDigits(source, kind)) kind else null;
+}
+
+fn diagnosticMessage(kind: LiteralKind) []const u8 {
+    return switch (kind) {
+        .binary => "Use a binary literal instead of parseInt().",
+        .octal => "Use an octal literal instead of parseInt().",
+        .hexadecimal => "Use a hexadecimal literal instead of parseInt().",
+    };
+}
+
+fn staticStringValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, index);
+    return switch (tree.data(unwrapped)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| if (tree.extra(literal.expressions).len == 0 and tree.extra(literal.quasis).len == 1)
+            templateElementCooked(tree, tree.extra(literal.quasis)[0])
+        else
+            null,
+        else => null,
+    };
+}
+
+fn templateElementCooked(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn radixLiteralKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralKind {
+    const unwrapped = unwrapTransparent(tree, index);
+    const literal = switch (tree.data(unwrapped)) {
+        .numeric_literal => |literal| literal,
+        else => return null,
+    };
+    const value = literal.value(tree);
+    if (value != @floor(value)) return null;
+
+    const integer: i64 = @intFromFloat(value);
+    return switch (integer) {
+        2 => .binary,
+        8 => .octal,
+        16 => .hexadecimal,
+        else => null,
+    };
+}
+
+fn isValidDigits(source: []const u8, kind: LiteralKind) bool {
+    if (source.len == 0) return false;
+
+    for (source) |char| {
+        const valid = switch (kind) {
+            .binary => char == '0' or char == '1',
+            .octal => char >= '0' and char <= '7',
+            .hexadecimal => std.ascii.isHex(char),
+        };
+        if (!valid) return false;
+    }
+
+    return true;
+}
+
+fn isGlobalParseIntCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return std.mem.eql(u8, name, "parseInt") and isUnresolvedReference(symbol_table, unwrapped);
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed or member.optional or member.property == .null) return false;
+
+    const property = switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    if (!std.mem.eql(u8, property, "parseInt")) return false;
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return std.mem.eql(u8, object_name, "Number") and isUnresolvedReference(symbol_table, object);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -216,6 +216,7 @@ pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_const = @import("prefer_const.zig");
 pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
+pub const prefer_numeric_literals = @import("prefer_numeric_literals.zig");
 pub const prefer_object_spread = @import("prefer_object_spread.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
@@ -714,6 +715,10 @@ pub fn runSemantic(
 
     if (options.prefer_regex_literals) {
         try prefer_regex_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_numeric_literals) {
+        try prefer_numeric_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.prefer_object_spread) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -807,6 +807,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_numeric_literals.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_object_spread.zig");
 }
 

--- a/tests/rules/prefer_numeric_literals.zig
+++ b/tests/rules/prefer_numeric_literals.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-numeric-literals for parseInt calls that can be numeric literals" {
+    const source =
+        \\parseInt("101", 2);
+        \\parseInt("755", 8);
+        \\Number.parseInt("ff", 16);
+        \\parseInt(`a0`, 16);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+    try std.testing.expectEqualStrings("Use a binary literal instead of parseInt().", result.diagnostics[0].message);
+}
+
+test "allows parseInt calls that cannot be safely represented as numeric literals" {
+    const source =
+        \\parseInt("101", 10);
+        \\parseInt("102", 2);
+        \\parseInt("89", 8);
+        \\parseInt("10px", 16);
+        \\parseInt(value, 16);
+        \\parseInt(`a${value}`, 16);
+        \\parseInt("101", radix);
+        \\parseInt("101", 2, extra);
+        \\Number["parseInt"]("ff", 16);
+        \\function local(parseInt, Number) {
+        \\  parseInt("101", 2);
+        \\  Number.parseInt("ff", 16);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_numeric_literals.id));
+}
+
+test "can disable prefer-numeric-literals" {
+    const source = "parseInt(\"101\", 2);\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_numeric_literals = false,
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_numeric_literals.id));
+}


### PR DESCRIPTION
Summary:
- add native `prefer-numeric-literals` lint rule for literal `parseInt` and `Number.parseInt` calls
- restrict reports to fully valid binary, octal, and hexadecimal digit strings to avoid parseInt truncation false positives
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=prefer-numeric-literals --format=json`
- git diff --check