### PR TITLE
feat: align prefer numeric literals static strings

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -165,7 +165,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators and assignment expressions |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
-| [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for literal `parseInt` calls with binary, octal, or hexadecimal radix |
+| [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Implemented |

--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -65,9 +65,9 @@ fn preferredLiteralKind(
     const arguments = tree.extra(call.arguments);
     if (arguments.len != 2) return null;
 
-    const source = staticStringValue(tree, arguments[0]) orelse return null;
+    _ = staticStringValue(tree, arguments[0]) orelse return null;
     const kind = radixLiteralKind(tree, arguments[1]) orelse return null;
-    return if (isValidDigits(source, kind)) kind else null;
+    return kind;
 }
 
 fn diagnosticMessage(kind: LiteralKind) []const u8 {
@@ -113,21 +113,6 @@ fn radixLiteralKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralKind {
         16 => .hexadecimal,
         else => null,
     };
-}
-
-fn isValidDigits(source: []const u8, kind: LiteralKind) bool {
-    if (source.len == 0) return false;
-
-    for (source) |char| {
-        const valid = switch (kind) {
-            .binary => char == '0' or char == '1',
-            .octal => char >= '0' and char <= '7',
-            .hexadecimal => std.ascii.isHex(char),
-        };
-        if (!valid) return false;
-    }
-
-    return true;
 }
 
 fn isGlobalParseIntCall(

--- a/tests/rules/prefer_numeric_literals.zig
+++ b/tests/rules/prefer_numeric_literals.zig
@@ -22,12 +22,29 @@ test "reports prefer-numeric-literals for parseInt calls that can be numeric lit
     try std.testing.expectEqualStrings("Use a binary literal instead of parseInt().", result.diagnostics[0].message);
 }
 
-test "allows parseInt calls that cannot be safely represented as numeric literals" {
+test "reports prefer-numeric-literals for static strings even when digits are invalid" {
     const source =
-        \\parseInt("101", 10);
         \\parseInt("102", 2);
         \\parseInt("89", 8);
         \\parseInt("10px", 16);
+        \\parseInt("", 16);
+        \\parseInt(`7999`, 8);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+}
+
+test "allows parseInt calls without static string and binary octal or hexadecimal radix" {
+    const source =
+        \\parseInt("101", 10);
         \\parseInt(value, 16);
         \\parseInt(`a${value}`, 16);
         \\parseInt("101", radix);


### PR DESCRIPTION
## Summary
- report `prefer-numeric-literals` for static string/template `parseInt` calls with binary, octal, or hexadecimal radix even when the string is empty or has invalid digits
- keep dynamic strings, non-2/8/16 radix values, shadowed globals, and extra-argument calls allowed
- update rule status docs for the broader static string/template coverage

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for invalid static string/template and dynamic string behavior
