### PR TITLE
feat: add prefer object has own rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -157,6 +157,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for fishlint's object variable declarator configuration |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |
+| [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Implemented |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -233,6 +233,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-destructuring",
   "prefer-exponentiation-operator",
   "prefer-numeric-literals",
+  "prefer-object-has-own",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -236,6 +236,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-destructuring",
   "prefer-exponentiation-operator",
   "prefer-numeric-literals",
+  "prefer-object-has-own",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
   "prefer-regex-literals",

--- a/src/core.zig
+++ b/src/core.zig
@@ -228,6 +228,7 @@ pub const Options = struct {
     prefer_const: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_numeric_literals: bool = true,
+    prefer_object_has_own: bool = true,
     prefer_promise_reject_errors: bool = true,
     prefer_destructuring: bool = true,
     prefer_regex_literals: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -524,6 +524,8 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_destructuring = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
             options.prefer_regex_literals = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-object-has-own=off")) {
+            options.prefer_object_has_own = false;
         } else if (std.mem.eql(u8, arg, "--prefer-object-spread=off")) {
             options.prefer_object_spread = false;
         } else if (std.mem.eql(u8, arg, "--prefer-rest-params=off")) {
@@ -1426,6 +1428,7 @@ fn printHelp() void {
         \\  --prefer-numeric-literals=off Disable prefer-numeric-literals
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
         \\  --prefer-destructuring=off Disable prefer-destructuring
+        \\  --prefer-object-has-own=off Disable prefer-object-has-own
         \\  --prefer-object-spread=off Disable prefer-object-spread
         \\  --prefer-regex-literals=off Disable prefer-regex-literals
         \\  --prefer-rest-params=off  Disable prefer-rest-params

--- a/src/root.zig
+++ b/src/root.zig
@@ -167,6 +167,7 @@ fn hasSemanticRules(options: Options) bool {
         options.prefer_const or
         options.prefer_exponentiation_operator or
         options.prefer_numeric_literals or
+        options.prefer_object_has_own or
         options.prefer_object_spread or
         options.prefer_promise_reject_errors or
         options.prefer_regex_literals or

--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-object-has-own";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isPreferableHasOwn(ctx.tree, self.symbol_table, call)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+            ctx.tree.span(index),
+        );
+
+        return .proceed;
+    }
+};
+
+fn isPreferableHasOwn(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    call: ast.CallExpression,
+) bool {
+    if (call.optional) return false;
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2) return false;
+
+    const call_member = memberExpression(tree, call.callee) orelse return false;
+    if (call_member.optional) return false;
+    if (!propertyNamed(tree, call_member, "call")) return false;
+
+    const target_member = memberExpression(tree, call_member.object) orelse return false;
+    if (target_member.optional) return false;
+    if (!propertyNamed(tree, target_member, "hasOwnProperty")) return false;
+
+    return isPreferredTargetObject(tree, symbol_table, target_member.object);
+}
+
+fn isPreferredTargetObject(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const object = unwrapTransparent(tree, index);
+
+    if (isObjectLiteral(tree, object)) return true;
+
+    if (isIdentifierReference(tree, object, "Object")) {
+        return isUnresolvedReference(symbol_table, object);
+    }
+
+    const prototype_member = memberExpression(tree, object) orelse return false;
+    if (prototype_member.optional) return false;
+    if (!propertyNamed(tree, prototype_member, "prototype")) return false;
+
+    const prototype_object = unwrapTransparent(tree, prototype_member.object);
+    if (!isIdentifierReference(tree, prototype_object, "Object")) return false;
+    return isUnresolvedReference(symbol_table, prototype_object);
+}
+
+fn memberExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.MemberExpression {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => null,
+    };
+}
+
+fn isObjectLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .object_expression => true,
+        else => false,
+    };
+}
+
+fn propertyNamed(tree: *const ast.Tree, member: ast.MemberExpression, expected: []const u8) bool {
+    const name = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
+        else => false,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -218,6 +218,7 @@ pub const prefer_const = @import("prefer_const.zig");
 pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
 pub const prefer_numeric_literals = @import("prefer_numeric_literals.zig");
+pub const prefer_object_has_own = @import("prefer_object_has_own.zig");
 pub const prefer_object_spread = @import("prefer_object_spread.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
@@ -729,6 +730,10 @@ pub fn runSemantic(
 
     if (options.prefer_numeric_literals) {
         try prefer_numeric_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.prefer_object_has_own) {
+        try prefer_object_has_own.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.prefer_object_spread) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -815,6 +815,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_object_has_own.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_object_spread.zig");
 }
 

--- a/tests/rules/prefer_object_has_own.zig
+++ b/tests/rules/prefer_object_has_own.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports prefer-object-has-own for hasOwnProperty call helpers" {
+    const source =
+        \\Object.prototype.hasOwnProperty.call(object, "key");
+        \\Object.hasOwnProperty.call(object, "key");
+        \\({}).hasOwnProperty.call(object, "key");
+        \\Object["prototype"]["hasOwnProperty"]["call"](object, "key");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_object_has_own.id));
+    try std.testing.expectEqualStrings(
+        "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not report prefer-object-has-own for other calls or shadowed Object" {
+    const source =
+        \\Object.hasOwn(object, "key");
+        \\Object.prototype.propertyIsEnumerable.call(object, "key");
+        \\object.hasOwnProperty("key");
+        \\Object.prototype.hasOwnProperty.apply(object, ["key"]);
+        \\function local(Object) {
+        \\  Object.prototype.hasOwnProperty.call(object, "key");
+        \\  Object.hasOwnProperty.call(object, "key");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_prototype_builtins = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_object_has_own.id));
+}
+
+test "can disable prefer-object-has-own" {
+    const source = "Object.prototype.hasOwnProperty.call(object, \"key\");\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .prefer_object_has_own = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_object_has_own.id));
+}


### PR DESCRIPTION
Summary:
- add native `prefer-object-has-own` lint rule
- report `Object.prototype.hasOwnProperty.call`, `Object.hasOwnProperty.call`, object-literal helper calls, and computed equivalents
- wire the rule through semantic gating, options, CLI disable flag, JS built-in metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=prefer-object-has-own --format=json`
- `git diff --check`