### PR TITLE
feat: add default param last rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -12,6 +12,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
+| [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Implemented |
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -88,6 +88,7 @@ const BUILTIN_RULE_IDS = [
   "curly",
   "default-case",
   "default-case-last",
+  "default-param-last",
   "dot-notation",
   "eol-last",
   "eqeqeq",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -91,6 +91,7 @@ const BUILTIN_RULE_IDS = [
   "curly",
   "default-case",
   "default-case-last",
+  "default-param-last",
   "dot-notation",
   "eol-last",
   "eqeqeq",

--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,7 @@ pub const Options = struct {
     typescript_eslint_dot_notation: bool = true,
     default_case: bool = true,
     default_case_last: bool = true,
+    default_param_last: bool = true,
     eol_last: bool = true,
     eslint_comments_no_restricted_disable: bool = true,
     eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,6 +122,8 @@ pub fn main(init: std.process.Init) !void {
             options.default_case = false;
         } else if (std.mem.eql(u8, arg, "--default-case-last=off")) {
             options.default_case_last = false;
+        } else if (std.mem.eql(u8, arg, "--default-param-last=off")) {
+            options.default_param_last = false;
         } else if (std.mem.eql(u8, arg, "--eol-last=off")) {
             options.eol_last = false;
         } else if (std.mem.eql(u8, arg, "--eslint-comments-no-restricted-disable=off")) {
@@ -1228,6 +1230,7 @@ fn printHelp() void {
         \\  --dot-notation=off       Disable dot-notation
         \\  --default-case=off        Disable default-case
         \\  --default-case-last=off   Disable default-case-last
+        \\  --default-param-last=off  Disable default-param-last
         \\  --eol-last=off            Disable eol-last
         \\  --eslint-comments-no-restricted-disable=off Disable eslint-comments/no-restricted-disable
         \\  --for-direction=off       Disable for-direction

--- a/src/rules/default_param_last.zig
+++ b/src/rules/default_param_last.zig
@@ -1,0 +1,76 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "default-param-last";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const params = formalParameters(tree, params_index) orelse return;
+    var required_after = false;
+
+    const items = tree.extra(params.items);
+    var index = items.len;
+    while (index > 0) {
+        index -= 1;
+
+        const parameter = parameterPattern(tree, items[index]) orelse continue;
+        if (isDefaultParameter(tree, parameter)) {
+            if (required_after) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Default parameters should be last.",
+                    tree.span(parameter),
+                );
+            }
+            continue;
+        }
+
+        if (isRequiredParameter(tree, parameter)) {
+            required_after = true;
+        }
+    }
+}
+
+fn formalParameters(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.FormalParameters {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .formal_parameters => |params| params,
+        else => null,
+    };
+}
+
+fn parameterPattern(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .formal_parameter => |parameter| parameter.pattern,
+        .ts_parameter_property => |property| property.parameter,
+        else => null,
+    };
+}
+
+fn isDefaultParameter(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .assignment_pattern => true,
+        else => false,
+    };
+}
+
+fn isRequiredParameter(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .assignment_pattern, .ts_this_parameter => false,
+        .binding_identifier => |identifier| !identifier.optional,
+        .array_pattern => |pattern| !pattern.optional,
+        .object_pattern => |pattern| !pattern.optional,
+        else => true,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -21,6 +21,7 @@ pub const constructor_super = @import("constructor_super.zig");
 pub const dot_notation = @import("dot_notation.zig");
 pub const default_case = @import("default_case.zig");
 pub const default_case_last = @import("default_case_last.zig");
+pub const default_param_last = @import("default_param_last.zig");
 pub const eol_last = @import("eol_last.zig");
 pub const eslint_comments_no_restricted_disable = @import("eslint_comments_no_restricted_disable.zig");
 pub const for_direction = @import("for_direction.zig");
@@ -919,6 +920,9 @@ const BasicVisitor = struct {
         }
         if (self.options.func_names) {
             try func_names.check(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
+        }
+        if (self.options.default_param_last) {
+            try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
@@ -1830,6 +1834,9 @@ const BasicVisitor = struct {
         }
         if (self.options.consistent_return) {
             try consistent_return.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
+        if (self.options.default_param_last) {
+            try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -31,6 +31,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/default_param_last.zig");
+}
+
+comptime {
     _ = @import("rules/eol_last.zig");
 }
 

--- a/tests/rules/default_param_last.zig
+++ b/tests/rules/default_param_last.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports default-param-last for default parameters before required parameters" {
+    const source =
+        \\function first(a = 1, b) {
+        \\  return b;
+        \\}
+        \\const second = function (a, b = 1, c) {
+        \\  return c;
+        \\};
+        \\const third = (a = 1, b) => b;
+        \\class Example {
+        \\  constructor(private a = 1, b: string) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.default_param_last.id));
+    try std.testing.expectEqualStrings("Default parameters should be last.", result.diagnostics[0].message);
+}
+
+test "allows default parameters after required and before optional parameters" {
+    const source =
+        \\function first(a, b = 1) {
+        \\  return b;
+        \\}
+        \\function second(a = 1, b?: string) {
+        \\  return b;
+        \\}
+        \\const third = (a, b = 1, ...rest) => rest;
+        \\class Example {
+        \\  constructor(private a?: string, public b = "value") {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_param_last.id));
+}
+
+test "can disable default-param-last" {
+    const source = "function first(a = 1, b) { return b; }\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .default_param_last = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.default_param_last.id));
+}


### PR DESCRIPTION
Summary:
- add native `default-param-last` lint rule
- report default parameters that appear before later required parameters in functions, arrows, and TS parameter properties
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=default-param-last --format=json`
- `git diff --check`