### PR TITLE
feat: add func names rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -16,6 +16,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
+| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for the default `always` option |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -92,6 +92,7 @@ const BUILTIN_RULE_IDS = [
   "eol-last",
   "eqeqeq",
   "for-direction",
+  "func-names",
   "getter-return",
   "guard-for-in",
   "linebreak-style",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -95,6 +95,7 @@ const BUILTIN_RULE_IDS = [
   "eol-last",
   "eqeqeq",
   "for-direction",
+  "func-names",
   "getter-return",
   "guard-for-in",
   "linebreak-style",

--- a/src/core.zig
+++ b/src/core.zig
@@ -30,6 +30,7 @@ pub const Options = struct {
     eslint_comments_no_restricted_disable: bool = true,
     eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,
     for_direction: bool = true,
+    func_names: bool = true,
     getter_return: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -128,6 +128,8 @@ pub fn main(init: std.process.Init) !void {
             options.eslint_comments_no_restricted_disable = false;
         } else if (std.mem.eql(u8, arg, "--for-direction=off")) {
             options.for_direction = false;
+        } else if (std.mem.eql(u8, arg, "--func-names=off")) {
+            options.func_names = false;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
             options.getter_return = false;
         } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
@@ -1227,6 +1229,7 @@ fn printHelp() void {
         \\  --eol-last=off            Disable eol-last
         \\  --eslint-comments-no-restricted-disable=off Disable eslint-comments/no-restricted-disable
         \\  --for-direction=off       Disable for-direction
+        \\  --func-names=off          Disable func-names
         \\  --getter-return=off       Disable getter-return
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style

--- a/src/rules/func_names.zig
+++ b/src/rules/func_names.zig
@@ -1,0 +1,54 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "func-names";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (function.id != .null) return;
+    if (!requiresName(tree, function, ctx)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected unnamed function.",
+        tree.span(index),
+    );
+}
+
+fn requiresName(tree: *const ast.Tree, function: ast.Function, ctx: *traverser.basic.Ctx) bool {
+    return switch (function.type) {
+        .function_expression => !isMethodParent(tree, ctx),
+        .function_declaration => isExportDefaultDeclarationParent(tree, ctx),
+        else => false,
+    };
+}
+
+fn isMethodParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.parent() orelse return false;
+    return switch (tree.data(parent)) {
+        .method_definition => true,
+        .object_property => |property| property.method,
+        else => false,
+    };
+}
+
+fn isExportDefaultDeclarationParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.parent() orelse return false;
+    return switch (tree.data(parent)) {
+        .export_default_declaration => true,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -24,6 +24,7 @@ pub const default_case_last = @import("default_case_last.zig");
 pub const eol_last = @import("eol_last.zig");
 pub const eslint_comments_no_restricted_disable = @import("eslint_comments_no_restricted_disable.zig");
 pub const for_direction = @import("for_direction.zig");
+pub const func_names = @import("func_names.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
@@ -910,6 +911,9 @@ const BasicVisitor = struct {
         }
         if (self.options.consistent_return) {
             try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+        }
+        if (self.options.func_names) {
+            try func_names.check(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
         }
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -43,6 +43,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/func_names.zig");
+}
+
+comptime {
     _ = @import("rules/getter_return.zig");
 }
 

--- a/tests/rules/func_names.zig
+++ b/tests/rules/func_names.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports func-names for unnamed function expressions" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\};
+        \\const object = {
+        \\  method: function () {
+        \\    return value;
+        \\  },
+        \\};
+        \\const generator = function* () {
+        \\  yield value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_names.id));
+    try std.testing.expectEqualStrings("Unexpected unnamed function.", result.diagnostics[0].message);
+}
+
+test "reports func-names for unnamed default-exported functions" {
+    const source =
+        \\export default function () {
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.func_names.id));
+}
+
+test "allows named functions and non-function-expression callbacks" {
+    const source =
+        \\function declaration() {
+        \\  return value;
+        \\}
+        \\export default function namedDefault() {
+        \\  return value;
+        \\}
+        \\const first = function namedExpression() {
+        \\  return value;
+        \\};
+        \\const object = {
+        \\  method() {
+        \\    return value;
+        \\  },
+        \\};
+        \\const arrow = () => value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_names.id));
+}
+
+test "can disable func-names" {
+    const source = "const value = function () { return 1; };\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_names = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_names.id));
+}

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -11,6 +11,7 @@ test "reports no-extend-native for native prototype assignments" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .dot_notation = false,
         .eol_last = false,
+        .func_names = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
         .no_undef = false,
@@ -36,6 +37,7 @@ test "reports no-extend-native for Object defineProperty calls" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .dot_notation = false,
         .eol_last = false,
+        .func_names = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
         .no_undef = false,
@@ -64,6 +66,7 @@ test "does not report no-extend-native for shadowed constructors or ordinary obj
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .dot_notation = false,
         .eol_last = false,
+        .func_names = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
         .no_undef = false,
@@ -85,6 +88,7 @@ test "can disable no-extend-native" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .dot_notation = false,
         .eol_last = false,
+        .func_names = false,
         .no_empty_block_statements = false,
         .no_empty_function = false,
         .no_extend_native = false,


### PR DESCRIPTION
Summary:
- add native `func-names` lint rule for default `always` behavior
- report anonymous function expressions and anonymous default-exported functions while allowing method shorthand and arrows
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=func-names --format=json`
- `git diff --check`