### PR TITLE
feat: support func names as needed

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -20,7 +20,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for ESLint's default `always` behavior |
-| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for the default `always` option |
+| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always` and optional `as-needed` options |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -43,6 +43,11 @@ pub const LogicalAssignmentOperatorsEnforceForIfStatements = enum {
     no,
 };
 
+pub const FuncNamesStyle = enum {
+    always,
+    as_needed,
+};
+
 pub const ArrayCallbackReturnAllowImplicit = enum {
     yes,
     no,
@@ -69,6 +74,7 @@ pub const Options = struct {
     for_direction: bool = true,
     func_name_matching: bool = true,
     func_names: bool = true,
+    func_names_style: FuncNamesStyle = .always,
     getter_return: bool = true,
     grouped_accessor_pairs: bool = true,
     grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,

--- a/src/main.zig
+++ b/src/main.zig
@@ -142,6 +142,8 @@ pub fn main(init: std.process.Init) !void {
             options.func_name_matching = false;
         } else if (std.mem.eql(u8, arg, "--func-names=off")) {
             options.func_names = false;
+        } else if (std.mem.eql(u8, arg, "--func-names=as-needed")) {
+            options.func_names_style = .as_needed;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
             options.getter_return = false;
         } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=off")) {
@@ -1274,6 +1276,7 @@ fn printHelp() void {
         \\  --for-direction=off       Disable for-direction
         \\  --func-name-matching=off Disable func-name-matching
         \\  --func-names=off          Disable func-names
+        \\  --func-names=as-needed    Allow inferable anonymous function names
         \\  --getter-return=off       Disable getter-return
         \\  --grouped-accessor-pairs=off Disable grouped-accessor-pairs
         \\  --grouped-accessor-pairs=get-before-set Require getters before setters

--- a/src/rules/func_names.zig
+++ b/src/rules/func_names.zig
@@ -7,6 +7,11 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "func-names";
 
+pub const Style = enum {
+    always,
+    as_needed,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -15,8 +20,20 @@ pub fn check(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    return checkWithStyle(allocator, diagnostics, tree, function, index, ctx, .always);
+}
+
+pub fn checkWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    style: Style,
+) Allocator.Error!void {
     if (function.id != .null) return;
-    if (!requiresName(tree, function, ctx)) return;
+    if (!requiresName(tree, function, index, ctx, style)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -28,10 +45,43 @@ pub fn check(
     );
 }
 
-fn requiresName(tree: *const ast.Tree, function: ast.Function, ctx: *traverser.basic.Ctx) bool {
+fn requiresName(tree: *const ast.Tree, function: ast.Function, index: ast.NodeIndex, ctx: *traverser.basic.Ctx, style: Style) bool {
     return switch (function.type) {
-        .function_expression => !isMethodParent(tree, ctx),
+        .function_expression => !isMethodParent(tree, ctx) and !allowsInferredName(tree, index, ctx, style),
         .function_declaration => isExportDefaultDeclarationParent(tree, ctx),
+        else => false,
+    };
+}
+
+fn allowsInferredName(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx, style: Style) bool {
+    if (style != .as_needed) return false;
+
+    const parent = ctx.path.parent() orelse return false;
+    return switch (tree.data(parent)) {
+        .variable_declarator => |declarator| declarator.init == index,
+        .object_property => |property| property.value == index,
+        .property_definition => |property| property.value == index,
+        .assignment_expression => |assignment| assignment.right == index and isInferredAssignment(tree, assignment),
+        else => false,
+    };
+}
+
+fn isInferredAssignment(tree: *const ast.Tree, assignment: ast.AssignmentExpression) bool {
+    if (!isNameInferringAssignmentOperator(assignment.operator)) return false;
+
+    return switch (tree.data(assignment.left)) {
+        .identifier_reference => true,
+        else => false,
+    };
+}
+
+fn isNameInferringAssignmentOperator(operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .assign,
+        .logical_or_assign,
+        .logical_and_assign,
+        .nullish_assign,
+        => true,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -952,7 +952,10 @@ const BasicVisitor = struct {
             try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
         }
         if (self.options.func_names) {
-            try func_names.check(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
+            try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, switch (self.options.func_names_style) {
+                .always => .always,
+                .as_needed => .as_needed,
+            });
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);

--- a/tests/rules/func_names.zig
+++ b/tests/rules/func_names.zig
@@ -73,6 +73,61 @@ test "allows named functions and non-function-expression callbacks" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.func_names.id));
 }
 
+test "allows func-names as-needed for inferable names" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\};
+        \\const object = {
+        \\  method: function () {
+        \\    return value;
+        \\  },
+        \\};
+        \\class Example {
+        \\  field = function () {
+        \\    return value;
+        \\  };
+        \\}
+        \\quux ??= function () {
+        \\  return value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_names_style = .as_needed,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_names.id));
+}
+
+test "reports func-names as-needed for non-inferable names" {
+    const source =
+        \\const call = (function () {
+        \\  return value;
+        \\})();
+        \\Foo.prototype.bar = function () {
+        \\  return value;
+        \\};
+        \\export default function () {
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_names_style = .as_needed,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_names.id));
+}
+
 test "can disable func-names" {
     const source = "const value = function () { return 1; };\n";
 


### PR DESCRIPTION
## Summary

- add the `func-names` `as-needed` style option while keeping `always` as the default
- allow anonymous function expressions when the name is inferred from variable, object property, class field, or identifier assignment positions
- expose `--func-names=as-needed` in the CLI and update rule status docs

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `func-names` vs `--func-names=as-needed`
