### PR TITLE
feat: support no console allow

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -41,7 +41,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-comma-operator`](https://eslint.org/docs/latest/rules/no-comma-operator) | Implemented |
 | [`no-compare-neg-zero`](https://eslint.org/docs/latest/rules/no-compare-neg-zero) | Implemented |
 | [`no-cond-assign`](https://eslint.org/docs/latest/rules/no-cond-assign) | Implemented |
-| [`no-console`](https://eslint.org/docs/latest/rules/no-console) | Implemented |
+| [`no-console`](https://eslint.org/docs/latest/rules/no-console) | Implemented with `allow` support for known console methods |
 | [`no-const-assign`](https://eslint.org/docs/latest/rules/no-const-assign) | Implemented |
 | [`no-constant-condition`](https://eslint.org/docs/latest/rules/no-constant-condition) | Implemented |
 | [`no-constructor-return`](https://eslint.org/docs/latest/rules/no-constructor-return) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,48 @@ pub const NoConfusingArrowAllowParens = enum {
     no,
 };
 
+pub const NoConsoleAllow = struct {
+    assert: bool = false,
+    clear: bool = false,
+    count: bool = false,
+    countReset: bool = false,
+    debug: bool = false,
+    dir: bool = false,
+    dirxml: bool = false,
+    @"error": bool = false,
+    group: bool = false,
+    groupCollapsed: bool = false,
+    groupEnd: bool = false,
+    info: bool = false,
+    log: bool = false,
+    profile: bool = false,
+    profileEnd: bool = false,
+    table: bool = false,
+    time: bool = false,
+    timeEnd: bool = false,
+    timeLog: bool = false,
+    timeStamp: bool = false,
+    trace: bool = false,
+    warn: bool = false,
+
+    pub fn contains(self: NoConsoleAllow, name: []const u8) bool {
+        inline for (@typeInfo(NoConsoleAllow).@"struct".fields) |field| {
+            if (std.mem.eql(u8, field.name, name)) return @field(self, field.name);
+        }
+        return false;
+    }
+
+    pub fn enable(self: *NoConsoleAllow, name: []const u8) bool {
+        inline for (@typeInfo(NoConsoleAllow).@"struct".fields) |field| {
+            if (std.mem.eql(u8, field.name, name)) {
+                @field(self, field.name) = true;
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
 pub const NoUnderscoreDangleAllowFunctionParams = enum {
     yes,
     no,
@@ -199,6 +241,7 @@ pub const Options = struct {
     no_const_assign: bool = true,
     no_control_regex: bool = true,
     no_console: bool = true,
+    no_console_allow: NoConsoleAllow = .{},
     no_comma_operator: bool = true,
     no_continue: bool = true,
     no_constructor_return: bool = true,
@@ -584,6 +627,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-console")) {
+            self.no_console_allow = try noConsoleAllowFromConfig(value);
+        }
     }
 
     pub const RuleConfigError = error{
@@ -667,6 +713,34 @@ pub const Options = struct {
             if (std.mem.eql(u8, rule, "no-nested-ternary")) return true;
         }
         return false;
+    }
+
+    fn noConsoleAllowFromConfig(value: std.json.Value) RuleConfigError!NoConsoleAllow {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow: NoConsoleAllow = .{};
+        for (allow_items) |item| {
+            const method = switch (item) {
+                .string => |method| method,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!allow.enable(method)) return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -1028,6 +1102,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("eslint-comments/no-restricted-disable", restricted_disable_config.value);
     try std.testing.expect(options.eslint_comments_no_restricted_disable);
     try std.testing.expect(options.eslint_comments_no_restricted_disable_no_nested_ternary);
+
+    var no_console_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"warn\",\"error\"]}]",
+        .{},
+    );
+    defer no_console_config.deinit();
+    try options.setByRuleConfigValue("no-console", no_console_config.value);
+    try std.testing.expect(options.no_console);
+    try std.testing.expect(options.no_console_allow.contains("warn"));
+    try std.testing.expect(options.no_console_allow.contains("error"));
+    try std.testing.expect(!options.no_console_allow.contains("log"));
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -206,6 +206,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_control_regex = false;
         } else if (std.mem.eql(u8, arg, "--no-console=off")) {
             options.no_console = false;
+        } else if (std.mem.startsWith(u8, arg, "--no-console-allow=")) {
+            parseNoConsoleAllow(arg["--no-console-allow=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-comma-operator=off")) {
             options.no_comma_operator = false;
         } else if (std.mem.eql(u8, arg, "--no-continue=off")) {
@@ -1017,6 +1019,28 @@ fn parseEnabledRules(value: []const u8, options: *lint.Options) void {
     }
 }
 
+fn parseNoConsoleAllow(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --no-console-allow requires a comma-separated method list\n", .{});
+        std.process.exit(2);
+    }
+
+    var allow: @TypeOf(options.no_console_allow) = .{};
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_method| {
+        const method = std.mem.trim(u8, raw_method, " \t\r\n");
+        if (method.len == 0) {
+            std.debug.print("utoo-lint: --no-console-allow contains an empty method name\n", .{});
+            std.process.exit(2);
+        }
+        if (!allow.enable(method)) {
+            std.debug.print("utoo-lint: unsupported --no-console-allow method: {s}\n", .{method});
+            std.process.exit(2);
+        }
+    }
+    options.no_console_allow = allow;
+}
+
 fn collectLintableDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -1359,6 +1383,7 @@ fn printHelp() void {
         \\  --no-control-regex=off   Disable no-control-regex
         \\  --no-comma-operator=off   Disable no-comma-operator
         \\  --no-console=off          Disable no-console
+        \\  --no-console-allow=warn,error Allow selected console methods
         \\  --no-continue=off         Disable no-continue
         \\  --no-constructor-return=off Disable no-constructor-return
         \\  --no-debugger=off         Disable no-debugger

--- a/src/rules/no_console.zig
+++ b/src/rules/no_console.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-console";
 
+pub const Options = struct {
+    allow: core.NoConsoleAllow = .{},
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +18,20 @@ pub fn check(
     call: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (!isConsoleMemberCall(tree, call.callee)) return;
+    try checkWithOptions(allocator, diagnostics, tree, call, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    const member = consoleMemberCall(tree, call.callee) orelse return;
+    const method = propertyName(tree, member);
+    if (method != null and options.allow.contains(method.?)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -26,7 +43,7 @@ pub fn check(
     );
 }
 
-fn isConsoleMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
+fn consoleMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex) ?ast.MemberExpression {
     var current = callee;
 
     switch (tree.data(current)) {
@@ -35,8 +52,22 @@ fn isConsoleMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
     }
 
     return switch (tree.data(current)) {
-        .member_expression => |member| isIdentifierNamed(tree, member.object, "console"),
-        else => false,
+        .member_expression => |member| if (isIdentifierNamed(tree, member.object, "console")) member else null,
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
     };
 }
 
@@ -48,4 +79,3 @@ fn isIdentifierNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const 
         else => false,
     };
 }
-

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2154,7 +2154,9 @@ const BasicVisitor = struct {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
         if (self.options.no_console) {
-            try no_console.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+            try no_console.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, call, index, .{
+                .allow = self.options.no_console_allow,
+            });
         }
         if (self.options.no_prototype_builtins) {
             try no_prototype_builtins.check(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/tests/rules/no_console.zig
+++ b/tests/rules/no_console.zig
@@ -16,3 +16,41 @@ test "reports no-console for console calls" {
 
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_console.id));
 }
+
+test "allows configured no-console methods" {
+    const source =
+        \\console.warn(value);
+        \\console["error"](value);
+        \\console.log(value);
+    ;
+
+    var allow = (lint.Options{}).no_console_allow;
+    try std.testing.expect(allow.enable("warn"));
+    try std.testing.expect(allow.enable("error"));
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console_allow = allow,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_console.id));
+}
+
+test "can disable no-console" {
+    const source =
+        \\console.log(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_console.id));
+}


### PR DESCRIPTION
## Summary

- add `no-console` support for ESLint's `allow` option across known console methods
- support `--no-console-allow=warn,error` for CLI usage
- parse ESLint-style config values such as `["error", { "allow": ["warn", "error"] }]`
- update rule status docs and focused tests

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default reports 3 `no-console`; `--no-console-allow=warn,error` reports only `console.log`
- config smoke: ESLint-style `allow` config reports only `console.log`