### PR TITLE
feat: support no void allow as statement

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -156,7 +156,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Implemented |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
-| [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented |
+| [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented for default `location: start`, optional `location: anywhere`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -42,6 +42,11 @@ pub const NoWarningCommentsDecoration = enum {
     slash_asterisk,
 };
 
+pub const NoVoidAllowAsStatement = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -345,6 +350,7 @@ pub const Options = struct {
     no_warning_comments_location: NoWarningCommentsLocation = .start,
     no_warning_comments_decoration: NoWarningCommentsDecoration = .none,
     no_void: bool = true,
+    no_void_allow_as_statement: NoVoidAllowAsStatement = .no,
     no_with: bool = true,
     no_var: bool = true,
     object_shorthand: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -554,6 +554,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_warning_comments_decoration = .slash_asterisk;
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
+        } else if (std.mem.eql(u8, arg, "--no-void-allow-as-statement=on")) {
+            options.no_void_allow_as_statement = .yes;
         } else if (std.mem.eql(u8, arg, "--no-with=off")) {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
@@ -1523,6 +1525,7 @@ fn printHelp() void {
         \\  --no-warning-comments-decoration=asterisk Ignore leading * comment decorations
         \\  --no-warning-comments-decoration=slash-asterisk Ignore leading / and * comment decorations
         \\  --no-void=off             Disable no-void
+        \\  --no-void-allow-as-statement=on Allow void as expression statement
         \\  --no-with=off             Disable no-with
         \\  --no-var=off              Disable no-var
         \\  --one-var=off             Disable one-var

--- a/src/rules/no_void.zig
+++ b/src/rules/no_void.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-void";
 
+pub const Options = struct {
+    allow_as_statement: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +18,20 @@ pub fn check(
     expression: ast.UnaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, expression, index, null, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (expression.operator != .void) return;
+    if (options.allow_as_statement and isExpressionStatementParent(tree, index, parent)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -24,4 +41,12 @@ pub fn check(
         "The use of void is not allowed.",
         tree.span(index),
     );
+}
+
+fn isExpressionStatementParent(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return false;
+    return switch (tree.data(parent_index)) {
+        .expression_statement => |statement| statement.expression == index,
+        else => false,
+    };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2080,7 +2080,9 @@ const BasicVisitor = struct {
             try no_delete_var.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_void) {
-            try no_void.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_void.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx.path.ancestor(1), .{
+                .allow_as_statement = self.options.no_void_allow_as_statement == .yes,
+            });
         }
         if (self.options.no_implicit_coercion) {
             try no_implicit_coercion.checkUnaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/rules/no_void.zig
+++ b/tests/rules/no_void.zig
@@ -40,6 +40,27 @@ test "does not report no-void for delete or property names" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_void.id));
 }
 
+test "allows void expression statements when allowAsStatement is enabled" {
+    const source =
+        \\void doSideEffect();
+        \\function f() {
+        \\  return void doSideEffect();
+        \\}
+        \\const value = void doSideEffect();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_void_allow_as_statement = .yes,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_void.id));
+}
+
 test "can disable no-void" {
     const source =
         \\void 0;


### PR DESCRIPTION
## Summary
- add `no-void` support for ESLint's `allowAsStatement` option
- expose `--no-void-allow-as-statement=on` for the current CLI migration path
- keep default `no-void` behavior unchanged and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default and `allowAsStatement` behavior
