### PR TITLE
feat: support accessor pairs get without set

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -5,7 +5,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
-| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for ESLint's default `setWithoutGet: true, getWithoutSet: false` behavior |
+| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for `setWithoutGet: true` and optional `getWithoutSet: true` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for fishlint's `allowImplicit: true, checkForEach: false, allowVoid: false` configuration |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for the default `always` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -27,8 +27,14 @@ pub const WrapIifeStyle = enum {
     any,
 };
 
+pub const AccessorPairsGetWithoutSet = enum {
+    yes,
+    no,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
+    accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
     array_callback_return: bool = true,
     block_scoped_var: bool = true,
     capitalized_comments: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,6 +108,8 @@ pub fn main(init: std.process.Init) !void {
             parseEnabledRules(arg["--rules=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--accessor-pairs=off")) {
             options.accessor_pairs = false;
+        } else if (std.mem.eql(u8, arg, "--accessor-pairs-get-without-set=on")) {
+            options.accessor_pairs_get_without_set = .yes;
         } else if (std.mem.eql(u8, arg, "--consistent-return=off")) {
             options.consistent_return = false;
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
@@ -1247,6 +1249,7 @@ fn printHelp() void {
         \\  --threads=N              Number of worker threads to use
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --accessor-pairs=off    Disable accessor-pairs
+        \\  --accessor-pairs-get-without-set=on Enable accessor-pairs getWithoutSet
         \\  --array-callback-return=off Disable array-callback-return
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --capitalized-comments=off Disable capitalized-comments

--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -7,10 +7,15 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "accessor-pairs";
 
+pub const Options = struct {
+    get_without_set: bool = false,
+};
+
 const Accessor = struct {
     name: []const u8,
     static: bool = false,
     get: bool = false,
+    get_index: ast.NodeIndex = .null,
     set: bool = false,
     set_index: ast.NodeIndex = .null,
 };
@@ -20,6 +25,16 @@ pub fn checkObjectExpression(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.ObjectExpression,
+) Allocator.Error!void {
+    try checkObjectExpressionWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkObjectExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+    options: Options,
 ) Allocator.Error!void {
     var accessors: std.ArrayList(Accessor) = .empty;
     defer accessors.deinit(allocator);
@@ -35,7 +50,7 @@ pub fn checkObjectExpression(
         try recordAccessor(allocator, &accessors, name, false, property.kind == .get, property.kind == .set, property_index);
     }
 
-    try reportSettersWithoutGetters(allocator, diagnostics, tree, accessors.items);
+    try reportMissingCounterparts(allocator, diagnostics, tree, accessors.items, options);
 }
 
 pub fn checkClassBody(
@@ -43,6 +58,16 @@ pub fn checkClassBody(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     body: ast.ClassBody,
+) Allocator.Error!void {
+    try checkClassBodyWithOptions(allocator, diagnostics, tree, body, .{});
+}
+
+pub fn checkClassBodyWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+    options: Options,
 ) Allocator.Error!void {
     var accessors: std.ArrayList(Accessor) = .empty;
     defer accessors.deinit(allocator);
@@ -58,7 +83,7 @@ pub fn checkClassBody(
         try recordAccessor(allocator, &accessors, name, method.static, method.kind == .get, method.kind == .set, member_index);
     }
 
-    try reportSettersWithoutGetters(allocator, diagnostics, tree, accessors.items);
+    try reportMissingCounterparts(allocator, diagnostics, tree, accessors.items, options);
 }
 
 pub fn checkCallExpression(
@@ -67,23 +92,33 @@ pub fn checkCallExpression(
     tree: *const ast.Tree,
     call: ast.CallExpression,
 ) Allocator.Error!void {
+    try checkCallExpressionWithOptions(allocator, diagnostics, tree, call, .{});
+}
+
+pub fn checkCallExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    options: Options,
+) Allocator.Error!void {
     const arguments = tree.extra(call.arguments);
 
     if (isStaticMemberCall(tree, call.callee, "Object", "defineProperty")) {
         if (arguments.len < 3) return;
-        try checkPropertyDescriptor(allocator, diagnostics, tree, arguments[2], arguments[1]);
+        try checkPropertyDescriptor(allocator, diagnostics, tree, arguments[2], arguments[1], options);
         return;
     }
 
     if (isStaticMemberCall(tree, call.callee, "Object", "defineProperties")) {
         if (arguments.len < 2) return;
-        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1]);
+        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1], options);
         return;
     }
 
     if (isStaticMemberCall(tree, call.callee, "Object", "create")) {
         if (arguments.len < 2) return;
-        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1]);
+        try checkNestedDescriptors(allocator, diagnostics, tree, arguments[1], options);
     }
 }
 
@@ -92,6 +127,7 @@ fn checkNestedDescriptors(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     descriptors_index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const descriptors = switch (tree.data(descriptors_index)) {
         .object_expression => |object| object,
@@ -104,7 +140,7 @@ fn checkNestedDescriptors(
             else => continue,
         };
         if (property.value == .null) continue;
-        try checkPropertyDescriptor(allocator, diagnostics, tree, property.value, property.key);
+        try checkPropertyDescriptor(allocator, diagnostics, tree, property.value, property.key, options);
     }
 }
 
