### PR TITLE
feat: support prefer const destructuring all

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -162,7 +162,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
-| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for fishlint's `destructuring: any, ignoreReadBeforeAssign: true` configuration |
+| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators and assignment expressions |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |

--- a/src/core.zig
+++ b/src/core.zig
@@ -74,6 +74,11 @@ pub const FuncNameMatchingStyle = enum {
     never,
 };
 
+pub const PreferConstDestructuring = enum {
+    any,
+    all,
+};
+
 pub const ArrayCallbackReturnAllowImplicit = enum {
     yes,
     no,
@@ -333,6 +338,7 @@ pub const Options = struct {
     no_use_before_define: bool = true,
     no_undef: bool = true,
     prefer_const: bool = true,
+    prefer_const_destructuring: PreferConstDestructuring = .any,
     prefer_exponentiation_operator: bool = true,
     prefer_numeric_literals: bool = true,
     prefer_object_has_own: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -576,6 +576,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_undef = false;
         } else if (std.mem.eql(u8, arg, "--prefer-const=off")) {
             options.prefer_const = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-const-destructuring=all")) {
+            options.prefer_const_destructuring = .all;
         } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
             options.prefer_exponentiation_operator = false;
         } else if (std.mem.eql(u8, arg, "--prefer-numeric-literals=off")) {
@@ -1523,6 +1525,7 @@ fn printHelp() void {
         \\  --no-use-before-define=off Disable no-use-before-define
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-const=off        Disable prefer-const
+        \\  --prefer-const-destructuring=all Require all destructured bindings to be const candidates
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
         \\  --prefer-numeric-literals=off Disable prefer-numeric-literals
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors

--- a/src/rules/prefer_const.zig
+++ b/src/rules/prefer_const.zig
@@ -11,11 +11,22 @@ pub const id = "prefer-const";
 const SymbolId = traverser.semantic.SymbolId;
 const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
 const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const DestructuringGroupMap = std.AutoHashMap(usize, bool);
+
+pub const Destructuring = enum {
+    any,
+    all,
+};
+
+pub const Options = struct {
+    destructuring: Destructuring = .any,
+};
 
 const Candidate = struct {
     node: ast.NodeIndex,
     name: []const u8,
     reassigned: bool = false,
+    destructuring_group: ?usize = null,
 };
 
 pub fn run(
@@ -24,11 +35,24 @@ pub fn run(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var decl_symbols = DeclSymbolMap.init(allocator);
     defer decl_symbols.deinit();
 
     var reference_lookup = ReferenceLookup.init(allocator);
     defer reference_lookup.deinit();
+
+    var destructuring_groups = DestructuringGroupMap.init(allocator);
+    defer destructuring_groups.deinit();
 
     const candidate_symbols = try allocator.alloc(bool, symbol_table.symbols.len);
     defer allocator.free(candidate_symbols);
@@ -63,6 +87,8 @@ pub fn run(
         .decl_symbols = &decl_symbols,
         .reference_lookup = &reference_lookup,
         .candidates = &candidates,
+        .destructuring_groups = &destructuring_groups,
+        .options = options,
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
 
@@ -70,6 +96,9 @@ pub fn run(
     while (candidate_iter.next()) |entry| {
         const candidate = entry.value_ptr.*;
         if (candidate.reassigned) continue;
+        if (candidate.destructuring_group) |group_id| {
+            if (options.destructuring == .all and (destructuring_groups.get(group_id) orelse false)) continue;
+        }
 
         try core.addDiagnosticFmt(
             allocator,
@@ -88,6 +117,9 @@ const Visitor = struct {
     decl_symbols: *const DeclSymbolMap,
     reference_lookup: *const ReferenceLookup,
     candidates: *std.AutoHashMap(SymbolId, Candidate),
+    destructuring_groups: *DestructuringGroupMap,
+    options: Options,
+    next_destructuring_group: usize = 0,
 
     pub fn enter_variable_declaration(
         self: *Visitor,
@@ -103,7 +135,15 @@ const Visitor = struct {
                 else => continue,
             };
             if (declarator.init == .null) continue;
-            try self.collectCandidate(ctx.tree, declarator.id);
+
+            const group = if (self.options.destructuring == .all and isDestructuringPattern(ctx.tree, declarator.id)) group: {
+                const group_id = self.next_destructuring_group;
+                self.next_destructuring_group += 1;
+                try self.destructuring_groups.put(group_id, false);
+                break :group group_id;
+            } else null;
+
+            try self.collectCandidate(ctx.tree, declarator.id, group);
         }
 
         return .proceed;
@@ -129,7 +169,7 @@ const Visitor = struct {
         return .proceed;
     }
 
-    fn collectCandidate(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+    fn collectCandidate(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex, group: ?usize) Allocator.Error!void {
         if (index == .null) return;
 
         switch (tree.data(index)) {
@@ -138,15 +178,16 @@ const Visitor = struct {
                 try self.candidates.put(symbol_id, .{
                     .node = index,
                     .name = tree.string(identifier.name),
+                    .destructuring_group = group,
                 });
             },
-            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left),
-            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument),
+            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left, group),
+            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument, group),
             .array_pattern => |pattern| {
                 for (tree.extra(pattern.elements)) |element| {
-                    try self.collectCandidate(tree, element);
+                    try self.collectCandidate(tree, element, group);
                 }
-                try self.collectCandidate(tree, pattern.rest);
+                try self.collectCandidate(tree, pattern.rest, group);
             },
             .object_pattern => |pattern| {
                 for (tree.extra(pattern.properties)) |property_index| {
@@ -154,9 +195,9 @@ const Visitor = struct {
                         .binding_property => |property| property,
                         else => continue,
                     };
-                    try self.collectCandidate(tree, property.value);
+                    try self.collectCandidate(tree, property.value, group);
                 }
-                try self.collectCandidate(tree, pattern.rest);
+                try self.collectCandidate(tree, pattern.rest, group);
             },
             else => {},
         }
@@ -171,6 +212,9 @@ const Visitor = struct {
                 const symbol_id = self.reference_lookup.get(unwrapped) orelse return;
                 if (self.candidates.getPtr(symbol_id)) |candidate| {
                     candidate.reassigned = true;
+                    if (candidate.destructuring_group) |group_id| {
+                        try self.destructuring_groups.put(group_id, true);
+                    }
                 }
             },
             .assignment_pattern => |pattern| try self.markReassigned(tree, pattern.left),
@@ -194,6 +238,16 @@ const Visitor = struct {
         }
     }
 };
+
+fn isDestructuringPattern(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .array_pattern,
+        .object_pattern,
+        => true,
+        else => false,
+    };
+}
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
     var current = index;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -829,7 +829,12 @@ pub fn runSemantic(
     }
 
     if (options.prefer_const) {
-        try prefer_const.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try prefer_const.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .destructuring = switch (options.prefer_const_destructuring) {
+                .any => .any,
+                .all => .all,
+            },
+        });
     }
 }
 

--- a/tests/rules/prefer_const.zig
+++ b/tests/rules/prefer_const.zig
@@ -37,6 +37,42 @@ test "does not report prefer-const for reassigned let bindings or uninitialized 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_const.id));
 }
 
+test "reports prefer-const for destructuring any by default" {
+    const source =
+        \\let { a, b } = obj;
+        \\b = 2;
+        \\let [c, d] = list;
+        \\d++;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_const.id));
+}
+
+test "reports prefer-const for destructuring only when all bindings qualify in all mode" {
+    const source =
+        \\let { a, b } = obj;
+        \\b = 2;
+        \\let [c, d] = list;
+        \\let { e: { f }, ...rest } = other;
+        \\rest = {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .prefer_const_destructuring = .all,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_const.id));
+}
+
 test "can disable prefer-const" {
     const source =
         \\let a = 1;


### PR DESCRIPTION
## Summary
- add `prefer-const` support for ESLint's `destructuring: "all"` behavior
- group destructured bindings so partially reassigned destructuring patterns are skipped in `all` mode
- expose `--prefer-const-destructuring=all` for the current CLI migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `any` and new `all` behavior
