### PR TITLE
feat: support no return assign always

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -121,7 +121,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) | Implemented |
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
-| [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented |
+| [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
 | [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented |
 | [`no-script-url`](https://eslint.org/docs/latest/rules/no-script-url) | Implemented |
 | [`no-self-assign`](https://eslint.org/docs/latest/rules/no-self-assign) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -97,6 +97,11 @@ pub const NoFallthroughAllowEmptyCase = enum {
     no,
 };
 
+pub const NoReturnAssignStyle = enum {
+    except_parens,
+    always,
+};
+
 pub const NoUnderscoreDangleAllowFunctionParams = enum {
     yes,
     no,
@@ -420,6 +425,7 @@ pub const Options = struct {
     no_regex_spaces: bool = true,
     no_return_await: bool = true,
     no_return_assign: bool = true,
+    no_return_assign_style: NoReturnAssignStyle = .except_parens,
     no_useless_return: bool = true,
     no_script_url: bool = true,
     no_self_assign: bool = true,
@@ -682,6 +688,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-return-assign")) {
+            self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
         }
@@ -860,6 +869,22 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .except_parens,
+        };
+        if (items.len < 2) return .except_parens;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "except-parens")) return .except_parens;
+        if (std.mem.eql(u8, style, "always")) return .always;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noUselessComputedKeyEnforceForClassMembersFromConfig(value: std.json.Value) RuleConfigError!NoUselessComputedKeyEnforceForClassMembers {
@@ -1287,6 +1312,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-fallthrough", no_fallthrough_config.value);
     try std.testing.expect(options.no_fallthrough);
     try std.testing.expectEqual(NoFallthroughAllowEmptyCase.yes, options.no_fallthrough_allow_empty_case);
+
+    var no_return_assign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer no_return_assign_config.deinit();
+    try options.setByRuleConfigValue("no-return-assign", no_return_assign_config.value);
+    try std.testing.expect(options.no_return_assign);
+    try std.testing.expectEqual(NoReturnAssignStyle.always, options.no_return_assign_style);
 
     var no_useless_computed_key_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -482,6 +482,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_return_await = false;
         } else if (std.mem.eql(u8, arg, "--no-return-assign=off")) {
             options.no_return_assign = false;
+        } else if (std.mem.eql(u8, arg, "--no-return-assign=always")) {
+            options.no_return_assign_style = .always;
         } else if (std.mem.eql(u8, arg, "--no-useless-return=off")) {
             options.no_useless_return = false;
         } else if (std.mem.eql(u8, arg, "--no-script-url=off")) {
@@ -1553,6 +1555,7 @@ fn printHelp() void {
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign
+        \\  --no-return-assign=always Report all returned assignments, including parenthesized ones
         \\  --no-useless-return=off   Disable no-useless-return
         \\  --no-script-url=off       Disable no-script-url
         \\  --no-self-assign=off      Disable no-self-assign

--- a/src/rules/no_return_assign.zig
+++ b/src/rules/no_return_assign.zig
@@ -6,13 +6,27 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-return-assign";
 
+pub const Options = struct {
+    style: core.NoReturnAssignStyle = .except_parens,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.NodeIndex,
 ) Allocator.Error!void {
-    const assignment = findUnparenthesizedAssignment(tree, expression) orelse return;
+    try checkWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    const assignment = findAssignment(tree, expression, options.style == .always) orelse return;
 
     try core.addDiagnostic(
         allocator,
@@ -24,50 +38,53 @@ pub fn check(
     );
 }
 
-fn findUnparenthesizedAssignment(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesized: bool) ?ast.NodeIndex {
     if (index == .null) return null;
 
     switch (tree.data(index)) {
-        .parenthesized_expression => return null,
+        .parenthesized_expression => |expression| {
+            if (!allow_parenthesized) return null;
+            return findAssignment(tree, expression.expression, allow_parenthesized);
+        },
         .assignment_expression => return index,
-        .chain_expression => |chain| return findUnparenthesizedAssignment(tree, chain.expression),
+        .chain_expression => |chain| return findAssignment(tree, chain.expression, allow_parenthesized),
         .binary_expression => |expression| {
-            if (findUnparenthesizedAssignment(tree, expression.left)) |assignment| return assignment;
-            return findUnparenthesizedAssignment(tree, expression.right);
+            if (findAssignment(tree, expression.left, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.right, allow_parenthesized);
         },
         .logical_expression => |expression| {
-            if (findUnparenthesizedAssignment(tree, expression.left)) |assignment| return assignment;
-            return findUnparenthesizedAssignment(tree, expression.right);
+            if (findAssignment(tree, expression.left, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.right, allow_parenthesized);
         },
-        .unary_expression => |expression| return findUnparenthesizedAssignment(tree, expression.argument),
+        .unary_expression => |expression| return findAssignment(tree, expression.argument, allow_parenthesized),
         .conditional_expression => |expression| {
-            if (findUnparenthesizedAssignment(tree, expression.@"test")) |assignment| return assignment;
-            if (findUnparenthesizedAssignment(tree, expression.consequent)) |assignment| return assignment;
-            return findUnparenthesizedAssignment(tree, expression.alternate);
+            if (findAssignment(tree, expression.@"test", allow_parenthesized)) |assignment| return assignment;
+            if (findAssignment(tree, expression.consequent, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.alternate, allow_parenthesized);
         },
         .sequence_expression => |expression| {
             for (tree.extra(expression.expressions)) |item| {
-                if (findUnparenthesizedAssignment(tree, item)) |assignment| return assignment;
+                if (findAssignment(tree, item, allow_parenthesized)) |assignment| return assignment;
             }
             return null;
         },
         .call_expression => |call| {
-            if (findUnparenthesizedAssignment(tree, call.callee)) |assignment| return assignment;
+            if (findAssignment(tree, call.callee, allow_parenthesized)) |assignment| return assignment;
             for (tree.extra(call.arguments)) |argument| {
-                if (findUnparenthesizedAssignment(tree, argument)) |assignment| return assignment;
+                if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
             }
             return null;
         },
         .new_expression => |new| {
-            if (findUnparenthesizedAssignment(tree, new.callee)) |assignment| return assignment;
+            if (findAssignment(tree, new.callee, allow_parenthesized)) |assignment| return assignment;
             for (tree.extra(new.arguments)) |argument| {
-                if (findUnparenthesizedAssignment(tree, argument)) |assignment| return assignment;
+                if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
             }
             return null;
         },
         .member_expression => |member| {
-            if (findUnparenthesizedAssignment(tree, member.object)) |assignment| return assignment;
-            if (member.computed) return findUnparenthesizedAssignment(tree, member.property);
+            if (findAssignment(tree, member.object, allow_parenthesized)) |assignment| return assignment;
+            if (member.computed) return findAssignment(tree, member.property, allow_parenthesized);
             return null;
         },
         else => return null,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1679,7 +1679,9 @@ const BasicVisitor = struct {
             try no_useless_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         if (self.options.no_return_assign) {
-            try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.argument);
+            try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.argument, .{
+                .style = self.options.no_return_assign_style,
+            });
         }
         return .proceed;
     }
@@ -1951,7 +1953,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_return_assign and expression.expression) {
-            try no_return_assign.check(self.allocator, self.diagnostics, ctx.tree, expression.body);
+            try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.body, .{
+                .style = self.options.no_return_assign_style,
+            });
         }
         if (self.options.consistent_return) {
             try consistent_return.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);

--- a/tests/rules/no_return_assign.zig
+++ b/tests/rules/no_return_assign.zig
@@ -41,6 +41,25 @@ test "does not report no-return-assign for comparisons or parenthesized assignme
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_return_assign.id));
 }
 
+test "reports parenthesized returned assignments in always mode" {
+    const source =
+        \\function update(value, next) {
+        \\  return (value = next);
+        \\}
+        \\const assign = (value, next) => (value += next);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_return_assign_style = .always,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_assign.id));
+}
+
 test "can disable no-return-assign" {
     const source =
         \\function update(value, next) {


### PR DESCRIPTION
## Summary
- add `no-return-assign` support for ESLint's `always` option
- expose `--no-return-assign=always` for CLI usage
- parse ESLint-style config such as `["error", "always"]`
- keep the default `except-parens` behavior unchanged

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default `--rules=no-return-assign` reports 0 diagnostics for parenthesized returned assignments
- CLI smoke: `--rules=no-return-assign --no-return-assign=always` reports 2 diagnostics
- config smoke: ESLint-style `no-return-assign` `always` config reports 2 diagnostics