### PR TITLE
feat: support no multiple empty lines max bof

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -97,7 +97,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
 | [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Implemented with optional `ignoreEOLComments` behavior |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
-| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max` and `maxEOF` behavior |
+| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max`, `maxBOF`, and `maxEOF` behavior |
 | [`no-negated-condition`](https://eslint.org/docs/latest/rules/no-negated-condition) | Implemented |
 | [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) | Implemented |
 | [`no-new`](https://eslint.org/docs/latest/rules/no-new) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -409,6 +409,7 @@ pub const Options = struct {
     no_misleading_character_class: bool = true,
     no_multiple_empty_lines: bool = true,
     no_multiple_empty_lines_max: usize = 2,
+    no_multiple_empty_lines_max_bof: ?usize = null,
     no_multiple_empty_lines_max_eof: ?usize = null,
     no_nonoctal_decimal_escape: bool = true,
     no_new: bool = true,
@@ -707,6 +708,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-multiple-empty-lines")) {
             self.no_multiple_empty_lines_max = try noMultipleEmptyLinesMaxFromConfig(value);
+            self.no_multiple_empty_lines_max_bof = try noMultipleEmptyLinesMaxBofFromConfig(value);
             self.no_multiple_empty_lines_max_eof = try noMultipleEmptyLinesMaxEofFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
@@ -925,6 +927,25 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         const max = switch (config.get("max") orelse return 2) {
+            .integer => |max| max,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (max < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(max);
+    }
+
+    fn noMultipleEmptyLinesMaxBofFromConfig(value: std.json.Value) RuleConfigError!?usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 2) return null;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const max = switch (config.get("maxBOF") orelse return null) {
             .integer => |max| max,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -1432,6 +1453,20 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_config.value);
     try std.testing.expect(options.no_multiple_empty_lines);
     try std.testing.expectEqual(@as(usize, 1), options.no_multiple_empty_lines_max);
+    try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_bof);
+    try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_eof);
+
+    var no_multiple_empty_lines_bof_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"maxBOF\":0}]",
+        .{},
+    );
+    defer no_multiple_empty_lines_bof_config.deinit();
+    try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_bof_config.value);
+    try std.testing.expect(options.no_multiple_empty_lines);
+    try std.testing.expectEqual(@as(usize, 2), options.no_multiple_empty_lines_max);
+    try std.testing.expectEqual(@as(?usize, 0), options.no_multiple_empty_lines_max_bof);
     try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_eof);
 
     var no_multiple_empty_lines_eof_config = try std.json.parseFromSlice(
@@ -1444,6 +1479,7 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-multiple-empty-lines", no_multiple_empty_lines_eof_config.value);
     try std.testing.expect(options.no_multiple_empty_lines);
     try std.testing.expectEqual(@as(usize, 2), options.no_multiple_empty_lines_max);
+    try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_bof);
     try std.testing.expectEqual(@as(?usize, 0), options.no_multiple_empty_lines_max_eof);
 
     var no_return_assign_config = try std.json.parseFromSlice(

--- a/src/main.zig
+++ b/src/main.zig
@@ -430,6 +430,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_multiple_empty_lines = false;
         } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max=")) {
             parseNoMultipleEmptyLinesMax(arg["--no-multiple-empty-lines-max=".len..], &options);
