### PR TITLE
feat: extend no undefined bindings

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -139,7 +139,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration and member-property checks |
-| [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references |
+| [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |

--- a/src/rules/no_undefined.zig
+++ b/src/rules/no_undefined.zig
@@ -26,3 +26,23 @@ pub fn checkIdentifierReference(
         tree.span(index),
     );
 }
+
+pub fn checkBindingIdentifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    identifier: ast.BindingIdentifier,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const name = tree.string(identifier.name);
+    if (!std.mem.eql(u8, name, "undefined")) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected use of undefined.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -834,6 +834,7 @@ const BasicVisitor = struct {
         if (self.options.no_undefined) {
             switch (data) {
                 .identifier_reference => |identifier| try no_undefined.checkIdentifierReference(self.allocator, self.diagnostics, ctx.tree, identifier, index),
+                .binding_identifier => |identifier| try no_undefined.checkBindingIdentifier(self.allocator, self.diagnostics, ctx.tree, identifier, index),
                 else => {},
             }
         }

--- a/tests/rules/no_undefined.zig
+++ b/tests/rules/no_undefined.zig
@@ -22,6 +22,31 @@ test "reports no-undefined for identifier references" {
     try std.testing.expectEqualStrings("Unexpected use of undefined.", result.diagnostics[0].message);
 }
 
+test "reports no-undefined for bindings" {
+    const source =
+        \\const undefined = 1;
+        \\let { value: undefined } = object;
+        \\function run(undefined) {
+        \\  return 1;
+        \\}
+        \\const arrow = (undefined) => undefined;
+        \\try {} catch (undefined) {}
+        \\class undefined {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_shadow_restricted_names = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_undefined.id));
+}
+
 test "allows void 0 and typeof other identifiers" {
     const source =
         \\const value = void 0;


### PR DESCRIPTION
## Summary

- extend `no-undefined` to report binding identifiers named `undefined`
- add coverage for variable, destructuring, function parameter, arrow parameter, catch parameter, and class bindings
- update rule status to reflect identifier references and binding names

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for enabled and disabled `no-undefined` binding diagnostics