### PR TITLE
feat: add logical assignment operators rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -22,6 +22,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
+| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -98,6 +98,7 @@ const BUILTIN_RULE_IDS = [
   "getter-return",
   "guard-for-in",
   "linebreak-style",
+  "logical-assignment-operators",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -101,6 +101,7 @@ const BUILTIN_RULE_IDS = [
   "getter-return",
   "guard-for-in",
   "linebreak-style",
+  "logical-assignment-operators",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/src/core.zig
+++ b/src/core.zig
@@ -36,6 +36,7 @@ pub const Options = struct {
     getter_return: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
+    logical_assignment_operators: bool = true,
     new_cap: bool = true,
     new_parens: bool = true,
     no_async_promise_executor: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -506,6 +506,8 @@ pub fn main(init: std.process.Init) !void {
             options.one_var = false;
         } else if (std.mem.eql(u8, arg, "--object-shorthand=off")) {
             options.object_shorthand = false;
+        } else if (std.mem.eql(u8, arg, "--logical-assignment-operators=off")) {
+            options.logical_assignment_operators = false;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
             options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -1356,6 +1358,7 @@ fn printHelp() void {
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
+        \\  --logical-assignment-operators=off Disable logical-assignment-operators
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str

--- a/src/rules/logical_assignment_operators.zig
+++ b/src/rules/logical_assignment_operators.zig
@@ -1,0 +1,158 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "logical-assignment-operators";
+
+const Reference = union(enum) {
+    this,
+    identifier: []const u8,
+    member: struct {
+        object: *const Reference,
+        property: []const u8,
+    },
+};
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    const logical = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+        .logical_expression => |logical| logical,
+        else => return,
+    };
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
+    const right_left = (try referenceFromExpression(arena_allocator, tree, logical.left)) orelse return;
+    if (!referencesEqual(left, right_left)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, logical.operator);
+}
+
+pub fn checkLogicalExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.LogicalExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const assignment = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+        .assignment_expression => |assignment| assignment,
+        else => return,
+    };
+    if (assignment.operator != .assign) return;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
+    const assignment_left = (try referenceFromExpression(arena_allocator, tree, assignment.left)) orelse return;
+    if (!referencesEqual(left, assignment_left)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, expression.operator);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    operator: ast.LogicalOperator,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Assignment can be replaced with `{s}=`.",
+        .{operator.toString()},
+    );
+}
+
+fn referenceFromExpression(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!?*const Reference {
+    if (index == .null) return null;
+
+    switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| return try newReference(allocator, .{ .identifier = tree.string(identifier.name) }),
+        .this_expression => return newReference(allocator, .this),
+        .member_expression => |member| {
+            const object = (try referenceFromExpression(allocator, tree, member.object)) orelse return null;
+            const property = propertyName(tree, member) orelse return null;
+            return try newReference(allocator, .{ .member = .{
+                .object = object,
+                .property = property,
+            } });
+        },
+        else => return null,
+    }
+}
+
+fn newReference(allocator: Allocator, reference: Reference) Allocator.Error!*const Reference {
+    const owned = try allocator.create(Reference);
+    owned.* = reference;
+    return owned;
+}
+
+fn referencesEqual(left: *const Reference, right: *const Reference) bool {
+    switch (left.*) {
+        .this => return right.* == .this,
+        .identifier => |left_name| return switch (right.*) {
+            .identifier => |right_name| std.mem.eql(u8, left_name, right_name),
+            else => false,
+        },
+        .member => |left_member| return switch (right.*) {
+            .member => |right_member| std.mem.eql(u8, left_member.property, right_member.property) and
+                referencesEqual(left_member.object, right_member.object),
+            else => false,
+        },
+    }
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .identifier_reference => |identifier| tree.string(identifier.name),
+            .string_literal => |literal| tree.string(literal.value),
+            .numeric_literal => |literal| tree.string(literal.raw),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -79,6 +79,7 @@ pub const jsx_a11y_role_has_required_aria_props = @import("jsx_a11y_role_has_req
 pub const jsx_a11y_role_supports_aria_props = @import("jsx_a11y_role_supports_aria_props.zig");
 pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
+pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
@@ -1870,6 +1871,9 @@ const BasicVisitor = struct {
         if (self.options.operator_assignment) {
             try operator_assignment.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
+        if (self.options.logical_assignment_operators) {
+            try logical_assignment_operators.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
@@ -1890,6 +1894,18 @@ const BasicVisitor = struct {
         }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_logical_expression(
+        self: *BasicVisitor,
+        expression: ast.LogicalExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.logical_assignment_operators) {
+            try logical_assignment_operators.checkLogicalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -259,6 +259,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/logical_assignment_operators.zig");
+}
+
+comptime {
     _ = @import("rules/new_cap.zig");
 }
 

--- a/tests/rules/logical_assignment_operators.zig
+++ b/tests/rules/logical_assignment_operators.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports logical-assignment-operators for self logical assignments" {
+    const source =
+        \\let first;
+        \\let second;
+        \\let third;
+        \\first = first || fallback;
+        \\second = second && fallback;
+        \\third = third ?? fallback;
+        \\object.value = object.value || fallback;
+        \\this.ready = this.ready && fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
+}
+
+test "reports logical-assignment-operators for short-circuit assignment expressions" {
+    const source =
+        \\let first;
+        \\let second;
+        \\let third;
+        \\first || (first = fallback);
+        \\second && (second = fallback);
+        \\third ?? (third = fallback);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
+    try std.testing.expectEqualStrings("Assignment can be replaced with `||=`.", result.diagnostics[0].message);
+}
+
+test "does not report logical-assignment-operators when shorthand would change meaning" {
+    const source =
+        \\let value;
+        \\value = fallback || value;
+        \\value = value + fallback;
+        \\value ||= fallback;
+        \\value || (other = fallback);
+        \\object[getKey()] = object[getKey()] || fallback;
+        \\object.value = other.value || fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.logical_assignment_operators.id));
+}
+
+test "can disable logical-assignment-operators" {
+    const source =
+        \\let value;
+        \\value = value || fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .logical_assignment_operators = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.logical_assignment_operators.id));
+}


### PR DESCRIPTION
Summary:
- add native `logical-assignment-operators` lint rule for ESLint default `always` expression behavior
- report self logical assignments such as `x = x || y` and short-circuit assignment expressions such as `x || (x = y)`
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=logical-assignment-operators --format=json`
- CLI smoke with `--logical-assignment-operators=off`
- `git diff --check`
