### PR TITLE
feat: support no empty allow empty catch

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -57,7 +57,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-duplicate-case`](https://eslint.org/docs/latest/rules/no-duplicate-case) | Implemented |
 | [`no-duplicate-imports`](https://eslint.org/docs/latest/rules/no-duplicate-imports) | Implemented |
 | [`no-else-return`](https://eslint.org/docs/latest/rules/no-else-return) | Implemented |
-| [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented |
+| [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented with optional `allowEmptyCatch` behavior |
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |
 | [`no-empty-character-class`](https://eslint.org/docs/latest/rules/no-empty-character-class) | Implemented |
 | [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -63,6 +63,11 @@ pub const NoConsoleAllow = struct {
     }
 };
 
+pub const NoEmptyAllowEmptyCatch = enum {
+    yes,
+    no,
+};
+
 pub const NoUnderscoreDangleAllowFunctionParams = enum {
     yes,
     no,
@@ -261,6 +266,7 @@ pub const Options = struct {
     no_delete_var: bool = true,
     no_div_regex: bool = true,
     no_empty: bool = true,
+    no_empty_allow_empty_catch: NoEmptyAllowEmptyCatch = .no,
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_function: bool = true,
@@ -636,6 +642,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-empty")) {
+            self.no_empty_allow_empty_catch = try noEmptyAllowEmptyCatchFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
         }
@@ -750,6 +759,24 @@ pub const Options = struct {
             if (!allow.enable(method)) return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noEmptyAllowEmptyCatchFromConfig(value: std.json.Value) RuleConfigError!NoEmptyAllowEmptyCatch {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowEmptyCatch") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
     }
 
     fn noUselessComputedKeyEnforceForClassMembersFromConfig(value: std.json.Value) RuleConfigError!NoUselessComputedKeyEnforceForClassMembers {
@@ -1142,6 +1169,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_console_allow.contains("warn"));
     try std.testing.expect(options.no_console_allow.contains("error"));
     try std.testing.expect(!options.no_console_allow.contains("log"));
+
+    var no_empty_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowEmptyCatch\":true}]",
+        .{},
+    );
+    defer no_empty_config.deinit();
+    try options.setByRuleConfigValue("no-empty", no_empty_config.value);
+    try std.testing.expect(options.no_empty);
+    try std.testing.expectEqual(NoEmptyAllowEmptyCatch.yes, options.no_empty_allow_empty_catch);
 
     var no_useless_computed_key_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -234,6 +234,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_div_regex = false;
         } else if (std.mem.eql(u8, arg, "--no-empty=off")) {
             options.no_empty = false;
+        } else if (std.mem.eql(u8, arg, "--no-empty-allow-empty-catch=on")) {
+            options.no_empty_allow_empty_catch = .yes;
         } else if (std.mem.eql(u8, arg, "--no-empty-block-statements=off")) {
             options.no_empty_block_statements = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-character-class=off")) {
@@ -1398,6 +1400,7 @@ fn printHelp() void {
         \\  --no-delete-var=off       Disable no-delete-var
         \\  --no-div-regex=off        Disable no-div-regex
         \\  --no-empty=off            Disable no-empty
+        \\  --no-empty-allow-empty-catch=on Allow empty catch blocks
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-function=off Disable no-empty-function

--- a/src/rules/no_empty.zig
+++ b/src/rules/no_empty.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-empty";
 
+pub const Options = struct {
+    allow_empty_catch: bool = false,
+    is_catch_body: bool = false,
+};
+
 pub fn checkBlockStatement(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +19,19 @@ pub fn checkBlockStatement(
     block: ast.BlockStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkBlockStatementWithOptions(allocator, diagnostics, tree, block, index, .{});
+}
+
+pub fn checkBlockStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    block: ast.BlockStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (block.body.len != 0) return;
+    if (options.allow_empty_catch and options.is_catch_body) return;
     if (hasCommentInsideBraces(tree, index)) return;
 
     try core.addDiagnostic(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -351,6 +351,14 @@ fn funcNameMatchingStyle(style: core.FuncNameMatchingStyle) func_name_matching.S
     };
 }
 
+fn isCatchBody(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return false;
+    return switch (tree.data(parent_index)) {
+        .catch_clause => |clause| clause.body == index,
+        else => false,
+    };
+}
+
 pub fn runBasic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -1729,7 +1737,10 @@ const BasicVisitor = struct {
             }
         }
         if (self.options.no_empty) {
-            try no_empty.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);
+            try no_empty.checkBlockStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, block, index, .{
+                .allow_empty_catch = self.options.no_empty_allow_empty_catch == .yes,
+                .is_catch_body = isCatchBody(ctx.tree, index, ctx.path.parent()),
+            });
         }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkBlockStatement(self.allocator, self.diagnostics, ctx.tree, block, index);

--- a/tests/rules/no_empty.zig
+++ b/tests/rules/no_empty.zig
@@ -44,6 +44,27 @@ test "does not report no-empty for non-empty or commented blocks" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty.id));
 }
 
+test "allows empty catch blocks when configured" {
+    const source =
+        \\try {
+        \\  work();
+        \\} catch (error) {}
+        \\if (ready) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_allow_empty_catch = .yes,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_empty.id));
+}
+
 test "can disable no-empty" {
     const source =
         \\if (ready) {}


### PR DESCRIPTION
## Summary

- add `no-empty` support for ESLint's `allowEmptyCatch` option
- expose `--no-empty-allow-empty-catch=on` for CLI usage
- parse ESLint-style config values such as `["error", { "allowEmptyCatch": true }]`
- keep default behavior unchanged: empty catch blocks still report unless the option is enabled

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default reports empty try/catch/if blocks; option on skips only the catch block
- config smoke: ESLint-style `allowEmptyCatch: true` skips only the catch block