### PR TITLE
feat: add accessor pairs rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -5,6 +5,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for ESLint's default `setWithoutGet: true, getWithoutSet: false` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for fishlint's `allowImplicit: true, checkForEach: false, allowVoid: false` configuration |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value and bare return statements |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -81,6 +81,7 @@ if (json === undefined) {
 process.stdout.write(json);
 `;
 const BUILTIN_RULE_IDS = [
+  "accessor-pairs",
   "array-callback-return",
   "block-scoped-var",
   "consistent-return",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -84,6 +84,7 @@ if (json === undefined) {
 process.stdout.write(json);
 `;
 const BUILTIN_RULE_IDS = [
+  "accessor-pairs",
   "array-callback-return",
   "block-scoped-var",
   "consistent-return",

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,6 +17,7 @@ pub const Severity = enum {
 };
 
 pub const Options = struct {
+    accessor_pairs: bool = true,
     array_callback_return: bool = true,
     block_scoped_var: bool = true,
     consistent_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -106,6 +106,8 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
             options = lint.Options.allDisabled();
             parseEnabledRules(arg["--rules=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--accessor-pairs=off")) {
+            options.accessor_pairs = false;
         } else if (std.mem.eql(u8, arg, "--consistent-return=off")) {
             options.consistent_return = false;
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
@@ -1224,6 +1226,7 @@ fn printHelp() void {
         \\  --json                   Alias for --format=json
         \\  --threads=N              Number of worker threads to use
         \\  --rules=a,b,c            Enable only the comma-separated rule list
+        \\  --accessor-pairs=off    Disable accessor-pairs
         \\  --array-callback-return=off Disable array-callback-return
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --consistent-return=off  Disable consistent-return

--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -1,0 +1,265 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "accessor-pairs";
+
+const Accessor = struct {
+    name: []const u8,
+    static: bool = false,
+    get: bool = false,
+    set: bool = false,
+    set_index: ast.NodeIndex = .null,
+};
+
+pub fn checkObjectExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+) Allocator.Error!void {
+    var accessors: std.ArrayList(Accessor) = .empty;
+    defer accessors.deinit(allocator);
+
+    for (tree.extra(expression.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        if (property.kind != .get and property.kind != .set) continue;
+
+        const name = propertyName(tree, property.key, property.computed) orelse continue;
+        try recordAccessor(allocator, &accessors, name, false, property.kind == .get, property.kind == .set, property_index);
+    }
+
+    try reportSettersWithoutGetters(allocator, diagnostics, tree, accessors.items);
+}
+
+pub fn checkClassBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+) Allocator.Error!void {
+    var accessors: std.ArrayList(Accessor) = .empty;
+    defer accessors.deinit(allocator);
+
+    for (tree.extra(body.body)) |member_index| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        if (method.kind != .get and method.kind != .set) continue;
+
+        const name = propertyName(tree, method.key, method.computed) orelse continue;
+        try recordAccessor(allocator, &accessors, name, method.static, method.kind == .get, method.kind == .set, member_index);
+    }
+
+    try reportSettersWithoutGetters(allocator, diagnostics, tree, accessors.items);
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    const arguments = tree.extra(call.arguments);
+
+    if (isStaticMemberCall(tree, call.callee, "Object", "defineProperty")) {
+        if (arguments.len < 3) return;
+        try checkPropertyDescriptor(allocator, diagnostics, tree, arguments[2], arguments[1]);
+        return;
+    }
+
+    if (isStaticMemberCall(tree, call.callee, "Object", "defineProperties")) {
+        if (arguments.len < 2) return;
+        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1]);
+        return;
+    }
+
+    if (isStaticMemberCall(tree, call.callee, "Object", "create")) {
+        if (arguments.len < 2) return;
+        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1]);
+    }
+}
+
+fn checkNestedDescriptors(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    descriptors_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const descriptors = switch (tree.data(descriptors_index)) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(descriptors.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        if (property.value == .null) continue;
+        try checkPropertyDescriptor(allocator, diagnostics, tree, property.value, property.key);
+    }
+}
+
+fn checkPropertyDescriptor(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    descriptor_index: ast.NodeIndex,
+    report_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const descriptor = switch (tree.data(descriptor_index)) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    var has_get = false;
+    var set_index: ast.NodeIndex = .null;
+
+    for (tree.extra(descriptor.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+
+        if (propertyKeyEquals(tree, property, "get")) {
+            has_get = true;
+        } else if (propertyKeyEquals(tree, property, "set")) {
+            set_index = property_index;
+        }
+    }
+
+    if (!has_get and set_index != .null) {
+        try addDiagnostic(allocator, diagnostics, tree, report_index);
+    }
+}
+
+fn recordAccessor(
+    allocator: Allocator,
+    accessors: *std.ArrayList(Accessor),
+    name: []const u8,
+    static: bool,
+    is_get: bool,
+    is_set: bool,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    for (accessors.items) |*accessor| {
+        if (accessor.static != static) continue;
+        if (!std.mem.eql(u8, accessor.name, name)) continue;
+
+        accessor.get = accessor.get or is_get;
+        if (is_set) {
+            accessor.set = true;
+            accessor.set_index = index;
+        }
+        return;
+    }
+
+    try accessors.append(allocator, .{
+        .name = name,
+        .static = static,
+        .get = is_get,
+        .set = is_set,
+        .set_index = if (is_set) index else .null,
+    });
+}
+
+fn reportSettersWithoutGetters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    accessors: []const Accessor,
+) Allocator.Error!void {
+    for (accessors) |accessor| {
+        if (accessor.set and !accessor.get) {
+            try addDiagnostic(allocator, diagnostics, tree, accessor.set_index);
+        }
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Setter must be accompanied by a getter.",
+        tree.span(index),
+    );
+}
+
+fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (key == .null) return null;
+
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| if (computed) null else tree.string(identifier.name),
+        .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn propertyKeyEquals(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
+    if (property.computed) return false;
+    if (property.key == .null) return false;
+
+    return switch (tree.data(property.key)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .string_literal => |literal| std.mem.eql(u8, tree.string(literal.value), name),
+        else => false,
+    };
+}
+
+fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name: []const u8, property_name: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    return isIdentifierReferenceNamed(tree, member.object, object_name) and
+        isIdentifierNameNamed(tree, member.property, property_name);
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -14,6 +14,7 @@ const promise_checks = @import("promise_checks.zig");
 const symbol_checks = @import("symbol_checks.zig");
 
 pub const curly = @import("curly.zig");
