### PR TITLE
feat: support no implicit coercion category options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -78,7 +78,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-global-assign`](https://eslint.org/docs/latest/rules/no-global-assign) | Implemented |
 | [`no-global-is-finite`](https://eslint.org/docs/latest/rules/no-global-is-finite) | Implemented |
 | [`no-global-is-nan`](https://eslint.org/docs/latest/rules/no-global-is-nan) | Implemented |
-| [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Implemented |
+| [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Implemented with optional `boolean`, `number`, and `string` category behavior |
 | [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -47,6 +47,21 @@ pub const NoVoidAllowAsStatement = enum {
     no,
 };
 
+pub const NoImplicitCoercionBoolean = enum {
+    yes,
+    no,
+};
+
+pub const NoImplicitCoercionNumber = enum {
+    yes,
+    no,
+};
+
+pub const NoImplicitCoercionString = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -210,6 +225,9 @@ pub const Options = struct {
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_implicit_coercion: bool = true,
+    no_implicit_coercion_boolean: NoImplicitCoercionBoolean = .yes,
+    no_implicit_coercion_number: NoImplicitCoercionNumber = .yes,
+    no_implicit_coercion_string: NoImplicitCoercionString = .yes,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -276,6 +276,12 @@ pub fn main(init: std.process.Init) !void {
             options.no_global_is_nan = false;
         } else if (std.mem.eql(u8, arg, "--no-implicit-coercion=off")) {
             options.no_implicit_coercion = false;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-coercion-boolean=off")) {
+            options.no_implicit_coercion_boolean = .no;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-coercion-number=off")) {
+            options.no_implicit_coercion_number = .no;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-coercion-string=off")) {
+            options.no_implicit_coercion_string = .no;
         } else if (std.mem.eql(u8, arg, "--no-implied-eval=off")) {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
@@ -1383,6 +1389,9 @@ fn printHelp() void {
         \\  --no-global-is-finite=off Disable no-global-is-finite
         \\  --no-global-is-nan=off    Disable no-global-is-nan
         \\  --no-implicit-coercion=off Disable no-implicit-coercion
+        \\  --no-implicit-coercion-boolean=off Disable boolean coercion checks
+        \\  --no-implicit-coercion-number=off Disable number coercion checks
+        \\  --no-implicit-coercion-string=off Disable string coercion checks
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos

--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -7,6 +7,12 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-implicit-coercion";
 
+pub const Options = struct {
+    boolean: bool = true,
+    number: bool = true,
+    string: bool = true,
+};
+
 pub fn checkUnaryExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,24 +20,35 @@ pub fn checkUnaryExpression(
     expression: ast.UnaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkUnaryExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkUnaryExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     switch (expression.operator) {
         .logical_not => {
-            if (isDoubleNegation(tree, expression)) {
+            if (options.boolean and isDoubleNegation(tree, expression)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Boolean()` instead of double negation.");
             }
         },
         .bitwise_not => {
-            if (isIndexOfCall(tree, expression.argument)) {
+            if (options.boolean and isIndexOfCall(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use an explicit comparison instead of bitwise negation.");
             }
         },
         .positive => {
-            if (!isNumeric(tree, expression.argument)) {
+            if (options.number and !isNumeric(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of unary plus.");
             }
         },
         .negate => {
-            if (isNegatedExpression(tree, expression.argument)) {
+            if (options.number and isNegatedExpression(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of double negation.");
             }
         },
@@ -46,20 +63,31 @@ pub fn checkBinaryExpression(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkBinaryExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkBinaryExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     switch (expression.operator) {
         .add => {
-            if (isConcatWithEmptyString(tree, expression)) {
+            if (options.string and isConcatWithEmptyString(tree, expression)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of string concatenation.");
             }
         },
         .subtract => {
-            if (isZeroLiteral(tree, expression.right) and !isNumeric(tree, expression.left)) {
+            if (options.number and isZeroLiteral(tree, expression.right) and !isNumeric(tree, expression.left)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of subtracting zero.");
             }
         },
         .multiply => {
-            if ((isOneLiteral(tree, expression.left) and !isNumeric(tree, expression.right)) or
-                (isOneLiteral(tree, expression.right) and !isNumeric(tree, expression.left)))
+            if (options.number and ((isOneLiteral(tree, expression.left) and !isNumeric(tree, expression.right)) or
+                (isOneLiteral(tree, expression.right) and !isNumeric(tree, expression.left))))
             {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of multiplying by one.");
             }
@@ -75,7 +103,18 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (expression.operator == .add_assign and isEmptyStringLiteral(tree, expression.right)) {
+    try checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.string and expression.operator == .add_assign and isEmptyStringLiteral(tree, expression.right)) {
         try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of appending an empty string.");
     }
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1981,7 +1981,7 @@ const BasicVisitor = struct {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_implicit_coercion) {
-            try no_implicit_coercion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_implicit_coercion.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noImplicitCoercionOptions());
         }
         if (self.options.typescript_eslint_no_confusing_non_null_assertion) {
             try typescript_eslint_no_confusing_non_null_assertion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
@@ -2053,7 +2053,7 @@ const BasicVisitor = struct {
             try prefer_template.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_implicit_coercion) {
-            try no_implicit_coercion.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_implicit_coercion.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noImplicitCoercionOptions());
         }
         if (self.options.no_path_concat) {
             try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
@@ -2085,9 +2085,17 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.no_implicit_coercion) {
-            try no_implicit_coercion.checkUnaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_implicit_coercion.checkUnaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noImplicitCoercionOptions());
         }
         return .proceed;
+    }
+
+    fn noImplicitCoercionOptions(self: *BasicVisitor) no_implicit_coercion.Options {
+        return .{
+            .boolean = self.options.no_implicit_coercion_boolean == .yes,
+            .number = self.options.no_implicit_coercion_number == .yes,
+            .string = self.options.no_implicit_coercion_string == .yes,
+        };
     }
 
     pub fn enter_update_expression(

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -86,6 +86,64 @@ test "does not report no-implicit-coercion for explicit conversions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implicit_coercion.id));
 }
 
+test "supports no-implicit-coercion category options" {
+    const source =
+        \\const first = !!value;
+        \\const second = ~items.indexOf(value);
+        \\const third = +value;
+        \\const fourth = value - 0;
+        \\const fifth = "" + value;
+        \\let sixth = value;
+        \\sixth += "";
+    ;
+
+    var boolean_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_implicit_coercion_boolean = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer boolean_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(boolean_result, lint.rules.no_implicit_coercion.id));
+
+    var number_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_implicit_coercion_number = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer number_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(number_result, lint.rules.no_implicit_coercion.id));
+
+    var string_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_implicit_coercion_string = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer string_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(string_result, lint.rules.no_implicit_coercion.id));
+
+    var all_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_implicit_coercion_boolean = .no,
+        .no_implicit_coercion_number = .no,
+        .no_implicit_coercion_string = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer all_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(all_result, lint.rules.no_implicit_coercion.id));
+}
+
 test "can disable no-implicit-coercion" {
     const source =
         \\const first = !!value;


### PR DESCRIPTION
## Summary
- add `no-implicit-coercion` support for ESLint's `boolean`, `number`, and `string` category options
- expose `--no-implicit-coercion-boolean=off`, `--no-implicit-coercion-number=off`, and `--no-implicit-coercion-string=off` for the current CLI migration path
- keep default behavior unchanged and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default and disabled category behavior
