### PR TITLE
feat: add no confusing arrow rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -32,6 +32,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-caller`](https://eslint.org/docs/latest/rules/no-caller) | Implemented |
 | [`no-case-declarations`](https://eslint.org/docs/latest/rules/no-case-declarations) | Implemented |
 | [`no-class-assign`](https://eslint.org/docs/latest/rules/no-class-assign) | Implemented |
+| [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow) | Implemented for the default `allowParens: true` option |
 | [`no-comma-operator`](https://eslint.org/docs/latest/rules/no-comma-operator) | Implemented |
 | [`no-compare-neg-zero`](https://eslint.org/docs/latest/rules/no-compare-neg-zero) | Implemented |
 | [`no-cond-assign`](https://eslint.org/docs/latest/rules/no-cond-assign) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -108,6 +108,7 @@ const BUILTIN_RULE_IDS = [
   "no-caller",
   "no-case-declarations",
   "no-class-assign",
+  "no-confusing-arrow",
   "no-comma-operator",
   "no-compare-neg-zero",
   "no-cond-assign",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -111,6 +111,7 @@ const BUILTIN_RULE_IDS = [
   "no-caller",
   "no-case-declarations",
   "no-class-assign",
+  "no-confusing-arrow",
   "no-comma-operator",
   "no-compare-neg-zero",
   "no-cond-assign",

--- a/src/core.zig
+++ b/src/core.zig
@@ -46,6 +46,7 @@ pub const Options = struct {
     no_caller: bool = true,
     no_case_declarations: bool = true,
     no_class_assign: bool = true,
+    no_confusing_arrow: bool = true,
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -160,6 +160,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_case_declarations = false;
         } else if (std.mem.eql(u8, arg, "--no-class-assign=off")) {
             options.no_class_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-confusing-arrow=off")) {
+            options.no_confusing_arrow = false;
         } else if (std.mem.eql(u8, arg, "--no-cond-assign=off")) {
             options.no_cond_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
@@ -1249,6 +1251,7 @@ fn printHelp() void {
         \\  --no-caller=off           Disable no-caller
         \\  --no-case-declarations=off Disable no-case-declarations
         \\  --no-class-assign=off     Disable no-class-assign
+        \\  --no-confusing-arrow=off  Disable no-confusing-arrow
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition

--- a/src/rules/no_confusing_arrow.zig
+++ b/src/rules/no_confusing_arrow.zig
@@ -1,0 +1,30 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-confusing-arrow";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+) Allocator.Error!void {
+    if (!expression.expression) return;
+
+    switch (tree.data(expression.body)) {
+        .conditional_expression => {},
+        else => return,
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Arrow function used ambiguously with a conditional expression.",
+        tree.span(expression.body),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -90,6 +90,7 @@ pub const no_buffer_constructor = @import("no_buffer_constructor.zig");
 pub const no_caller = @import("no_caller.zig");
 pub const no_case_declarations = @import("no_case_declarations.zig");
 pub const no_class_assign = @import("no_class_assign.zig");
+pub const no_confusing_arrow = @import("no_confusing_arrow.zig");
 pub const no_cond_assign = @import("no_cond_assign.zig");
 pub const no_compare_neg_zero = @import("no_compare_neg_zero.zig");
 pub const no_constant_condition = @import("no_constant_condition.zig");
@@ -1837,6 +1838,9 @@ const BasicVisitor = struct {
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
+        }
+        if (self.options.no_confusing_arrow) {
+            try no_confusing_arrow.check(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -303,6 +303,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_confusing_arrow.zig");
+}
+
+comptime {
     _ = @import("rules/no_comma_operator.zig");
 }
 

--- a/tests/rules/no_confusing_arrow.zig
+++ b/tests/rules/no_confusing_arrow.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-confusing-arrow for unparenthesized conditional expression bodies" {
+    const source =
+        \\const first = value => value ? firstValue : secondValue;
+        \\const second = (value) => value ? firstValue : secondValue;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_confusing_arrow.id));
+    try std.testing.expectEqualStrings(
+        "Arrow function used ambiguously with a conditional expression.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "allows parenthesized conditional expression bodies and block bodies" {
+    const source =
+        \\const first = value => (value ? firstValue : secondValue);
+        \\const second = value => {
+        \\  return value ? firstValue : secondValue;
+        \\};
+        \\const third = value => value || fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_confusing_arrow.id));
+}
+
+test "can disable no-confusing-arrow" {
+    const source = "const first = value => value ? firstValue : secondValue;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_confusing_arrow = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_confusing_arrow.id));
+}


### PR DESCRIPTION
Summary:
- add native `no-confusing-arrow` lint rule for default `allowParens: true` behavior
- report unparenthesized conditional expression arrow bodies while allowing parenthesized conditionals and block bodies
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=no-confusing-arrow --format=json`
- `git diff --check`