### PR TITLE
feat: support prefer destructuring assignments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -163,7 +163,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for fishlint's `destructuring: any, ignoreReadBeforeAssign: true` configuration |
-| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators |
+| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators and assignment expressions |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -36,6 +36,26 @@ pub fn checkVariableDeclaration(
     }
 }
 
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    const kind = preferredAssignmentDestructuringKind(tree, expression) orelse return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        diagnosticMessage(kind),
+        tree.span(expression.left),
+    );
+}
+
 fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDeclarator) ?DestructuringKind {
     if (declarator.init == .null) return null;
 
@@ -53,6 +73,21 @@ fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDec
     return if (std.mem.eql(u8, local_name, property_name)) .object else null;
 }
 
+fn preferredAssignmentDestructuringKind(tree: *const ast.Tree, expression: ast.AssignmentExpression) ?DestructuringKind {
+    const target_name = identifierReferenceName(tree, expression.left) orelse return null;
+
+    const member = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    if (member.optional) return null;
+
+    if (isArrayIndexProperty(tree, member)) return .array;
+
+    const property_name = propertyName(tree, member) orelse return null;
+    return if (std.mem.eql(u8, target_name, property_name)) .object else null;
+}
+
 fn diagnosticMessage(kind: DestructuringKind) []const u8 {
     return switch (kind) {
         .object => "Use object destructuring.",
@@ -63,6 +98,13 @@ fn diagnosticMessage(kind: DestructuringKind) []const u8 {
 fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1910,6 +1910,9 @@ const BasicVisitor = struct {
         if (self.options.func_name_matching) {
             try func_name_matching.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
+        if (self.options.prefer_destructuring) {
+            try prefer_destructuring.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -38,14 +38,39 @@ test "reports prefer-destructuring for array index variable declarators" {
     try std.testing.expectEqualStrings("Use array destructuring.", result.diagnostics[0].message);
 }
 
-test "does not report prefer-destructuring for renamed dynamic or assignment cases" {
+test "reports prefer-destructuring for assignment expressions" {
+    const source =
+        \\first = object.first;
+        \\second = object["second"];
+        \\item = array[0];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Use array destructuring.", result.diagnostics[2].message);
+}
+
+test "does not report prefer-destructuring for renamed dynamic or optional cases" {
     const source =
         \\const renamed = object.first;
         \\const value = object[key];
         \\const fractional = array[1.5];
         \\const maybe = object?.maybe;
         \\const maybeArray = array?.[0];
-        \\target = object.target;
+        \\renamed = object.target;
+        \\value = object[key];
+        \\fractional = array[1.5];
+        \\maybe = object?.maybe;
+        \\maybeArray = array?.[0];
         \\const { direct } = object;
     ;
 


### PR DESCRIPTION
## Summary

- extend `prefer-destructuring` to assignment expressions
- report matching object property assignments and array index assignments
- preserve existing variable declarator behavior and renamed/dynamic/optional exclusions

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for assignment expression and renamed assignment `prefer-destructuring` cases
- `git diff --check`