+        } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max-bof=")) {
+            parseNoMultipleEmptyLinesMaxBof(arg["--no-multiple-empty-lines-max-bof=".len..], &options);
         } else if (std.mem.startsWith(u8, arg, "--no-multiple-empty-lines-max-eof=")) {
             parseNoMultipleEmptyLinesMaxEof(arg["--no-multiple-empty-lines-max-eof=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-nonoctal-decimal-escape=off")) {
@@ -1089,6 +1091,14 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn parseNoMultipleEmptyLinesMaxBof(value: []const u8, options: *lint.Options) void {
+    const max_bof = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max-bof value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.no_multiple_empty_lines_max_bof = max_bof;
+}
+
 fn parseNoMultipleEmptyLinesMaxEof(value: []const u8, options: *lint.Options) void {
     const max_eof = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max-eof value: {s}\n", .{value});
@@ -1553,6 +1563,7 @@ fn printHelp() void {
         \\  --no-misleading-character-class=off Disable no-misleading-character-class
         \\  --no-multiple-empty-lines=off Disable no-multiple-empty-lines
         \\  --no-multiple-empty-lines-max=N Configure no-multiple-empty-lines max
+        \\  --no-multiple-empty-lines-max-bof=N Configure no-multiple-empty-lines maxBOF
         \\  --no-multiple-empty-lines-max-eof=N Configure no-multiple-empty-lines maxEOF
         \\  --no-nonoctal-decimal-escape=off Disable no-nonoctal-decimal-escape
         \\  --no-new=off              Disable no-new

--- a/src/rules/no_multiple_empty_lines.zig
+++ b/src/rules/no_multiple_empty_lines.zig
@@ -9,6 +9,7 @@ pub const id = "no-multiple-empty-lines";
 
 pub const Options = struct {
     max: usize = 2,
+    max_bof: ?usize = null,
     max_eof: ?usize = null,
 };
 
@@ -35,7 +36,12 @@ pub fn runWithOptions(
 
         if (isEmptyLine(source[line_start..line_end])) {
             empty_lines += 1;
-            const max = if (isTrailingEmptyLine(source, line_start)) options.max_eof orelse options.max else options.max;
+            const max = if (isLeadingEmptyLine(source, line_start))
+                options.max_bof orelse options.max
+            else if (isTrailingEmptyLine(source, line_start))
+                options.max_eof orelse options.max
+            else
+                options.max;
             if (empty_lines > max) {
                 try core.addDiagnosticFmt(
                     allocator,
@@ -58,6 +64,14 @@ pub fn runWithOptions(
             line_start += 1;
         }
     }
+}
+
+fn isLeadingEmptyLine(source: []const u8, line_start: usize) bool {
+    for (source[0..line_start]) |char| {
+        if (char == '\n' or char == '\r') continue;
+        if (!isBlankWhitespace(char)) return false;
+    }
+    return true;
 }
 
 fn isTrailingEmptyLine(source: []const u8, line_start: usize) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -439,6 +439,7 @@ pub fn runBasic(
     if (options.no_multiple_empty_lines) {
         try no_multiple_empty_lines.runWithOptions(allocator, diagnostics, tree, .{
             .max = options.no_multiple_empty_lines_max,
+            .max_bof = options.no_multiple_empty_lines_max_bof,
             .max_eof = options.no_multiple_empty_lines_max_eof,
         });
     }

--- a/tests/rules/no_multiple_empty_lines.zig
+++ b/tests/rules/no_multiple_empty_lines.zig
@@ -80,6 +80,25 @@ test "supports no-multiple-empty-lines max option" {
     );
 }
 
+test "supports no-multiple-empty-lines maxBOF option" {
+    const source =
+        "\n" ++
+        "const first = 1;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multiple_empty_lines_max_bof = 0,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_multiple_empty_lines.id));
+    try std.testing.expectEqualStrings(
+        "More than 0 blank lines not allowed.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "supports no-multiple-empty-lines maxEOF option" {
     const source =
         "const first = 1;\n" ++


### PR DESCRIPTION
## Summary
- add `no-multiple-empty-lines` support for ESLint's `maxBOF` option
- expose `--no-multiple-empty-lines-max-bof=N` for CLI usage
- parse ESLint-style config such as `["error", { "maxBOF": 0 }]`
- keep default behavior unchanged when `maxBOF` is not configured

## Validation
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_multiple_empty_lines.zig src/rules/root.zig tests/rules/no_multiple_empty_lines.zig`
- `git diff --check`
- CLI smoke: default `--rules=no-multiple-empty-lines` reports 0 diagnostics for one BOF empty line
- CLI smoke: `--rules=no-multiple-empty-lines --no-multiple-empty-lines-max-bof=0` reports 1 diagnostic
- config smoke: ESLint-style `no-multiple-empty-lines` `maxBOF: 0` config reports 1 diagnostic