### PR TITLE
feat: support no empty function allow

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -60,7 +60,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented with optional `allowEmptyCatch` behavior |
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |
 | [`no-empty-character-class`](https://eslint.org/docs/latest/rules/no-empty-character-class) | Implemented |
-| [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented |
+| [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented with partial `allow` behavior for functions, arrow functions, methods, and constructors |
 | [`no-empty-pattern`](https://eslint.org/docs/latest/rules/no-empty-pattern) | Implemented |
 | [`no-empty-static-block`](https://eslint.org/docs/latest/rules/no-empty-static-block) | Implemented |
 | [`no-eq-null`](https://eslint.org/docs/latest/rules/no-eq-null) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -68,6 +68,30 @@ pub const NoEmptyAllowEmptyCatch = enum {
     no,
 };
 
+pub const NoEmptyFunctionAllow = struct {
+    functions: bool = false,
+    arrowFunctions: bool = false,
+    methods: bool = false,
+    constructors: bool = false,
+
+    pub fn contains(self: NoEmptyFunctionAllow, name: []const u8) bool {
+        inline for (@typeInfo(NoEmptyFunctionAllow).@"struct".fields) |field| {
+            if (std.mem.eql(u8, field.name, name)) return @field(self, field.name);
+        }
+        return false;
+    }
+
+    pub fn enable(self: *NoEmptyFunctionAllow, name: []const u8) bool {
+        inline for (@typeInfo(NoEmptyFunctionAllow).@"struct".fields) |field| {
+            if (std.mem.eql(u8, field.name, name)) {
+                @field(self, field.name) = true;
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
 pub const NoFallthroughAllowEmptyCase = enum {
     yes,
     no,
@@ -275,6 +299,7 @@ pub const Options = struct {
     no_empty_block_statements: bool = true,
     no_empty_character_class: bool = true,
     no_empty_function: bool = true,
+    no_empty_function_allow: NoEmptyFunctionAllow = .{},
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
@@ -651,6 +676,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-empty")) {
             self.no_empty_allow_empty_catch = try noEmptyAllowEmptyCatchFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-empty-function")) {
+            self.no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
         }
@@ -786,6 +814,34 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noEmptyFunctionAllowFromConfig(value: std.json.Value) RuleConfigError!NoEmptyFunctionAllow {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow: NoEmptyFunctionAllow = .{};
+        for (allow_items) |item| {
+            const kind = switch (item) {
+                .string => |kind| kind,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!allow.enable(kind)) return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn noFallthroughAllowEmptyCaseFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughAllowEmptyCase {
@@ -1207,6 +1263,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-empty", no_empty_config.value);
     try std.testing.expect(options.no_empty);
     try std.testing.expectEqual(NoEmptyAllowEmptyCatch.yes, options.no_empty_allow_empty_catch);
+
+    var no_empty_function_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"functions\",\"constructors\"]}]",
+        .{},
+    );
+    defer no_empty_function_config.deinit();
+    try options.setByRuleConfigValue("no-empty-function", no_empty_function_config.value);
+    try std.testing.expect(options.no_empty_function);
+    try std.testing.expect(options.no_empty_function_allow.functions);
+    try std.testing.expect(options.no_empty_function_allow.constructors);
+    try std.testing.expect(!options.no_empty_function_allow.arrowFunctions);
 
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -242,6 +242,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_empty_character_class = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-function=off")) {
             options.no_empty_function = false;
+        } else if (std.mem.startsWith(u8, arg, "--no-empty-function-allow=")) {
+            parseNoEmptyFunctionAllow(arg["--no-empty-function-allow=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-empty-pattern=off")) {
             options.no_empty_pattern = false;
         } else if (std.mem.eql(u8, arg, "--no-empty-static-block=off")) {
@@ -1047,6 +1049,28 @@ fn parseNoConsoleAllow(value: []const u8, options: *lint.Options) void {
     options.no_console_allow = allow;
 }
 
+fn parseNoEmptyFunctionAllow(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --no-empty-function-allow requires a comma-separated kind list\n", .{});
+        std.process.exit(2);
+    }
+
+    var allow: @TypeOf(options.no_empty_function_allow) = .{};
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_kind| {
+        const kind = std.mem.trim(u8, raw_kind, " \t\r\n");
+        if (kind.len == 0) {
+            std.debug.print("utoo-lint: --no-empty-function-allow contains an empty kind\n", .{});
+            std.process.exit(2);
+        }
+        if (!allow.enable(kind)) {
+            std.debug.print("utoo-lint: unsupported --no-empty-function-allow kind: {s}\n", .{kind});
+            std.process.exit(2);
+        }
+    }
+    options.no_empty_function_allow = allow;
+}
+
 fn collectLintableDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -1406,6 +1430,7 @@ fn printHelp() void {
         \\  --no-empty-block-statements=off Disable no-empty-block-statements
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-function=off Disable no-empty-function
+        \\  --no-empty-function-allow=functions,arrowFunctions Allow selected empty function kinds
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return

--- a/src/rules/no_empty_function.zig
+++ b/src/rules/no_empty_function.zig
@@ -7,6 +7,18 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-empty-function";
 
+pub const Kind = enum {
+    functions,
+    arrowFunctions,
+    methods,
+    constructors,
+};
+
+pub const Options = struct {
+    allow: core.NoEmptyFunctionAllow = .{},
+    kind: Kind = .functions,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +26,19 @@ pub fn check(
     body: ast.FunctionBody,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, body, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (body.body.len != 0) return;
+    if (allowsKind(options.allow, options.kind)) return;
     if (hasCommentInsideBraces(tree, index)) return;
 
     try core.addDiagnostic(
@@ -25,6 +49,15 @@ pub fn check(
         "Unexpected empty function.",
         tree.span(index),
     );
+}
+
+fn allowsKind(allow: core.NoEmptyFunctionAllow, kind: Kind) bool {
+    return switch (kind) {
+        .functions => allow.functions,
+        .arrowFunctions => allow.arrowFunctions,
+        .methods => allow.methods,
+        .constructors => allow.constructors,
+    };
 }
 
 pub fn hasCommentInsideBraces(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -359,6 +359,23 @@ fn isCatchBody(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeInd
     };
 }
 
+fn emptyFunctionKind(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) no_empty_function.Kind {
+    const parent_index = ctx.path.parent() orelse return .functions;
+
+    switch (tree.data(parent_index)) {
+        .arrow_function_expression => return .arrowFunctions,
+        .function => {},
+        else => return .functions,
+    }
+
+    const grandparent_index = ctx.path.ancestor(2) orelse return .functions;
+    return switch (tree.data(grandparent_index)) {
+        .method_definition => |method| if (method.kind == .constructor) .constructors else .methods,
+        .object_property => |property| if (property.method or property.kind != .init) .methods else .functions,
+        else => .functions,
+    };
+}
+
 pub fn runBasic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -1778,7 +1795,10 @@ const BasicVisitor = struct {
             try no_empty_block_statements.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index);
         }
         if (self.options.no_empty_function and !self.options.typescript_eslint_no_empty_function) {
-            try no_empty_function.check(self.allocator, self.diagnostics, ctx.tree, body, index);
+            try no_empty_function.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, body, index, .{
+                .allow = self.options.no_empty_function_allow,
+                .kind = emptyFunctionKind(ctx.tree, ctx),
+            });
         }
         if (self.options.typescript_eslint_no_empty_function) {
             try typescript_eslint_no_empty_function.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);

--- a/tests/rules/no_empty_function.zig
+++ b/tests/rules/no_empty_function.zig
@@ -48,6 +48,33 @@ test "does not report no-empty-function for non-empty or commented bodies" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_function.id));
 }
 
+test "allows configured no-empty-function kinds" {
+    const source =
+        \\function empty() {}
+        \\const arrow = () => {};
+        \\class Example {
+        \\  constructor() {}
+        \\  method() {}
+        \\}
+    ;
+
+    var allow = (lint.Options{}).no_empty_function_allow;
+    try std.testing.expect(allow.enable("functions"));
+    try std.testing.expect(allow.enable("constructors"));
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function_allow = allow,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_empty_function.id));
+}
+
 test "can disable no-empty-function" {
     const source =
         \\function empty() {}


### PR DESCRIPTION
## Summary
- add partial ESLint `allow` support for `no-empty-function` kinds: `functions`, `arrowFunctions`, `methods`, and `constructors`
- expose `--no-empty-function-allow=functions,arrowFunctions` for CLI usage
- parse ESLint-style config such as `["error", { "allow": ["functions", "constructors"] }]`
- keep default `no-empty-function` behavior unchanged

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: `--rules=no-empty-function --no-empty-function-allow=functions,constructors` reports 2 diagnostics
- CLI smoke: `--rules=no-empty-function` reports 4 diagnostics
- config smoke: ESLint-style `no-empty-function` `allow` config reports 2 diagnostics