### PR TITLE
feat: support spaced-comment never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -177,7 +177,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Implemented |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
-| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Implemented |
+| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Implemented for `always` and optional `never` behavior |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -182,6 +182,11 @@ pub const NoWarningCommentsTerms = struct {
     }
 };
 
+pub const SpacedCommentStyle = enum {
+    always,
+    never,
+};
+
 pub const NoVoidAllowAsStatement = enum {
     yes,
     no,
@@ -606,6 +611,7 @@ pub const Options = struct {
     require_atomic_updates: bool = true,
     require_yield: bool = true,
     spaced_comment: bool = true,
+    spaced_comment_style: SpacedCommentStyle = .always,
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
@@ -774,6 +780,9 @@ pub const Options = struct {
             self.no_warning_comments_location = try noWarningCommentsLocationFromConfig(value);
             self.no_warning_comments_decoration = try noWarningCommentsDecorationFromConfig(value);
             self.no_warning_comments_terms = try noWarningCommentsTermsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "spaced-comment")) {
+            self.spaced_comment_style = try spacedCommentStyleFromConfig(value);
         }
     }
 
@@ -1165,6 +1174,22 @@ pub const Options = struct {
             terms.append(term) catch return error.UnsupportedRuleConfigValue;
         }
         return terms;
+    }
+
+    fn spacedCommentStyleFromConfig(value: std.json.Value) RuleConfigError!SpacedCommentStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -1675,6 +1700,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(@as(usize, 2), options.no_warning_comments_terms.len());
     try std.testing.expectEqualStrings("review", options.no_warning_comments_terms.at(0));
     try std.testing.expectEqualStrings("blocked by upstream", options.no_warning_comments_terms.at(1));
+
+    var spaced_comment_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer spaced_comment_config.deinit();
+    try options.setByRuleConfigValue("spaced-comment", spaced_comment_config.value);
+    try std.testing.expect(options.spaced_comment);
+    try std.testing.expectEqual(SpacedCommentStyle.never, options.spaced_comment_style);
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -734,6 +734,8 @@ pub fn main(init: std.process.Init) !void {
             options.require_yield = false;
         } else if (std.mem.eql(u8, arg, "--spaced-comment=off")) {
             options.spaced_comment = false;
+        } else if (std.mem.eql(u8, arg, "--spaced-comment=never")) {
+            options.spaced_comment_style = .never;
         } else if (std.mem.eql(u8, arg, "--symbol-description=off")) {
             options.symbol_description = false;
         } else if (std.mem.eql(u8, arg, "--typescript-eslint-adjacent-overload-signatures=off")) {
@@ -1735,6 +1737,7 @@ fn printHelp() void {
         \\  --require-atomic-updates=off Disable require-atomic-updates
         \\  --require-yield=off       Disable require-yield
         \\  --spaced-comment=off      Disable spaced-comment
+        \\  --spaced-comment=never    Disallow spacing after comment markers
         \\  --symbol-description=off  Disable symbol-description
         \\  --typescript-eslint-adjacent-overload-signatures=off Disable @typescript-eslint/adjacent-overload-signatures
         \\  --typescript-eslint-array-type=off Disable @typescript-eslint/array-type

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -454,7 +454,12 @@ pub fn runBasic(
         });
     }
     if (options.spaced_comment) {
-        try spaced_comment.run(allocator, diagnostics, tree);
+        try spaced_comment.runWithOptions(allocator, diagnostics, tree, .{
+            .style = switch (options.spaced_comment_style) {
+                .always => .always,
+                .never => .never,
+            },
+        });
     }
     if (options.typescript_eslint_ban_ts_comment) {
         try typescript_eslint_ban_ts_comment.run(allocator, diagnostics, tree);

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -7,33 +7,66 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "spaced-comment";
 
+pub const Style = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    style: Style = .always,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     for (tree.comments) |comment| {
-        if (hasExpectedSpacing(tree, comment)) continue;
+        if (hasExpectedSpacing(tree, comment, options.style)) continue;
 
         try core.addDiagnostic(
             allocator,
             diagnostics,
             .warning,
             id,
-            "Expected space or tab after comment marker.",
+            message(options.style),
             .{ .start = comment.start, .end = comment.end },
         );
     }
 }
 
-fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment) bool {
+fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, style: Style) bool {
     const value = tree.string(comment.value);
     if (value.len == 0) return true;
-    if (isWhitespace(value[0])) return true;
 
-    return switch (comment.type) {
-        .line => value[0] == '/',
-        .block => value[0] == '*' or value[0] == '!',
+    if (isMarker(value[0], comment.type)) return true;
+
+    return switch (style) {
+        .always => isWhitespace(value[0]),
+        .never => !isWhitespace(value[0]),
+    };
+}
+
+fn isMarker(char: u8, comment_type: ast.Comment.Type) bool {
+    return switch (comment_type) {
+        .line => char == '/',
+        .block => char == '*' or char == '!',
+    };
+}
+
+fn message(style: Style) []const u8 {
+    return switch (style) {
+        .always => "Expected space or tab after comment marker.",
+        .never => "Expected no space or tab after comment marker.",
     };
 }
 

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -44,6 +44,29 @@ test "does not report spaced-comment for spaced comments and common markers" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.spaced_comment.id));
 }
 
+test "reports spaced-comment for spaced comments in never mode" {
+    const source =
+        \\// space is disallowed
+        \\/* block space is disallowed */
+        \\//nospace
+        \\/*nospace */
+        \\/// common marker
+        \\/** jsdoc */
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .spaced_comment_style = .never,
+        .no_inline_comments = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.spaced_comment.id));
+}
+
 test "can disable spaced-comment" {
     const source =
         \\//missing space


### PR DESCRIPTION
## Summary

- add `never` style support to `spaced-comment`
- parse ESLint-style `["error", "never"]` config values
- expose `--spaced-comment=never` in the CLI

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/spaced_comment.zig src/rules/root.zig tests/rules/spaced_comment.zig`
- `git diff --check`

Smoke checked CLI and config `spaced-comment` never mode locally.
