### PR TITLE
feat: support logical assignment never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -25,7 +25,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
-| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for ESLint's default `always` expression behavior and optional `enforceForIfStatements: true` |
+| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -64,6 +64,11 @@ pub const LogicalAssignmentOperatorsEnforceForIfStatements = enum {
     no,
 };
 
+pub const LogicalAssignmentOperatorsStyle = enum {
+    always,
+    never,
+};
+
 pub const FuncNamesStyle = enum {
     always,
     as_needed,
@@ -131,6 +136,7 @@ pub const Options = struct {
     guard_for_in: bool = true,
     linebreak_style: bool = true,
     logical_assignment_operators: bool = true,
+    logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
     new_cap: bool = true,
     new_parens: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -560,6 +560,8 @@ pub fn main(init: std.process.Init) !void {
             options.object_shorthand = false;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators=off")) {
             options.logical_assignment_operators = false;
+        } else if (std.mem.eql(u8, arg, "--logical-assignment-operators=never")) {
+            options.logical_assignment_operators_style = .never;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators-enforce-for-if-statements=on")) {
             options.logical_assignment_operators_enforce_for_if_statements = .yes;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
@@ -1434,6 +1436,7 @@ fn printHelp() void {
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
+        \\  --logical-assignment-operators=never Disallow logical assignment operators
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision

--- a/src/rules/logical_assignment_operators.zig
+++ b/src/rules/logical_assignment_operators.zig
@@ -7,6 +7,15 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "logical-assignment-operators";
 
+pub const Style = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    style: Style = .always,
+};
+
 const Reference = union(enum) {
     this,
     identifier: []const u8,
@@ -23,6 +32,22 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.style == .never) {
+        try checkLogicalAssignmentOperator(allocator, diagnostics, tree, expression, index);
+        return;
+    }
+
     if (expression.operator != .assign) return;
 
     const logical = switch (tree.data(unwrapTransparent(tree, expression.right))) {
@@ -39,6 +64,25 @@ pub fn checkAssignmentExpression(
     if (!referencesEqual(left, right_left)) return;
 
     try addDiagnostic(allocator, diagnostics, tree, index, logical.operator);
+}
+
+fn checkLogicalAssignmentOperator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    const operator = logicalOperatorFromAssignment(expression.operator) orelse return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Unexpected logical assignment operator `{s}=`.",
+        .{operator.toString()},
+    );
 }
 
 pub fn checkLogicalExpression(
@@ -109,6 +153,15 @@ fn addDiagnostic(
         "Assignment can be replaced with `{s}=`.",
         .{operator.toString()},
     );
+}
+
+fn logicalOperatorFromAssignment(operator: ast.AssignmentOperator) ?ast.LogicalOperator {
+    return switch (operator) {
+        .logical_or_assign => .@"or",
+        .logical_and_assign => .@"and",
+        .nullish_assign => .nullish_coalescing,
+        else => null,
+    };
 }
 
 fn conditionReference(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1102,7 +1102,10 @@ const BasicVisitor = struct {
         if (self.options.no_negated_condition) {
             try no_negated_condition.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
-        if (self.options.logical_assignment_operators and self.options.logical_assignment_operators_enforce_for_if_statements == .yes) {
+        if (self.options.logical_assignment_operators and
+            self.options.logical_assignment_operators_style == .always and
+            self.options.logical_assignment_operators_enforce_for_if_statements == .yes)
+        {
             try logical_assignment_operators.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
@@ -1958,7 +1961,12 @@ const BasicVisitor = struct {
             try operator_assignment.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.logical_assignment_operators) {
-            try logical_assignment_operators.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try logical_assignment_operators.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .style = switch (self.options.logical_assignment_operators_style) {
+                    .always => .always,
+                    .never => .never,
+                },
+            });
         }
         if (self.options.func_name_matching) {
             try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
@@ -1998,7 +2006,7 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.logical_assignment_operators) {
+        if (self.options.logical_assignment_operators and self.options.logical_assignment_operators_style == .always) {
             try logical_assignment_operators.checkLogicalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         return .proceed;

--- a/tests/rules/logical_assignment_operators.zig
+++ b/tests/rules/logical_assignment_operators.zig
@@ -119,6 +119,33 @@ test "does not report logical-assignment-operators when shorthand would change m
     try std.testing.expect(!helpers.hasRule(result, lint.rules.logical_assignment_operators.id));
 }
 
+test "reports logical-assignment-operators for logical assignments in never mode" {
+    const source =
+        \\first ||= fallback;
+        \\second &&= fallback;
+        \\third ??= fallback;
+        \\fourth = fourth || fallback;
+        \\fourth || (fourth = fallback);
+        \\if (fourth) fourth = fallback;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .logical_assignment_operators_style = .never,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
+        .no_unused_expressions = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
+    try std.testing.expectEqualStrings("Unexpected logical assignment operator `||=`.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Unexpected logical assignment operator `&&=`.", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("Unexpected logical assignment operator `??=`.", result.diagnostics[2].message);
+}
+
 test "can disable logical-assignment-operators" {
     const source =
         \\let value;


### PR DESCRIPTION
## Summary
- add `logical-assignment-operators` support for ESLint's `never` option
- report existing `||=`, `&&=`, and `??=` operators in `never` mode while preserving default `always` behavior
- expose `--logical-assignment-operators=never` for the current CLI migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default `always` and new `never` behavior
