### PR TITLE
feat: detect consistent return fallthrough

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -9,7 +9,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for `allowImplicit: true` by default, with optional `allowImplicit: false`; `checkForEach: false, allowVoid: false` |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for the default `always` behavior |
-| [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value and bare return statements |
+| [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented |

--- a/src/rules/consistent_return.zig
+++ b/src/rules/consistent_return.zig
@@ -26,6 +26,7 @@ pub fn checkFunction(
 
     var state = ScanState{};
     try scanNode(allocator, diagnostics, tree, function.body, &state);
+    try checkFallthrough(allocator, diagnostics, tree, function.body, &state);
 }
 
 pub fn checkArrowFunction(
@@ -38,6 +39,7 @@ pub fn checkArrowFunction(
 
     var state = ScanState{};
     try scanNode(allocator, diagnostics, tree, expression.body, &state);
+    try checkFallthrough(allocator, diagnostics, tree, expression.body, &state);
 }
 
 fn scanNode(
@@ -123,4 +125,66 @@ fn checkReturn(
         return;
     }
     state.expected = kind;
+}
+
+fn checkFallthrough(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body_index: ast.NodeIndex,
+    state: *ScanState,
+) Allocator.Error!void {
+    if (state.reported or state.expected != .value) return;
+    if (!nodeCanCompleteNormally(tree, body_index)) return;
+
+    state.reported = true;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected to return a value at the end of function.",
+        tree.span(body_index),
+    );
+}
+
+fn nodeCanCompleteNormally(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return true;
+
+    return switch (tree.data(index)) {
+        .function_body => |body| rangeCanCompleteNormally(tree, body.body),
+        .block_statement => |block| rangeCanCompleteNormally(tree, block.body),
+        .return_statement,
+        .throw_statement,
+        => false,
+        .if_statement => |statement| ifCanCompleteNormally(tree, statement),
+        .try_statement => |statement| tryCanCompleteNormally(tree, statement),
+        else => true,
+    };
+}
+
+fn rangeCanCompleteNormally(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |statement| {
+        if (!nodeCanCompleteNormally(tree, statement)) return false;
+    }
+    return true;
+}
+
+fn ifCanCompleteNormally(tree: *const ast.Tree, statement: ast.IfStatement) bool {
+    if (statement.alternate == .null) return true;
+    return nodeCanCompleteNormally(tree, statement.consequent) or
+        nodeCanCompleteNormally(tree, statement.alternate);
+}
+
+fn tryCanCompleteNormally(tree: *const ast.Tree, statement: ast.TryStatement) bool {
+    if (statement.finalizer != .null and !nodeCanCompleteNormally(tree, statement.finalizer)) return false;
+
+    const block_can_complete = nodeCanCompleteNormally(tree, statement.block);
+    if (block_can_complete or statement.handler == .null) return block_can_complete;
+
+    const handler_body = switch (tree.data(statement.handler)) {
+        .catch_clause => |handler| handler.body,
+        else => return true,
+    };
+    return nodeCanCompleteNormally(tree, handler_body);
 }

--- a/tests/rules/consistent_return.zig
+++ b/tests/rules/consistent_return.zig
@@ -26,6 +26,53 @@ test "reports consistent-return for mixed return values" {
     try std.testing.expectEqualStrings("Expected no return value.", result.diagnostics[1].message);
 }
 
+test "reports consistent-return when value-returning functions can fall through" {
+    const source =
+        "function maybeValue(flag) {\n" ++
+        "  if (flag) return 1;\n" ++
+        "}\n" ++
+        "const maybeArrow = (flag) => {\n" ++
+        "  if (flag) {\n" ++
+        "    return 1;\n" ++
+        "  }\n" ++
+        "};\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .no_unused_vars = false,
+        .no_unused_expressions = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.consistent_return.id));
+    try std.testing.expectEqualStrings("Expected to return a value at the end of function.", result.diagnostics[0].message);
+}
+
+test "allows value-returning functions when all paths are terminal" {
+    const source =
+        "function bothBranches(flag) {\n" ++
+        "  if (flag) {\n" ++
+        "    return 1;\n" ++
+        "  } else {\n" ++
+        "    return 2;\n" ++
+        "  }\n" ++
+        "}\n" ++
+        "function returnOrThrow(flag) {\n" ++
+        "  if (flag) {\n" ++
+        "    return 1;\n" ++
+        "  }\n" ++
+        "  throw error;\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.consistent_return.id));
+}
+
 test "scopes nested functions separately" {
     const source =
         "function values(flag) {\n" ++


### PR DESCRIPTION
## Summary

- extend `consistent-return` to report value-returning functions that can fall through without returning
- cover ordinary functions and block-bodied arrow functions
- keep existing mixed explicit-value/bare-return diagnostics intact

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for fallthrough and fully-returning `consistent-return` cases
- `git diff --check`
