### PR TITLE
feat: support no multi spaces eol comments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -95,7 +95,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Implemented |
 | [`no-misleading-character-class`](https://eslint.org/docs/latest/rules/no-misleading-character-class) | Implemented |
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
-| [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Implemented |
+| [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Implemented with optional `ignoreEOLComments` behavior |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
 | [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented |
 | [`no-negated-condition`](https://eslint.org/docs/latest/rules/no-negated-condition) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -97,6 +97,11 @@ pub const NoFallthroughAllowEmptyCase = enum {
     no,
 };
 
+pub const NoMultiSpacesIgnoreEOLComments = enum {
+    yes,
+    no,
+};
+
 pub const NoReturnAssignStyle = enum {
     except_parens,
     always,
@@ -399,6 +404,7 @@ pub const Options = struct {
     no_multi_str: bool = true,
     no_multi_assign: bool = true,
     no_multi_spaces: bool = true,
+    no_multi_spaces_ignore_eol_comments: NoMultiSpacesIgnoreEOLComments = .no,
     no_mixed_spaces_and_tabs: bool = true,
     no_misleading_character_class: bool = true,
     no_multiple_empty_lines: bool = true,
@@ -694,6 +700,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
+            self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
         }
@@ -878,6 +887,24 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noMultiSpacesIgnoreEOLCommentsFromConfig(value: std.json.Value) RuleConfigError!NoMultiSpacesIgnoreEOLComments {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore = switch (config.get("ignoreEOLComments") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (ignore) .yes else .no;
     }
 
     fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
@@ -1339,6 +1366,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-fallthrough", no_fallthrough_config.value);
     try std.testing.expect(options.no_fallthrough);
     try std.testing.expectEqual(NoFallthroughAllowEmptyCase.yes, options.no_fallthrough_allow_empty_case);
+
+    var no_multi_spaces_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreEOLComments\":true}]",
+        .{},
+    );
+    defer no_multi_spaces_config.deinit();
+    try options.setByRuleConfigValue("no-multi-spaces", no_multi_spaces_config.value);
+    try std.testing.expect(options.no_multi_spaces);
+    try std.testing.expectEqual(NoMultiSpacesIgnoreEOLComments.yes, options.no_multi_spaces_ignore_eol_comments);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -420,6 +420,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_multi_assign = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-spaces=off")) {
             options.no_multi_spaces = false;
+        } else if (std.mem.eql(u8, arg, "--no-multi-spaces-ignore-eol-comments=on")) {
+            options.no_multi_spaces_ignore_eol_comments = .yes;
         } else if (std.mem.eql(u8, arg, "--no-mixed-spaces-and-tabs=off")) {
             options.no_mixed_spaces_and_tabs = false;
         } else if (std.mem.eql(u8, arg, "--no-misleading-character-class=off")) {
@@ -1526,6 +1528,7 @@ fn printHelp() void {
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-multi-assign=off     Disable no-multi-assign
         \\  --no-multi-spaces=off     Disable no-multi-spaces
+        \\  --no-multi-spaces-ignore-eol-comments=on Allow spacing before end-of-line comments
         \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
         \\  --no-misleading-character-class=off Disable no-misleading-character-class
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines

--- a/src/rules/no_multi_spaces.zig
+++ b/src/rules/no_multi_spaces.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-multi-spaces";
 
+pub const Options = struct {
+    ignore_eol_comments: core.NoMultiSpacesIgnoreEOLComments = .no,
+};
+
 const IgnoredSpan = struct {
     start: u32,
     end: u32,
@@ -17,6 +21,15 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     const source = tree.source;
     const ignored_spans = try collectIgnoredSpans(allocator, tree);
     defer allocator.free(ignored_spans);
@@ -26,7 +39,7 @@ pub fn run(
 
     while (line_start <= source.len) {
         const line_end = findLineEnd(source, line_start);
-        try checkLine(allocator, diagnostics, tree, line_start, line_end, ignored_spans, &ignored_index);
+        try checkLine(allocator, diagnostics, tree, line_start, line_end, ignored_spans, &ignored_index, options);
 
         if (line_end >= source.len) break;
 
@@ -45,6 +58,7 @@ fn checkLine(
     line_end: usize,
     ignored_spans: []const IgnoredSpan,
     ignored_index: *usize,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
     var index = line_start;
@@ -73,6 +87,8 @@ fn checkLine(
         while (index < line_end and source[index] == ' ') : (index += 1) {}
 
         if (index - start > 1) {
+            if (options.ignore_eol_comments == .yes and isBeforeEndOfLineComment(tree, index, line_end)) continue;
+
             try core.addDiagnostic(
                 allocator,
                 diagnostics,
@@ -83,6 +99,26 @@ fn checkLine(
             );
         }
     }
+}
+
+fn isBeforeEndOfLineComment(tree: *const ast.Tree, index: usize, line_end: usize) bool {
+    for (tree.comments) |comment| {
+        const start: usize = comment.start;
+        if (start != index) continue;
+        if (comment.type == .line) return true;
+
+        const end: usize = comment.end;
+        if (end > line_end) return false;
+        return isOnlyWhitespace(tree.source[end..line_end]);
+    }
+    return false;
+}
+
+fn isOnlyWhitespace(source: []const u8) bool {
+    for (source) |byte| {
+        if (byte != ' ' and byte != '\t') return false;
+    }
+    return true;
 }
 
 fn collectIgnoredSpans(allocator: Allocator, tree: *const ast.Tree) Allocator.Error![]IgnoredSpan {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -443,7 +443,9 @@ pub fn runBasic(
         try no_inline_comments.run(allocator, diagnostics, tree);
     }
     if (options.no_multi_spaces) {
-        try no_multi_spaces.run(allocator, diagnostics, tree);
+        try no_multi_spaces.runWithOptions(allocator, diagnostics, tree, .{
+            .ignore_eol_comments = options.no_multi_spaces_ignore_eol_comments,
+        });
     }
     if (options.spaced_comment) {
         try spaced_comment.run(allocator, diagnostics, tree);

--- a/tests/rules/no_multi_spaces.zig
+++ b/tests/rules/no_multi_spaces.zig
@@ -34,6 +34,23 @@ test "reports no-multi-spaces before end-of-line comments" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multi_spaces.id));
 }
 
+test "allows no-multi-spaces before end-of-line comments when configured" {
+    const source =
+        "const value =  1;\n" ++
+        "const line = 1;  // comment\n" ++
+        "const block = 1;  /* comment */\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multi_spaces_ignore_eol_comments = .yes,
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multi_spaces.id));
+}
+
 test "does not report no-multi-spaces for indentation or inside literals and comments" {
     const source =
         "  const text = \"hello  world\";\n" ++


### PR DESCRIPTION
## Summary
- add `no-multi-spaces` support for ESLint's `ignoreEOLComments: true` option
- expose `--no-multi-spaces-ignore-eol-comments=on` for CLI usage
- parse ESLint-style config such as `["error", { "ignoreEOLComments": true }]`
- keep default reporting before end-of-line comments unchanged

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- CLI smoke: default `--rules=no-multi-spaces` reports 3 diagnostics for ordinary spacing plus EOL comments
- CLI smoke: `--rules=no-multi-spaces --no-multi-spaces-ignore-eol-comments=on` reports 1 diagnostic
- config smoke: ESLint-style `no-multi-spaces` `ignoreEOLComments: true` config reports 1 diagnostic