### PR TITLE
feat: add wrap iife rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -171,6 +171,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Implemented |
+| [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for the default `outside` option |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented |
 
 ## Import plugin rules

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -247,6 +247,7 @@ const BUILTIN_RULE_IDS = [
   "unicode-bom",
   "use-isnan",
   "valid-typeof",
+  "wrap-iife",
   "yoda",
   "import/default",
   "import/export",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -250,6 +250,7 @@ const BUILTIN_RULE_IDS = [
   "unicode-bom",
   "use-isnan",
   "valid-typeof",
+  "wrap-iife",
   "yoda",
   "import/default",
   "import/export",

--- a/src/core.zig
+++ b/src/core.zig
@@ -327,6 +327,7 @@ pub const Options = struct {
     typescript_eslint_restrict_plus_operands: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
+    wrap_iife: bool = true,
     yoda: bool = true,
 
     pub fn allDisabled() Options {

--- a/src/main.zig
+++ b/src/main.zig
@@ -720,6 +720,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_restrict_plus_operands = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
+        } else if (std.mem.eql(u8, arg, "--wrap-iife=off")) {
+            options.wrap_iife = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
             options.parser_semantic_errors = false;
         } else if (std.mem.eql(u8, arg, "--yoda=off")) {
@@ -1514,6 +1516,7 @@ fn printHelp() void {
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
         \\  --typescript-eslint-restrict-plus-operands=off Disable @typescript-eslint/restrict-plus-operands
         \\  --valid-typeof=off        Disable valid-typeof
+        \\  --wrap-iife=off           Disable wrap-iife
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -321,6 +321,7 @@ pub const typescript_eslint_restrict_plus_operands = @import("typescript_eslint_
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
+pub const wrap_iife = @import("wrap_iife.zig");
 pub const yoda = @import("yoda.zig");
 
 pub fn runBasic(
@@ -344,6 +345,9 @@ pub fn runBasic(
     }
     if (options.unicode_bom) {
         try unicode_bom.run(allocator, diagnostics, tree);
+    }
+    if (options.wrap_iife) {
+        try wrap_iife.run(allocator, diagnostics, tree);
     }
     if (options.no_tabs) {
         try no_tabs.run(allocator, diagnostics, tree);

--- a/src/rules/wrap_iife.zig
+++ b/src/rules/wrap_iife.zig
@@ -1,0 +1,75 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "wrap-iife";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isIifeCall(ctx.tree, call) and !isParenthesized(ctx.tree, index, ctx.path.ancestor(1))) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Wrap an immediate function invocation in parentheses.",
+                ctx.tree.span(index),
+            );
+        }
+
+        return .proceed;
+    }
+};
+
+fn isIifeCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    return switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .function => |function| function.type == .function_expression,
+        else => false,
+    };
+}
+
+fn isParenthesized(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return false;
+    return switch (tree.data(parent_index)) {
+        .parenthesized_expression => |parenthesized| parenthesized.expression == index,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1219,5 +1219,9 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/wrap_iife.zig");
+}
+
+comptime {
     _ = @import("rules/yoda.zig");
 }

--- a/tests/rules/wrap_iife.zig
+++ b/tests/rules/wrap_iife.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports wrap-iife for unwrapped and inside-wrapped IIFEs" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\}();
+        \\const second = (function () {
+        \\  return value;
+        \\})();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.wrap_iife.id));
+    try std.testing.expectEqualStrings("Wrap an immediate function invocation in parentheses.", result.diagnostics[0].message);
+}
+
+test "allows outside-wrapped IIFEs and non-IIFE calls" {
+    const source =
+        \\const first = (function () {
+        \\  return value;
+        \\}());
+        \\const second = callback(function () {
+        \\  return value;
+        \\});
+        \\const third = (() => value)();
+        \\const fourth = function () {
+        \\  return value;
+        \\}.call(context);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.wrap_iife.id));
+}
+
+test "can disable wrap-iife" {
+    const source = "const value = function () { return 1; }();\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .wrap_iife = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.wrap_iife.id));
+}


### PR DESCRIPTION
Summary:
- add native `wrap-iife` lint rule for default `outside` IIFE wrapping
- report unwrapped function IIFEs and function-expression-only wrapped calls
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=wrap-iife --format=json`
- git diff --check