### PR TITLE
feat: support no multiple empty lines max eof

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -97,7 +97,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
 | [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Implemented with optional `ignoreEOLComments` behavior |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
-| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max` behavior |
+| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max` and `maxEOF` behavior |
 | [`no-negated-condition`](https://eslint.org/docs/latest/rules/no-negated-condition) | Implemented |
 | [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) | Implemented |
 | [`no-new`](https://eslint.org/docs/latest/rules/no-new) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -409,6 +409,7 @@ pub const Options = struct {
     no_misleading_character_class: bool = true,
     no_multiple_empty_lines: bool = true,
     no_multiple_empty_lines_max: usize = 2,
+    no_multiple_empty_lines_max_eof: ?usize = null,
     no_nonoctal_decimal_escape: bool = true,
     no_new: bool = true,
     no_nested_ternary: bool = true,
@@ -706,6 +707,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-multiple-empty-lines")) {
             self.no_multiple_empty_lines_max = try noMultipleEmptyLinesMaxFromConfig(value);
+            self.no_multiple_empty_lines_max_eof = try noMultipleEmptyLinesMaxEofFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
@@ -923,6 +925,25 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         const max = switch (config.get("max") orelse return 2) {
+            .integer => |max| max,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (max < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(max);
+    }
+
+    fn noMultipleEmptyLinesMaxEofFromConfig(value: std.json.Value) RuleConfigError!?usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 2) return null;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const max = switch (config.get("maxEOF") orelse return null) {
             .integer => |max| max,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -1411,6 +1432,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_config.value);
     try std.testing.expect(options.no_multiple_empty_lines);
     try std.testing.expectEqual(@as(usize, 1), options.no_multiple_empty_lines_max);
+    try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_eof);
+
+    var no_multiple_empty_lines_eof_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"maxEOF\":0}]",
+        .{},
+    );
+    defer no_multiple_empty_lines_eof_config.deinit();
+    try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_eof_config.value);
+    try std.testing.expect(options.no_multiple_empty_lines);
+    try std.testing.expectEqual(@as(usize, 2), options.no_multiple_empty_lines_max);
+    try std.testing.expectEqual(@as(?usize, 0), options.no_multiple_empty_lines_max_eof);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -430,6 +430,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_multiple_empty_lines = false;
         } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max=")) {
             parseNoMultipleEmptyLinesMax(arg["--no-multiple-empty-lines-max=".len..], &options);
+        } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max-eof=")) {
+            parseNoMultipleEmptyLinesMaxEof(arg["--no-multiple-empty-lines-max-eof=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-nonoctal-decimal-escape=off")) {
             options.no_nonoctal_decimal_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-new=off")) {
@@ -1087,6 +1089,14 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn parseNoMultipleEmptyLinesMaxEof(value: []const u8, options: *lint.Options) void {
+    const max_eof = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max-eof value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.no_multiple_empty_lines_max_eof = max_eof;
+}
+
 fn collectLintableDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -1543,6 +1553,7 @@ fn printHelp() void {
         \\  --no-misleading-character-class=off Disable no-misleading-character-class
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
         \\  --no-multiple-empty-lines-max=N Configure no-multiple-empty-lines max
+        \\  --no-multiple-empty-lines-max-eof=N Configure no-multiple-empty-lines maxEOF
         \\  --no-nonoctal-decimal-escape=off Disable no-nonoctal-decimal-escape
         \\  --no-new=off              Disable no-new
         \\  --no-nested-ternary=off   Disable no-nested-ternary

--- a/src/rules/no_multiple_empty_lines.zig
+++ b/src/rules/no_multiple_empty_lines.zig
@@ -9,6 +9,7 @@ pub const id = "no-multiple-empty-lines";
 
 pub const Options = struct {
     max: usize = 2,
+    max_eof: ?usize = null,
 };
 
 pub fn run(
@@ -29,12 +30,13 @@ pub fn runWithOptions(
     var line_start: usize = 0;
     var empty_lines: usize = 0;
 
-    while (line_start <= source.len) {
+    while (line_start < source.len) {
         const line_end = findLineEnd(source, line_start);
 
         if (isEmptyLine(source[line_start..line_end])) {
             empty_lines += 1;
-            if (empty_lines > options.max) {
+            const max = if (isTrailingEmptyLine(source, line_start)) options.max_eof orelse options.max else options.max;
+            if (empty_lines > max) {
                 try core.addDiagnosticFmt(
                     allocator,
                     diagnostics,
@@ -42,7 +44,7 @@ pub fn runWithOptions(
                     id,
                     .{ .start = @intCast(line_start), .end = @intCast(line_end) },
                     "More than {d} blank lines not allowed.",
-                    .{options.max},
+                    .{max},
                 );
             }
         } else {
@@ -56,6 +58,14 @@ pub fn runWithOptions(
             line_start += 1;
         }
     }
+}
+
+fn isTrailingEmptyLine(source: []const u8, line_start: usize) bool {
+    for (source[line_start..]) |char| {
+        if (char == '\n' or char == '\r') continue;
+        if (!isBlankWhitespace(char)) return false;
+    }
+    return true;
 }
 
 fn findLineEnd(source: []const u8, start: usize) usize {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -439,6 +439,7 @@ pub fn runBasic(
     if (options.no_multiple_empty_lines) {
         try no_multiple_empty_lines.runWithOptions(allocator, diagnostics, tree, .{
             .max = options.no_multiple_empty_lines_max,
+            .max_eof = options.no_multiple_empty_lines_max_eof,
         });
     }
     if (options.no_inline_comments) {

--- a/tests/rules/no_multiple_empty_lines.zig
+++ b/tests/rules/no_multiple_empty_lines.zig
@@ -80,6 +80,38 @@ test "supports no-multiple-empty-lines max option" {
     );
 }
 
+test "supports no-multiple-empty-lines maxEOF option" {
+    const source =
+        "const first = 1;\n" ++
+        "\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multiple_empty_lines_max_eof = 0,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multiple_empty_lines.id));
+    try std.testing.expectEqualStrings(
+        "More than 0 blank lines not allowed.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "does not count a single final newline as an empty EOF line" {
+    const source = "const first = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multiple_empty_lines_max_eof = 0,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multiple_empty_lines.id));
+}
+
 test "can disable no-multiple-empty-lines" {
     const source = "const first = 1;\n\n\n\nconst second = 2;\n";
 


### PR DESCRIPTION
## Summary
- add `no-multiple-empty-lines` support for ESLint's `maxEOF` option
- expose `--no-multiple-empty-lines-max-eof=N` for CLI usage
- parse ESLint-style config such as `["error", { "maxEOF": 0 }]`
- avoid counting a single final newline as an EOF empty line
- keep default behavior unchanged when `maxEOF` is not configured

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_multiple_empty_lines.zig src/rules/root.zig tests/rules/no_multiple_empty_lines.zig`
- `git diff --check`
- CLI smoke: single final newline with `--no-multiple-empty-lines-max-eof=0` reports 0 diagnostics
- CLI smoke: extra EOF empty line with `--no-multiple-empty-lines-max-eof=0` reports 1 diagnostic
- config smoke: ESLint-style `no-multiple-empty-lines` `maxEOF: 0` config reports 1 diagnostic