### PR TITLE
feat: support no fallthrough empty cases

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -71,7 +71,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Implemented |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
-| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Implemented |
+| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Implemented with optional `allowEmptyCase` behavior |
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
 | [`no-func-assign`](https://eslint.org/docs/latest/rules/no-func-assign) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -68,6 +68,11 @@ pub const NoEmptyAllowEmptyCatch = enum {
     no,
 };
 
+pub const NoFallthroughAllowEmptyCase = enum {
+    yes,
+    no,
+};
+
 pub const NoUnderscoreDangleAllowFunctionParams = enum {
     yes,
     no,
@@ -283,6 +288,7 @@ pub const Options = struct {
     no_extra_boolean_cast: bool = true,
     no_floating_decimal: bool = true,
     no_fallthrough: bool = true,
+    no_fallthrough_allow_empty_case: NoFallthroughAllowEmptyCase = .no,
     no_for_in: bool = true,
     no_func_assign: bool = true,
     no_global_assign: bool = true,
@@ -645,6 +651,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-empty")) {
             self.no_empty_allow_empty_catch = try noEmptyAllowEmptyCatchFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
+            self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
         }
@@ -773,6 +782,24 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         const allow = switch (config.get("allowEmptyCatch") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
+    }
+
+    fn noFallthroughAllowEmptyCaseFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughAllowEmptyCase {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowEmptyCase") orelse return .no) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -1180,6 +1207,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-empty", no_empty_config.value);
     try std.testing.expect(options.no_empty);
     try std.testing.expectEqual(NoEmptyAllowEmptyCatch.yes, options.no_empty_allow_empty_catch);
+
+    var no_fallthrough_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowEmptyCase\":true}]",
+        .{},
+    );
+    defer no_fallthrough_config.deinit();
+    try options.setByRuleConfigValue("no-fallthrough", no_fallthrough_config.value);
+    try std.testing.expect(options.no_fallthrough);
+    try std.testing.expectEqual(NoFallthroughAllowEmptyCase.yes, options.no_fallthrough_allow_empty_case);
 
     var no_useless_computed_key_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -268,6 +268,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_floating_decimal = false;
         } else if (std.mem.eql(u8, arg, "--no-fallthrough=off")) {
             options.no_fallthrough = false;
+        } else if (std.mem.eql(u8, arg, "--no-fallthrough-allow-empty-case=on")) {
+            options.no_fallthrough_allow_empty_case = .yes;
         } else if (std.mem.eql(u8, arg, "--no-for-in=off")) {
             options.no_for_in = false;
         } else if (std.mem.eql(u8, arg, "--no-func-assign=off")) {
@@ -1417,6 +1419,7 @@ fn printHelp() void {
         \\  --no-extra-boolean-cast=off Disable no-extra-boolean-cast
         \\  --no-floating-decimal=off Disable no-floating-decimal
         \\  --no-fallthrough=off      Disable no-fallthrough
+        \\  --no-fallthrough-allow-empty-case=on Allow empty switch cases
         \\  --no-for-in=off           Disable no-for-in
         \\  --no-func-assign=off      Disable no-func-assign
         \\  --no-global-assign=off    Disable no-global-assign

--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -7,11 +7,25 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-fallthrough";
 
+pub const Options = struct {
+    allow_empty_case: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     statement: ast.SwitchStatement,
+) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, statement, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+    options: Options,
 ) Allocator.Error!void {
     const cases = tree.extra(statement.cases);
     if (cases.len < 2) return;
@@ -22,9 +36,12 @@ pub fn check(
             else => continue,
         };
 
-        if (switch_case.consequent.len == 0) continue;
-        if (caseAlwaysExits(tree, switch_case)) continue;
-        if (hasFallthroughComment(tree, switch_case, next_case_index)) continue;
+        if (switch_case.consequent.len == 0) {
+            if (allowsEmptyCase(tree, case_index, next_case_index, options)) continue;
+        } else {
+            if (caseAlwaysExits(tree, switch_case)) continue;
+            if (hasFallthroughComment(tree, switch_case, next_case_index)) continue;
+        }
 
         try core.addDiagnostic(
             allocator,
@@ -35,6 +52,18 @@ pub fn check(
             tree.span(case_index),
         );
     }
+}
+
+fn allowsEmptyCase(tree: *const ast.Tree, case_index: ast.NodeIndex, next_case_index: ast.NodeIndex, options: Options) bool {
+    if (options.allow_empty_case) return true;
+    if (caseLabelsAreAdjacent(tree, case_index, next_case_index)) return true;
+    return hasFallthroughCommentBetween(tree, tree.span(case_index).end, tree.span(next_case_index).start);
+}
+
+fn caseLabelsAreAdjacent(tree: *const ast.Tree, case_index: ast.NodeIndex, next_case_index: ast.NodeIndex) bool {
+    const current = offsetToLine(tree.source, tree.span(case_index).end);
+    const next = offsetToLine(tree.source, tree.span(next_case_index).start);
+    return next <= current + 1;
 }
 
 fn caseAlwaysExits(tree: *const ast.Tree, switch_case: ast.SwitchCase) bool {
@@ -80,6 +109,12 @@ fn hasFallthroughComment(tree: *const ast.Tree, switch_case: ast.SwitchCase, nex
     const end: u32 = next_span.start;
     if (start > end) return false;
 
+    return hasFallthroughCommentBetween(tree, start, end);
+}
+
+fn hasFallthroughCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    if (start > end) return false;
+
     for (tree.comments) |comment| {
         if (comment.start < start or comment.end > end) continue;
         if (isFallthroughComment(tree.string(comment.value))) return true;
@@ -100,4 +135,15 @@ fn isFallthroughComment(comment: []const u8) bool {
     return std.mem.indexOf(u8, lower, "fallthrough") != null or
         std.mem.indexOf(u8, lower, "fall through") != null or
         std.mem.indexOf(u8, lower, "falls through") != null;
+}
+
+fn offsetToLine(source: []const u8, offset: u32) usize {
+    const limit = @min(@as(usize, @intCast(offset)), source.len);
+    var line: usize = 1;
+
+    for (source[0..limit]) |byte| {
+        if (byte == '\n') line += 1;
+    }
+
+    return line;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1582,7 +1582,9 @@ const BasicVisitor = struct {
             try no_duplicate_case.check(self.allocator, self.diagnostics, ctx.tree, statement);
         }
         if (self.options.no_fallthrough) {
-            try no_fallthrough.check(self.allocator, self.diagnostics, ctx.tree, statement);
+            try no_fallthrough.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, .{
+                .allow_empty_case = self.options.no_fallthrough_allow_empty_case == .yes,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/no_fallthrough.zig
+++ b/tests/rules/no_fallthrough.zig
@@ -30,7 +30,7 @@ test "reports no-fallthrough for non-empty cases without abrupt completion" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_fallthrough.id));
 }
 
-test "does not report no-fallthrough for break, return, throw, empty case, or fallthrough comments" {
+test "does not report no-fallthrough for break, return, throw, adjacent empty case, or fallthrough comments" {
     const source =
         \\function run(value) {
         \\  switch (value) {
@@ -52,6 +52,47 @@ test "does not report no-fallthrough for break, return, throw, empty case, or fa
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
+}
+
+test "reports no-fallthrough for separated empty cases by default" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\
+        \\  case 2:
+        \\    two();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_fallthrough.id));
+}
+
+test "allows separated empty cases when configured" {
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\
+        \\  case 2:
+        \\    two();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_fallthrough_allow_empty_case = .yes,
         .no_undef = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary

- add `no-fallthrough` support for ESLint's `allowEmptyCase` option
- tighten default empty-case handling to require adjacent case labels or a fallthrough comment
- expose `--no-fallthrough-allow-empty-case=on` for CLI usage
- parse ESLint-style config values such as `["error", { "allowEmptyCase": true }]`

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default reports separated empty case; option on reports none
- config smoke: ESLint-style `allowEmptyCase: true` reports none