### PR TITLE
feat: support accessor pairs setWithoutGet option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -5,7 +5,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
-| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for `setWithoutGet: true` and optional `getWithoutSet: true` behavior |
+| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for optional `setWithoutGet` and `getWithoutSet` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always` and optional `never` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -53,6 +53,11 @@ pub const AccessorPairsGetWithoutSet = enum {
     no,
 };
 
+pub const AccessorPairsSetWithoutGet = enum {
+    yes,
+    no,
+};
+
 pub const GroupedAccessorPairsStyle = enum {
     any_order,
     get_before_set,
@@ -107,6 +112,7 @@ pub const CapitalizedCommentsMode = enum {
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
+    accessor_pairs_set_without_get: AccessorPairsSetWithoutGet = .yes,
     array_callback_return: bool = true,
     array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .yes,
     array_callback_return_check_for_each: ArrayCallbackReturnCheckForEach = .no,

--- a/src/main.zig
+++ b/src/main.zig
@@ -110,6 +110,8 @@ pub fn main(init: std.process.Init) !void {
             options.accessor_pairs = false;
         } else if (std.mem.eql(u8, arg, "--accessor-pairs-get-without-set=on")) {
             options.accessor_pairs_get_without_set = .yes;
+        } else if (std.mem.eql(u8, arg, "--accessor-pairs-set-without-get=off")) {
+            options.accessor_pairs_set_without_get = .no;
         } else if (std.mem.eql(u8, arg, "--consistent-return=off")) {
             options.consistent_return = false;
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
@@ -1294,6 +1296,7 @@ fn printHelp() void {
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --accessor-pairs=off    Disable accessor-pairs
         \\  --accessor-pairs-get-without-set=on Enable accessor-pairs getWithoutSet
+        \\  --accessor-pairs-set-without-get=off Disable accessor-pairs setWithoutGet
         \\  --array-callback-return=off Disable array-callback-return
         \\  --array-callback-return-allow-implicit=off Require explicit values from array callbacks
         \\  --array-callback-return-check-for-each=on Check forEach callbacks for return values

--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -9,6 +9,7 @@ pub const id = "accessor-pairs";
 
 pub const Options = struct {
     get_without_set: bool = false,
+    set_without_get: bool = true,
 };
 
 const Accessor = struct {
@@ -177,7 +178,7 @@ fn checkPropertyDescriptor(
         }
     }
 
-    if (!has_get and set_index != .null) {
+    if (options.set_without_get and !has_get and set_index != .null) {
         try addSetterDiagnostic(allocator, diagnostics, tree, report_index);
     }
     if (options.get_without_set and has_get and !has_set and get_index != .null) {
@@ -225,7 +226,7 @@ fn reportMissingCounterparts(
     options: Options,
 ) Allocator.Error!void {
     for (accessors) |accessor| {
-        if (accessor.set and !accessor.get) {
+        if (options.set_without_get and accessor.set and !accessor.get) {
             try addSetterDiagnostic(allocator, diagnostics, tree, accessor.set_index);
         }
         if (options.get_without_set and accessor.get and !accessor.set) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2130,6 +2130,7 @@ const BasicVisitor = struct {
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+                .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
             });
         }
         if (self.options.import_no_amd) {
@@ -2527,6 +2528,7 @@ const BasicVisitor = struct {
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkObjectExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+                .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
             });
         }
         if (self.options.grouped_accessor_pairs) {
@@ -2630,6 +2632,7 @@ const BasicVisitor = struct {
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkClassBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, body, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
+                .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
             });
         }
         if (self.options.grouped_accessor_pairs) {

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -138,6 +138,44 @@ test "reports accessor-pairs for getters without setters when enabled" {
     try std.testing.expectEqualStrings("Getter must be accompanied by a setter.", result.diagnostics[0].message);
 }
 
+test "does not report accessor-pairs for setters without getters when disabled" {
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\  get ready() { return true; },
+        \\};
+        \\class Example {
+        \\  set value(next) {}
+        \\  get ready() { return true; }
+        \\}
+        \\Object.defineProperty(target, "value", {
+        \\  set(next) {}
+        \\});
+        \\Object.defineProperties(target, {
+        \\  first: {
+        \\    set(next) {}
+        \\  },
+        \\  second: {
+        \\    get() { return 1; }
+        \\  }
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .accessor_pairs_get_without_set = .yes,
+        .accessor_pairs_set_without_get = .no,
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.accessor_pairs.id));
+    try std.testing.expectEqualStrings("Getter must be accompanied by a setter.", result.diagnostics[0].message);
+}
+
 test "does not treat ordinary descriptor-looking objects as property descriptors" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary
- add `accessor-pairs` support for ESLint's `setWithoutGet: false` option
- preserve default setter-without-get diagnostics while allowing them to be disabled independently from `getWithoutSet`
- expose `--accessor-pairs-set-without-get=off` for the current CLI migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default, `setWithoutGet: false`, and combined `getWithoutSet: true` behavior
