### PR TITLE
feat: support no multiple empty lines max

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -97,7 +97,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
 | [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Implemented with optional `ignoreEOLComments` behavior |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
-| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented |
+| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max` behavior |
 | [`no-negated-condition`](https://eslint.org/docs/latest/rules/no-negated-condition) | Implemented |
 | [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) | Implemented |
 | [`no-new`](https://eslint.org/docs/latest/rules/no-new) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -408,6 +408,7 @@ pub const Options = struct {
     no_mixed_spaces_and_tabs: bool = true,
     no_misleading_character_class: bool = true,
     no_multiple_empty_lines: bool = true,
+    no_multiple_empty_lines_max: usize = 2,
     no_nonoctal_decimal_escape: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
@@ -703,6 +704,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
             self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-multiple-empty-lines")) {
+            self.no_multiple_empty_lines_max = try noMultipleEmptyLinesMaxFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
         }
@@ -905,6 +909,25 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (ignore) .yes else .no;
+    }
+
+    fn noMultipleEmptyLinesMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 2,
+        };
+        if (items.len < 2) return 2;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const max = switch (config.get("max") orelse return 2) {
+            .integer => |max| max,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (max < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(max);
     }
 
     fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
@@ -1377,6 +1400,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-multi-spaces", no_multi_spaces_config.value);
     try std.testing.expect(options.no_multi_spaces);
     try std.testing.expectEqual(NoMultiSpacesIgnoreEOLComments.yes, options.no_multi_spaces_ignore_eol_comments);
+
+    var no_multiple_empty_lines_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"max\":1}]",
+        .{},
+    );
+    defer no_multiple_empty_lines_config.deinit();
+    try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_config.value);
+    try std.testing.expect(options.no_multiple_empty_lines);
+    try std.testing.expectEqual(@as(usize, 1), options.no_multiple_empty_lines_max);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -428,6 +428,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_misleading_character_class = false;
         } else if (std.mem.eql(u8, arg, "--no-multiple-empty-lines=off")) {
             options.no_multiple_empty_lines = false;
+        } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max=")) {
+            parseNoMultipleEmptyLinesMax(arg["--no-multiple-empty-lines-max=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-nonoctal-decimal-escape=off")) {
             options.no_nonoctal_decimal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
@@ -1077,6 +1079,14 @@ fn parseNoEmptyFunctionAllow(value: []const u8, options: *lint.Options) void {
     options.no_empty_function_allow = allow;
 }
 
+fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.no_multiple_empty_lines_max = max;
+}
+
 fn collectLintableDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -1532,6 +1542,7 @@ fn printHelp() void {
         \\  --no-mixed-spaces-and-tabs=off Disable no-mixed-spaces-and-tabs
         \\  --no-misleading-character-class=off Disable no-misleading-character-class
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
+        \\  --no-multiple-empty-lines-max=N Configure no-multiple-empty-lines max
         \\  --no-nonoctal-decimal-escape=off Disable no-nonoctal-decimal-escape
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary

--- a/src/rules/no_multiple_empty_lines.zig
+++ b/src/rules/no_multiple_empty_lines.zig
@@ -7,12 +7,23 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-multiple-empty-lines";
 
-const max_empty_lines = 2;
+pub const Options = struct {
+    max: usize = 2,
+};
 
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
     var line_start: usize = 0;
@@ -23,14 +34,15 @@ pub fn run(
 
         if (isEmptyLine(source[line_start..line_end])) {
             empty_lines += 1;
-            if (empty_lines > max_empty_lines) {
-                try core.addDiagnostic(
+            if (empty_lines > options.max) {
+                try core.addDiagnosticFmt(
                     allocator,
                     diagnostics,
                     .warning,
                     id,
-                    "More than 2 blank lines not allowed.",
                     .{ .start = @intCast(line_start), .end = @intCast(line_end) },
+                    "More than {d} blank lines not allowed.",
+                    .{options.max},
                 );
             }
         } else {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -437,7 +437,9 @@ pub fn runBasic(
         try no_irregular_whitespace.run(allocator, diagnostics, tree);
     }
     if (options.no_multiple_empty_lines) {
-        try no_multiple_empty_lines.run(allocator, diagnostics, tree);
+        try no_multiple_empty_lines.runWithOptions(allocator, diagnostics, tree, .{
+            .max = options.no_multiple_empty_lines_max,
+        });
     }
     if (options.no_inline_comments) {
         try no_inline_comments.run(allocator, diagnostics, tree);

--- a/tests/rules/no_multiple_empty_lines.zig
+++ b/tests/rules/no_multiple_empty_lines.zig
@@ -59,6 +59,27 @@ test "does not report no-multiple-empty-lines for two blank lines" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multiple_empty_lines.id));
 }
 
+test "supports no-multiple-empty-lines max option" {
+    const source =
+        "const first = 1;\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multiple_empty_lines_max = 1,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multiple_empty_lines.id));
+    try std.testing.expectEqualStrings(
+        "More than 1 blank lines not allowed.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable no-multiple-empty-lines" {
     const source = "const first = 1;\n\n\n\nconst second = 2;\n";
 


### PR DESCRIPTION
## Summary
- add `no-multiple-empty-lines` support for ESLint's `max` option
- expose `--no-multiple-empty-lines-max=N` for CLI usage
- parse ESLint-style config such as `["error", { "max": 1 }]`
- keep the default `max: 2` behavior unchanged

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_multiple_empty_lines.zig src/rules/root.zig tests/rules/no_multiple_empty_lines.zig`
- `git diff --check`
- CLI smoke: default `--rules=no-multiple-empty-lines` reports 0 diagnostics for two blank lines
- CLI smoke: `--rules=no-multiple-empty-lines --no-multiple-empty-lines-max=1` reports 1 diagnostic
- config smoke: ESLint-style `no-multiple-empty-lines` `max: 1` config reports 1 diagnostic