### PR TITLE
feat: support logical assignment if statements

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -25,7 +25,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for the default `anyOrder` option |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
-| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior |
+| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior and optional `enforceForIfStatements: true` |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,6 +32,11 @@ pub const AccessorPairsGetWithoutSet = enum {
     no,
 };
 
+pub const LogicalAssignmentOperatorsEnforceForIfStatements = enum {
+    yes,
+    no,
+};
+
 pub const ArrayCallbackReturnAllowImplicit = enum {
     yes,
     no,
@@ -63,6 +68,7 @@ pub const Options = struct {
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     logical_assignment_operators: bool = true,
+    logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
     new_cap: bool = true,
     new_parens: bool = true,
     no_async_promise_executor: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -524,6 +524,8 @@ pub fn main(init: std.process.Init) !void {
             options.object_shorthand = false;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators=off")) {
             options.logical_assignment_operators = false;
+        } else if (std.mem.eql(u8, arg, "--logical-assignment-operators-enforce-for-if-statements=on")) {
+            options.logical_assignment_operators_enforce_for_if_statements = .yes;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
             options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -1387,6 +1389,7 @@ fn printHelp() void {
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
+        \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str

--- a/src/rules/logical_assignment_operators.zig
+++ b/src/rules/logical_assignment_operators.zig
@@ -65,6 +65,34 @@ pub fn checkLogicalExpression(
     try addDiagnostic(allocator, diagnostics, tree, index, expression.operator);
 }
 
+pub fn checkIfStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (statement.alternate != .null) return;
+
+    const assignment = assignmentFromStatement(tree, statement.consequent) orelse return;
+    if (assignment.operator != .assign) return;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const test_reference = (try conditionReference(arena_allocator, tree, statement.@"test")) orelse return;
+    const assignment_left = (try referenceFromExpression(arena_allocator, tree, assignment.left)) orelse return;
+    if (!referencesEqual(test_reference.reference, assignment_left)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, test_reference.operator);
+}
+
+const ConditionReference = struct {
+    reference: *const Reference,
+    operator: ast.LogicalOperator,
+};
+
 fn addDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -81,6 +109,76 @@ fn addDiagnostic(
         "Assignment can be replaced with `{s}=`.",
         .{operator.toString()},
     );
+}
+
+fn conditionReference(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!?ConditionReference {
+    const unwrapped = unwrapTransparent(tree, index);
+    switch (tree.data(unwrapped)) {
+        .unary_expression => |expression| {
+            if (expression.operator != .logical_not) return null;
+            const reference = (try referenceFromExpression(allocator, tree, expression.argument)) orelse return null;
+            return .{
+                .reference = reference,
+                .operator = .@"or",
+            };
+        },
+        .binary_expression => |expression| {
+            if (expression.operator != .equal) return null;
+            if (isNullLiteral(tree, expression.left)) {
+                const reference = (try referenceFromExpression(allocator, tree, expression.right)) orelse return null;
+                return .{
+                    .reference = reference,
+                    .operator = .nullish_coalescing,
+                };
+            }
+            if (isNullLiteral(tree, expression.right)) {
+                const reference = (try referenceFromExpression(allocator, tree, expression.left)) orelse return null;
+                return .{
+                    .reference = reference,
+                    .operator = .nullish_coalescing,
+                };
+            }
+            return null;
+        },
+        else => {
+            const reference = (try referenceFromExpression(allocator, tree, unwrapped)) orelse return null;
+            return .{
+                .reference = reference,
+                .operator = .@"and",
+            };
+        },
+    }
+}
+
+fn assignmentFromStatement(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.AssignmentExpression {
+    const unwrapped = unwrapTransparent(tree, index);
+    switch (tree.data(unwrapped)) {
+        .expression_statement => |statement| return assignmentFromExpression(tree, statement.expression),
+        .block_statement => |block| {
+            const statements = tree.extra(block.body);
+            if (statements.len != 1) return null;
+            return assignmentFromStatement(tree, statements[0]);
+        },
+        else => return null,
+    }
+}
+
+fn assignmentFromExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.AssignmentExpression {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .assignment_expression => |assignment| assignment,
+        else => null,
+    };
+}
+
+fn isNullLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        else => false,
+    };
 }
 
 fn referenceFromExpression(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1062,6 +1062,9 @@ const BasicVisitor = struct {
         if (self.options.no_negated_condition) {
             try no_negated_condition.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
+        if (self.options.logical_assignment_operators and self.options.logical_assignment_operators_enforce_for_if_statements == .yes) {
+            try logical_assignment_operators.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
             try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }

--- a/tests/rules/logical_assignment_operators.zig
+++ b/tests/rules/logical_assignment_operators.zig
@@ -47,6 +47,47 @@ test "reports logical-assignment-operators for short-circuit assignment expressi
     try std.testing.expectEqualStrings("Assignment can be replaced with `||=`.", result.diagnostics[0].message);
 }
 
+test "reports logical-assignment-operators for if statements when enabled" {
+    const source =
+        \\if (first) first = fallback;
+        \\if (!second) {
+        \\  second = fallback;
+        \\}
+        \\if (third == null) third = fallback;
+        \\if (null == fourth) fourth = fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
+    try std.testing.expectEqualStrings("Assignment can be replaced with `&&=`.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Assignment can be replaced with `||=`.", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("Assignment can be replaced with `??=`.", result.diagnostics[2].message);
+}
+
+test "does not report logical-assignment-operators for if statements by default" {
+    const source =
+        \\if (value) value = fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.logical_assignment_operators.id));
+}
+
 test "does not report logical-assignment-operators when shorthand would change meaning" {
     const source =
         \\let value;
@@ -56,9 +97,18 @@ test "does not report logical-assignment-operators when shorthand would change m
         \\value || (other = fallback);
         \\object[getKey()] = object[getKey()] || fallback;
         \\object.value = other.value || fallback;
+        \\if (value) other = fallback;
+        \\if (value != null) value = fallback;
+        \\if (value === null) value = fallback;
+        \\if (value) {
+        \\  value = fallback;
+        \\  other = fallback;
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
         .no_unused_expressions = false,
         .no_unused_vars = false,
         .no_undef = false,


### PR DESCRIPTION
## Summary

- add optional `logical-assignment-operators` support for `enforceForIfStatements`
- add CLI support via `--logical-assignment-operators-enforce-for-if-statements=on`
- preserve the default expression-only behavior while checking safe if-statement patterns when enabled

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for default and enabled if-statement behavior
- `git diff --check`
