### PR TITLE
feat: support no underscore dangle class field option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -138,7 +138,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
-| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, and `enforceInMethodNames` behavior |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` behavior |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -267,6 +267,7 @@ pub const Options = struct {
     no_underscore_dangle_allow_in_array_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
     no_underscore_dangle_allow_in_object_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
     no_underscore_dangle_enforce_in_method_names: bool = false,
+    no_underscore_dangle_enforce_in_class_fields: bool = false,
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -502,6 +502,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_underscore_dangle_allow_in_object_destructuring = .no;
         } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-enforce-in-method-names=on")) {
             options.no_underscore_dangle_enforce_in_method_names = true;
+        } else if (std.mem.eql(u8, arg, "--no-underscore-dangle-enforce-in-class-fields=on")) {
+            options.no_underscore_dangle_enforce_in_class_fields = true;
         } else if (std.mem.eql(u8, arg, "--no-undefined=off")) {
             options.no_undefined = false;
         } else if (std.mem.eql(u8, arg, "--unicode-bom=off")) {
@@ -1472,6 +1474,7 @@ fn printHelp() void {
         \\  --no-underscore-dangle-allow-in-array-destructuring=off Report dangling underscores in array destructuring
         \\  --no-underscore-dangle-allow-in-object-destructuring=off Report dangling underscores in object destructuring
         \\  --no-underscore-dangle-enforce-in-method-names=on Report dangling underscores in method names
+        \\  --no-underscore-dangle-enforce-in-class-fields=on Report dangling underscores in class fields
         \\  --no-undefined=off        Disable no-undefined
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -15,6 +15,7 @@ pub const Options = struct {
     allow_in_array_destructuring: bool = true,
     allow_in_object_destructuring: bool = true,
     enforce_in_method_names: bool = false,
+    enforce_in_class_fields: bool = false,
 };
 
 pub fn checkVariableDeclarator(
@@ -151,6 +152,19 @@ pub fn checkObjectPropertyWithOptions(
 ) Allocator.Error!void {
     if (!options.enforce_in_method_names) return;
     if (!property.method and property.kind == .init) return;
+
+    const name = staticName(tree, property.key, property.computed) orelse return;
+    try checkName(allocator, diagnostics, tree, property.key, name, false);
+}
+
+pub fn checkPropertyDefinitionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_in_class_fields) return;
 
     const name = staticName(tree, property.key, property.computed) orelse return;
     try checkName(allocator, diagnostics, tree, property.key, name, false);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2659,6 +2659,11 @@ const BasicVisitor = struct {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
+        if (self.options.no_underscore_dangle) {
+            try no_underscore_dangle.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .enforce_in_class_fields = self.options.no_underscore_dangle_enforce_in_class_fields,
+            });
+        }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -170,6 +170,26 @@ test "reports no-underscore-dangle for method names when configured" {
     try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "reports no-underscore-dangle for class fields when configured" {
+    const source =
+        \\class Model {
+        \\  _field = 1;
+        \\  #private_ = 2;
+        \\  static value_ = 3;
+        \\  ["_computed"] = 4;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_underscore_dangle_enforce_in_class_fields = true,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "can disable no-underscore-dangle" {
     const source =
         \\const _value = 1;


### PR DESCRIPTION
## Summary

- add `enforceInClassFields` handling for `no-underscore-dangle`
- report dangling underscores in public, private, and static class field names when enabled
- keep class fields allowed by default and expose the CLI switch

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default class field behavior vs `--no-underscore-dangle-enforce-in-class-fields=on`
