### PR TITLE
ci: upgrade actions to node 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,9 @@ on:
       - "src/**"
       - "vendor/yuku/**"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   codspeed:
     name: CodSpeed
@@ -33,7 +36,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -41,9 +44,9 @@ jobs:
         uses: mlugg/setup-zig@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: benchmarks/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test-darwin-arm64:
     name: Test macOS arm64
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-release-assets:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
@@ -54,7 +57,7 @@ jobs:
             package_path: npm/@utoo/lint-win32-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -85,7 +88,7 @@ jobs:
           chmod 755 dist/native/${{ matrix.package_path }}/bin/${{ matrix.binary }}
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-${{ matrix.asset }}
           path: |
@@ -93,7 +96,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload native npm package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: native-${{ matrix.asset }}
           path: dist/native
@@ -106,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: release-*
           path: dist/release-assets
@@ -130,16 +133,17 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Download native npm packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: native-*
           path: dist/native-packages


### PR DESCRIPTION
## Summary

Upgrade workflow actions and Node runtime usage to the current Node 24 line.

## Details

- Update `actions/checkout` from v4 to v5 in CI, benchmark, and release workflows.
- Update `actions/setup-node` from v4 to v6 and run benchmark/release Node steps on Node 24.
- Update artifact upload/download actions in the release workflow to `actions/upload-artifact@v6` and `actions/download-artifact@v7`.
- Disable `setup-node` package manager cache auto-detection in the release publishing job.
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so `mlugg/setup-zig@v2` also runs on Node 24 until it publishes a Node 24-based action release.

## Validation

- Parsed all workflow YAML files locally.
- Confirmed the upgraded action major tags exist upstream.
- Confirmed `setup-node@v6`, `checkout@v5`, `upload-artifact@v6`, and `download-artifact@v7` use Node 24 action runtimes.
- GitHub checks passed: `Test macOS arm64` and `CodSpeed`.
- Checked logs for the latest PR runs; the Node 20 deprecation warning is no longer present.
