### PR TITLE
feat: support no sequences parentheses option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -126,7 +126,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-script-url`](https://eslint.org/docs/latest/rules/no-script-url) | Implemented |
 | [`no-self-assign`](https://eslint.org/docs/latest/rules/no-self-assign) | Implemented |
 | [`no-self-compare`](https://eslint.org/docs/latest/rules/no-self-compare) | Implemented |
-| [`no-sequences`](https://eslint.org/docs/latest/rules/no-sequences) | Implemented |
+| [`no-sequences`](https://eslint.org/docs/latest/rules/no-sequences) | Implemented with optional `allowInParentheses` behavior |
 | [`no-setter-return`](https://eslint.org/docs/latest/rules/no-setter-return) | Implemented |
 | [`no-shadow-restricted-names`](https://eslint.org/docs/latest/rules/no-shadow-restricted-names) | Implemented |
 | [`no-sparse-arrays`](https://eslint.org/docs/latest/rules/no-sparse-arrays) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -102,6 +102,11 @@ pub const NoReturnAssignStyle = enum {
     always,
 };
 
+pub const NoSequencesAllowInParentheses = enum {
+    yes,
+    no,
+};
+
 pub const NoUnderscoreDangleAllowFunctionParams = enum {
     yes,
     no,
@@ -434,6 +439,7 @@ pub const Options = struct {
     no_shadow: bool = true,
     no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
+    no_sequences_allow_in_parentheses: NoSequencesAllowInParentheses = .yes,
     no_sparse_arrays: bool = true,
     no_ternary: bool = true,
     no_template_curly_in_string: bool = true,
@@ -691,6 +697,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-sequences")) {
+            self.no_sequences_allow_in_parentheses = try noSequencesAllowInParenthesesFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
         }
@@ -885,6 +894,24 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "except-parens")) return .except_parens;
         if (std.mem.eql(u8, style, "always")) return .always;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noSequencesAllowInParenthesesFromConfig(value: std.json.Value) RuleConfigError!NoSequencesAllowInParentheses {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .yes,
+        };
+        if (items.len < 2) return .yes;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowInParentheses") orelse return .yes) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
     }
 
     fn noUselessComputedKeyEnforceForClassMembersFromConfig(value: std.json.Value) RuleConfigError!NoUselessComputedKeyEnforceForClassMembers {
@@ -1323,6 +1350,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-return-assign", no_return_assign_config.value);
     try std.testing.expect(options.no_return_assign);
     try std.testing.expectEqual(NoReturnAssignStyle.always, options.no_return_assign_style);
+
+    var no_sequences_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowInParentheses\":false}]",
+        .{},
+    );
+    defer no_sequences_config.deinit();
+    try options.setByRuleConfigValue("no-sequences", no_sequences_config.value);
+    try std.testing.expect(options.no_sequences);
+    try std.testing.expectEqual(NoSequencesAllowInParentheses.no, options.no_sequences_allow_in_parentheses);
 
     var no_useless_computed_key_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -500,6 +500,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_shadow_restricted_names = false;
         } else if (std.mem.eql(u8, arg, "--no-sequences=off")) {
             options.no_sequences = false;
+        } else if (std.mem.eql(u8, arg, "--no-sequences-allow-in-parentheses=off")) {
+            options.no_sequences_allow_in_parentheses = .no;
         } else if (std.mem.eql(u8, arg, "--no-sparse-arrays=off")) {
             options.no_sparse_arrays = false;
         } else if (std.mem.eql(u8, arg, "--no-ternary=off")) {
@@ -1564,6 +1566,7 @@ fn printHelp() void {
         \\  --no-shadow=off           Disable no-shadow
         \\  --no-shadow-restricted-names=off Disable no-shadow-restricted-names
         \\  --no-sequences=off        Disable no-sequences
+        \\  --no-sequences-allow-in-parentheses=off Report parenthesized sequence expressions
         \\  --no-sparse-arrays=off    Disable no-sparse-arrays
         \\  --no-ternary=off          Disable no-ternary
         \\  --no-template-curly-in-string=off Disable no-template-curly-in-string

--- a/src/rules/no_sequences.zig
+++ b/src/rules/no_sequences.zig
@@ -8,6 +8,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-sequences";
 
+pub const Options = struct {
+    allow_in_parentheses: core.NoSequencesAllowInParentheses = .yes,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -16,9 +20,20 @@ pub fn check(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, index, ctx, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
     if (isNestedSequence(tree, ctx)) return;
     if (isAllowedForPart(tree, index, ctx)) return;
-    if (isAllowedParenthesizedSequence(tree, index, ctx)) return;
+    if (options.allow_in_parentheses == .yes and isAllowedParenthesizedSequence(tree, index, ctx)) return;
 
     try core.addDiagnostic(
         allocator,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2163,7 +2163,9 @@ const BasicVisitor = struct {
             try no_comma_operator.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
         }
         if (self.options.no_sequences) {
-            try no_sequences.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
+            try no_sequences.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .allow_in_parentheses = self.options.no_sequences_allow_in_parentheses,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/no_sequences.zig
+++ b/tests/rules/no_sequences.zig
@@ -39,6 +39,26 @@ test "does not report no-sequences for allowed sequence expressions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_sequences.id));
 }
 
+test "reports parenthesized sequences when configured" {
+    const source =
+        \\const value = (foo = doSomething(), foo);
+        \\const arrow = () => ((foo = doSomething(), foo));
+        \\for (i = 0, j = 0; test; i++, j++) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_sequences_allow_in_parentheses = .no,
+        .no_comma_operator = false,
+        .no_self_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_sequences.id));
+}
+
 test "can disable no-sequences" {
     const source =
         \\foo = doSomething(), bar = foo;


### PR DESCRIPTION
## Summary
- add `no-sequences` support for ESLint's `allowInParentheses: false` option
- expose `--no-sequences-allow-in-parentheses=off` for CLI usage
- parse ESLint-style config such as `["error", { "allowInParentheses": false }]`
- keep the default parenthesized-sequence allowance unchanged

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default `--rules=no-sequences` reports 0 diagnostics for parenthesized sequences
- CLI smoke: `--rules=no-sequences --no-sequences-allow-in-parentheses=off` reports 2 diagnostics
- config smoke: ESLint-style `no-sequences` `allowInParentheses: false` config reports 2 diagnostics