### PR TITLE
feat: add grouped accessor pairs rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -21,6 +21,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for ESLint's default `always` behavior |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for the default `always` option |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
+| [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for the default `anyOrder` option |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -97,6 +97,7 @@ const BUILTIN_RULE_IDS = [
   "func-name-matching",
   "func-names",
   "getter-return",
+  "grouped-accessor-pairs",
   "guard-for-in",
   "linebreak-style",
   "logical-assignment-operators",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -100,6 +100,7 @@ const BUILTIN_RULE_IDS = [
   "func-name-matching",
   "func-names",
   "getter-return",
+  "grouped-accessor-pairs",
   "guard-for-in",
   "linebreak-style",
   "logical-assignment-operators",

--- a/src/core.zig
+++ b/src/core.zig
@@ -35,6 +35,7 @@ pub const Options = struct {
     func_name_matching: bool = true,
     func_names: bool = true,
     getter_return: bool = true,
+    grouped_accessor_pairs: bool = true,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     logical_assignment_operators: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,6 +138,8 @@ pub fn main(init: std.process.Init) !void {
             options.func_names = false;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
             options.getter_return = false;
+        } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=off")) {
+            options.grouped_accessor_pairs = false;
         } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
@@ -1248,6 +1250,7 @@ fn printHelp() void {
         \\  --func-name-matching=off Disable func-name-matching
         \\  --func-names=off          Disable func-names
         \\  --getter-return=off       Disable getter-return
+        \\  --grouped-accessor-pairs=off Disable grouped-accessor-pairs
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
         \\  --new-cap=off             Disable new-cap

--- a/src/rules/grouped_accessor_pairs.zig
+++ b/src/rules/grouped_accessor_pairs.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "grouped-accessor-pairs";
+
+const AccessorKind = enum {
+    get,
+    set,
+};
+
+const Accessor = struct {
+    name: []const u8,
+    static: bool = false,
+    kind: AccessorKind,
+    position: usize,
+    index: ast.NodeIndex,
+};
+
+pub fn checkObjectExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+) Allocator.Error!void {
+    var accessors: std.ArrayList(Accessor) = .empty;
+    defer accessors.deinit(allocator);
+
+    for (tree.extra(expression.properties), 0..) |property_index, position| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const kind: AccessorKind = switch (property.kind) {
+            .get => .get,
+            .set => .set,
+            else => continue,
+        };
+        const name = propertyName(tree, property.key, property.computed) orelse continue;
+
+        try accessors.append(allocator, .{
+            .name = name,
+            .kind = kind,
+            .position = position,
+            .index = property_index,
+        });
+    }
+
+    try checkAccessors(allocator, diagnostics, tree, accessors.items);
+}
+
+pub fn checkClassBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+) Allocator.Error!void {
+    var accessors: std.ArrayList(Accessor) = .empty;
+    defer accessors.deinit(allocator);
+
+    for (tree.extra(body.body), 0..) |member_index, position| {
+        const method = switch (tree.data(member_index)) {
+            .method_definition => |method| method,
+            else => continue,
+        };
+        const kind: AccessorKind = switch (method.kind) {
+            .get => .get,
+            .set => .set,
+            else => continue,
+        };
+        const name = propertyName(tree, method.key, method.computed) orelse continue;
+
+        try accessors.append(allocator, .{
+            .name = name,
+            .static = method.static,
+            .kind = kind,
+            .position = position,
+            .index = member_index,
+        });
+    }
+
+    try checkAccessors(allocator, diagnostics, tree, accessors.items);
+}
+
+fn checkAccessors(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    accessors: []const Accessor,
+) Allocator.Error!void {
+    for (accessors, 0..) |accessor, index| {
+        const previous = previousCounterpart(accessors[0..index], accessor) orelse continue;
+        if (previous.position + 1 == accessor.position) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(accessor.index),
+            "Getter and setter for '{s}' should be grouped together.",
+            .{accessor.name},
+        );
+    }
+}
+
+fn previousCounterpart(previous_accessors: []const Accessor, accessor: Accessor) ?Accessor {
+    var index = previous_accessors.len;
+    while (index > 0) {
+        index -= 1;
+        const previous = previous_accessors[index];
+        if (previous.static != accessor.static) continue;
+        if (previous.kind == accessor.kind) continue;
+        if (!std.mem.eql(u8, previous.name, accessor.name)) continue;
+        return previous;
+    }
+    return null;
+}
+
+fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (key == .null) return null;
+
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| if (computed) null else tree.string(identifier.name),
+        .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -29,6 +29,7 @@ pub const for_direction = @import("for_direction.zig");
 pub const func_name_matching = @import("func_name_matching.zig");
 pub const func_names = @import("func_names.zig");
 pub const getter_return = @import("getter_return.zig");
+pub const grouped_accessor_pairs = @import("grouped_accessor_pairs.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
@@ -2432,6 +2433,9 @@ const BasicVisitor = struct {
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
+        if (self.options.grouped_accessor_pairs) {
+            try grouped_accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
         }
@@ -2522,6 +2526,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);
+        }
+        if (self.options.grouped_accessor_pairs) {
+            try grouped_accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);
         }
         if (self.options.no_dupe_class_members and !self.options.typescript_eslint_no_dupe_class_members) {
             try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -63,6 +63,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/grouped_accessor_pairs.zig");
+}
+
+comptime {
     _ = @import("rules/guard_for_in.zig");
 }
 

--- a/tests/rules/grouped_accessor_pairs.zig
+++ b/tests/rules/grouped_accessor_pairs.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports grouped-accessor-pairs for object accessors separated by other properties" {
+    const source =
+        \\const object = {
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\  other: 1,
+        \\  set value(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
+    try std.testing.expectEqualStrings("Getter and setter for 'value' should be grouped together.", result.diagnostics[0].message);
+}
+
+test "reports grouped-accessor-pairs for class accessors separated by other members" {
+    const source =
+        \\class Example {
+        \\  get value() {
+        \\    return this.x;
+        \\  }
+        \\  method() {}
+        \\  set value(next) {
+        \\    this.x = next;
+        \\  }
+        \\  static set count(next) {}
+        \\  static method() {}
+        \\  static get count() {
+        \\    return 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
+}
+
+test "allows adjacent accessors in either order and distinct static pairs" {
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\  get only() {
+        \\    return 2;
+        \\  },
+        \\};
+        \\class Example {
+        \\  set value(next) {}
+        \\  get value() {
+        \\    return 1;
+        \\  }
+        \\  get only() {
+        \\    return 2;
+        \\  }
+        \\  static get count() {
+        \\    return 1;
+        \\  }
+        \\  static set count(next) {}
+        \\  get shared() {
+        \\    return 1;
+        \\  }
+        \\  static set shared(next) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .accessor_pairs = false,
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.grouped_accessor_pairs.id));
+}
+
+test "can disable grouped-accessor-pairs" {
+    const source =
+        \\const object = {
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\  other: 1,
+        \\  set value(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .grouped_accessor_pairs = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.grouped_accessor_pairs.id));
+}


### PR DESCRIPTION
Summary
- add a built-in grouped-accessor-pairs rule for ESLint default anyOrder behavior
- report getter/setter pairs that are separated by other object or class members
- expose the rule through CLI options and JS API rule metadata
- document the rule status and add focused tests

Validation
- zig build test
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build run -- --rules=grouped-accessor-pairs --format=json /tmp/utoo-grouped-accessor-pairs-fixture.js
- zig build run -- --rules=grouped-accessor-pairs --grouped-accessor-pairs=off --format=json /tmp/utoo-grouped-accessor-pairs-fixture.js