### PR TITLE
feat: support prefer destructuring array declarators

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -163,7 +163,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for fishlint's `destructuring: any, ignoreReadBeforeAssign: true` configuration |
-| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for fishlint's object variable declarator configuration |
+| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-destructuring";
 
+const DestructuringKind = enum {
+    object,
+    array,
+};
+
 pub fn checkVariableDeclaration(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -18,32 +23,41 @@ pub fn checkVariableDeclaration(
             .variable_declarator => |declarator| declarator,
             else => continue,
         };
-        if (!shouldPreferObjectDestructuring(tree, declarator)) continue;
+        const kind = preferredDestructuringKind(tree, declarator) orelse continue;
 
         try core.addDiagnostic(
             allocator,
             diagnostics,
             .warning,
             id,
-            "Use object destructuring.",
+            diagnosticMessage(kind),
             tree.span(declarator.id),
         );
     }
 }
 
-fn shouldPreferObjectDestructuring(tree: *const ast.Tree, declarator: ast.VariableDeclarator) bool {
-    if (declarator.init == .null) return false;
+fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDeclarator) ?DestructuringKind {
+    if (declarator.init == .null) return null;
 
-    const local_name = bindingIdentifierName(tree, declarator.id) orelse return false;
+    const local_name = bindingIdentifierName(tree, declarator.id) orelse return null;
 
     const member = switch (tree.data(unwrapTransparent(tree, declarator.init))) {
         .member_expression => |member| member,
-        else => return false,
+        else => return null,
     };
-    if (member.optional) return false;
+    if (member.optional) return null;
 
-    const property_name = propertyName(tree, member) orelse return false;
-    return std.mem.eql(u8, local_name, property_name);
+    if (isArrayIndexProperty(tree, member)) return .array;
+
+    const property_name = propertyName(tree, member) orelse return null;
+    return if (std.mem.eql(u8, local_name, property_name)) .object else null;
+}
+
+fn diagnosticMessage(kind: DestructuringKind) []const u8 {
+    return switch (kind) {
+        .object => "Use object destructuring.",
+        .array => "Use array destructuring.",
+    };
 }
 
 fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
@@ -65,6 +79,28 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
         .identifier_name => |identifier| tree.string(identifier.name),
         else => null,
     };
+}
+
+fn isArrayIndexProperty(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    if (!member.computed or member.property == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, member.property))) {
+        .numeric_literal => |literal| isArrayIndexNumber(literal.value(tree)),
+        .string_literal => |literal| isArrayIndexString(tree.string(literal.value)),
+        else => false,
+    };
+}
+
+fn isArrayIndexNumber(value: f64) bool {
+    return value >= 0 and value == @floor(value);
+}
+
+fn isArrayIndexString(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |char| {
+        if (char < '0' or char > '9') return false;
+    }
+    return true;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -20,12 +20,31 @@ test "reports prefer-destructuring for object property variable declarators" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
 }
 
+test "reports prefer-destructuring for array index variable declarators" {
+    const source =
+        \\const first = array[0];
+        \\let second = array["1"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+    try std.testing.expectEqualStrings("Use array destructuring.", result.diagnostics[0].message);
+}
+
 test "does not report prefer-destructuring for renamed dynamic or assignment cases" {
     const source =
         \\const renamed = object.first;
         \\const value = object[key];
-        \\const zero = array[0];
+        \\const fractional = array[1.5];
         \\const maybe = object?.maybe;
+        \\const maybeArray = array?.[0];
         \\target = object.target;
         \\const { direct } = object;
     ;


### PR DESCRIPTION
## Summary

- extend `prefer-destructuring` to report array index variable declarators
- keep existing object property declarator behavior and assignment-expression exclusions intact
- update rule status to reflect object and array variable declarator coverage

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for array index and renamed object `prefer-destructuring` cases
- `git diff --check`
