### PR TITLE
feat: support capitalized comments inline ignore

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -8,7 +8,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for optional `setWithoutGet` and `getWithoutSet` behavior |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
-| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always` and optional `never` behavior |
+| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always`, optional `never`, and optional `ignoreInlineComments` behavior |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -109,6 +109,11 @@ pub const CapitalizedCommentsMode = enum {
     never,
 };
 
+pub const CapitalizedCommentsIgnoreInlineComments = enum {
+    yes,
+    no,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
@@ -120,6 +125,7 @@ pub const Options = struct {
     block_scoped_var: bool = true,
     capitalized_comments: bool = true,
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
+    capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
     consistent_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,6 +130,8 @@ pub fn main(init: std.process.Init) !void {
             options.capitalized_comments = false;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=never")) {
             options.capitalized_comments_mode = .never;
+        } else if (std.mem.eql(u8, arg, "--capitalized-comments-ignore-inline-comments=on")) {
+            options.capitalized_comments_ignore_inline_comments = .yes;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
         } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
@@ -1304,6 +1306,7 @@ fn printHelp() void {
         \\  --block-scoped-var=off   Disable block-scoped-var
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --capitalized-comments=never Require lowercase comment starts
+        \\  --capitalized-comments-ignore-inline-comments=on Ignore inline comments
         \\  --consistent-return=off  Disable consistent-return
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -14,6 +14,7 @@ pub const Mode = enum {
 
 pub const Options = struct {
     mode: Mode = .always,
+    ignore_inline_comments: bool = false,
 };
 
 pub fn run(
@@ -31,6 +32,8 @@ pub fn runWithOptions(
     options: Options,
 ) Allocator.Error!void {
     for (tree.comments) |comment| {
+        if (options.ignore_inline_comments and isInlineComment(tree, comment)) continue;
+
         const value = trimLeftDecorations(tree.string(comment.value));
         if (isIgnoredComment(value)) continue;
 
@@ -60,6 +63,32 @@ fn violatesMode(first: u8, mode: Mode) bool {
         .always => std.ascii.isLower(first),
         .never => std.ascii.isUpper(first),
     };
+}
+
+fn isInlineComment(tree: *const ast.Tree, comment: ast.Comment) bool {
+    return hasNonWhitespaceBeforeOnLine(tree.source, comment.start) and
+        hasNonWhitespaceAfterOnLine(tree.source, comment.end);
+}
+
+fn hasNonWhitespaceBeforeOnLine(source: []const u8, offset: usize) bool {
+    var cursor = offset;
+    while (cursor > 0) {
+        cursor -= 1;
+        const char = source[cursor];
+        if (char == '\n' or char == '\r') return false;
+        if (!isWhitespace(char)) return true;
+    }
+    return false;
+}
+
+fn hasNonWhitespaceAfterOnLine(source: []const u8, offset: usize) bool {
+    var cursor = offset;
+    while (cursor < source.len) : (cursor += 1) {
+        const char = source[cursor];
+        if (char == '\n' or char == '\r') return false;
+        if (!isWhitespace(char)) return true;
+    }
+    return false;
 }
 
 fn trimLeftDecorations(value: []const u8) []const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -364,6 +364,7 @@ pub fn runBasic(
                 .always => .always,
                 .never => .never,
             },
+            .ignore_inline_comments = options.capitalized_comments_ignore_inline_comments == .yes,
         });
     }
     if (options.no_warning_comments) {

--- a/tests/rules/capitalized_comments.zig
+++ b/tests/rules/capitalized_comments.zig
@@ -66,6 +66,34 @@ test "reports capitalized-comments for uppercase starts in never mode" {
     try std.testing.expectEqualStrings("Comments should not start with an uppercase character.", result.diagnostics[0].message);
 }
 
+test "ignores only inline comments when ignoreInlineComments is enabled" {
+    const source =
+        \\const first = call(/* lowercase inline block */ value);
+        \\const second = value; // lowercase trailing line comment
+        \\/* lowercase standalone block */
+        \\const third = 1;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(default_result, lint.rules.capitalized_comments.id));
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments_ignore_inline_comments = .yes,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer ignored_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(ignored_result, lint.rules.capitalized_comments.id));
+}
+
 test "can disable capitalized-comments" {
     const source =
         \\// lowercase line comment


### PR DESCRIPTION
## Summary
- add `capitalized-comments` support for ESLint’s `ignoreInlineComments` option
- treat comments as inline only when they have non-whitespace code before and after them on the same line
- expose `--capitalized-comments-ignore-inline-comments=on` for the current CLI migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default and `ignoreInlineComments` behavior