@@ -114,6 +150,7 @@ fn checkPropertyDescriptor(
     tree: *const ast.Tree,
     descriptor_index: ast.NodeIndex,
     report_index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const descriptor = switch (tree.data(descriptor_index)) {
         .object_expression => |object| object,
@@ -121,6 +158,8 @@ fn checkPropertyDescriptor(
     };
 
     var has_get = false;
+    var get_index: ast.NodeIndex = .null;
+    var has_set = false;
     var set_index: ast.NodeIndex = .null;
 
     for (tree.extra(descriptor.properties)) |property_index| {
@@ -131,13 +170,18 @@ fn checkPropertyDescriptor(
 
         if (propertyKeyEquals(tree, property, "get")) {
             has_get = true;
+            get_index = property_index;
         } else if (propertyKeyEquals(tree, property, "set")) {
+            has_set = true;
             set_index = property_index;
         }
     }
 
     if (!has_get and set_index != .null) {
-        try addDiagnostic(allocator, diagnostics, tree, report_index);
+        try addSetterDiagnostic(allocator, diagnostics, tree, report_index);
+    }
+    if (options.get_without_set and has_get and !has_set and get_index != .null) {
+        try addGetterDiagnostic(allocator, diagnostics, tree, report_index);
     }
 }
 
@@ -155,6 +199,7 @@ fn recordAccessor(
         if (!std.mem.eql(u8, accessor.name, name)) continue;
 
         accessor.get = accessor.get or is_get;
+        if (is_get) accessor.get_index = index;
         if (is_set) {
             accessor.set = true;
             accessor.set_index = index;
@@ -166,25 +211,30 @@ fn recordAccessor(
         .name = name,
         .static = static,
         .get = is_get,
+        .get_index = if (is_get) index else .null,
         .set = is_set,
         .set_index = if (is_set) index else .null,
     });
 }
 
-fn reportSettersWithoutGetters(
+fn reportMissingCounterparts(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     accessors: []const Accessor,
+    options: Options,
 ) Allocator.Error!void {
     for (accessors) |accessor| {
         if (accessor.set and !accessor.get) {
-            try addDiagnostic(allocator, diagnostics, tree, accessor.set_index);
+            try addSetterDiagnostic(allocator, diagnostics, tree, accessor.set_index);
+        }
+        if (options.get_without_set and accessor.get and !accessor.set) {
+            try addGetterDiagnostic(allocator, diagnostics, tree, accessor.get_index);
         }
     }
 }
 
-fn addDiagnostic(
+fn addSetterDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
@@ -196,6 +246,22 @@ fn addDiagnostic(
         .warning,
         id,
         "Setter must be accompanied by a getter.",
+        tree.span(index),
+    );
+}
+
+fn addGetterDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Getter must be accompanied by a setter.",
         tree.span(index),
     );
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2058,7 +2058,9 @@ const BasicVisitor = struct {
             try array_callback_return.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         if (self.options.accessor_pairs) {
-            try accessor_pairs.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+            try accessor_pairs.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, .{
+                .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+            });
         }
         if (self.options.import_no_amd) {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
@@ -2449,7 +2451,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.accessor_pairs) {
-            try accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try accessor_pairs.checkObjectExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+            });
         }
         if (self.options.grouped_accessor_pairs) {
             try grouped_accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -2543,7 +2547,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.accessor_pairs) {
-            try accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);
+            try accessor_pairs.checkClassBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, body, .{
+                .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+            });
         }
         if (self.options.grouped_accessor_pairs) {
             try grouped_accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -97,6 +97,47 @@ test "does not report accessor-pairs for getters without setters by default" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.accessor_pairs.id));
 }
 
+test "reports accessor-pairs for getters without setters when enabled" {
+    const source =
+        \\const object = {
+        \\  get value() { return 1; },
+        \\};
+        \\class Example {
+        \\  get value() { return 1; }
+        \\}
+        \\Object.defineProperty(target, "value", {
+        \\  get() { return 1; }
+        \\});
+        \\Object.defineProperties(target, {
+        \\  first: {
+        \\    get() { return 1; }
+        \\  },
+        \\  second: {
+        \\    get() { return 1; },
+        \\    set(next) {}
+        \\  }
+        \\});
+        \\Object.create(proto, {
+        \\  third: {
+        \\    get() { return 1; }
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .accessor_pairs_get_without_set = .yes,
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.accessor_pairs.id));
+    try std.testing.expectEqualStrings("Getter must be accompanied by a setter.", result.diagnostics[0].message);
+}
+
 test "does not treat ordinary descriptor-looking objects as property descriptors" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary

- add an accessor-pairs `getWithoutSet` option with default behavior unchanged
- report getter-only object/class accessors and property descriptors when enabled
- expose `--accessor-pairs-get-without-set=on` in the CLI
- update rule status and tests for the expanded coverage

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default getter-only behavior and enabled getWithoutSet diagnostics