### PR TITLE
feat: support no warning comments decoration

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -157,7 +157,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented |
-| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented for default `location: start` and optional `location: anywhere` behavior |
+| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented for default `location: start`, optional `location: anywhere`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -36,6 +36,12 @@ pub const NoWarningCommentsLocation = enum {
     anywhere,
 };
 
+pub const NoWarningCommentsDecoration = enum {
+    none,
+    asterisk,
+    slash_asterisk,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -290,6 +296,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
     no_warning_comments_location: NoWarningCommentsLocation = .start,
+    no_warning_comments_decoration: NoWarningCommentsDecoration = .none,
     no_void: bool = true,
     no_with: bool = true,
     no_var: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -536,6 +536,10 @@ pub fn main(init: std.process.Init) !void {
             options.no_warning_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments-location=anywhere")) {
             options.no_warning_comments_location = .anywhere;
+        } else if (std.mem.eql(u8, arg, "--no-warning-comments-decoration=asterisk")) {
+            options.no_warning_comments_decoration = .asterisk;
+        } else if (std.mem.eql(u8, arg, "--no-warning-comments-decoration=slash-asterisk")) {
+            options.no_warning_comments_decoration = .slash_asterisk;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
@@ -1493,6 +1497,8 @@ fn printHelp() void {
         \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-warning-comments-location=anywhere Report warning terms anywhere in comments
+        \\  --no-warning-comments-decoration=asterisk Ignore leading * comment decorations
+        \\  --no-warning-comments-decoration=slash-asterisk Ignore leading / and * comment decorations
         \\  --no-void=off             Disable no-void
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var

--- a/src/rules/no_warning_comments.zig
+++ b/src/rules/no_warning_comments.zig
@@ -18,8 +18,15 @@ pub const Location = enum {
     anywhere,
 };
 
+pub const Decoration = enum {
+    none,
+    asterisk,
+    slash_asterisk,
+};
+
 pub const Options = struct {
     location: Location = .start,
+    decoration: Decoration = .none,
 };
 
 pub fn run(
@@ -37,7 +44,7 @@ pub fn runWithOptions(
     options: Options,
 ) Allocator.Error!void {
     for (tree.comments) |comment| {
-        const match = warningTerm(tree, comment, options.location) orelse continue;
+        const match = warningTerm(tree, comment, options) orelse continue;
 
         try core.addDiagnosticFmt(
             allocator,
@@ -51,22 +58,36 @@ pub fn runWithOptions(
     }
 }
 
-fn warningTerm(tree: *const ast.Tree, comment: ast.Comment, location: Location) ?[]const u8 {
-    return switch (location) {
-        .start => warningTermAtStart(tree, comment),
+fn warningTerm(tree: *const ast.Tree, comment: ast.Comment, options: Options) ?[]const u8 {
+    return switch (options.location) {
+        .start => warningTermAtStart(tree, comment, options.decoration),
         .anywhere => warningTermAnywhere(tree, comment),
     };
 }
 
-fn warningTermAtStart(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {
+fn warningTermAtStart(tree: *const ast.Tree, comment: ast.Comment, decoration: Decoration) ?[]const u8 {
     const value = tree.string(comment.value);
-    const trimmed = trimLeftWhitespace(value);
+    const trimmed = trimLeftDecoration(trimLeftWhitespace(value), decoration);
 
     inline for (terms) |term| {
         if (startsWithWholeWordIgnoreCase(trimmed, term)) return term;
     }
 
     return null;
+}
+
+fn trimLeftDecoration(value: []const u8, decoration: Decoration) []const u8 {
+    var index: usize = 0;
+    while (index < value.len and isDecoration(value[index], decoration)) : (index += 1) {}
+    return trimLeftWhitespace(value[index..]);
+}
+
+fn isDecoration(char: u8, decoration: Decoration) bool {
+    return switch (decoration) {
+        .none => false,
+        .asterisk => char == '*',
+        .slash_asterisk => char == '*' or char == '/',
+    };
 }
 
 fn warningTermAnywhere(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -360,6 +360,11 @@ pub fn runBasic(
                 .start => .start,
                 .anywhere => .anywhere,
             },
+            .decoration = switch (options.no_warning_comments_decoration) {
+                .none => .none,
+                .asterisk => .asterisk,
+                .slash_asterisk => .slash_asterisk,
+            },
         });
     }
     if (options.no_trailing_spaces) {

--- a/tests/rules/no_warning_comments.zig
+++ b/tests/rules/no_warning_comments.zig
@@ -54,6 +54,25 @@ test "reports no-warning-comments anywhere when configured" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_warning_comments.id));
 }
 
+test "reports no-warning-comments after configured decorations" {
+    const source =
+        \\/* * TODO decoration is ignored */
+        \\//***** fixme decoration is ignored
+        \\//// xxx slash decoration is ignored
+        \\//??? todo unsupported decoration is not ignored
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_warning_comments_decoration = .slash_asterisk,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_warning_comments.id));
+}
+
 test "can disable no-warning-comments" {
     const source =
         \\// TODO: handle this case


### PR DESCRIPTION
## Summary

- add `decoration` handling for `no-warning-comments` start-location checks
- support common `['*']` and `['/', '*']` decoration modes via CLI
- keep default behavior unchanged and update rule coverage docs

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js && node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default behavior vs `--no-warning-comments-decoration=slash-asterisk`
