### PR TITLE
feat: add capitalized comments rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -8,6 +8,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for ESLint's default `setWithoutGet: true, getWithoutSet: false` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for fishlint's `allowImplicit: true, checkForEach: false, allowVoid: false` configuration |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
+| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for the default `always` behavior |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value and bare return statements |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -84,6 +84,7 @@ const BUILTIN_RULE_IDS = [
   "accessor-pairs",
   "array-callback-return",
   "block-scoped-var",
+  "capitalized-comments",
   "consistent-return",
   "constructor-super",
   "curly",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -87,6 +87,7 @@ const BUILTIN_RULE_IDS = [
   "accessor-pairs",
   "array-callback-return",
   "block-scoped-var",
+  "capitalized-comments",
   "consistent-return",
   "constructor-super",
   "curly",

--- a/src/core.zig
+++ b/src/core.zig
@@ -20,6 +20,7 @@ pub const Options = struct {
     accessor_pairs: bool = true,
     array_callback_return: bool = true,
     block_scoped_var: bool = true,
+    capitalized_comments: bool = true,
     consistent_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,8 @@ pub fn main(init: std.process.Init) !void {
             options.array_callback_return = false;
         } else if (std.mem.eql(u8, arg, "--block-scoped-var=off")) {
             options.block_scoped_var = false;
+        } else if (std.mem.eql(u8, arg, "--capitalized-comments=off")) {
+            options.capitalized_comments = false;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
         } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
@@ -1237,6 +1239,7 @@ fn printHelp() void {
         \\  --accessor-pairs=off    Disable accessor-pairs
         \\  --array-callback-return=off Disable array-callback-return
         \\  --block-scoped-var=off   Disable block-scoped-var
+        \\  --capitalized-comments=off Disable capitalized-comments
         \\  --consistent-return=off  Disable consistent-return
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "capitalized-comments";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    for (tree.comments) |comment| {
+        const value = trimLeftDecorations(tree.string(comment.value));
+        if (isIgnoredComment(value)) continue;
+
+        const first = firstAsciiLetter(value) orelse continue;
+        if (!std.ascii.isLower(first)) continue;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Comments should start with an uppercase character.",
+            .{ .start = comment.start, .end = comment.end },
+        );
+    }
+}
+
+fn trimLeftDecorations(value: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index < value.len) : (index += 1) {
+        const char = value[index];
+        if (isWhitespace(char) or char == '*') continue;
+        return value[index..];
+    }
+    return "";
+}
+
+fn isIgnoredComment(value: []const u8) bool {
+    if (startsWithAnyIgnoreCase(value, &.{
+        "eslint",
+        "exported",
+        "global",
+        "globals",
+        "jshint",
+        "jslint",
+    })) return true;
+
+    return startsWithAnyIgnoreCase(value, &.{
+        "http://",
+        "https://",
+        "ftp://",
+        "www.",
+    });
+}
+
+fn startsWithAnyIgnoreCase(value: []const u8, prefixes: []const []const u8) bool {
+    for (prefixes) |prefix| {
+        if (value.len < prefix.len) continue;
+        if (std.ascii.eqlIgnoreCase(value[0..prefix.len], prefix)) return true;
+    }
+    return false;
+}
+
+fn firstAsciiLetter(value: []const u8) ?u8 {
+    var index: usize = 0;
+    while (index < value.len) : (index += 1) {
+        const char = value[index];
+        if (std.ascii.isAlphabetic(char)) return char;
+        if (std.ascii.isDigit(char)) return null;
+        if (char == '_' or char == '$') return null;
+    }
+    return null;
+}
+
+fn isWhitespace(char: u8) bool {
+    return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -17,6 +17,7 @@ pub const curly = @import("curly.zig");
 pub const accessor_pairs = @import("accessor_pairs.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
+pub const capitalized_comments = @import("capitalized_comments.zig");
 pub const consistent_return = @import("consistent_return.zig");
 pub const constructor_super = @import("constructor_super.zig");
 pub const dot_notation = @import("dot_notation.zig");
@@ -341,6 +342,9 @@ pub fn runBasic(
     file_path: []const u8,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.capitalized_comments) {
+        try capitalized_comments.run(allocator, diagnostics, tree);
+    }
     if (options.no_warning_comments) {
         try no_warning_comments.run(allocator, diagnostics, tree);
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -11,6 +11,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/capitalized_comments.zig");
+}
+
+comptime {
     _ = @import("rules/consistent_return.zig");
 }
 

--- a/tests/rules/capitalized_comments.zig
+++ b/tests/rules/capitalized_comments.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports capitalized-comments for comments starting with lowercase words" {
+    const source =
+        \\// lowercase line comment
+        \\/* lowercase block comment */
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.capitalized_comments.id));
+    try std.testing.expectEqualStrings("Comments should start with an uppercase character.", result.diagnostics[0].message);
+}
+
+test "allows uppercase, numeric, symbolic, directives, urls, and empty comments" {
+    const source =
+        \\// Uppercase line comment
+        \\/* Uppercase block comment */
+        \\// 123 numeric prefix
+        \\// _symbolic prefix
+        \\// eslint-disable-next-line no-alert
+        \\/* global window */
+        \\// https://example.com/path
+        \\//
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.capitalized_comments.id));
+}
+
+test "can disable capitalized-comments" {
+    const source =
+        \\// lowercase line comment
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.capitalized_comments.id));
+}

--- a/tests/rules/no_inline_comments.zig
+++ b/tests/rules/no_inline_comments.zig
@@ -9,6 +9,7 @@ test "reports no-inline-comments for comments sharing a line with code" {
         "const third = 3; /* trailing */\n";
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/no_irregular_whitespace.zig
+++ b/tests/rules/no_irregular_whitespace.zig
@@ -10,6 +10,7 @@ test "reports no-irregular-whitespace outside strings" {
         "const second = 2;\n";
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });


### PR DESCRIPTION
Summary
- add a built-in capitalized-comments rule for ESLint default always behavior
- ignore directive and URL-style comments while reporting lowercase comment starts
- expose the rule through CLI options and JS API rule metadata
- document the rule status and add focused tests

Validation
- zig build test
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- zig build run -- --rules=capitalized-comments --format=json /tmp/utoo-capitalized-comments-fixture.js
- zig build run -- --rules=capitalized-comments --capitalized-comments=off --format=json /tmp/utoo-capitalized-comments-fixture.js