### PR TITLE
feat: support no-warning-comments terms

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -157,7 +157,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
-| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented for default `location: start`, optional `location: anywhere`, and common `decoration` behavior |
+| [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -130,7 +130,56 @@ pub const NoWarningCommentsLocation = enum {
 pub const NoWarningCommentsDecoration = enum {
     none,
     asterisk,
+    slash,
     slash_asterisk,
+};
+
+pub const no_warning_comments_default_terms = [_][]const u8{
+    "todo",
+    "fixme",
+    "xxx",
+};
+
+pub const max_no_warning_comments_terms = 32;
+pub const max_no_warning_comments_term_len = 128;
+
+pub const NoWarningCommentsTermsError = error{
+    EmptyNoWarningCommentsTerm,
+    TooManyNoWarningCommentsTerms,
+    NoWarningCommentsTermTooLong,
+};
+
+pub const NoWarningCommentsTerms = struct {
+    custom: bool = false,
+    count: usize = 0,
+    lengths: [max_no_warning_comments_terms]usize = undefined,
+    storage: [max_no_warning_comments_terms][max_no_warning_comments_term_len]u8 = undefined,
+
+    pub fn len(self: *const NoWarningCommentsTerms) usize {
+        return if (self.custom) self.count else no_warning_comments_default_terms.len;
+    }
+
+    pub fn at(self: *const NoWarningCommentsTerms, index: usize) []const u8 {
+        if (!self.custom) return no_warning_comments_default_terms[index];
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn set(self: *NoWarningCommentsTerms, terms: []const []const u8) NoWarningCommentsTermsError!void {
+        self.custom = true;
+        self.count = 0;
+        for (terms) |term| try self.append(term);
+    }
+
+    pub fn append(self: *NoWarningCommentsTerms, term: []const u8) NoWarningCommentsTermsError!void {
+        if (term.len == 0) return error.EmptyNoWarningCommentsTerm;
+        if (self.count >= max_no_warning_comments_terms) return error.TooManyNoWarningCommentsTerms;
+        if (term.len > max_no_warning_comments_term_len) return error.NoWarningCommentsTermTooLong;
+
+        self.custom = true;
+        @memcpy(self.storage[self.count][0..term.len], term);
+        self.lengths[self.count] = term.len;
+        self.count += 1;
+    }
 };
 
 pub const NoVoidAllowAsStatement = enum {
@@ -486,6 +535,7 @@ pub const Options = struct {
     no_warning_comments: bool = true,
     no_warning_comments_location: NoWarningCommentsLocation = .start,
     no_warning_comments_decoration: NoWarningCommentsDecoration = .none,
+    no_warning_comments_terms: NoWarningCommentsTerms = .{},
     no_void: bool = true,
     no_void_allow_as_statement: NoVoidAllowAsStatement = .no,
     no_with: bool = true,
@@ -719,6 +769,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-warning-comments")) {
+            self.no_warning_comments_location = try noWarningCommentsLocationFromConfig(value);
+            self.no_warning_comments_decoration = try noWarningCommentsDecorationFromConfig(value);
+            self.no_warning_comments_terms = try noWarningCommentsTermsFromConfig(value);
         }
     }
 
@@ -1022,6 +1077,94 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enforce) .yes else .no;
+    }
+
+    fn noWarningCommentsLocationFromConfig(value: std.json.Value) RuleConfigError!NoWarningCommentsLocation {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .start,
+        };
+        if (items.len < 2) return .start;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const location = switch (config.get("location") orelse return .start) {
+            .string => |location| location,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, location, "start")) return .start;
+        if (std.mem.eql(u8, location, "anywhere")) return .anywhere;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noWarningCommentsDecorationFromConfig(value: std.json.Value) RuleConfigError!NoWarningCommentsDecoration {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .none,
+        };
+        if (items.len < 2) return .none;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const decoration_value = config.get("decoration") orelse return .none;
+        const decoration_items = switch (decoration_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var has_asterisk = false;
+        var has_slash = false;
+        for (decoration_items) |item| {
+            const char = switch (item) {
+                .string => |char| char,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, char, "*")) {
+                has_asterisk = true;
+            } else if (std.mem.eql(u8, char, "/")) {
+                has_slash = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        if (has_asterisk and has_slash) return .slash_asterisk;
+        if (has_asterisk) return .asterisk;
+        if (has_slash) return .slash;
+        return .none;
+    }
+
+    fn noWarningCommentsTermsFromConfig(value: std.json.Value) RuleConfigError!NoWarningCommentsTerms {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const terms_value = config.get("terms") orelse return .{};
+        const term_items = switch (terms_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var terms = NoWarningCommentsTerms{};
+        terms.custom = true;
+        for (term_items) |item| {
+            const term = switch (item) {
+                .string => |term| term,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            terms.append(term) catch return error.UnsupportedRuleConfigValue;
+        }
+        return terms;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -1517,6 +1660,21 @@ test "Options can apply ESLint-style rule config values" {
         NoUselessComputedKeyEnforceForClassMembers.no,
         options.no_useless_computed_key_enforce_for_class_members,
     );
+
+    var no_warning_comments_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"terms\":[\"review\",\"blocked by upstream\"],\"location\":\"anywhere\",\"decoration\":[\"/\",\"*\"]}]",
+        .{},
+    );
+    defer no_warning_comments_config.deinit();
+    try options.setByRuleConfigValue("no-warning-comments", no_warning_comments_config.value);
+    try std.testing.expect(options.no_warning_comments);
+    try std.testing.expectEqual(NoWarningCommentsLocation.anywhere, options.no_warning_comments_location);
+    try std.testing.expectEqual(NoWarningCommentsDecoration.slash_asterisk, options.no_warning_comments_decoration);
+    try std.testing.expectEqual(@as(usize, 2), options.no_warning_comments_terms.len());
+    try std.testing.expectEqualStrings("review", options.no_warning_comments_terms.at(0));
+    try std.testing.expectEqualStrings("blocked by upstream", options.no_warning_comments_terms.at(1));
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -582,8 +582,12 @@ pub fn main(init: std.process.Init) !void {
             options.no_warning_comments_location = .anywhere;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments-decoration=asterisk")) {
             options.no_warning_comments_decoration = .asterisk;
+        } else if (std.mem.eql(u8, arg, "--no-warning-comments-decoration=slash")) {
+            options.no_warning_comments_decoration = .slash;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments-decoration=slash-asterisk")) {
             options.no_warning_comments_decoration = .slash_asterisk;
+        } else if (std.mem.startsWith(u8, arg, "--no-warning-comments-terms=")) {
+            parseNoWarningCommentsTerms(arg["--no-warning-comments-terms=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-void=off")) {
             options.no_void = false;
         } else if (std.mem.eql(u8, arg, "--no-void-allow-as-statement=on")) {
@@ -1081,6 +1085,25 @@ fn parseNoEmptyFunctionAllow(value: []const u8, options: *lint.Options) void {
         }
     }
     options.no_empty_function_allow = allow;
+}
+
+fn parseNoWarningCommentsTerms(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --no-warning-comments-terms requires a comma-separated term list\n", .{});
+        std.process.exit(2);
+    }
+
+    var terms: @TypeOf(options.no_warning_comments_terms) = .{};
+    terms.custom = true;
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_term| {
+        const term = std.mem.trim(u8, raw_term, " \t\r\n");
+        terms.append(term) catch {
+            std.debug.print("utoo-lint: invalid --no-warning-comments-terms term: {s}\n", .{term});
+            std.process.exit(2);
+        };
+    }
+    options.no_warning_comments_terms = terms;
 }
 
 fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
@@ -1639,7 +1662,9 @@ fn printHelp() void {
         \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-warning-comments-location=anywhere Report warning terms anywhere in comments
         \\  --no-warning-comments-decoration=asterisk Ignore leading * comment decorations
+        \\  --no-warning-comments-decoration=slash Ignore leading / comment decorations
         \\  --no-warning-comments-decoration=slash-asterisk Ignore leading / and * comment decorations
+        \\  --no-warning-comments-terms=todo,fixme Configure no-warning-comments terms
         \\  --no-void=off             Disable no-void
         \\  --no-void-allow-as-statement=on Allow void as expression statement
         \\  --no-with=off             Disable no-with

--- a/src/rules/no_warning_comments.zig
+++ b/src/rules/no_warning_comments.zig
@@ -7,12 +7,6 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-warning-comments";
 
-const terms = [_][]const u8{
-    "todo",
-    "fixme",
-    "xxx",
-};
-
 pub const Location = enum {
     start,
     anywhere,
@@ -21,12 +15,14 @@ pub const Location = enum {
 pub const Decoration = enum {
     none,
     asterisk,
+    slash,
     slash_asterisk,
 };
 
 pub const Options = struct {
     location: Location = .start,
     decoration: Decoration = .none,
+    terms: core.NoWarningCommentsTerms = .{},
 };
 
 pub fn run(
@@ -44,7 +40,7 @@ pub fn runWithOptions(
     options: Options,
 ) Allocator.Error!void {
     for (tree.comments) |comment| {
-        const match = warningTerm(tree, comment, options) orelse continue;
+        const match = warningTerm(tree, comment, &options) orelse continue;
 
         try core.addDiagnosticFmt(
             allocator,
@@ -58,18 +54,24 @@ pub fn runWithOptions(
     }
 }
 
-fn warningTerm(tree: *const ast.Tree, comment: ast.Comment, options: Options) ?[]const u8 {
+fn warningTerm(tree: *const ast.Tree, comment: ast.Comment, options: *const Options) ?[]const u8 {
     return switch (options.location) {
-        .start => warningTermAtStart(tree, comment, options.decoration),
-        .anywhere => warningTermAnywhere(tree, comment),
+        .start => warningTermAtStart(tree, comment, options.decoration, &options.terms),
+        .anywhere => warningTermAnywhere(tree, comment, &options.terms),
     };
 }
 
-fn warningTermAtStart(tree: *const ast.Tree, comment: ast.Comment, decoration: Decoration) ?[]const u8 {
+fn warningTermAtStart(
+    tree: *const ast.Tree,
+    comment: ast.Comment,
+    decoration: Decoration,
+    warning_terms: *const core.NoWarningCommentsTerms,
+) ?[]const u8 {
     const value = tree.string(comment.value);
     const trimmed = trimLeftDecoration(trimLeftWhitespace(value), decoration);
 
-    inline for (terms) |term| {
+    for (0..warning_terms.len()) |index| {
+        const term = warning_terms.at(index);
         if (startsWithWholeWordIgnoreCase(trimmed, term)) return term;
     }
 
@@ -86,16 +88,22 @@ fn isDecoration(char: u8, decoration: Decoration) bool {
     return switch (decoration) {
         .none => false,
         .asterisk => char == '*',
+        .slash => char == '/',
         .slash_asterisk => char == '*' or char == '/',
     };
 }
 
-fn warningTermAnywhere(tree: *const ast.Tree, comment: ast.Comment) ?[]const u8 {
+fn warningTermAnywhere(
+    tree: *const ast.Tree,
+    comment: ast.Comment,
+    warning_terms: *const core.NoWarningCommentsTerms,
+) ?[]const u8 {
     const value = tree.string(comment.value);
     var index: usize = 0;
 
     while (index < value.len) : (index += 1) {
-        inline for (terms) |term| {
+        for (0..warning_terms.len()) |term_index| {
+            const term = warning_terms.at(term_index);
             if (matchesWholeWordAt(value, index, term)) return term;
         }
     }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -401,8 +401,10 @@ pub fn runBasic(
             .decoration = switch (options.no_warning_comments_decoration) {
                 .none => .none,
                 .asterisk => .asterisk,
+                .slash => .slash,
                 .slash_asterisk => .slash_asterisk,
             },
+            .terms = options.no_warning_comments_terms,
         });
     }
     if (options.no_trailing_spaces) {

--- a/tests/rules/no_warning_comments.zig
+++ b/tests/rules/no_warning_comments.zig
@@ -73,6 +73,29 @@ test "reports no-warning-comments after configured decorations" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_warning_comments.id));
 }
 
+test "reports no-warning-comments for configured terms" {
+    const source =
+        \\// review needed before release
+        \\// TODO default term is disabled by custom terms
+        \\// note: blocked by upstream
+        \\// reviewer is not the whole word
+        \\const value = 1;
+    ;
+
+    var terms = (lint.Options{}).no_warning_comments_terms;
+    try terms.set(&[_][]const u8{ "review", "blocked by upstream" });
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_warning_comments_location = .anywhere,
+        .no_warning_comments_terms = terms,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_warning_comments.id));
+}
+
 test "can disable no-warning-comments" {
     const source =
         \\// TODO: handle this case


### PR DESCRIPTION
## Summary

- add configurable `terms` support for `no-warning-comments`
- parse ESLint-style `terms`, `location`, and common `decoration` options from config
- add CLI support for custom warning terms and slash decoration

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_warning_comments.zig src/rules/root.zig tests/rules/no_warning_comments.zig`
- `git diff --check`

Smoke checked config and CLI custom `no-warning-comments` terms locally.
