### PR TITLE
feat: support no plusplus for afterthoughts

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -114,7 +114,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-octal-escape`](https://eslint.org/docs/latest/rules/no-octal-escape) | Implemented |
 | [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented |
 | [`no-path-concat`](https://eslint.org/docs/latest/rules/no-path-concat) | Implemented |
-| [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented |
+| [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented with optional `allowForLoopAfterthoughts` behavior |
 | [`no-process-env`](https://eslint.org/docs/latest/rules/no-process-env) | Implemented |
 | [`no-process-exit`](https://eslint.org/docs/latest/rules/no-process-exit) | Implemented |
 | [`no-promise-executor-return`](https://eslint.org/docs/latest/rules/no-promise-executor-return) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -62,6 +62,11 @@ pub const NoImplicitCoercionString = enum {
     no,
 };
 
+pub const NoPlusplusAllowForLoopAfterthoughts = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -314,6 +319,7 @@ pub const Options = struct {
     no_param_reassign: bool = true,
     no_path_concat: bool = true,
     no_plusplus: bool = true,
+    no_plusplus_allow_for_loop_afterthoughts: NoPlusplusAllowForLoopAfterthoughts = .no,
     no_promise_executor_return: bool = true,
     no_proto: bool = true,
     no_process_env: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -452,6 +452,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
             options.no_plusplus = false;
+        } else if (std.mem.eql(u8, arg, "--no-plusplus-allow-for-loop-afterthoughts=on")) {
+            options.no_plusplus_allow_for_loop_afterthoughts = .yes;
         } else if (std.mem.eql(u8, arg, "--no-promise-executor-return=off")) {
             options.no_promise_executor_return = false;
         } else if (std.mem.eql(u8, arg, "--no-proto=off")) {
@@ -1480,6 +1482,7 @@ fn printHelp() void {
         \\  --no-param-reassign=off   Disable no-param-reassign
         \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
+        \\  --no-plusplus-allow-for-loop-afterthoughts=on Allow ++/-- in for afterthoughts
         \\  --no-promise-executor-return=off Disable no-promise-executor-return
         \\  --no-proto=off            Disable no-proto
         \\  --no-process-env=off      Disable no-process-env

--- a/src/rules/no_plusplus.zig
+++ b/src/rules/no_plusplus.zig
@@ -2,11 +2,37 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-plusplus";
 
+pub const Options = struct {
+    allow_for_loop_afterthoughts: bool = false,
+};
+
 pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (options.allow_for_loop_afterthoughts and isForLoopAfterthought(tree, index, ctx)) return;
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
@@ -20,4 +46,33 @@ pub fn check(
         "Unary operator '++' or '--' used.",
         tree.span(index),
     );
+}
+
+fn isForLoopAfterthought(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    if (isForStatementUpdate(tree, index, parent)) return true;
+    if (isSequenceForStatementUpdate(tree, parent, ctx.path.ancestor(2))) return true;
+
+    const parenthesized = switch (tree.data(parent)) {
+        .parenthesized_expression => |parenthesized| parenthesized,
+        else => return false,
+    };
+    if (parenthesized.expression != index) return false;
+
+    const grandparent = ctx.path.ancestor(2) orelse return false;
+    if (isForStatementUpdate(tree, parent, grandparent)) return true;
+    return isSequenceForStatementUpdate(tree, grandparent, ctx.path.ancestor(3));
+}
+
+fn isForStatementUpdate(tree: *const ast.Tree, update: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    return switch (tree.data(parent)) {
+        .for_statement => |statement| statement.update == update,
+        else => false,
+    };
+}
+
+fn isSequenceForStatementUpdate(tree: *const ast.Tree, sequence: ast.NodeIndex, grandparent: ?ast.NodeIndex) bool {
+    if (tree.data(sequence) != .sequence_expression) return false;
+    const for_index = grandparent orelse return false;
+    return isForStatementUpdate(tree, sequence, for_index);
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2105,7 +2105,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_plusplus) {
-            try no_plusplus.check(self.allocator, self.diagnostics, ctx.tree, index);
+            try no_plusplus.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .allow_for_loop_afterthoughts = self.options.no_plusplus_allow_for_loop_afterthoughts == .yes,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/no_plusplus.zig
+++ b/tests/rules/no_plusplus.zig
@@ -41,6 +41,38 @@ test "does not report no-plusplus for compound assignments" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_plusplus.id));
 }
 
+test "allows no-plusplus in for afterthoughts when configured" {
+    const source =
+        \\let index = 0;
+        \\index++;
+        \\for (let i = 0; i < 3; i++) {
+        \\  run(i);
+        \\}
+        \\for (let i = 0, j = 3; i < j; i++, j--) {
+        \\  run(i);
+        \\}
+        \\for (let i = 0; i < 3; (i++)) {
+        \\  run(i);
+        \\}
+        \\for (let i = 0; i++ < 3;) {
+        \\  run(i);
+        \\}
+        \\for (let i = 0, j = 0; i < 3; j = i++) {
+        \\  run(i);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_plusplus_allow_for_loop_afterthoughts = .yes,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_plusplus.id));
+}
+
 test "can disable no-plusplus" {
     const source =
         \\let index = 0;


### PR DESCRIPTION
## Summary
- add `no-plusplus` support for ESLint's `allowForLoopAfterthoughts` option
- allow direct and sequence `++`/`--` expressions in `for` update clauses while keeping nested update expressions reported
- expose `--no-plusplus-allow-for-loop-afterthoughts=on` for the current CLI migration path and update rule status docs

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke for default and `allowForLoopAfterthoughts` behavior
