### PR TITLE
feat: support array callback implicit return option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -6,7 +6,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for `setWithoutGet: true` and optional `getWithoutSet: true` behavior |
-| [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for fishlint's `allowImplicit: true, checkForEach: false, allowVoid: false` configuration |
+| [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for `allowImplicit: true` by default, with optional `allowImplicit: false`; `checkForEach: false, allowVoid: false` |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for the default `always` behavior |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value and bare return statements |

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,10 +32,16 @@ pub const AccessorPairsGetWithoutSet = enum {
     no,
 };
 
+pub const ArrayCallbackReturnAllowImplicit = enum {
+    yes,
+    no,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
     array_callback_return: bool = true,
+    array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .yes,
     block_scoped_var: bool = true,
     capitalized_comments: bool = true,
     consistent_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,8 @@ pub fn main(init: std.process.Init) !void {
             options.constructor_super = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
             options.array_callback_return = false;
+        } else if (std.mem.eql(u8, arg, "--array-callback-return-allow-implicit=off")) {
+            options.array_callback_return_allow_implicit = .no;
         } else if (std.mem.eql(u8, arg, "--block-scoped-var=off")) {
             options.block_scoped_var = false;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=off")) {
@@ -1251,6 +1253,7 @@ fn printHelp() void {
         \\  --accessor-pairs=off    Disable accessor-pairs
         \\  --accessor-pairs-get-without-set=on Enable accessor-pairs getWithoutSet
         \\  --array-callback-return=off Disable array-callback-return
+        \\  --array-callback-return-allow-implicit=off Require explicit values from array callbacks
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --consistent-return=off  Disable consistent-return

--- a/src/rules/array_callback_return.zig
+++ b/src/rules/array_callback_return.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "array-callback-return";
 
+pub const Options = struct {
+    allow_implicit: bool = true,
+};
+
 const Completion = enum {
     continues,
     valid_terminal,
@@ -20,8 +24,18 @@ pub fn check(
     call: ast.CallExpression,
     _: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, call, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    options: Options,
+) Allocator.Error!void {
     const callback = callbackArgument(tree, call) orelse return;
-    if (callbackReturnsValue(tree, callback)) return;
+    if (callbackReturnsValue(tree, callback, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -92,18 +106,18 @@ fn isArrayCallbackMethod(method: []const u8) bool {
     return false;
 }
 
-fn callbackReturnsValue(tree: *const ast.Tree, callback: ast.NodeIndex) bool {
+fn callbackReturnsValue(tree: *const ast.Tree, callback: ast.NodeIndex, options: Options) bool {
     return switch (tree.data(callback)) {
-        .function => |function| functionReturnsValue(tree, function.body),
+        .function => |function| functionReturnsValue(tree, function.body, options),
         .arrow_function_expression => |arrow| if (arrow.expression)
             !isVoidExpression(tree, arrow.body)
         else
-            functionReturnsValue(tree, arrow.body),
+            functionReturnsValue(tree, arrow.body, options),
         else => true,
     };
 }
 
-fn functionReturnsValue(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+fn functionReturnsValue(tree: *const ast.Tree, body_index: ast.NodeIndex, options: Options) bool {
     if (body_index == .null) return true;
 
     const body = switch (tree.data(body_index)) {
@@ -111,12 +125,12 @@ fn functionReturnsValue(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
         else => return true,
     };
 
-    return rangeCompletion(tree, body.body) == .valid_terminal;
+    return rangeCompletion(tree, body.body, options) == .valid_terminal;
 }
 
-fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
+fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange, options: Options) Completion {
     for (tree.extra(range)) |statement| {
-        switch (statementCompletion(tree, statement)) {
+        switch (statementCompletion(tree, statement, options)) {
             .continues => {},
             .valid_terminal => return .valid_terminal,
             .invalid_return => return .invalid_return,
@@ -126,44 +140,47 @@ fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
     return .continues;
 }
 
-fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex) Completion {
+fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) Completion {
     if (index == .null) return .continues;
 
     return switch (tree.data(index)) {
-        .return_statement => |statement| returnCompletion(tree, statement),
+        .return_statement => |statement| returnCompletion(tree, statement, options),
         .throw_statement => .valid_terminal,
-        .block_statement => |block| rangeCompletion(tree, block.body),
-        .if_statement => |statement| ifCompletion(tree, statement),
-        .try_statement => |statement| tryCompletion(tree, statement),
+        .block_statement => |block| rangeCompletion(tree, block.body, options),
+        .if_statement => |statement| ifCompletion(tree, statement, options),
+        .try_statement => |statement| tryCompletion(tree, statement, options),
         else => .continues,
     };
 }
 
-fn returnCompletion(tree: *const ast.Tree, statement: ast.ReturnStatement) Completion {
-    if (statement.argument == .null) return .valid_terminal;
+fn returnCompletion(tree: *const ast.Tree, statement: ast.ReturnStatement, options: Options) Completion {
+    if (statement.argument == .null) return if (options.allow_implicit)
+        .valid_terminal
+    else
+        .invalid_return;
     if (isVoidExpression(tree, statement.argument)) return .invalid_return;
     return .valid_terminal;
 }
 
-fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement) Completion {
-    const consequent = statementCompletion(tree, statement.consequent);
+fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement, options: Options) Completion {
+    const consequent = statementCompletion(tree, statement.consequent, options);
     if (consequent == .invalid_return) return .invalid_return;
 
     if (statement.alternate == .null) return .continues;
-    const alternate = statementCompletion(tree, statement.alternate);
+    const alternate = statementCompletion(tree, statement.alternate, options);
     if (alternate == .invalid_return) return .invalid_return;
 
     if (consequent == .valid_terminal and alternate == .valid_terminal) return .valid_terminal;
     return .continues;
 }
 
-fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion {
+fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement, options: Options) Completion {
     if (statement.finalizer != .null) {
-        const finalizer = statementCompletion(tree, statement.finalizer);
+        const finalizer = statementCompletion(tree, statement.finalizer, options);
         if (finalizer != .continues) return finalizer;
     }
 
-    const block = statementCompletion(tree, statement.block);
+    const block = statementCompletion(tree, statement.block, options);
     if (block == .invalid_return) return .invalid_return;
     if (statement.handler == .null) return block;
 
@@ -171,7 +188,7 @@ fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion 
         .catch_clause => |handler| handler.body,
         else => return .continues,
     };
-    const handler = statementCompletion(tree, handler_node);
+    const handler = statementCompletion(tree, handler_node, options);
     if (handler == .invalid_return) return .invalid_return;
 
     if (block == .valid_terminal and handler == .valid_terminal) return .valid_terminal;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2055,7 +2055,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.array_callback_return) {
-            try array_callback_return.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+            try array_callback_return.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, call, .{
+                .allow_implicit = self.options.array_callback_return_allow_implicit == .yes,
+            });
         }
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, .{

--- a/tests/rules/array_callback_return.zig
+++ b/tests/rules/array_callback_return.zig
@@ -58,6 +58,28 @@ test "does not report array-callback-return for callbacks that return on all pat
     try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
 }
 
+test "reports array-callback-return for implicit returns when allowImplicit is disabled" {
+    const source =
+        \\items.filter(function(item) {
+        \\  if (item) {
+        \\    return item;
+        \\  }
+        \\  return;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .array_callback_return_allow_implicit = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.array_callback_return.id));
+}
+
 test "ignores forEach callbacks and non-function callback references" {
     const source =
         \\items.forEach((item) => {


### PR DESCRIPTION
## Summary

- add an explicit `array-callback-return` option for `allowImplicit`
- add CLI support via `--array-callback-return-allow-implicit=off`
- preserve the current default behavior while enabling stricter ESLint-style handling for bare `return;` in array callbacks

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for default and strict `array-callback-return` behavior
- `git diff --check`
