### PR TITLE
feat: support no warning comments anywhere

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -157,7 +157,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented |
-| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented |
+| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented for default `location: start` and optional `location: anywhere` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -31,6 +31,11 @@ pub const NoUnderscoreDangleAllowDestructuring = enum {
     no,
 };
 
+pub const NoWarningCommentsLocation = enum {
+    start,
+    anywhere,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -284,6 +289,7 @@ pub const Options = struct {
     no_unused_expressions: bool = true,
     typescript_eslint_no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
+    no_warning_comments_location: NoWarningCommentsLocation = .start,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -534,6 +534,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unused_expressions = false;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments=off")) {
             options.no_warning_comments = false;
+        } else if (std.mem.eql(u8, arg, "--no-warning-comments-location=anywhere")) {
+            options.no_warning_comments_location = .anywhere;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -1490,6 +1492,7 @@ fn printHelp() void {
         \\  --no-useless-rename=off   Disable no-useless-rename
         \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-warning-comments=off Disable no-warning-comments
+        \\  --no-warning-comments-location=anywhere Report warning terms anywhere in comments
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/rules/no_warning_comments.zig
+++ b/src/rules/no_warning_comments.zig
@@ -13,13 +13,31 @@ const terms = [_][]const u8{
     "xxx",
 };
 
+pub const Location = enum {
+    start,
+    anywhere,
+};
+
+pub const Options = struct {
+    location: Location = .start,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     for (tree.comments) |comment| {
-        const match = warningTermAtStart(tree, comment) orelse continue;
+        const match = warningTerm(tree, comment, options.location) orelse continue;
 
         try core.addDiagnosticFmt(
             allocator,
@@ -33,12 +51,32 @@ pub fn run(
     }
 }
 
+fn warningTerm(tree: *const ast.Tree, comment: ast.Comment, location: Location) ?[]const u8 {
+    return switch (location) {
+        .start => warningTermAtStart(tree, comment),
+        .anywhere => warningTermAnywhere(tree, comment),
+    };
+}
+
 fn warningTermAtStart(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {
     const value = tree.string(comment.value);
     const trimmed = trimLeftWhitespace(value);
 
     inline for (terms) |term| {
         if (startsWithWholeWordIgnoreCase(trimmed, term)) return term;
+    }
+
+    return null;
+}
+
+fn warningTermAnywhere(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {
+    const value = tree.string(comment.value);
+    var index: usize = 0;
+
+    while (index < value.len) : (index += 1) {
+        inline for (terms) |term| {
+            if (matchesWholeWordAt(value, index, term)) return term;
+        }
     }
 
     return null;
@@ -55,11 +93,18 @@ fn isWhitespace(char: u8) bool {
 }
 
 fn startsWithWholeWordIgnoreCase(value: []const u8, term: []const u8) bool {
-    if (value.len < term.len) return false;
-    if (!std.ascii.eqlIgnoreCase(value[0..term.len], term)) return false;
-    if (value.len == term.len) return true;
+    return matchesWholeWordAt(value, 0, term);
+}
 
-    return !isAsciiIdentifierPart(value[term.len]);
+fn matchesWholeWordAt(value: []const u8, index: usize, term: []const u8) bool {
+    if (index > value.len) return false;
+    if (index != 0 and isAsciiIdentifierPart(value[index - 1])) return false;
+    const remaining = value[index..];
+    if (remaining.len < term.len) return false;
+    if (!std.ascii.eqlIgnoreCase(remaining[0..term.len], term)) return false;
+    if (remaining.len == term.len) return true;
+
+    return !isAsciiIdentifierPart(remaining[term.len]);
 }
 
 fn isAsciiIdentifierPart(char: u8) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -355,7 +355,12 @@ pub fn runBasic(
         try capitalized_comments.run(allocator, diagnostics, tree);
     }
     if (options.no_warning_comments) {
-        try no_warning_comments.run(allocator, diagnostics, tree);
+        try no_warning_comments.runWithOptions(allocator, diagnostics, tree, .{
+            .location = switch (options.no_warning_comments_location) {
+                .start => .start,
+                .anywhere => .anywhere,
+            },
+        });
     }
     if (options.no_trailing_spaces) {
         try no_trailing_spaces.run(allocator, diagnostics, tree);

--- a/tests/rules/no_warning_comments.zig
+++ b/tests/rules/no_warning_comments.zig
@@ -36,6 +36,24 @@ test "does not report no-warning-comments away from start or as partial words" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_warning_comments.id));
 }
 
+test "reports no-warning-comments anywhere when configured" {
+    const source =
+        \\// this TODO is not at the start
+        \\// prefix fixme suffix
+        \\// todoing is not the whole word
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_warning_comments_location = .anywhere,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_warning_comments.id));
+}
+
 test "can disable no-warning-comments" {
     const source =
         \\// TODO: handle this case


### PR DESCRIPTION
## Summary

- add `location: anywhere` handling for `no-warning-comments`
- keep the default `location: start` behavior unchanged
- expose `--no-warning-comments-location=anywhere` and document the expanded coverage

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default start matching vs `--no-warning-comments-location=anywhere`
