### PR TITLE
feat: support grouped accessor order options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -22,7 +22,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for ESLint's default `always` behavior |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for the default `always` option |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
-| [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for the default `anyOrder` option |
+| [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior and optional `enforceForIfStatements: true` |

--- a/src/core.zig
+++ b/src/core.zig
@@ -32,6 +32,12 @@ pub const AccessorPairsGetWithoutSet = enum {
     no,
 };
 
+pub const GroupedAccessorPairsStyle = enum {
+    any_order,
+    get_before_set,
+    set_before_get,
+};
+
 pub const LogicalAssignmentOperatorsEnforceForIfStatements = enum {
     yes,
     no,
@@ -65,6 +71,7 @@ pub const Options = struct {
     func_names: bool = true,
     getter_return: bool = true,
     grouped_accessor_pairs: bool = true,
+    grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     logical_assignment_operators: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -146,6 +146,10 @@ pub fn main(init: std.process.Init) !void {
             options.getter_return = false;
         } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=off")) {
             options.grouped_accessor_pairs = false;
+        } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=get-before-set")) {
+            options.grouped_accessor_pairs_style = .get_before_set;
+        } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=set-before-get")) {
+            options.grouped_accessor_pairs_style = .set_before_get;
         } else if (std.mem.eql(u8, arg, "--guard-for-in=off")) {
             options.guard_for_in = false;
         } else if (std.mem.eql(u8, arg, "--linebreak-style=off")) {
@@ -1272,6 +1276,8 @@ fn printHelp() void {
         \\  --func-names=off          Disable func-names
         \\  --getter-return=off       Disable getter-return
         \\  --grouped-accessor-pairs=off Disable grouped-accessor-pairs
+        \\  --grouped-accessor-pairs=get-before-set Require getters before setters
+        \\  --grouped-accessor-pairs=set-before-get Require setters before getters
         \\  --guard-for-in=off        Disable guard-for-in
         \\  --linebreak-style=off     Disable linebreak-style
         \\  --new-cap=off             Disable new-cap

--- a/src/rules/grouped_accessor_pairs.zig
+++ b/src/rules/grouped_accessor_pairs.zig
@@ -12,6 +12,12 @@ const AccessorKind = enum {
     set,
 };
 
+pub const Style = enum {
+    any_order,
+    get_before_set,
+    set_before_get,
+};
+
 const Accessor = struct {
     name: []const u8,
     static: bool = false,
@@ -25,6 +31,16 @@ pub fn checkObjectExpression(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.ObjectExpression,
+) Allocator.Error!void {
+    return checkObjectExpressionWithStyle(allocator, diagnostics, tree, expression, .any_order);
+}
+
+pub fn checkObjectExpressionWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+    style: Style,
 ) Allocator.Error!void {
     var accessors: std.ArrayList(Accessor) = .empty;
     defer accessors.deinit(allocator);
@@ -49,7 +65,7 @@ pub fn checkObjectExpression(
         });
     }
 
-    try checkAccessors(allocator, diagnostics, tree, accessors.items);
+    try checkAccessors(allocator, diagnostics, tree, accessors.items, style);
 }
 
 pub fn checkClassBody(
@@ -57,6 +73,16 @@ pub fn checkClassBody(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     body: ast.ClassBody,
+) Allocator.Error!void {
+    return checkClassBodyWithStyle(allocator, diagnostics, tree, body, .any_order);
+}
+
+pub fn checkClassBodyWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+    style: Style,
 ) Allocator.Error!void {
     var accessors: std.ArrayList(Accessor) = .empty;
     defer accessors.deinit(allocator);
@@ -82,7 +108,7 @@ pub fn checkClassBody(
         });
     }
 
-    try checkAccessors(allocator, diagnostics, tree, accessors.items);
+    try checkAccessors(allocator, diagnostics, tree, accessors.items, style);
 }
 
 fn checkAccessors(
@@ -90,10 +116,11 @@ fn checkAccessors(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     accessors: []const Accessor,
+    style: Style,
 ) Allocator.Error!void {
     for (accessors, 0..) |accessor, index| {
         const previous = previousCounterpart(accessors[0..index], accessor) orelse continue;
-        if (previous.position + 1 == accessor.position) continue;
+        if (previous.position + 1 == accessor.position and orderMatches(style, previous.kind, accessor.kind)) continue;
 
         try core.addDiagnosticFmt(
             allocator,
@@ -105,6 +132,14 @@ fn checkAccessors(
             .{accessor.name},
         );
     }
+}
+
+fn orderMatches(style: Style, previous: AccessorKind, current: AccessorKind) bool {
+    return switch (style) {
+        .any_order => true,
+        .get_before_set => previous == .get and current == .set,
+        .set_before_get => previous == .set and current == .get,
+    };
 }
 
 fn previousCounterpart(previous_accessors: []const Accessor, accessor: Accessor) ?Accessor {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -336,6 +336,14 @@ pub const vars_on_top = @import("vars_on_top.zig");
 pub const wrap_iife = @import("wrap_iife.zig");
 pub const yoda = @import("yoda.zig");
 
+fn groupedAccessorPairsStyle(style: core.GroupedAccessorPairsStyle) grouped_accessor_pairs.Style {
+    return switch (style) {
+        .any_order => .any_order,
+        .get_before_set => .get_before_set,
+        .set_before_get => .set_before_get,
+    };
+}
+
 pub fn runBasic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -2464,7 +2472,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.grouped_accessor_pairs) {
-            try grouped_accessor_pairs.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try grouped_accessor_pairs.checkObjectExpressionWithStyle(self.allocator, self.diagnostics, ctx.tree, expression, groupedAccessorPairsStyle(self.options.grouped_accessor_pairs_style));
         }
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -2560,7 +2568,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.grouped_accessor_pairs) {
-            try grouped_accessor_pairs.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body);
+            try grouped_accessor_pairs.checkClassBodyWithStyle(self.allocator, self.diagnostics, ctx.tree, body, groupedAccessorPairsStyle(self.options.grouped_accessor_pairs_style));
         }
         if (self.options.no_dupe_class_members and !self.options.typescript_eslint_no_dupe_class_members) {
             try no_dupe_class_members.check(self.allocator, self.diagnostics, ctx.tree, body);

--- a/tests/rules/grouped_accessor_pairs.zig
+++ b/tests/rules/grouped_accessor_pairs.zig
@@ -96,6 +96,57 @@ test "allows adjacent accessors in either order and distinct static pairs" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.grouped_accessor_pairs.id));
 }
 
+test "reports grouped-accessor-pairs when getBeforeSet order is required" {
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\};
+        \\class Example {
+        \\  set value(next) {}
+        \\  get value() {
+        \\    return 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .accessor_pairs = false,
+        .eol_last = false,
+        .grouped_accessor_pairs_style = .get_before_set,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
+}
+
+test "reports grouped-accessor-pairs when setBeforeGet order is required" {
+    const source =
+        \\const object = {
+        \\  get value() {
+        \\    return 1;
+        \\  },
+        \\  set value(next) {},
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .grouped_accessor_pairs_style = .set_before_get,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
+}
+
 test "can disable grouped-accessor-pairs" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary

- add `grouped-accessor-pairs` support for `getBeforeSet` and `setBeforeGet`
- keep `anyOrder` as the default behavior
- expose CLI switches for the new ordering modes

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- CLI smoke for default any-order and get-before-set behavior
- `git diff --check`
