### PR TITLE
feat: add require await rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -163,6 +163,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-spread`](https://eslint.org/docs/latest/rules/prefer-spread) | Implemented |
 | [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) | Implemented |
 | [`radix`](https://eslint.org/docs/latest/rules/radix) | Implemented |
+| [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Implemented |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -239,6 +239,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-spread",
   "prefer-template",
   "radix",
+  "require-await",
   "require-atomic-updates",
   "require-yield",
   "spaced-comment",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -242,6 +242,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-spread",
   "prefer-template",
   "radix",
+  "require-await",
   "require-atomic-updates",
   "require-yield",
   "spaced-comment",

--- a/src/core.zig
+++ b/src/core.zig
@@ -276,6 +276,7 @@ pub const Options = struct {
     react_void_dom_elements_no_children: bool = true,
     react_hooks_rules_of_hooks: bool = true,
     radix: bool = true,
+    require_await: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,
     spaced_comment: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -614,6 +614,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_hooks_rules_of_hooks = false;
         } else if (std.mem.eql(u8, arg, "--radix=off")) {
             options.radix = false;
+        } else if (std.mem.eql(u8, arg, "--require-await=off")) {
+            options.require_await = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
             options.require_atomic_updates = false;
         } else if (std.mem.eql(u8, arg, "--require-yield=off")) {
@@ -1464,6 +1466,7 @@ fn printHelp() void {
         \\  --react-void-dom-elements-no-children=off Disable react/void-dom-elements-no-children
         \\  --react-hooks-rules-of-hooks=off Disable react-hooks/rules-of-hooks
         \\  --radix=off               Disable radix
+        \\  --require-await=off      Disable require-await
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
         \\  --spaced-comment=off      Disable spaced-comment

--- a/src/rules/require_await.zig
+++ b/src/rules/require_await.zig
@@ -1,0 +1,107 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "require-await";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (function.async and !function.generator and !containsDirectAwait(ctx.tree, function.body)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        function: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (function.async and !containsDirectAwait(ctx.tree, function.body)) {
+            try self.addDiagnostic(ctx.tree, index);
+        }
+        return .proceed;
+    }
+
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Async function has no await expression.",
+            tree.span(index),
+        );
+    }
+};
+
+const AwaitScanner = struct {
+    found: bool = false,
+
+    pub fn enter_await_expression(
+        self: *AwaitScanner,
+        _: ast.AwaitExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.found = true;
+        return .stop;
+    }
+
+    pub fn enter_function(
+        _: *AwaitScanner,
+        _: ast.Function,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return .skip;
+    }
+
+    pub fn enter_arrow_function_expression(
+        _: *AwaitScanner,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return .skip;
+    }
+};
+
+fn containsDirectAwait(tree: *const ast.Tree, root: ast.NodeIndex) bool {
+    if (root == .null) return false;
+
+    var scanner = AwaitScanner{};
+    var subtree = tree.*;
+    subtree.root = root;
+    traverser.basic.traverse(AwaitScanner, &subtree, &scanner) catch return false;
+    return scanner.found;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -265,6 +265,7 @@ pub const react_self_closing_comp = @import("react_self_closing_comp.zig");
 pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
 pub const react_hooks_rules_of_hooks = @import("react_hooks_rules_of_hooks.zig");
 pub const radix = @import("radix.zig");
+pub const require_await = @import("require_await.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
@@ -385,6 +386,9 @@ pub fn runBasic(
     }
     if (options.react_hooks_rules_of_hooks) {
         try react_hooks_rules_of_hooks.run(allocator, diagnostics, tree);
+    }
+    if (options.require_await) {
+        try require_await.run(allocator, diagnostics, tree);
     }
     if (options.react_prop_types) {
         try react_prop_types.run(allocator, diagnostics, tree);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -999,6 +999,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/require_await.zig");
+}
+
+comptime {
     _ = @import("rules/require_atomic_updates.zig");
 }
 

--- a/tests/rules/require_await.zig
+++ b/tests/rules/require_await.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports require-await for async functions without await" {
+    const source =
+        \\async function first() {
+        \\  return value;
+        \\}
+        \\const second = async () => value;
+        \\const third = async function () {
+        \\  return value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.require_await.id));
+    try std.testing.expectEqualStrings("Async function has no await expression.", result.diagnostics[0].message);
+}
+
+test "allows async functions with await and ignores nested awaits" {
+    const source =
+        \\async function withAwait() {
+        \\  await value;
+        \\}
+        \\const expressionBody = async () => await value;
+        \\async function outer() {
+        \\  async function inner() {
+        \\    await value;
+        \\  }
+        \\  return inner;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.require_await.id));
+}
+
+test "allows non-async functions and async generators" {
+    const source =
+        \\function regular() {
+        \\  return value;
+        \\}
+        \\async function* generator() {
+        \\  yield value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_await.id));
+}
+
+test "can disable require-await" {
+    const source = "async function first() {}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .require_await = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_await.id));
+}


### PR DESCRIPTION
Summary:
- add native `require-await` lint rule for async functions and async arrows without direct await expressions
- skip async generators and keep nested function awaits scoped to their own function
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=require-await --format=json`
- git diff --check