### PR TITLE
ci: add Zig formatting check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
 
+      - name: Check Zig formatting
+        run: zig fmt --check build.zig src tests
+
       - name: Test
         run: zig build test -Doptimize=ReleaseFast -j1
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,12 +22,12 @@ const OutputFormat = enum {
 };
 
 const JsonDiagnostic = struct {
-    @"filePath": []const u8,
+    filePath: []const u8,
     line: usize,
     column: usize,
     severity: []const u8,
     message: []const u8,
-    @"ruleId": []const u8,
+    ruleId: []const u8,
 };
 
 const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
@@ -1301,20 +1301,20 @@ fn appendJsonDiagnostic(
     errdefer allocator.free(owned_rule_id);
 
     try diagnostics.append(allocator, .{
-        .@"filePath" = owned_path,
+        .filePath = owned_path,
         .line = line,
         .column = column,
         .severity = severity,
         .message = owned_message,
-        .@"ruleId" = owned_rule_id,
+        .ruleId = owned_rule_id,
     });
 }
 
 fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosticList) void {
     for (diagnostics.items) |diagnostic| {
-        allocator.free(diagnostic.@"filePath");
+        allocator.free(diagnostic.filePath);
         allocator.free(diagnostic.message);
-        allocator.free(diagnostic.@"ruleId");
+        allocator.free(diagnostic.ruleId);
     }
     diagnostics.deinit(allocator);
 }

--- a/src/rules/eqeqeq.zig
+++ b/src/rules/eqeqeq.zig
@@ -25,4 +25,3 @@ pub fn check(
         tree.span(index),
     );
 }
-

--- a/src/rules/no_debugger.zig
+++ b/src/rules/no_debugger.zig
@@ -22,4 +22,3 @@ pub fn check(
         tree.span(index),
     );
 }
-

--- a/src/rules/no_var.zig
+++ b/src/rules/no_var.zig
@@ -25,4 +25,3 @@ pub fn check(
         tree.span(index),
     );
 }
-


### PR DESCRIPTION
## Summary

Adds a Zig formatting gate to CI so pull requests fail when project-owned Zig sources are not formatted.

## Details

- Runs `zig fmt --check build.zig src tests` after Zig setup in CI.
- Applies current `zig fmt` output to the project-owned files that were blocking the new check.
- Leaves `vendor/yuku` out of the check because vendored sources currently contain many formatting differences under this Zig version.

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
