### PR TITLE
feat: support no underscore dangle method option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -138,7 +138,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
-| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, and `allowInObjectDestructuring` behavior |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, and `enforceInMethodNames` behavior |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -266,6 +266,7 @@ pub const Options = struct {
     no_underscore_dangle_allow_function_params: NoUnderscoreDangleAllowFunctionParams = .yes,
     no_underscore_dangle_allow_in_array_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
     no_underscore_dangle_allow_in_object_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
+    no_underscore_dangle_enforce_in_method_names: bool = false,
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -500,6 +500,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_underscore_dangle_allow_in_array_destructuring = .no;
         } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-allow-in-object-destructuring=off")) {
             options.no_underscore_dangle_allow_in_object_destructuring = .no;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-enforce-in-method-names=on")) {
+            options.no_underscore_dangle_enforce_in_method_names = true;
         } else if (std.mem.eql(u8, arg, "--no-undefined=off")) {
             options.no_undefined = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
@@ -1469,6 +1471,7 @@ fn printHelp() void {
         \\  --no-underscore-dangle-allow-function-params=off Report dangling underscores in function parameters
         \\  --no-underscore-dangle-allow-in-array-destructuring=off Report dangling underscores in array destructuring
         \\  --no-underscore-dangle-allow-in-object-destructuring=off Report dangling underscores in object destructuring
+        \\  --no-underscore-dangle-enforce-in-method-names=on Report dangling underscores in method names
         \\  --no-undefined=off        Disable no-undefined
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -14,6 +14,7 @@ pub const Options = struct {
     allow_function_params: bool = true,
     allow_in_array_destructuring: bool = true,
     allow_in_object_destructuring: bool = true,
+    enforce_in_method_names: bool = false,
 };
 
 pub fn checkVariableDeclarator(
@@ -128,6 +129,33 @@ pub fn checkMemberExpressionWithOptions(
     try checkName(allocator, diagnostics, tree, member.property, name, true);
 }
 
+pub fn checkMethodDefinitionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_in_method_names) return;
+
+    const name = staticName(tree, method.key, method.computed) orelse return;
+    try checkName(allocator, diagnostics, tree, method.key, name, false);
+}
+
+pub fn checkObjectPropertyWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_in_method_names) return;
+    if (!property.method and property.kind == .init) return;
+
+    const name = staticName(tree, property.key, property.computed) orelse return;
+    try checkName(allocator, diagnostics, tree, property.key, name, false);
+}
+
 fn isAllowedMemberAccess(tree: *const ast.Tree, member: ast.MemberExpression, options: Options) bool {
     if (options.allow_after_this and isThisExpression(tree, member.object)) return true;
     if (options.allow_after_super and isSuperExpression(tree, member.object)) return true;
@@ -223,6 +251,17 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
 
     return switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn staticName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null or computed) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2538,6 +2538,11 @@ const BasicVisitor = struct {
         if (self.options.func_name_matching) {
             try func_name_matching.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property);
         }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
+            });
+        }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
@@ -2610,6 +2615,11 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+        }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkMethodDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, method, .{
+                .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
+            });
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -144,6 +144,32 @@ test "reports no-underscore-dangle for destructuring when configured" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "reports no-underscore-dangle for method names when configured" {
+    const source =
+        \\class Model {
+        \\  _run() {}
+        \\  #private_() {}
+        \\}
+        \\const object = {
+        \\  _run() {},
+        \\  get value_() {
+        \\    return 1;
+        \\  },
+        \\  _field: 1,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_underscore_dangle_enforce_in_method_names = true,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "can disable no-underscore-dangle" {
     const source =
         \\const _value = 1;


### PR DESCRIPTION
## Summary

- add `enforceInMethodNames` handling for `no-underscore-dangle`
- report dangling underscores in class methods, private methods, object methods, and accessor method names when enabled
- keep method names allowed by default and expose the CLI switch

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default method behavior vs `--no-underscore-dangle-enforce-in-method-names=on`
