### PR TITLE
feat: support wrap iife styles

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -183,7 +183,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Implemented |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
-| [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for the default `outside` option |
+| [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented |
 
 ## Import plugin rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,12 @@ pub const NoConfusingArrowAllowParens = enum {
     no,
 };
 
+pub const WrapIifeStyle = enum {
+    outside,
+    inside,
+    any,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     array_callback_return: bool = true,
@@ -346,6 +352,7 @@ pub const Options = struct {
     valid_typeof: bool = true,
     vars_on_top: bool = true,
     wrap_iife: bool = true,
+    wrap_iife_style: WrapIifeStyle = .outside,
     yoda: bool = true,
 
     pub fn allDisabled() Options {

--- a/src/main.zig
+++ b/src/main.zig
@@ -748,6 +748,12 @@ pub fn main(init: std.process.Init) !void {
             options.vars_on_top = false;
         } else if (std.mem.eql(u8, arg, "--wrap-iife=off")) {
             options.wrap_iife = false;
+        } else if (std.mem.eql(u8, arg, "--wrap-iife=outside")) {
+            options.wrap_iife_style = .outside;
+        } else if (std.mem.eql(u8, arg, "--wrap-iife=inside")) {
+            options.wrap_iife_style = .inside;
+        } else if (std.mem.eql(u8, arg, "--wrap-iife=any")) {
+            options.wrap_iife_style = .any;
         } else if (std.mem.eql(u8, arg, "--semantic-errors=off")) {
             options.parser_semantic_errors = false;
         } else if (std.mem.eql(u8, arg, "--yoda=off")) {
@@ -1555,7 +1561,7 @@ fn printHelp() void {
         \\  --typescript-eslint-restrict-plus-operands=off Disable @typescript-eslint/restrict-plus-operands
         \\  --valid-typeof=off        Disable valid-typeof
         \\  --vars-on-top=off         Disable vars-on-top
-        \\  --wrap-iife=off           Disable wrap-iife
+        \\  --wrap-iife=off|outside|inside|any Configure wrap-iife
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
         \\

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -362,7 +362,11 @@ pub fn runBasic(
         try unicode_bom.run(allocator, diagnostics, tree);
     }
     if (options.wrap_iife) {
-        try wrap_iife.run(allocator, diagnostics, tree);
+        try wrap_iife.runWithStyle(allocator, diagnostics, tree, switch (options.wrap_iife_style) {
+            .outside => .outside,
+            .inside => .inside,
+            .any => .any,
+        });
     }
     if (options.no_tabs) {
         try no_tabs.run(allocator, diagnostics, tree);

--- a/src/rules/wrap_iife.zig
+++ b/src/rules/wrap_iife.zig
@@ -7,14 +7,30 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "wrap-iife";
 
+pub const Style = enum {
+    outside,
+    inside,
+    any,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    try runWithStyle(allocator, diagnostics, tree, .outside);
+}
+
+pub fn runWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    style: Style,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .style = style,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -23,6 +39,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    style: Style,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -30,7 +47,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isIifeCall(ctx.tree, call) and !isParenthesized(ctx.tree, index, ctx.path.ancestor(1))) {
+        if (isIifeCall(ctx.tree, call) and !isAllowedStyle(ctx.tree, call, index, ctx.path.ancestor(1), self.style)) {
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,
@@ -44,6 +61,14 @@ const Visitor = struct {
         return .proceed;
     }
 };
+
+fn isAllowedStyle(tree: *const ast.Tree, call: ast.CallExpression, index: ast.NodeIndex, parent: ?ast.NodeIndex, style: Style) bool {
+    return switch (style) {
+        .outside => isParenthesized(tree, index, parent),
+        .inside => tree.data(call.callee) == .parenthesized_expression,
+        .any => isParenthesized(tree, index, parent) or tree.data(call.callee) == .parenthesized_expression,
+    };
+}
 
 fn isIifeCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
     return switch (tree.data(unwrapTransparent(tree, call.callee))) {

--- a/tests/rules/wrap_iife.zig
+++ b/tests/rules/wrap_iife.zig
@@ -47,6 +47,51 @@ test "allows outside-wrapped IIFEs and non-IIFE calls" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.wrap_iife.id));
 }
 
+test "supports inside style" {
+    const source =
+        \\const outside = (function () {
+        \\  return value;
+        \\}());
+        \\const inside = (function () {
+        \\  return value;
+        \\})();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .wrap_iife_style = .inside,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.wrap_iife.id));
+}
+
+test "supports any style" {
+    const source =
+        \\const unwrapped = function () {
+        \\  return value;
+        \\}();
+        \\const outside = (function () {
+        \\  return value;
+        \\}());
+        \\const inside = (function () {
+        \\  return value;
+        \\})();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .wrap_iife_style = .any,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.wrap_iife.id));
+}
+
 test "can disable wrap-iife" {
     const source = "const value = function () { return 1; }();\n";
 


### PR DESCRIPTION
## Summary

- add `wrap_iife_style` with `outside`, `inside`, and `any` modes
- keep the default `outside` behavior unchanged
- expose `--wrap-iife=outside|inside|any` while preserving `--wrap-iife=off`
- update wrap-iife rule status and tests for the new styles

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for `inside` and `any` wrap-iife styles