### PR TITLE
feat: add no underscore dangle rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -136,6 +136,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration and member-property checks |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -212,6 +212,7 @@ const BUILTIN_RULE_IDS = [
   "no-trailing-spaces",
   "no-undef",
   "no-undef-init",
+  "no-underscore-dangle",
   "no-unneeded-ternary",
   "no-unreachable",
   "no-unsafe-finally",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -215,6 +215,7 @@ const BUILTIN_RULE_IDS = [
   "no-trailing-spaces",
   "no-undef",
   "no-undef-init",
+  "no-underscore-dangle",
   "no-unneeded-ternary",
   "no-unreachable",
   "no-unsafe-finally",

--- a/src/core.zig
+++ b/src/core.zig
@@ -204,6 +204,7 @@ pub const Options = struct {
     no_trailing_spaces: bool = true,
     no_unreachable: bool = true,
     no_undef_init: bool = true,
+    no_underscore_dangle: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
     no_unused_labels: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -470,6 +470,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unreachable = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
             options.no_undef_init = false;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle=off")) {
+            options.no_underscore_dangle = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
             options.unicode_bom = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
@@ -1413,6 +1415,7 @@ fn printHelp() void {
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-unreachable=off      Disable no-unreachable
         \\  --no-undef-init=off       Disable no-undef-init
+        \\  --no-underscore-dangle=off Disable no-underscore-dangle
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unused-labels=off   Disable no-unused-labels

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-underscore-dangle";
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    const name = bindingName(tree, declarator.id) orelse return;
+    try checkName(allocator, diagnostics, tree, declarator.id, name, false);
+}
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    if (function.id == .null) return;
+
+    const name = bindingName(tree, function.id) orelse return;
+    try checkName(allocator, diagnostics, tree, function.id, name, false);
+}
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    if (class.id == .null) return;
+
+    const name = bindingName(tree, class.id) orelse return;
+    try checkName(allocator, diagnostics, tree, class.id, name, false);
+}
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+) Allocator.Error!void {
+    if (member.computed) return;
+
+    const name = propertyName(tree, member) orelse return;
+    try checkName(allocator, diagnostics, tree, member.property, name, true);
+}
+
+fn checkName(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    name: []const u8,
+    allow_proto: bool,
+) Allocator.Error!void {
+    if (!hasDanglingUnderscore(name)) return;
+    if (isAllowedName(name, allow_proto)) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(node),
+        "Unexpected dangling '_' in '{s}'.",
+        .{name},
+    );
+}
+
+fn hasDanglingUnderscore(name: []const u8) bool {
+    if (name.len == 0) return false;
+    return name[0] == '_' or name[name.len - 1] == '_';
+}
+
+fn isAllowedName(name: []const u8, allow_proto: bool) bool {
+    if (std.mem.eql(u8, name, "_")) return true;
+    if (std.mem.eql(u8, name, "__dirname")) return true;
+    if (std.mem.eql(u8, name, "__filename")) return true;
+    return allow_proto and std.mem.eql(u8, name, "__proto__");
+}
+
+fn bindingName(tree: *const ast.Tree, node: ast.NodeIndex) ?[]const u8 {
+    if (node == .null) return null;
+
+    return switch (tree.data(node)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -197,6 +197,7 @@ pub const no_this_before_super = @import("no_this_before_super.zig");
 pub const no_trailing_spaces = @import("no_trailing_spaces.zig");
 pub const no_unreachable = @import("no_unreachable.zig");
 pub const no_undef_init = @import("no_undef_init.zig");
+pub const no_underscore_dangle = @import("no_underscore_dangle.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
@@ -919,6 +920,9 @@ const BasicVisitor = struct {
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
         }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+        }
         if (self.options.consistent_return) {
             try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
         }
@@ -960,6 +964,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.constructor_super) {
             try constructor_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         if (self.options.react_require_render_return) {
             try react_require_render_return.checkClass(self.allocator, self.diagnostics, ctx.tree, class, self.react_require_render_return_state);
@@ -1241,6 +1248,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         if (self.options.func_name_matching) {
             try func_name_matching.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
@@ -2204,6 +2214,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_proto) {
             try no_proto.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+        }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);
         }
         if (self.options.no_iterator) {
             try no_iterator.check(self.allocator, self.diagnostics, ctx.tree, member, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -727,6 +727,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_underscore_dangle.zig");
+}
+
+comptime {
     _ = @import("rules/no_shadow_restricted_names.zig");
 }
 

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-underscore-dangle for declarations" {
+    const source =
+        \\const _value = 1;
+        \\let value_ = 2;
+        \\function _run() {}
+        \\class Model_ {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
+test "reports no-underscore-dangle for member properties" {
+    const source =
+        \\object._value;
+        \\object.value_;
+        \\this._value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
+test "allows default names and skipped forms" {
+    const source =
+        \\const _ = 1;
+        \\const __filename = "file";
+        \\const __dirname = "dir";
+        \\const { _value } = object;
+        \\function run(_param) {}
+        \\object.__proto__;
+        \\object["_value"];
+        \\const record = { _value: 1, method_() {} };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_underscore_dangle.id));
+}
+
+test "can disable no-underscore-dangle" {
+    const source =
+        \\const _value = 1;
+        \\object._value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_underscore_dangle = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_underscore_dangle.id));
+}


### PR DESCRIPTION
Summary
- add a built-in no-underscore-dangle rule for default declaration and member-property checks
- expose the rule through CLI options and JS API rule metadata
- document the rule status and add focused tests

Validation
- zig build test
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build run -- --rules=no-underscore-dangle --format=json /tmp/utoo-no-underscore-dangle-fixture.js
- zig build run -- --rules=no-underscore-dangle --no-underscore-dangle=off --format=json /tmp/utoo-no-underscore-dangle-fixture.js