### PR TITLE
feat: support no underscore dangle destructuring options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -138,7 +138,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
-| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, and `allowFunctionParams` behavior |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, and `allowInObjectDestructuring` behavior |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,11 @@ pub const NoUnderscoreDangleAllowFunctionParams = enum {
     no,
 };
 
+pub const NoUnderscoreDangleAllowDestructuring = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -259,6 +264,8 @@ pub const Options = struct {
     no_underscore_dangle_allow_after_super: bool = false,
     no_underscore_dangle_allow_after_this_constructor: bool = false,
     no_underscore_dangle_allow_function_params: NoUnderscoreDangleAllowFunctionParams = .yes,
+    no_underscore_dangle_allow_in_array_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
+    no_underscore_dangle_allow_in_object_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -496,6 +496,10 @@ pub fn main(init: std.process.Init) !void {
             options.no_underscore_dangle_allow_after_this_constructor = true;
         } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-function-params=off")) {
             options.no_underscore_dangle_allow_function_params = .no;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-in-array-destructuring=off")) {
+            options.no_underscore_dangle_allow_in_array_destructuring = .no;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-in-object-destructuring=off")) {
+            options.no_underscore_dangle_allow_in_object_destructuring = .no;
         } else if (std.mem.eql(u8, arg, "--no-undefined=off")) {
             options.no_undefined = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
@@ -1463,6 +1467,8 @@ fn printHelp() void {
         \\  --no-underscore-dangle-allow-after-super=on Allow dangling underscores after super
         \\  --no-underscore-dangle-allow-after-this-constructor=on Allow dangling underscores after this.constructor
         \\  --no-underscore-dangle-allow-function-params=off Report dangling underscores in function parameters
+        \\  --no-underscore-dangle-allow-in-array-destructuring=off Report dangling underscores in array destructuring
+        \\  --no-underscore-dangle-allow-in-object-destructuring=off Report dangling underscores in object destructuring
         \\  --no-undefined=off        Disable no-undefined
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -12,6 +12,8 @@ pub const Options = struct {
     allow_after_super: bool = false,
     allow_after_this_constructor: bool = false,
     allow_function_params: bool = true,
+    allow_in_array_destructuring: bool = true,
+    allow_in_object_destructuring: bool = true,
 };
 
 pub fn checkVariableDeclarator(
@@ -20,8 +22,30 @@ pub fn checkVariableDeclarator(
     tree: *const ast.Tree,
     declarator: ast.VariableDeclarator,
 ) Allocator.Error!void {
-    const name = bindingName(tree, declarator.id) orelse return;
-    try checkName(allocator, diagnostics, tree, declarator.id, name, false);
+    return checkVariableDeclaratorWithOptions(allocator, diagnostics, tree, declarator, .{});
+}
+
+pub fn checkVariableDeclaratorWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    options: Options,
+) Allocator.Error!void {
+    switch (tree.data(declarator.id)) {
+        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, declarator.id, tree.string(identifier.name), false),
+        .array_pattern => {
+            if (!options.allow_in_array_destructuring) {
+                try checkBinding(allocator, diagnostics, tree, declarator.id);
+            }
+        },
+        .object_pattern => {
+            if (!options.allow_in_object_destructuring) {
+                try checkBinding(allocator, diagnostics, tree, declarator.id);
+            }
+        },
+        else => {},
+    }
 }
 
 pub fn checkFunction(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1283,7 +1283,10 @@ const BasicVisitor = struct {
             try typescript_eslint_no_inferrable_types.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         if (self.options.no_underscore_dangle) {
-            try no_underscore_dangle.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+            try no_underscore_dangle.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, .{
+                .allow_in_array_destructuring = self.options.no_underscore_dangle_allow_in_array_destructuring == .yes,
+                .allow_in_object_destructuring = self.options.no_underscore_dangle_allow_in_object_destructuring == .yes,
+            });
         }
         if (self.options.func_name_matching) {
             try func_name_matching.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -126,6 +126,24 @@ test "reports no-underscore-dangle for function params when configured" {
     try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "reports no-underscore-dangle for destructuring when configured" {
+    const source =
+        \\const [_array, value_, ..._rest] = values;
+        \\const { _object, nested: { child_ }, _alias: alias } = record;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_underscore_dangle_allow_in_array_destructuring = .no,
+        .no_underscore_dangle_allow_in_object_destructuring = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "can disable no-underscore-dangle" {
     const source =
         \\const _value = 1;


### PR DESCRIPTION
## Summary

- add `allowInArrayDestructuring` and `allowInObjectDestructuring` handling for `no-underscore-dangle`
- keep destructuring bindings allowed by default, matching ESLint defaults
- expose CLI switches for disabling those allowances and update rule coverage docs

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default destructuring behavior vs both destructuring allow options disabled
