### PR TITLE
feat: support more no-empty-function allow kinds

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -60,7 +60,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented with optional `allowEmptyCatch` behavior |
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |
 | [`no-empty-character-class`](https://eslint.org/docs/latest/rules/no-empty-character-class) | Implemented |
-| [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented with partial `allow` behavior for functions, arrow functions, methods, and constructors |
+| [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented with `allow` behavior for functions, arrow functions, async/generator functions, methods, async/generator methods, getters, setters, and constructors |
 | [`no-empty-pattern`](https://eslint.org/docs/latest/rules/no-empty-pattern) | Implemented |
 | [`no-empty-static-block`](https://eslint.org/docs/latest/rules/no-empty-static-block) | Implemented |
 | [`no-eq-null`](https://eslint.org/docs/latest/rules/no-eq-null) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -71,7 +71,13 @@ pub const NoEmptyAllowEmptyCatch = enum {
 pub const NoEmptyFunctionAllow = struct {
     functions: bool = false,
     arrowFunctions: bool = false,
+    generatorFunctions: bool = false,
+    asyncFunctions: bool = false,
     methods: bool = false,
+    generatorMethods: bool = false,
+    asyncMethods: bool = false,
+    getters: bool = false,
+    setters: bool = false,
     constructors: bool = false,
 
     pub fn contains(self: NoEmptyFunctionAllow, name: []const u8) bool {
@@ -1588,6 +1594,21 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_empty_function_allow.functions);
     try std.testing.expect(options.no_empty_function_allow.constructors);
     try std.testing.expect(!options.no_empty_function_allow.arrowFunctions);
+
+    var no_empty_function_extended_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"asyncFunctions\",\"generatorFunctions\",\"asyncMethods\",\"generatorMethods\",\"getters\",\"setters\"]}]",
+        .{},
+    );
+    defer no_empty_function_extended_config.deinit();
+    try options.setByRuleConfigValue("no-empty-function", no_empty_function_extended_config.value);
+    try std.testing.expect(options.no_empty_function_allow.asyncFunctions);
+    try std.testing.expect(options.no_empty_function_allow.generatorFunctions);
+    try std.testing.expect(options.no_empty_function_allow.asyncMethods);
+    try std.testing.expect(options.no_empty_function_allow.generatorMethods);
+    try std.testing.expect(options.no_empty_function_allow.getters);
+    try std.testing.expect(options.no_empty_function_allow.setters);
 
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1492,6 +1492,7 @@ fn printHelp() void {
         \\  --no-empty-character-class=off Disable no-empty-character-class
         \\  --no-empty-function=off Disable no-empty-function
         \\  --no-empty-function-allow=functions,arrowFunctions Allow selected empty function kinds
+        \\      also supports asyncFunctions,generatorFunctions,methods,asyncMethods,generatorMethods,getters,setters,constructors
         \\  --no-empty-pattern=off  Disable no-empty-pattern
         \\  --no-empty-static-block=off Disable no-empty-static-block
         \\  --no-else-return=off    Disable no-else-return

--- a/src/rules/no_empty_function.zig
+++ b/src/rules/no_empty_function.zig
@@ -10,7 +10,13 @@ pub const id = "no-empty-function";
 pub const Kind = enum {
     functions,
     arrowFunctions,
+    generatorFunctions,
+    asyncFunctions,
     methods,
+    generatorMethods,
+    asyncMethods,
+    getters,
+    setters,
     constructors,
 };
 
@@ -55,7 +61,13 @@ fn allowsKind(allow: core.NoEmptyFunctionAllow, kind: Kind) bool {
     return switch (kind) {
         .functions => allow.functions,
         .arrowFunctions => allow.arrowFunctions,
+        .generatorFunctions => allow.generatorFunctions,
+        .asyncFunctions => allow.asyncFunctions,
         .methods => allow.methods,
+        .generatorMethods => allow.generatorMethods,
+        .asyncMethods => allow.asyncMethods,
+        .getters => allow.getters,
+        .setters => allow.setters,
         .constructors => allow.constructors,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -362,18 +362,50 @@ fn isCatchBody(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeInd
 fn emptyFunctionKind(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) no_empty_function.Kind {
     const parent_index = ctx.path.parent() orelse return .functions;
 
-    switch (tree.data(parent_index)) {
+    const function = switch (tree.data(parent_index)) {
         .arrow_function_expression => return .arrowFunctions,
-        .function => {},
+        .function => |function| function,
         else => return .functions,
-    }
+    };
 
     const grandparent_index = ctx.path.ancestor(2) orelse return .functions;
     return switch (tree.data(grandparent_index)) {
-        .method_definition => |method| if (method.kind == .constructor) .constructors else .methods,
-        .object_property => |property| if (property.method or property.kind != .init) .methods else .functions,
-        else => .functions,
+        .method_definition => |method| methodKind(method.kind, function),
+        .object_property => |property| if (property.method or property.kind != .init)
+            propertyMethodKind(property.kind, function)
+        else
+            functionKind(function),
+        else => functionKind(function),
     };
+}
+
+fn functionKind(function: ast.Function) no_empty_function.Kind {
+    if (function.async) return .asyncFunctions;
+    if (function.generator) return .generatorFunctions;
+    return .functions;
+}
+
+fn methodKind(kind: ast.MethodDefinitionKind, function: ast.Function) no_empty_function.Kind {
+    return switch (kind) {
+        .constructor => .constructors,
+        .get => .getters,
+        .set => .setters,
+        .method => methodFunctionKind(function),
+    };
+}
+
+fn propertyMethodKind(kind: ast.PropertyKind, function: ast.Function) no_empty_function.Kind {
+    return switch (kind) {
+        .get => .getters,
+        .set => .setters,
+        else => methodFunctionKind(function),
+    };
+}
+
+fn methodFunctionKind(function: ast.Function) no_empty_function.Kind {
+    if (function.async) return .asyncMethods;
+    if (function.generator) return .generatorMethods;
+    return .methods;
 }
 
 pub fn runBasic(

--- a/tests/rules/no_empty_function.zig
+++ b/tests/rules/no_empty_function.zig
@@ -75,6 +75,47 @@ test "allows configured no-empty-function kinds" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_empty_function.id));
 }
 
+test "allows configured async generator and accessor no-empty-function kinds" {
+    const source =
+        \\async function asyncEmpty() {}
+        \\function* generatorEmpty() {}
+        \\class Example {
+        \\  async asyncMethod() {}
+        \\  *generatorMethod() {}
+        \\  get value() {}
+        \\  set value(next) {}
+        \\  method() {}
+        \\}
+        \\const object = {
+        \\  async asyncMethod() {},
+        \\  *generatorMethod() {},
+        \\  get value() {},
+        \\  set value(next) {},
+        \\  method() {},
+        \\};
+    ;
+
+    var allow = (lint.Options{}).no_empty_function_allow;
+    try std.testing.expect(allow.enable("asyncFunctions"));
+    try std.testing.expect(allow.enable("generatorFunctions"));
+    try std.testing.expect(allow.enable("asyncMethods"));
+    try std.testing.expect(allow.enable("generatorMethods"));
+    try std.testing.expect(allow.enable("getters"));
+    try std.testing.expect(allow.enable("setters"));
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_function_allow = allow,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_empty_function.id));
+}
+
 test "can disable no-empty-function" {
     const source =
         \\function empty() {}


### PR DESCRIPTION
## Summary

- add `no-empty-function` allow support for async/generator functions and methods
- add getter and setter allow support for class and object methods
- extend config/CLI allow parsing coverage through existing allow-list handling

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_empty_function.zig src/rules/root.zig tests/rules/no_empty_function.zig`
- `git diff --check`

Smoke checked CLI and config `no-empty-function` allow kinds locally.
