### PR TITLE
feat: support no param reassign props

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -112,7 +112,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-object-constructor`](https://eslint.org/docs/latest/rules/no-object-constructor) | Implemented |
 | [`no-octal`](https://eslint.org/docs/latest/rules/no-octal) | Implemented |
 | [`no-octal-escape`](https://eslint.org/docs/latest/rules/no-octal-escape) | Implemented |
-| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented |
+| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented with optional `props` behavior |
 | [`no-path-concat`](https://eslint.org/docs/latest/rules/no-path-concat) | Implemented |
 | [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented with optional `allowForLoopAfterthoughts` behavior |
 | [`no-process-env`](https://eslint.org/docs/latest/rules/no-process-env) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -67,6 +67,11 @@ pub const NoPlusplusAllowForLoopAfterthoughts = enum {
     no,
 };
 
+pub const NoParamReassignProps = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -317,6 +322,7 @@ pub const Options = struct {
     no_octal_escape: bool = true,
     no_object_constructor: bool = true,
     no_param_reassign: bool = true,
+    no_param_reassign_props: NoParamReassignProps = .no,
     no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_plusplus_allow_for_loop_afterthoughts: NoPlusplusAllowForLoopAfterthoughts = .no,

--- a/src/main.zig
+++ b/src/main.zig
@@ -448,6 +448,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_object_constructor = false;
         } else if (std.mem.eql(u8, arg, "--no-param-reassign=off")) {
             options.no_param_reassign = false;
+        } else if (std.mem.eql(u8, arg, "--no-param-reassign-props=on")) {
+            options.no_param_reassign_props = .yes;
         } else if (std.mem.eql(u8, arg, "--no-path-concat=off")) {
             options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
@@ -1480,6 +1482,7 @@ fn printHelp() void {
         \\  --no-octal-escape=off     Disable no-octal-escape
         \\  --no-object-constructor=off Disable no-object-constructor
         \\  --no-param-reassign=off   Disable no-param-reassign
+        \\  --no-param-reassign-props=on Report parameter property writes
         \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-plusplus-allow-for-loop-afterthoughts=on Allow ++/-- in for afterthoughts

--- a/src/rules/no_param_reassign.zig
+++ b/src/rules/no_param_reassign.zig
@@ -9,11 +9,25 @@ pub const id = "no-param-reassign";
 
 const ParamSet = std.StringHashMapUnmanaged(void);
 
+pub const Options = struct {
+    props: bool = false,
+};
+
 pub fn checkFunction(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     function: ast.Function,
+) Allocator.Error!void {
+    try checkFunctionWithOptions(allocator, diagnostics, tree, function, .{});
+}
+
+pub fn checkFunctionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
 ) Allocator.Error!void {
     var params: ParamSet = .empty;
     defer params.deinit(allocator);
@@ -21,7 +35,7 @@ pub fn checkFunction(
     try collectFormalParameters(allocator, tree, function.params, &params);
     if (params.size == 0 or function.body == .null) return;
 
-    try scanNode(allocator, diagnostics, tree, &params, function.body);
+    try scanNode(allocator, diagnostics, tree, &params, function.body, options);
 }
 
 pub fn checkArrowFunction(
@@ -30,13 +44,23 @@ pub fn checkArrowFunction(
     tree: *const ast.Tree,
     expression: ast.ArrowFunctionExpression,
 ) Allocator.Error!void {
+    try checkArrowFunctionWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkArrowFunctionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
     var params: ParamSet = .empty;
     defer params.deinit(allocator);
 
     try collectFormalParameters(allocator, tree, expression.params, &params);
     if (params.size == 0) return;
 
-    try scanNode(allocator, diagnostics, tree, &params, expression.body);
+    try scanNode(allocator, diagnostics, tree, &params, expression.body, options);
 }
 
 fn collectFormalParameters(
@@ -101,20 +125,38 @@ fn scanNode(
     tree: *const ast.Tree,
     params: *const ParamSet,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
         .assignment_expression => |expression| {
-            try checkTarget(allocator, diagnostics, tree, params, expression.left);
-            try scanNode(allocator, diagnostics, tree, params, expression.right);
+            try checkTarget(allocator, diagnostics, tree, params, expression.left, options);
+            try scanNode(allocator, diagnostics, tree, params, expression.right, options);
         },
-        .update_expression => |expression| try checkTarget(allocator, diagnostics, tree, params, expression.argument),
-        .function => |function| try scanNestedFunction(allocator, diagnostics, tree, params, function),
-        .arrow_function_expression => |expression| try scanNestedArrowFunction(allocator, diagnostics, tree, params, expression),
+        .update_expression => |expression| try checkTarget(allocator, diagnostics, tree, params, expression.argument, options),
+        .unary_expression => |expression| {
+            if (expression.operator == .delete) {
+                try checkTarget(allocator, diagnostics, tree, params, expression.argument, options);
+            } else {
+                try scanNode(allocator, diagnostics, tree, params, expression.argument, options);
+            }
+        },
+        .for_in_statement => |statement| {
+            try checkTarget(allocator, diagnostics, tree, params, statement.left, options);
+            try scanNode(allocator, diagnostics, tree, params, statement.right, options);
+            try scanNode(allocator, diagnostics, tree, params, statement.body, options);
+        },
+        .for_of_statement => |statement| {
+            try checkTarget(allocator, diagnostics, tree, params, statement.left, options);
+            try scanNode(allocator, diagnostics, tree, params, statement.right, options);
+            try scanNode(allocator, diagnostics, tree, params, statement.body, options);
+        },
+        .function => |function| try scanNestedFunction(allocator, diagnostics, tree, params, function, options),
+        .arrow_function_expression => |expression| try scanNestedArrowFunction(allocator, diagnostics, tree, params, expression, options),
         .class,
         => return,
-        inline else => |node| try scanChildren(allocator, diagnostics, tree, params, @TypeOf(node), node),
+        inline else => |node| try scanChildren(allocator, diagnostics, tree, params, @TypeOf(node), node, options),
     }
 }
 
@@ -124,6 +166,7 @@ fn scanNestedFunction(
     tree: *const ast.Tree,
     params: *const ParamSet,
     function: ast.Function,
+    options: Options,
 ) Allocator.Error!void {
     if (function.body == .null) return;
 
@@ -131,7 +174,7 @@ fn scanNestedFunction(
     defer filtered.deinit(allocator);
 
     if (filtered.size == 0) return;
-    try scanNode(allocator, diagnostics, tree, &filtered, function.body);
+    try scanNode(allocator, diagnostics, tree, &filtered, function.body, options);
 }
 
 fn scanNestedArrowFunction(
@@ -140,12 +183,13 @@ fn scanNestedArrowFunction(
     tree: *const ast.Tree,
     params: *const ParamSet,
     expression: ast.ArrowFunctionExpression,
+    options: Options,
 ) Allocator.Error!void {
     var filtered = try filterShadowedParams(allocator, tree, params, expression.params, expression.body);
     defer filtered.deinit(allocator);
 
     if (filtered.size == 0) return;
-    try scanNode(allocator, diagnostics, tree, &filtered, expression.body);
+    try scanNode(allocator, diagnostics, tree, &filtered, expression.body, options);
 }
 
 fn filterShadowedParams(
@@ -231,15 +275,16 @@ fn scanChildren(
     params: *const ParamSet,
     comptime T: type,
     node: T,
+    options: Options,
 ) Allocator.Error!void {
     if (@typeInfo(T) != .@"struct") return;
 
     inline for (@typeInfo(T).@"struct".fields) |field| {
         if (field.type == ast.NodeIndex) {
-            try scanNode(allocator, diagnostics, tree, params, @field(node, field.name));
+            try scanNode(allocator, diagnostics, tree, params, @field(node, field.name), options);
         } else if (field.type == ast.IndexRange) {
             for (tree.extra(@field(node, field.name))) |child| {
-                try scanNode(allocator, diagnostics, tree, params, child);
+                try scanNode(allocator, diagnostics, tree, params, child, options);
             }
         }
     }
@@ -251,6 +296,7 @@ fn checkTarget(
     tree: *const ast.Tree,
     params: *const ParamSet,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (index == .null) return;
 
@@ -269,12 +315,27 @@ fn checkTarget(
                 .{name},
             );
         },
-        .assignment_pattern => |pattern| try checkTarget(allocator, diagnostics, tree, params, pattern.left),
+        .member_expression => |member| {
+            if (!options.props) return;
+            const name = rootIdentifierReferenceName(tree, member.object) orelse return;
+            if (!params.contains(name)) return;
+
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                tree.span(index),
+                "Assignment to property of function parameter '{s}'.",
+                .{name},
+            );
+        },
+        .assignment_pattern => |pattern| try checkTarget(allocator, diagnostics, tree, params, pattern.left, options),
         .array_pattern => |pattern| {
             for (tree.extra(pattern.elements)) |element| {
-                try checkTarget(allocator, diagnostics, tree, params, element);
+                try checkTarget(allocator, diagnostics, tree, params, element, options);
             }
-            try checkTarget(allocator, diagnostics, tree, params, pattern.rest);
+            try checkTarget(allocator, diagnostics, tree, params, pattern.rest, options);
         },
         .object_pattern => |pattern| {
             for (tree.extra(pattern.properties)) |property_index| {
@@ -282,13 +343,21 @@ fn checkTarget(
                     .binding_property => |property| property,
                     else => continue,
                 };
-                try checkTarget(allocator, diagnostics, tree, params, property.value);
+                try checkTarget(allocator, diagnostics, tree, params, property.value, options);
             }
-            try checkTarget(allocator, diagnostics, tree, params, pattern.rest);
+            try checkTarget(allocator, diagnostics, tree, params, pattern.rest, options);
         },
-        .binding_rest_element => |element| try checkTarget(allocator, diagnostics, tree, params, element.argument),
+        .binding_rest_element => |element| try checkTarget(allocator, diagnostics, tree, params, element.argument, options),
         else => {},
     }
+}
+
+fn rootIdentifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .member_expression => |member| rootIdentifierReferenceName(tree, member.object),
+        else => null,
+    };
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -991,7 +991,9 @@ const BasicVisitor = struct {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
         if (self.options.no_param_reassign) {
-            try no_param_reassign.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+            try no_param_reassign.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
+                .props = self.options.no_param_reassign_props == .yes,
+            });
         }
         if (self.options.no_inner_declarations) {
             try no_inner_declarations.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx);
@@ -1938,7 +1940,9 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkFormalParameters(self.allocator, self.diagnostics, ctx.tree, expression.params);
         }
         if (self.options.no_param_reassign) {
-            try no_param_reassign.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);
+            try no_param_reassign.checkArrowFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .props = self.options.no_param_reassign_props == .yes,
+            });
         }
         if (self.options.react_display_name) {
             try react_display_name.checkArrowFunction(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_display_name_state);

--- a/tests/rules/no_param_reassign.zig
+++ b/tests/rules/no_param_reassign.zig
@@ -85,6 +85,34 @@ test "does not report no-param-reassign for property writes or shadowed local as
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_param_reassign.id));
 }
 
+test "reports no-param-reassign for parameter property writes when props is enabled" {
+    const source =
+        \\function run(value, other) {
+        \\  value.name = next;
+        \\  value.name++;
+        \\  delete value.name;
+        \\  for (value.name in source) {
+        \\    run(value);
+        \\  }
+        \\  for (value.item of source) {
+        \\    run(value);
+        \\  }
+        \\  other.nested.value = next;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_param_reassign_props = .yes,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_plusplus = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
 test "can disable no-param-reassign" {
     const source =
         \\function run(value) {


### PR DESCRIPTION
## Summary

- add `no-param-reassign` support for ESLint's `props` option
- report parameter property writes in assignments, updates, `delete`, and `for-in`/`for-of` left-hand sides when enabled
- expose `--no-param-reassign-props=on` and update rule status docs

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default `props` off reports 0 `no-param-reassign`; `--no-param-reassign-props=on` reports 6 property-write diagnostics