### PR TITLE
ci: publish npm packages with oidc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,6 @@ jobs:
 
       - name: Publish native npm packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
         run: |
           for package_dir in dist/native-packages/npm/@utoo/lint-*; do
@@ -215,6 +214,5 @@ jobs:
 
       - name: Publish npm CLI package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
         run: npm publish ./npm/utoo-lint --access public --provenance --tag "${NPM_TAG}"


### PR DESCRIPTION
## Summary

Switch npm publishing in the release workflow from `NPM_TOKEN` authentication to npm Trusted Publishing / OIDC.

## Details

- Keep the existing `id-token: write` permission on the `publish-npm` job.
- Keep the GitHub-hosted runner, Node 22 setup, and npm 11.6.2 upgrade required for trusted publishing.
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from both npm publish steps so npm can use the configured trusted publisher identity.

## Validation

- Parsed `.github/workflows/release.yml` with Ruby YAML loading.
- Inspected the diff to confirm only the token env entries were removed.
