### PR TITLE
feat: support no useless computed key class option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -149,7 +149,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Implemented |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
-| [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented |
+| [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -114,6 +114,11 @@ pub const NoParamReassignProps = enum {
     no,
 };
 
+pub const NoUselessComputedKeyEnforceForClassMembers = enum {
+    yes,
+    no,
+};
+
 pub const WrapIifeStyle = enum {
     outside,
     inside,
@@ -411,6 +416,7 @@ pub const Options = struct {
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_useless_computed_key: bool = true,
+    no_useless_computed_key_enforce_for_class_members: NoUselessComputedKeyEnforceForClassMembers = .yes,
     no_useless_call: bool = true,
     no_useless_concat: bool = true,
     no_useless_constructor: bool = true,
@@ -630,6 +636,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
+            self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
+        }
     }
 
     pub const RuleConfigError = error{
@@ -741,6 +750,24 @@ pub const Options = struct {
             if (!allow.enable(method)) return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noUselessComputedKeyEnforceForClassMembersFromConfig(value: std.json.Value) RuleConfigError!NoUselessComputedKeyEnforceForClassMembers {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .yes,
+        };
+        if (items.len < 2) return .yes;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const enforce = switch (config.get("enforceForClassMembers") orelse return .yes) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (enforce) .yes else .no;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -1115,6 +1142,20 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_console_allow.contains("warn"));
     try std.testing.expect(options.no_console_allow.contains("error"));
     try std.testing.expect(!options.no_console_allow.contains("log"));
+
+    var no_useless_computed_key_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForClassMembers\":false}]",
+        .{},
+    );
+    defer no_useless_computed_key_config.deinit();
+    try options.setByRuleConfigValue("no-useless-computed-key", no_useless_computed_key_config.value);
+    try std.testing.expect(options.no_useless_computed_key);
+    try std.testing.expectEqual(
+        NoUselessComputedKeyEnforceForClassMembers.no,
+        options.no_useless_computed_key_enforce_for_class_members,
+    );
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -542,6 +542,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key=off")) {
             options.no_useless_computed_key = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-computed-key-enforce-for-class-members=off")) {
+            options.no_useless_computed_key_enforce_for_class_members = .no;
         } else if (std.mem.eql(u8, arg, "--no-useless-call=off")) {
             options.no_useless_call = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
@@ -1553,6 +1555,7 @@ fn printHelp() void {
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
+        \\  --no-useless-computed-key-enforce-for-class-members=off Disable class member checks
         \\  --no-useless-call=off     Disable no-useless-call
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-constructor=off Disable no-useless-constructor

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2678,7 +2678,7 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.no_useless_computed_key) {
+        if (self.options.no_useless_computed_key and self.options.no_useless_computed_key_enforce_for_class_members == .yes) {
             try no_useless_computed_key.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
         }
         if (self.options.no_underscore_dangle) {
@@ -2721,7 +2721,7 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.no_useless_computed_key) {
+        if (self.options.no_useless_computed_key and self.options.no_useless_computed_key_enforce_for_class_members == .yes) {
             try no_useless_computed_key.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         if (self.options.no_underscore_dangle) {

--- a/tests/rules/no_useless_computed_key.zig
+++ b/tests/rules/no_useless_computed_key.zig
@@ -46,6 +46,29 @@ test "reports no-useless-computed-key for class members with literal keys" {
     try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_computed_key.id));
 }
 
+test "allows class member computed keys when enforcement is disabled" {
+    const source =
+        \\const object = {
+        \\  ["name"]: value,
+        \\};
+        \\class Example {
+        \\  ["method"]() {}
+        \\  ["field"] = value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_useless_computed_key_enforce_for_class_members = .no,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_useless_computed_key.id));
+}
+
 test "does not report no-useless-computed-key for dynamic keys or semantic exceptions" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary

- add `no-useless-computed-key` support for ESLint's `enforceForClassMembers` option
- expose `--no-useless-computed-key-enforce-for-class-members=off` for CLI usage
- parse ESLint-style config values such as `["error", { "enforceForClassMembers": false }]`
- update rule status docs and focused tests

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default reports object plus class member computed keys; option off reports only object computed keys
- config smoke: ESLint-style `enforceForClassMembers: false` reports only object computed keys