### PR TITLE
feat: support no underscore dangle param option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -138,7 +138,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
-| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, and `allowAfterThisConstructor` behavior |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, and `allowFunctionParams` behavior |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,11 @@ pub const NoConfusingArrowAllowParens = enum {
     no,
 };
 
+pub const NoUnderscoreDangleAllowFunctionParams = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -253,6 +258,7 @@ pub const Options = struct {
     no_underscore_dangle_allow_after_this: bool = false,
     no_underscore_dangle_allow_after_super: bool = false,
     no_underscore_dangle_allow_after_this_constructor: bool = false,
+    no_underscore_dangle_allow_function_params: NoUnderscoreDangleAllowFunctionParams = .yes,
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -494,6 +494,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_underscore_dangle_allow_after_super = true;
         } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-after-this-constructor=on")) {
             options.no_underscore_dangle_allow_after_this_constructor = true;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-function-params=off")) {
+            options.no_underscore_dangle_allow_function_params = .no;
         } else if (std.mem.eql(u8, arg, "--no-undefined=off")) {
             options.no_undefined = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
@@ -1460,6 +1462,7 @@ fn printHelp() void {
         \\  --no-underscore-dangle-allow-after-this=on Allow dangling underscores after this
         \\  --no-underscore-dangle-allow-after-super=on Allow dangling underscores after super
         \\  --no-underscore-dangle-allow-after-this-constructor=on Allow dangling underscores after this.constructor
+        \\  --no-underscore-dangle-allow-function-params=off Report dangling underscores in function parameters
         \\  --no-undefined=off        Disable no-undefined
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -11,6 +11,7 @@ pub const Options = struct {
     allow_after_this: bool = false,
     allow_after_super: bool = false,
     allow_after_this_constructor: bool = false,
+    allow_function_params: bool = true,
 };
 
 pub fn checkVariableDeclarator(
@@ -29,10 +30,43 @@ pub fn checkFunction(
     tree: *const ast.Tree,
     function: ast.Function,
 ) Allocator.Error!void {
-    if (function.id == .null) return;
+    return checkFunctionWithOptions(allocator, diagnostics, tree, function, .{});
+}
 
-    const name = bindingName(tree, function.id) orelse return;
-    try checkName(allocator, diagnostics, tree, function.id, name, false);
+pub fn checkFunctionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
+) Allocator.Error!void {
+    if (function.id != .null) {
+        if (bindingName(tree, function.id)) |name| {
+            try checkName(allocator, diagnostics, tree, function.id, name, false);
+        }
+    }
+    try checkFormalParametersWithOptions(allocator, diagnostics, tree, function.params, options);
+}
+
+pub fn checkFormalParametersWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.allow_function_params) return;
+
+    const params = formalParameters(tree, params_index) orelse return;
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter),
+            else => {},
+        }
+    }
+
+    try checkBinding(allocator, diagnostics, tree, params.rest);
 }
 
 pub fn checkClass(
@@ -77,6 +111,38 @@ fn isAllowedMemberAccess(tree: *const ast.Tree, member: ast.MemberExpression, op
     return false;
 }
 
+fn checkBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, index, tree.string(identifier.name), false),
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBinding(allocator, diagnostics, tree, element);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBinding(allocator, diagnostics, tree, property.value);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest);
+        },
+        else => {},
+    }
+}
+
 fn checkName(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -116,6 +182,14 @@ fn bindingName(tree: *const ast.Tree, node: ast.NodeIndex) ?[]const u8 {
 
     return switch (tree.data(node)) {
         .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn formalParameters(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.FormalParameters {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .formal_parameters => |params| params,
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -946,7 +946,9 @@ const BasicVisitor = struct {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
         }
         if (self.options.no_underscore_dangle) {
-            try no_underscore_dangle.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+            try no_underscore_dangle.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
+                .allow_function_params = self.options.no_underscore_dangle_allow_function_params == .yes,
+            });
         }
         if (self.options.consistent_return) {
             try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
@@ -1885,6 +1887,11 @@ const BasicVisitor = struct {
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
+        }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkFormalParametersWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.params, .{
+                .allow_function_params = self.options.no_underscore_dangle_allow_function_params == .yes,
+            });
         }
         if (self.options.no_confusing_arrow) {
             try no_confusing_arrow.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -109,6 +109,23 @@ test "allows default names and skipped forms" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "reports no-underscore-dangle for function params when configured" {
+    const source =
+        \\function run(_value, value_, _default = 1, ..._rest) {}
+        \\const arrow = ({ _object }, [_item]) => _object + _item;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_underscore_dangle_allow_function_params = .no,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "can disable no-underscore-dangle" {
     const source =
         \\const _value = 1;


### PR DESCRIPTION
## Summary

- add the `no-underscore-dangle` `allowFunctionParams` option while preserving the default allowed-parameter behavior
- report dangling underscores in ordinary, default, rest, and destructured parameters when the option is disabled
- expose `--no-underscore-dangle-allow-function-params=off` and update rule coverage docs

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `--rules=no-underscore-dangle` vs `--no-underscore-dangle-allow-function-params=off`
