### PR TITLE
feat: support capitalized comments never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -8,7 +8,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for `setWithoutGet: true` and optional `getWithoutSet: true` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for `allowImplicit: true` by default, with optional `allowImplicit: false`; `checkForEach: false, allowVoid: false` |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
-| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for the default `always` behavior |
+| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always` and optional `never` behavior |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -74,6 +74,11 @@ pub const ArrayCallbackReturnAllowImplicit = enum {
     no,
 };
 
+pub const CapitalizedCommentsMode = enum {
+    always,
+    never,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
@@ -81,6 +86,7 @@ pub const Options = struct {
     array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .yes,
     block_scoped_var: bool = true,
     capitalized_comments: bool = true,
+    capitalized_comments_mode: CapitalizedCommentsMode = .always,
     consistent_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,6 +122,8 @@ pub fn main(init: std.process.Init) !void {
             options.block_scoped_var = false;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=off")) {
             options.capitalized_comments = false;
+        } else if (std.mem.eql(u8, arg, "--capitalized-comments=never")) {
+            options.capitalized_comments_mode = .never;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
         } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
@@ -1286,6 +1288,7 @@ fn printHelp() void {
         \\  --array-callback-return-allow-implicit=off Require explicit values from array callbacks
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --capitalized-comments=off Disable capitalized-comments
+        \\  --capitalized-comments=never Require lowercase comment starts
         \\  --consistent-return=off  Disable consistent-return
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -7,27 +7,59 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "capitalized-comments";
 
+pub const Mode = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    mode: Mode = .always,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.comments) |comment| {
         const value = trimLeftDecorations(tree.string(comment.value));
         if (isIgnoredComment(value)) continue;
 
         const first = firstAsciiLetter(value) orelse continue;
-        if (!std.ascii.isLower(first)) continue;
+        if (!violatesMode(first, options.mode)) continue;
 
         try core.addDiagnostic(
             allocator,
             diagnostics,
             .warning,
             id,
-            "Comments should start with an uppercase character.",
+            diagnosticMessage(options.mode),
             .{ .start = comment.start, .end = comment.end },
         );
     }
+}
+
+fn diagnosticMessage(mode: Mode) []const u8 {
+    return switch (mode) {
+        .always => "Comments should start with an uppercase character.",
+        .never => "Comments should not start with an uppercase character.",
+    };
+}
+
+fn violatesMode(first: u8, mode: Mode) bool {
+    return switch (mode) {
+        .always => std.ascii.isLower(first),
+        .never => std.ascii.isUpper(first),
+    };
 }
 
 fn trimLeftDecorations(value: []const u8) []const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -352,7 +352,12 @@ pub fn runBasic(
     options: core.Options,
 ) Allocator.Error!void {
     if (options.capitalized_comments) {
-        try capitalized_comments.run(allocator, diagnostics, tree);
+        try capitalized_comments.runWithOptions(allocator, diagnostics, tree, .{
+            .mode = switch (options.capitalized_comments_mode) {
+                .always => .always,
+                .never => .never,
+            },
+        });
     }
     if (options.no_warning_comments) {
         try no_warning_comments.runWithOptions(allocator, diagnostics, tree, .{

--- a/tests/rules/capitalized_comments.zig
+++ b/tests/rules/capitalized_comments.zig
@@ -43,6 +43,29 @@ test "allows uppercase, numeric, symbolic, directives, urls, and empty comments"
     try std.testing.expect(!helpers.hasRule(result, lint.rules.capitalized_comments.id));
 }
 
+test "reports capitalized-comments for uppercase starts in never mode" {
+    const source =
+        \\// Uppercase line comment
+        \\/* Lowercase block comment */
+        \\// lowercase line comment
+        \\/* lowercase block comment */
+        \\// eslint-disable-next-line no-alert
+        \\// https://example.com/path
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments_mode = .never,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.capitalized_comments.id));
+    try std.testing.expectEqualStrings("Comments should not start with an uppercase character.", result.diagnostics[0].message);
+}
+
 test "can disable capitalized-comments" {
     const source =
         \\// lowercase line comment


### PR DESCRIPTION
## Summary
- add a `capitalized-comments` mode option for ESLint's `never` behavior
- expose `--capitalized-comments=never` for the current CLI migration path
- cover the new mode in rule tests and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `always` and new `never` modes
