### PR TITLE
feat: add func name matching rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -18,6 +18,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
+| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for ESLint's default `always` behavior |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for the default `always` option |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -94,6 +94,7 @@ const BUILTIN_RULE_IDS = [
   "eol-last",
   "eqeqeq",
   "for-direction",
+  "func-name-matching",
   "func-names",
   "getter-return",
   "guard-for-in",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -97,6 +97,7 @@ const BUILTIN_RULE_IDS = [
   "eol-last",
   "eqeqeq",
   "for-direction",
+  "func-name-matching",
   "func-names",
   "getter-return",
   "guard-for-in",

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,6 +32,7 @@ pub const Options = struct {
     eslint_comments_no_restricted_disable: bool = true,
     eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,
     for_direction: bool = true,
+    func_name_matching: bool = true,
     func_names: bool = true,
     getter_return: bool = true,
     guard_for_in: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -132,6 +132,8 @@ pub fn main(init: std.process.Init) !void {
             options.eslint_comments_no_restricted_disable = false;
         } else if (std.mem.eql(u8, arg, "--for-direction=off")) {
             options.for_direction = false;
+        } else if (std.mem.eql(u8, arg, "--func-name-matching=off")) {
+            options.func_name_matching = false;
         } else if (std.mem.eql(u8, arg, "--func-names=off")) {
             options.func_names = false;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
@@ -1241,6 +1243,7 @@ fn printHelp() void {
         \\  --eol-last=off            Disable eol-last
         \\  --eslint-comments-no-restricted-disable=off Disable eslint-comments/no-restricted-disable
         \\  --for-direction=off       Disable for-direction
+        \\  --func-name-matching=off Disable func-name-matching
         \\  --func-names=off          Disable func-names
         \\  --getter-return=off       Disable getter-return
         \\  --guard-for-in=off        Disable guard-for-in

--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -1,0 +1,167 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "func-name-matching";
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    if (declarator.init == .null) return;
+
+    const target = bindingIdentifierName(tree, declarator.id) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, declarator.init, target);
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    const target = assignmentTargetName(tree, expression.left) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, expression.right, target);
+}
+
+pub fn checkObjectProperty(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+) Allocator.Error!void {
+    if (property.method or property.value == .null) return;
+
+    const target = propertyName(tree, property.key, property.computed) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+) Allocator.Error!void {
+    if (property.value == .null) return;
+
+    const target = propertyName(tree, property.key, property.computed) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target);
+}
+
+fn checkFunctionName(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    value: ast.NodeIndex,
+    target: []const u8,
+) Allocator.Error!void {
+    const function = switch (tree.data(unwrapTransparent(tree, value))) {
+        .function => |function| function,
+        else => return,
+    };
+    if (function.type != .function_expression) return;
+
+    const actual = bindingIdentifierName(tree, function.id) orelse return;
+    if (std.mem.eql(u8, actual, target)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(value),
+        "Function name `{s}` should match target name `{s}`.",
+        .{ actual, target },
+    );
+}
+
+fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .member_expression => |member| memberTargetName(tree, member),
+        else => null,
+    };
+}
+
+fn memberTargetName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (isCommonJsExportTarget(tree, member)) return null;
+    return propertyName(tree, member.property, member.computed);
+}
+
+fn isCommonJsExportTarget(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    if (isIdentifierReferenceNamed(tree, member.object, "exports")) return true;
+    if (!member.computed and
+        isIdentifierReferenceNamed(tree, member.object, "module") and
+        propertyName(tree, member.property, member.computed) != null and
+        std.mem.eql(u8, propertyName(tree, member.property, member.computed).?, "exports"))
+    {
+        return true;
+    }
+
+    const object = switch (tree.data(unwrapTransparent(tree, member.object))) {
+        .member_expression => |object| object,
+        else => return false,
+    };
+    if (object.computed) return false;
+
+    return isIdentifierReferenceNamed(tree, object.object, "module") and
+        propertyName(tree, object.property, object.computed) != null and
+        std.mem.eql(u8, propertyName(tree, object.property, object.computed).?, "exports");
+}
+
+fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (key == .null) return null;
+
+    return if (computed)
+        switch (tree.data(unwrapTransparent(tree, key))) {
+            .identifier_reference => |identifier| tree.string(identifier.name),
+            .string_literal => |literal| tree.string(literal.value),
+            .numeric_literal => |literal| tree.string(literal.raw),
+            else => null,
+        }
+    else switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -26,6 +26,7 @@ pub const default_param_last = @import("default_param_last.zig");
 pub const eol_last = @import("eol_last.zig");
 pub const eslint_comments_no_restricted_disable = @import("eslint_comments_no_restricted_disable.zig");
 pub const for_direction = @import("for_direction.zig");
+pub const func_name_matching = @import("func_name_matching.zig");
 pub const func_names = @import("func_names.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
@@ -1241,6 +1242,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
+        if (self.options.func_name_matching) {
+            try func_name_matching.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
         }
@@ -1874,6 +1878,9 @@ const BasicVisitor = struct {
         if (self.options.logical_assignment_operators) {
             try logical_assignment_operators.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
+        if (self.options.func_name_matching) {
+            try func_name_matching.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
@@ -2456,6 +2463,9 @@ const BasicVisitor = struct {
         if (self.options.object_shorthand) {
             try object_shorthand.check(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
+        if (self.options.func_name_matching) {
+            try func_name_matching.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property);
+        }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
@@ -2570,6 +2580,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+        }
+        if (self.options.func_name_matching) {
+            try func_name_matching.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -55,6 +55,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/func_name_matching.zig");
+}
+
+comptime {
     _ = @import("rules/getter_return.zig");
 }
 

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports func-name-matching for mismatched variable and assignment targets" {
+    const source =
+        \\const first = function second() {};
+        \\let third;
+        \\third = function fourth() {};
+        \\object.value = function other() {};
+        \\this.ready = function done() {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.func_name_matching.id));
+    try std.testing.expectEqualStrings(
+        "Function name `second` should match target name `first`.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "reports func-name-matching for mismatched object and class fields" {
+    const source =
+        \\const object = {
+        \\  value: function other() {},
+        \\  ["computed"]: function otherComputed() {},
+        \\};
+        \\class Example {
+        \\  field = function otherField() {};
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_name_matching.id));
+}
+
+test "does not report func-name-matching for matching or unsupported cases" {
+    const source =
+        \\const first = function first() {};
+        \\const unnamed = function () {};
+        \\const arrow = () => {};
+        \\object.value = function value() {};
+        \\object[getName()] = function dynamic() {};
+        \\module.exports = function exported() {};
+        \\exports.value = function exportedValue() {};
+        \\const object = {
+        \\  method() {},
+        \\  value: function value() {},
+        \\};
+        \\class Example {
+        \\  field = function field() {};
+        \\  #private = function other() {};
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_names = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_name_matching.id));
+}
+
+test "can disable func-name-matching" {
+    const source =
+        \\const first = function second() {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_name_matching = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_name_matching.id));
+}


### PR DESCRIPTION
Summary:
- add native `func-name-matching` lint rule for ESLint default `always` behavior
- report mismatched named function expressions assigned to variables, assignments, object properties, and class fields
- skip anonymous functions, arrow functions, methods, private fields, and CommonJS exports for default compatibility
- wire the rule through options, CLI disable flag, JS built-in rule metadata, tests, and rule status docs

Validation:
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke with `--rules=func-name-matching --format=json`
- CLI smoke with `--func-name-matching=off`
- `git diff --check`