+pub const accessor_pairs = @import("accessor_pairs.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
 pub const consistent_return = @import("consistent_return.zig");
@@ -2004,6 +2005,9 @@ const BasicVisitor = struct {
         if (self.options.array_callback_return) {
             try array_callback_return.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
+        if (self.options.accessor_pairs) {
+            try accessor_pairs.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
         if (self.options.import_no_amd) {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -2389,6 +2393,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.accessor_pairs) {
+            try accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
         }
@@ -2474,6 +2481,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.accessor_pairs) {
+            try accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);
+        }
         if (self.options.no_dupe_class_members and !self.options.typescript_eslint_no_dupe_class_members) {
             try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1,4 +1,8 @@
 comptime {
+    _ = @import("rules/accessor_pairs.zig");
+}
+
+comptime {
     _ = @import("rules/array_callback_return.zig");
 }
 

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports accessor-pairs for object setters without getters" {
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\  get ready() { return true; },
+        \\  set ready(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.accessor_pairs.id));
+    try std.testing.expectEqualStrings("Setter must be accompanied by a getter.", result.diagnostics[0].message);
+}
+
+test "reports accessor-pairs for class setters without getters" {
+    const source =
+        \\class Example {
+        \\  set value(next) {}
+        \\  static set count(next) {}
+        \\  static get count() { return 1; }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.accessor_pairs.id));
+}
+
+test "reports accessor-pairs for property descriptors without get" {
+    const source =
+        \\Object.defineProperty(target, "value", {
+        \\  set(next) {}
+        \\});
+        \\Object.defineProperties(target, {
+        \\  first: {
+        \\    set(next) {}
+        \\  },
+        \\  second: {
+        \\    get() { return 1; },
+        \\    set(next) {}
+        \\  }
+        \\});
+        \\Object.create(proto, {
+        \\  third: {
+        \\    set(next) {}
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.accessor_pairs.id));
+}
+
+test "does not report accessor-pairs for getters without setters by default" {
+    const source =
+        \\const object = {
+        \\  get value() { return 1; },
+        \\};
+        \\class Example {
+        \\  get value() { return 1; }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.accessor_pairs.id));
+}
+
+test "does not treat ordinary descriptor-looking objects as property descriptors" {
+    const source =
+        \\const object = {
+        \\  set(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.accessor_pairs.id));
+}
+
+test "can disable accessor-pairs" {
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .accessor_pairs = false,
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.accessor_pairs.id));
+}


### PR DESCRIPTION
Summary:
- add native `accessor-pairs` lint rule for ESLint default setter-without-getter behavior
- report object/class setters and `Object.defineProperty` / `Object.defineProperties` / `Object.create` descriptor setters without matching getters
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=accessor-pairs --format=json`
- CLI smoke with `--accessor-pairs=off`
- `git diff --check`
