### PR TITLE
feat: support func name matching never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -19,7 +19,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
-| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for ESLint's default `always` behavior |
+| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always` and optional `as-needed` options |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |

--- a/src/core.zig
+++ b/src/core.zig
@@ -69,6 +69,11 @@ pub const FuncNamesStyle = enum {
     as_needed,
 };
 
+pub const FuncNameMatchingStyle = enum {
+    always,
+    never,
+};
+
 pub const ArrayCallbackReturnAllowImplicit = enum {
     yes,
     no,
@@ -112,6 +117,7 @@ pub const Options = struct {
     eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,
     for_direction: bool = true,
     func_name_matching: bool = true,
+    func_name_matching_style: FuncNameMatchingStyle = .always,
     func_names: bool = true,
     func_names_style: FuncNamesStyle = .always,
     getter_return: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -146,6 +146,8 @@ pub fn main(init: std.process.Init) !void {
             options.for_direction = false;
         } else if (std.mem.eql(u8, arg, "--func-name-matching=off")) {
             options.func_name_matching = false;
+        } else if (std.mem.eql(u8, arg, "--func-name-matching=never")) {
+            options.func_name_matching_style = .never;
         } else if (std.mem.eql(u8, arg, "--func-names=off")) {
             options.func_names = false;
         } else if (std.mem.eql(u8, arg, "--func-names=as-needed")) {
@@ -1306,6 +1308,7 @@ fn printHelp() void {
         \\  --eslint-comments-no-restricted-disable=off Disable eslint-comments/no-restricted-disable
         \\  --for-direction=off       Disable for-direction
         \\  --func-name-matching=off Disable func-name-matching
+        \\  --func-name-matching=never Disallow matching function expression names
         \\  --func-names=off          Disable func-names
         \\  --func-names=as-needed    Allow inferable anonymous function names
         \\  --getter-return=off       Disable getter-return

--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -7,6 +7,15 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "func-name-matching";
 
+pub const Style = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    style: Style = .always,
+};
+
 pub fn checkVariableDeclarator(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -16,7 +25,20 @@ pub fn checkVariableDeclarator(
     if (declarator.init == .null) return;
 
     const target = bindingIdentifierName(tree, declarator.id) orelse return;
-    try checkFunctionName(allocator, diagnostics, tree, declarator.init, target);
+    try checkFunctionName(allocator, diagnostics, tree, declarator.init, target, .{});
+}
+
+pub fn checkVariableDeclaratorWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    options: Options,
+) Allocator.Error!void {
+    if (declarator.init == .null) return;
+
+    const target = bindingIdentifierName(tree, declarator.id) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, declarator.init, target, options);
 }
 
 pub fn checkAssignmentExpression(
@@ -28,7 +50,20 @@ pub fn checkAssignmentExpression(
     if (expression.operator != .assign) return;
 
     const target = assignmentTargetName(tree, expression.left) orelse return;
-    try checkFunctionName(allocator, diagnostics, tree, expression.right, target);
+    try checkFunctionName(allocator, diagnostics, tree, expression.right, target, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    options: Options,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    const target = assignmentTargetName(tree, expression.left) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, expression.right, target, options);
 }
 
 pub fn checkObjectProperty(
@@ -40,7 +75,20 @@ pub fn checkObjectProperty(
     if (property.method or property.value == .null) return;
 
     const target = propertyName(tree, property.key, property.computed) orelse return;
-    try checkFunctionName(allocator, diagnostics, tree, property.value, target);
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target, .{});
+}
+
+pub fn checkObjectPropertyWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    options: Options,
+) Allocator.Error!void {
+    if (property.method or property.value == .null) return;
+
+    const target = propertyName(tree, property.key, property.computed) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target, options);
 }
 
 pub fn checkPropertyDefinition(
@@ -52,7 +100,20 @@ pub fn checkPropertyDefinition(
     if (property.value == .null) return;
 
     const target = propertyName(tree, property.key, property.computed) orelse return;
-    try checkFunctionName(allocator, diagnostics, tree, property.value, target);
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target, .{});
+}
+
+pub fn checkPropertyDefinitionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (property.value == .null) return;
+
+    const target = propertyName(tree, property.key, property.computed) orelse return;
+    try checkFunctionName(allocator, diagnostics, tree, property.value, target, options);
 }
 
 fn checkFunctionName(
@@ -61,6 +122,7 @@ fn checkFunctionName(
     tree: *const ast.Tree,
     value: ast.NodeIndex,
     target: []const u8,
+    options: Options,
 ) Allocator.Error!void {
     const function = switch (tree.data(unwrapTransparent(tree, value))) {
         .function => |function| function,
@@ -69,17 +131,29 @@ fn checkFunctionName(
     if (function.type != .function_expression) return;
 
     const actual = bindingIdentifierName(tree, function.id) orelse return;
-    if (std.mem.eql(u8, actual, target)) return;
+    const matches = std.mem.eql(u8, actual, target);
+    if (matches == (options.style == .always)) return;
 
-    try core.addDiagnosticFmt(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        tree.span(value),
-        "Function name `{s}` should match target name `{s}`.",
-        .{ actual, target },
-    );
+    switch (options.style) {
+        .always => try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(value),
+            "Function name `{s}` should match target name `{s}`.",
+            .{ actual, target },
+        ),
+        .never => try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(value),
+            "Function name `{s}` should not match target name `{s}`.",
+            .{ actual, target },
+        ),
+    }
 }
 
 fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -344,6 +344,13 @@ fn groupedAccessorPairsStyle(style: core.GroupedAccessorPairsStyle) grouped_acce
     };
 }
 
+fn funcNameMatchingStyle(style: core.FuncNameMatchingStyle) func_name_matching.Style {
+    return switch (style) {
+        .always => .always,
+        .never => .never,
+    };
+}
+
 pub fn runBasic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -1304,7 +1311,9 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+            try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, .{
+                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
+            });
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
@@ -1947,7 +1956,9 @@ const BasicVisitor = struct {
             try logical_assignment_operators.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
+            });
         }
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -2553,7 +2564,9 @@ const BasicVisitor = struct {
             try object_shorthand.check(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property);
+            try func_name_matching.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
+            });
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
@@ -2691,7 +2704,9 @@ const BasicVisitor = struct {
             try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+            try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
+            });
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -83,6 +83,37 @@ test "does not report func-name-matching for matching or unsupported cases" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.func_name_matching.id));
 }
 
+test "reports func-name-matching for matching names in never mode" {
+    const source =
+        \\const first = function first() {};
+        \\object.value = function value() {};
+        \\const object = {
+        \\  prop: function prop() {},
+        \\};
+        \\class Example {
+        \\  field = function field() {};
+        \\}
+        \\const mismatch = function other() {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .func_name_matching_style = .never,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.func_name_matching.id));
+    try std.testing.expectEqualStrings(
+        "Function name `first` should not match target name `first`.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable func-name-matching" {
     const source =
         \\const first = function second() {};


### PR DESCRIPTION
## Summary
- add `func-name-matching` support for ESLint's `never` option
- expose `--func-name-matching=never` for the current CLI migration path
- cover the new mode in rule tests and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `always` and new `never` behavior
