### PR TITLE
feat: support no confusing arrow parens option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -37,7 +37,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-caller`](https://eslint.org/docs/latest/rules/no-caller) | Implemented |
 | [`no-case-declarations`](https://eslint.org/docs/latest/rules/no-case-declarations) | Implemented |
 | [`no-class-assign`](https://eslint.org/docs/latest/rules/no-class-assign) | Implemented |
-| [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow) | Implemented for the default `allowParens: true` option |
+| [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow) | Implemented for `allowParens: true` and `allowParens: false` |
 | [`no-comma-operator`](https://eslint.org/docs/latest/rules/no-comma-operator) | Implemented |
 | [`no-compare-neg-zero`](https://eslint.org/docs/latest/rules/no-compare-neg-zero) | Implemented |
 | [`no-cond-assign`](https://eslint.org/docs/latest/rules/no-cond-assign) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -16,6 +16,11 @@ pub const Severity = enum {
     }
 };
 
+pub const NoConfusingArrowAllowParens = enum {
+    yes,
+    no,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     array_callback_return: bool = true,
@@ -52,6 +57,7 @@ pub const Options = struct {
     no_case_declarations: bool = true,
     no_class_assign: bool = true,
     no_confusing_arrow: bool = true,
+    no_confusing_arrow_allow_parens: NoConfusingArrowAllowParens = .yes,
     no_cond_assign: bool = true,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -170,6 +170,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_class_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-confusing-arrow=off")) {
             options.no_confusing_arrow = false;
+        } else if (std.mem.eql(u8, arg, "--no-confusing-arrow-allow-parens=off")) {
+            options.no_confusing_arrow_allow_parens = .no;
         } else if (std.mem.eql(u8, arg, "--no-cond-assign=off")) {
             options.no_cond_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-compare-neg-zero=off")) {
@@ -1270,6 +1272,7 @@ fn printHelp() void {
         \\  --no-case-declarations=off Disable no-case-declarations
         \\  --no-class-assign=off     Disable no-class-assign
         \\  --no-confusing-arrow=off  Disable no-confusing-arrow
+        \\  --no-confusing-arrow-allow-parens=off Set no-confusing-arrow allowParens false
         \\  --no-cond-assign=off      Disable no-cond-assign
         \\  --no-compare-neg-zero=off Disable no-compare-neg-zero
         \\  --no-constant-condition=off Disable no-constant-condition

--- a/src/rules/no_confusing_arrow.zig
+++ b/src/rules/no_confusing_arrow.zig
@@ -6,18 +6,29 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-confusing-arrow";
 
+pub const Options = struct {
+    allow_parens: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.ArrowFunctionExpression,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
     if (!expression.expression) return;
 
-    switch (tree.data(expression.body)) {
-        .conditional_expression => {},
-        else => return,
-    }
+    if (!isConfusingBody(tree, expression.body, options.allow_parens)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -27,4 +38,15 @@ pub fn check(
         "Arrow function used ambiguously with a conditional expression.",
         tree.span(expression.body),
     );
+}
+
+fn isConfusingBody(tree: *const ast.Tree, index: ast.NodeIndex, allow_parens: bool) bool {
+    switch (tree.data(index)) {
+        .conditional_expression => return true,
+        .parenthesized_expression => |parenthesized| {
+            if (allow_parens) return false;
+            return tree.data(parenthesized.expression) == .conditional_expression;
+        },
+        else => return false,
+    }
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1869,7 +1869,9 @@ const BasicVisitor = struct {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
         }
         if (self.options.no_confusing_arrow) {
-            try no_confusing_arrow.check(self.allocator, self.diagnostics, ctx.tree, expression);
+            try no_confusing_arrow.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .allow_parens = self.options.no_confusing_arrow_allow_parens == .yes,
+            });
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);

--- a/tests/rules/no_confusing_arrow.zig
+++ b/tests/rules/no_confusing_arrow.zig
@@ -41,6 +41,25 @@ test "allows parenthesized conditional expression bodies and block bodies" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_confusing_arrow.id));
 }
 
+test "reports parenthesized conditional expression bodies when allowParens is false" {
+    const source =
+        \\const first = value => (value ? firstValue : secondValue);
+        \\const second = value => {
+        \\  return value ? firstValue : secondValue;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_confusing_arrow_allow_parens = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_confusing_arrow.id));
+}
+
 test "can disable no-confusing-arrow" {
     const source = "const first = value => value ? firstValue : secondValue;\n";
 


### PR DESCRIPTION
## Summary

- add a `no_confusing_arrow_allow_parens` option with default `allowParens: true` behavior preserved
- support reporting parenthesized conditional arrow bodies when `allowParens` is disabled
- expose `--no-confusing-arrow-allow-parens=off` in the CLI and document the wider rule coverage

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `allowParens: true` and disabled allowParens diagnostics