### PR TITLE
feat: support array callback forEach options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -6,7 +6,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for `setWithoutGet: true` and optional `getWithoutSet: true` behavior |
-| [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for `allowImplicit: true` by default, with optional `allowImplicit: false`; `checkForEach: false, allowVoid: false` |
+| [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always` and optional `never` behavior |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |

--- a/src/core.zig
+++ b/src/core.zig
@@ -74,6 +74,16 @@ pub const ArrayCallbackReturnAllowImplicit = enum {
     no,
 };
 
+pub const ArrayCallbackReturnCheckForEach = enum {
+    yes,
+    no,
+};
+
+pub const ArrayCallbackReturnAllowVoid = enum {
+    yes,
+    no,
+};
+
 pub const CapitalizedCommentsMode = enum {
     always,
     never,
@@ -84,6 +94,8 @@ pub const Options = struct {
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
     array_callback_return: bool = true,
     array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .yes,
+    array_callback_return_check_for_each: ArrayCallbackReturnCheckForEach = .no,
+    array_callback_return_allow_void: ArrayCallbackReturnAllowVoid = .no,
     block_scoped_var: bool = true,
     capitalized_comments: bool = true,
     capitalized_comments_mode: CapitalizedCommentsMode = .always,

--- a/src/main.zig
+++ b/src/main.zig
@@ -118,6 +118,10 @@ pub fn main(init: std.process.Init) !void {
             options.array_callback_return = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return-allow-implicit=off")) {
             options.array_callback_return_allow_implicit = .no;
+        } else if (std.mem.eql(u8, arg, "--array-callback-return-check-for-each=on")) {
+            options.array_callback_return_check_for_each = .yes;
+        } else if (std.mem.eql(u8, arg, "--array-callback-return-allow-void=on")) {
+            options.array_callback_return_allow_void = .yes;
         } else if (std.mem.eql(u8, arg, "--block-scoped-var=off")) {
             options.block_scoped_var = false;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=off")) {
@@ -1286,6 +1290,8 @@ fn printHelp() void {
         \\  --accessor-pairs-get-without-set=on Enable accessor-pairs getWithoutSet
         \\  --array-callback-return=off Disable array-callback-return
         \\  --array-callback-return-allow-implicit=off Require explicit values from array callbacks
+        \\  --array-callback-return-check-for-each=on Check forEach callbacks for return values
+        \\  --array-callback-return-allow-void=on Allow void returns in checked forEach callbacks
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --capitalized-comments=never Require lowercase comment starts

--- a/src/rules/array_callback_return.zig
+++ b/src/rules/array_callback_return.zig
@@ -9,6 +9,18 @@ pub const id = "array-callback-return";
 
 pub const Options = struct {
     allow_implicit: bool = true,
+    check_for_each: bool = false,
+    allow_void: bool = false,
+};
+
+const CallbackKind = enum {
+    value_required,
+    for_each,
+};
+
+const CallbackTarget = struct {
+    callback: ast.NodeIndex,
+    kind: CallbackKind,
 };
 
 const Completion = enum {
@@ -34,8 +46,14 @@ pub fn checkWithOptions(
     call: ast.CallExpression,
     options: Options,
 ) Allocator.Error!void {
-    const callback = callbackArgument(tree, call) orelse return;
-    if (callbackReturnsValue(tree, callback, options)) return;
+    const target = callbackTarget(tree, call, options) orelse return;
+
+    if (target.kind == .for_each) {
+        try checkForEachCallback(allocator, diagnostics, tree, target.callback, options);
+        return;
+    }
+
+    if (callbackReturnsValue(tree, target.callback, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -43,11 +61,11 @@ pub fn checkWithOptions(
         .warning,
         id,
         "Expected to return a value in array callback.",
-        tree.span(callback),
+        tree.span(target.callback),
     );
 }
 
-fn callbackArgument(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+fn callbackTarget(tree: *const ast.Tree, call: ast.CallExpression, options: Options) ?CallbackTarget {
     const arguments = tree.extra(call.arguments);
     if (arguments.len == 0) return null;
 
@@ -58,15 +76,27 @@ fn callbackArgument(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIn
     };
 
     const method = propertyName(tree, member) orelse return null;
-    if (std.mem.eql(u8, method, "forEach")) return null;
+    if (std.mem.eql(u8, method, "forEach")) {
+        if (!options.check_for_each) return null;
+        return .{
+            .callback = callbackIfFunction(tree, arguments[0]) orelse return null,
+            .kind = .for_each,
+        };
+    }
 
     if (isArrayFromCall(tree, member, method)) {
         if (arguments.len < 2) return null;
-        return callbackIfFunction(tree, arguments[1]);
+        return .{
+            .callback = callbackIfFunction(tree, arguments[1]) orelse return null,
+            .kind = .value_required,
+        };
     }
 
     if (!isArrayCallbackMethod(method)) return null;
-    return callbackIfFunction(tree, arguments[0]);
+    return .{
+        .callback = callbackIfFunction(tree, arguments[0]) orelse return null,
+        .kind = .value_required,
+    };
 }
 
 fn callbackIfFunction(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
@@ -110,7 +140,7 @@ fn callbackReturnsValue(tree: *const ast.Tree, callback: ast.NodeIndex, options:
     return switch (tree.data(callback)) {
         .function => |function| functionReturnsValue(tree, function.body, options),
         .arrow_function_expression => |arrow| if (arrow.expression)
-            !isVoidExpression(tree, arrow.body)
+            expressionIsValidReturnValue(tree, arrow.body, options)
         else
             functionReturnsValue(tree, arrow.body, options),
         else => true,
@@ -158,8 +188,129 @@ fn returnCompletion(tree: *const ast.Tree, statement: ast.ReturnStatement, optio
         .valid_terminal
     else
         .invalid_return;
-    if (isVoidExpression(tree, statement.argument)) return .invalid_return;
+    if (!expressionIsValidReturnValue(tree, statement.argument, options)) return .invalid_return;
     return .valid_terminal;
+}
+
+fn checkForEachCallback(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    callback: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    switch (tree.data(callback)) {
+        .function => |function| try scanForEachFunctionBody(allocator, diagnostics, tree, function.body, options),
+        .arrow_function_expression => |arrow| if (arrow.expression) {
+            if (expressionIsForbiddenForEachReturn(tree, arrow.body, options)) {
+                try addForEachDiagnostic(allocator, diagnostics, tree, callback);
+            }
+        } else {
+            try scanForEachFunctionBody(allocator, diagnostics, tree, arrow.body, options);
+        },
+        else => {},
+    }
+}
+
+fn scanForEachFunctionBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (body_index == .null) return;
+
+    const body = switch (tree.data(body_index)) {
+        .function_body => |body| body,
+        else => return,
+    };
+
+    try scanForEachRange(allocator, diagnostics, tree, body.body, options);
+}
+
+fn scanForEachRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    options: Options,
+) Allocator.Error!void {
+    for (tree.extra(range)) |statement| {
+        try scanForEachNode(allocator, diagnostics, tree, statement, options);
+    }
+}
+
+fn scanForEachNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .return_statement => |statement| {
+            if (statement.argument != .null and expressionIsForbiddenForEachReturn(tree, statement.argument, options)) {
+                try addForEachDiagnostic(allocator, diagnostics, tree, index);
+            }
+        },
+        .block_statement => |block| try scanForEachRange(allocator, diagnostics, tree, block.body, options),
+        .static_block => |block| try scanForEachRange(allocator, diagnostics, tree, block.body, options),
+        .if_statement => |statement| {
+            try scanForEachNode(allocator, diagnostics, tree, statement.consequent, options);
+            try scanForEachNode(allocator, diagnostics, tree, statement.alternate, options);
+        },
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const switch_case = switch (tree.data(case_index)) {
+                    .switch_case => |switch_case| switch_case,
+                    else => continue,
+                };
+                try scanForEachRange(allocator, diagnostics, tree, switch_case.consequent, options);
+            }
+        },
+        .for_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .for_in_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .for_of_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .while_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .do_while_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .with_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .labeled_statement => |statement| try scanForEachNode(allocator, diagnostics, tree, statement.body, options),
+        .try_statement => |statement| {
+            try scanForEachNode(allocator, diagnostics, tree, statement.block, options);
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return,
+                };
+                try scanForEachNode(allocator, diagnostics, tree, handler.body, options);
+            }
+            try scanForEachNode(allocator, diagnostics, tree, statement.finalizer, options);
+        },
+        .function,
+        .arrow_function_expression,
+        .class,
+        => return,
+        else => return,
+    }
+}
+
+fn addForEachDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Array.prototype.forEach() expects no useless return value from callback.",
+        tree.span(index),
+    );
 }
 
 fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement, options: Options) Completion {
@@ -200,6 +351,14 @@ fn isVoidExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .unary_expression => |expression| expression.operator == .void,
         else => false,
     };
+}
+
+fn expressionIsValidReturnValue(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) bool {
+    return !isVoidExpression(tree, index) or options.allow_void;
+}
+
+fn expressionIsForbiddenForEachReturn(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) bool {
+    return !isVoidExpression(tree, index) or !options.allow_void;
 }
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2099,6 +2099,8 @@ const BasicVisitor = struct {
         if (self.options.array_callback_return) {
             try array_callback_return.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, call, .{
                 .allow_implicit = self.options.array_callback_return_allow_implicit == .yes,
+                .check_for_each = self.options.array_callback_return_check_for_each == .yes,
+                .allow_void = self.options.array_callback_return_allow_void == .yes,
             });
         }
         if (self.options.accessor_pairs) {

--- a/tests/rules/array_callback_return.zig
+++ b/tests/rules/array_callback_return.zig
@@ -22,6 +22,7 @@ test "reports array-callback-return when callbacks can fall through" {
         .no_unused_vars = false,
         .no_useless_return = false,
         .no_void = false,
+        .eol_last = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -83,6 +84,9 @@ test "reports array-callback-return for implicit returns when allowImplicit is d
 test "ignores forEach callbacks and non-function callback references" {
     const source =
         \\items.forEach((item) => {
+        \\  return item.id;
+        \\});
+        \\items.forEach((item) => {
         \\  item.toString();
         \\});
         \\items.map(callback);
@@ -96,6 +100,66 @@ test "ignores forEach callbacks and non-function callback references" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
+}
+
+test "reports array-callback-return for forEach return values when checkForEach is enabled" {
+    const source =
+        \\items.forEach((item) => item.id);
+        \\items.forEach(function(item) {
+        \\  if (item.ready) {
+        \\    return item.id;
+        \\  }
+        \\  return;
+        \\});
+        \\items.forEach((item) => {
+        \\  return void item.touch();
+        \\});
+        \\items.forEach((item) => {
+        \\  item.touch();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .array_callback_return_check_for_each = .yes,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .no_void = false,
+        .eol_last = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.array_callback_return.id));
+    try std.testing.expectEqualStrings(
+        "Array.prototype.forEach() expects no useless return value from callback.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "allows void returns from forEach callbacks when allowVoid is enabled" {
+    const source =
+        \\items.forEach((item) => void item.touch());
+        \\items.forEach(function(item) {
+        \\  return void item.touch();
+        \\});
+        \\items.forEach(function(item) {
+        \\  return item.id;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .array_callback_return_check_for_each = .yes,
+        .array_callback_return_allow_void = .yes,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .no_void = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.array_callback_return.id));
 }
 
 test "can disable array-callback-return" {


### PR DESCRIPTION
## Summary
- add `array-callback-return` support for `checkForEach` callback return checks
- add `allowVoid` handling for checked `forEach` callbacks and value-returning callbacks
- expose temporary CLI switches for the current migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default, `checkForEach`, and `allowVoid` behavior
