### PR TITLE
feat: support no-param-reassign ignored property names

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -112,7 +112,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-object-constructor`](https://eslint.org/docs/latest/rules/no-object-constructor) | Implemented |
 | [`no-octal`](https://eslint.org/docs/latest/rules/no-octal) | Implemented |
 | [`no-octal-escape`](https://eslint.org/docs/latest/rules/no-octal-escape) | Implemented |
-| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented with optional `props` behavior |
+| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented with optional `props` and `ignorePropertyModificationsFor` behavior |
 | [`no-path-concat`](https://eslint.org/docs/latest/rules/no-path-concat) | Implemented |
 | [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented with optional `allowForLoopAfterthoughts` behavior |
 | [`no-process-env`](https://eslint.org/docs/latest/rules/no-process-env) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -223,6 +223,42 @@ pub const NoParamReassignProps = enum {
     no,
 };
 
+pub const max_no_param_reassign_ignored_names = 32;
+pub const max_no_param_reassign_ignored_name_len = 128;
+
+pub const NoParamReassignIgnoredNamesError = error{
+    EmptyNoParamReassignIgnoredName,
+    TooManyNoParamReassignIgnoredNames,
+    NoParamReassignIgnoredNameTooLong,
+};
+
+pub const NoParamReassignIgnoredNames = struct {
+    count: usize = 0,
+    lengths: [max_no_param_reassign_ignored_names]usize = undefined,
+    storage: [max_no_param_reassign_ignored_names][max_no_param_reassign_ignored_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoParamReassignIgnoredNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoParamReassignIgnoredNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoParamReassignIgnoredNames, name: []const u8) NoParamReassignIgnoredNamesError!void {
+        if (name.len == 0) return error.EmptyNoParamReassignIgnoredName;
+        if (self.count >= max_no_param_reassign_ignored_names) return error.TooManyNoParamReassignIgnoredNames;
+        if (name.len > max_no_param_reassign_ignored_name_len) return error.NoParamReassignIgnoredNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const NoUselessComputedKeyEnforceForClassMembers = enum {
     yes,
     no,
@@ -487,6 +523,7 @@ pub const Options = struct {
     no_object_constructor: bool = true,
     no_param_reassign: bool = true,
     no_param_reassign_props: NoParamReassignProps = .no,
+    no_param_reassign_ignore_property_modifications_for: NoParamReassignIgnoredNames = .{},
     no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_plusplus_allow_for_loop_afterthoughts: NoPlusplusAllowForLoopAfterthoughts = .no,
@@ -773,6 +810,10 @@ pub const Options = struct {
             self.no_multiple_empty_lines_max_bof = try noMultipleEmptyLinesMaxBofFromConfig(value);
             self.no_multiple_empty_lines_max_eof = try noMultipleEmptyLinesMaxEofFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-param-reassign")) {
+            self.no_param_reassign_props = try noParamReassignPropsFromConfig(value);
+            self.no_param_reassign_ignore_property_modifications_for = try noParamReassignIgnoredNamesFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
         }
@@ -1040,6 +1081,52 @@ pub const Options = struct {
         };
         if (max < 0) return error.UnsupportedRuleConfigValue;
         return @intCast(max);
+    }
+
+    fn noParamReassignPropsFromConfig(value: std.json.Value) RuleConfigError!NoParamReassignProps {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const props = switch (config.get("props") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (props) .yes else .no;
+    }
+
+    fn noParamReassignIgnoredNamesFromConfig(value: std.json.Value) RuleConfigError!NoParamReassignIgnoredNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignored_value = config.get("ignorePropertyModificationsFor") orelse return .{};
+        const ignored_items = switch (ignored_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignored = NoParamReassignIgnoredNames{};
+        for (ignored_items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            ignored.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return ignored;
     }
 
     fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
@@ -1670,6 +1757,20 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(@as(usize, 2), options.no_multiple_empty_lines_max);
     try std.testing.expectEqual(@as(?usize, null), options.no_multiple_empty_lines_max_bof);
     try std.testing.expectEqual(@as(?usize, 0), options.no_multiple_empty_lines_max_eof);
+
+    var no_param_reassign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"props\":true,\"ignorePropertyModificationsFor\":[\"req\",\"res\"]}]",
+        .{},
+    );
+    defer no_param_reassign_config.deinit();
+    try options.setByRuleConfigValue("no-param-reassign", no_param_reassign_config.value);
+    try std.testing.expect(options.no_param_reassign);
+    try std.testing.expectEqual(NoParamReassignProps.yes, options.no_param_reassign_props);
+    try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("req"));
+    try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("res"));
+    try std.testing.expect(!options.no_param_reassign_ignore_property_modifications_for.contains("ctx"));
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -466,6 +466,11 @@ pub fn main(init: std.process.Init) !void {
             options.no_param_reassign = false;
         } else if (std.mem.eql(u8, arg, "--no-param-reassign-props=on")) {
             options.no_param_reassign_props = .yes;
+        } else if (std.mem.startsWith(u8, arg, "--no-param-reassign-ignore-property-modifications-for=")) {
+            parseNoParamReassignIgnorePropertyModificationsFor(
+                arg["--no-param-reassign-ignore-property-modifications-for=".len..],
+                &options,
+            );
         } else if (std.mem.eql(u8, arg, "--no-path-concat=off")) {
             options.no_path_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-plusplus=off")) {
@@ -1089,6 +1094,24 @@ fn parseNoEmptyFunctionAllow(value: []const u8, options: *lint.Options) void {
     options.no_empty_function_allow = allow;
 }
 
+fn parseNoParamReassignIgnorePropertyModificationsFor(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --no-param-reassign-ignore-property-modifications-for requires a comma-separated name list\n", .{});
+        std.process.exit(2);
+    }
+
+    var ignored: @TypeOf(options.no_param_reassign_ignore_property_modifications_for) = .{};
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_name| {
+        const name = std.mem.trim(u8, raw_name, " \t\r\n");
+        ignored.append(name) catch {
+            std.debug.print("utoo-lint: invalid --no-param-reassign-ignore-property-modifications-for name: {s}\n", .{name});
+            std.process.exit(2);
+        };
+    }
+    options.no_param_reassign_ignore_property_modifications_for = ignored;
+}
+
 fn parseNoWarningCommentsTerms(value: []const u8, options: *lint.Options) void {
     if (value.len == 0) {
         std.debug.print("utoo-lint: --no-warning-comments-terms requires a comma-separated term list\n", .{});
@@ -1607,6 +1630,7 @@ fn printHelp() void {
         \\  --no-object-constructor=off Disable no-object-constructor
         \\  --no-param-reassign=off   Disable no-param-reassign
         \\  --no-param-reassign-props=on Report parameter property writes
+        \\  --no-param-reassign-ignore-property-modifications-for=req,res Allow listed parameter property writes
         \\  --no-path-concat=off      Disable no-path-concat
         \\  --no-plusplus=off         Disable no-plusplus
         \\  --no-plusplus-allow-for-loop-afterthoughts=on Allow ++/-- in for afterthoughts

--- a/src/rules/no_param_reassign.zig
+++ b/src/rules/no_param_reassign.zig
@@ -11,6 +11,7 @@ const ParamSet = std.StringHashMapUnmanaged(void);
 
 pub const Options = struct {
     props: bool = false,
+    ignore_property_modifications_for: core.NoParamReassignIgnoredNames = .{},
 };
 
 pub fn checkFunction(
@@ -319,6 +320,7 @@ fn checkTarget(
             if (!options.props) return;
             const name = rootIdentifierReferenceName(tree, member.object) orelse return;
             if (!params.contains(name)) return;
+            if (options.ignore_property_modifications_for.contains(name)) return;
 
             try core.addDiagnosticFmt(
                 allocator,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1063,6 +1063,7 @@ const BasicVisitor = struct {
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
                 .props = self.options.no_param_reassign_props == .yes,
+                .ignore_property_modifications_for = self.options.no_param_reassign_ignore_property_modifications_for,
             });
         }
         if (self.options.no_inner_declarations) {
@@ -2024,6 +2025,7 @@ const BasicVisitor = struct {
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkArrowFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .props = self.options.no_param_reassign_props == .yes,
+                .ignore_property_modifications_for = self.options.no_param_reassign_ignore_property_modifications_for,
             });
         }
         if (self.options.react_display_name) {

--- a/tests/rules/no_param_reassign.zig
+++ b/tests/rules/no_param_reassign.zig
@@ -113,6 +113,34 @@ test "reports no-param-reassign for parameter property writes when props is enab
     try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_param_reassign.id));
 }
 
+test "allows configured parameter property modification names" {
+    const source =
+        \\function middleware(req, res, ctx) {
+        \\  req.body = next;
+        \\  res.statusCode++;
+        \\  delete req.headers;
+        \\  ctx.value = next;
+        \\  req = next;
+        \\}
+    ;
+
+    var ignored = (lint.Options{}).no_param_reassign_ignore_property_modifications_for;
+    try ignored.append("req");
+    try ignored.append("res");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_param_reassign_props = .yes,
+        .no_param_reassign_ignore_property_modifications_for = ignored,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_plusplus = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
 test "can disable no-param-reassign" {
     const source =
         \\function run(value) {


### PR DESCRIPTION
## Summary

- parse `no-param-reassign` `props` from ESLint-style config
- support `ignorePropertyModificationsFor` for parameter property writes
- add CLI support for ignored parameter property names

## Validation

- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_param_reassign.zig src/rules/root.zig tests/rules/no_param_reassign.zig`
- `git diff --check`

Smoke checked CLI and config `ignorePropertyModificationsFor` locally.
