### PR TITLE
feat: add vars on top rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -171,6 +171,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Implemented |
+| [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for the default `outside` option |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented |
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -247,6 +247,7 @@ const BUILTIN_RULE_IDS = [
   "unicode-bom",
   "use-isnan",
   "valid-typeof",
+  "vars-on-top",
   "wrap-iife",
   "yoda",
   "import/default",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -250,6 +250,7 @@ const BUILTIN_RULE_IDS = [
   "unicode-bom",
   "use-isnan",
   "valid-typeof",
+  "vars-on-top",
   "wrap-iife",
   "yoda",
   "import/default",

--- a/src/core.zig
+++ b/src/core.zig
@@ -327,6 +327,7 @@ pub const Options = struct {
     typescript_eslint_restrict_plus_operands: bool = true,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
+    vars_on_top: bool = true,
     wrap_iife: bool = true,
     yoda: bool = true,
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -720,6 +720,8 @@ pub fn main(init: std.process.Init) !void {
             options.typescript_eslint_restrict_plus_operands = false;
         } else if (std.mem.eql(u8, arg, "--valid-typeof=off")) {
             options.valid_typeof = false;
+        } else if (std.mem.eql(u8, arg, "--vars-on-top=off")) {
+            options.vars_on_top = false;
         } else if (std.mem.eql(u8, arg, "--wrap-iife=off")) {
             options.wrap_iife = false;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
@@ -1516,6 +1518,7 @@ fn printHelp() void {
         \\  --typescript-eslint-prefer-namespace-keyword=off Disable @typescript-eslint/prefer-namespace-keyword
         \\  --typescript-eslint-restrict-plus-operands=off Disable @typescript-eslint/restrict-plus-operands
         \\  --valid-typeof=off        Disable valid-typeof
+        \\  --vars-on-top=off         Disable vars-on-top
         \\  --wrap-iife=off           Disable wrap-iife
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -321,6 +321,7 @@ pub const typescript_eslint_restrict_plus_operands = @import("typescript_eslint_
 pub const unicode_bom = @import("unicode_bom.zig");
 pub const use_isnan = @import("use_isnan.zig");
 pub const valid_typeof = @import("valid_typeof.zig");
+pub const vars_on_top = @import("vars_on_top.zig");
 pub const wrap_iife = @import("wrap_iife.zig");
 pub const yoda = @import("yoda.zig");
 
@@ -1718,6 +1719,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_var) {
             try no_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
+        if (self.options.vars_on_top) {
+            try vars_on_top.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
         }
         if (self.options.no_undef_init) {
             try no_undef_init.check(self.allocator, self.diagnostics, ctx.tree, declaration);

--- a/src/rules/vars_on_top.zig
+++ b/src/rules/vars_on_top.zig
@@ -1,0 +1,98 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "vars-on-top";
+
+const Scope = struct {
+    index: ast.NodeIndex,
+    is_function: bool,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (declaration.kind != .@"var") return;
+
+    const scope = nearestScope(tree, ctx) orelse return;
+    const statement = statementForDeclaration(tree, index, ctx);
+    if (statement != .null and isLeadingVarStatement(tree, scope.index, statement)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        if (scope.is_function)
+            "All 'var' declarations must be at the top of the function scope."
+        else
+            "All 'var' declarations must be at the top of the program scope.",
+        tree.span(index),
+    );
+}
+
+fn statementForDeclaration(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) ast.NodeIndex {
+    const parent = ctx.path.ancestor(1) orelse return .null;
+    return switch (tree.data(parent)) {
+        .program, .function_body => index,
+        .export_named_declaration, .export_default_declaration => parent,
+        else => .null,
+    };
+}
+
+fn nearestScope(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?Scope {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .function_body => return .{ .index = ancestor, .is_function = true },
+            .program => return .{ .index = ancestor, .is_function = false },
+            else => {},
+        }
+    }
+
+    return null;
+}
+
+fn isLeadingVarStatement(tree: *const ast.Tree, scope_index: ast.NodeIndex, statement: ast.NodeIndex) bool {
+    const body = switch (tree.data(scope_index)) {
+        .program => |program| program.body,
+        .function_body => |function_body| function_body.body,
+        else => return false,
+    };
+
+    var seen_non_leading_statement = false;
+    for (tree.extra(body)) |child| {
+        if (child == statement) return !seen_non_leading_statement;
+        if (!isLeadingStatement(tree, child)) {
+            seen_non_leading_statement = true;
+        }
+    }
+
+    return false;
+}
+
+fn isLeadingStatement(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .directive => true,
+        .variable_declaration => |declaration| declaration.kind == .@"var",
+        .export_named_declaration => |declaration| isVarDeclaration(tree, declaration.declaration),
+        .export_default_declaration => |declaration| isVarDeclaration(tree, declaration.declaration),
+        else => false,
+    };
+}
+
+fn isVarDeclaration(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .variable_declaration => |declaration| declaration.kind == .@"var",
+        else => false,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1219,6 +1219,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/vars_on_top.zig");
+}
+
+comptime {
     _ = @import("rules/wrap_iife.zig");
 }
 

--- a/tests/rules/vars_on_top.zig
+++ b/tests/rules/vars_on_top.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports vars-on-top for var declarations after statements and nested blocks" {
+    const source =
+        \\function run() {
+        \\  doSomething();
+        \\  var later = true;
+        \\  if (later) {
+        \\    var nested = true;
+        \\  }
+        \\}
+        \\for (var i = 0; i < 10; i++) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_var = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.vars_on_top.id));
+    try std.testing.expectEqualStrings("All 'var' declarations must be at the top of the function scope.", result.diagnostics[0].message);
+}
+
+test "allows leading var declarations after directives" {
+    const source =
+        \\"use strict";
+        \\var first = true;
+        \\var second = first;
+        \\function run() {
+        \\  "use strict";
+        \\  var local = true;
+        \\  var another = local;
+        \\  return another;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_var = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.vars_on_top.id));
+}
+
+test "can disable vars-on-top" {
+    const source =
+        \\doSomething();
+        \\var later = true;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_var = false,
+        .vars_on_top = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.vars_on_top.id));
+}


### PR DESCRIPTION
Summary:
- add native `vars-on-top` lint rule for `var` declarations outside leading program/function declaration groups
- report nested block declarations and `for (var ...)` initializers against their containing scope
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig build
- zig build test
- CLI smoke with `--rules=vars-on-top --format=json`
- git diff --check