### PR TITLE
feat: support func names never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -20,7 +20,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |
-| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always` and optional `as-needed` options |
+| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always`, `as-needed`, and `never` options |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -299,6 +299,7 @@ pub const LogicalAssignmentOperatorsStyle = enum {
 pub const FuncNamesStyle = enum {
     always,
     as_needed,
+    never,
 };
 
 pub const FuncNameMatchingStyle = enum {
@@ -790,6 +791,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
+        if (std.mem.eql(u8, cli_name, "func-names")) {
+            self.func_names_style = try funcNamesStyleFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
         }
@@ -914,6 +918,23 @@ pub const Options = struct {
             if (std.mem.eql(u8, rule, "no-nested-ternary")) return true;
         }
         return false;
+    }
+
+    fn funcNamesStyleFromConfig(value: std.json.Value) RuleConfigError!FuncNamesStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "as-needed")) return .as_needed;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noConsoleAllowFromConfig(value: std.json.Value) RuleConfigError!NoConsoleAllow {
@@ -1644,6 +1665,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("eslint-comments/no-restricted-disable", restricted_disable_config.value);
     try std.testing.expect(options.eslint_comments_no_restricted_disable);
     try std.testing.expect(options.eslint_comments_no_restricted_disable_no_nested_ternary);
+
+    var func_names_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer func_names_config.deinit();
+    try options.setByRuleConfigValue("func-names", func_names_config.value);
+    try std.testing.expect(options.func_names);
+    try std.testing.expectEqual(FuncNamesStyle.never, options.func_names_style);
 
     var no_console_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,6 +156,8 @@ pub fn main(init: std.process.Init) !void {
             options.func_names = false;
         } else if (std.mem.eql(u8, arg, "--func-names=as-needed")) {
             options.func_names_style = .as_needed;
+        } else if (std.mem.eql(u8, arg, "--func-names=never")) {
+            options.func_names_style = .never;
         } else if (std.mem.eql(u8, arg, "--getter-return=off")) {
             options.getter_return = false;
         } else if (std.mem.eql(u8, arg, "--grouped-accessor-pairs=off")) {
@@ -1471,6 +1473,7 @@ fn printHelp() void {
         \\  --func-name-matching=never Disallow matching function expression names
         \\  --func-names=off          Disable func-names
         \\  --func-names=as-needed    Allow inferable anonymous function names
+        \\  --func-names=never        Disallow named function expressions
         \\  --getter-return=off       Disable getter-return
         \\  --grouped-accessor-pairs=off Disable grouped-accessor-pairs
         \\  --grouped-accessor-pairs=get-before-set Require getters before setters

--- a/src/rules/func_names.zig
+++ b/src/rules/func_names.zig
@@ -10,6 +10,7 @@ pub const id = "func-names";
 pub const Style = enum {
     always,
     as_needed,
+    never,
 };
 
 pub fn check(
@@ -32,6 +33,20 @@ pub fn checkWithStyle(
     ctx: *traverser.basic.Ctx,
     style: Style,
 ) Allocator.Error!void {
+    if (style == .never) {
+        if (!disallowsName(tree, function, ctx)) return;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unexpected named function.",
+            tree.span(index),
+        );
+        return;
+    }
+
     if (function.id != .null) return;
     if (!requiresName(tree, function, index, ctx, style)) return;
 
@@ -49,6 +64,13 @@ fn requiresName(tree: *const ast.Tree, function: ast.Function, index: ast.NodeIn
     return switch (function.type) {
         .function_expression => !isMethodParent(tree, ctx) and !allowsInferredName(tree, index, ctx, style),
         .function_declaration => isExportDefaultDeclarationParent(tree, ctx),
+        else => false,
+    };
+}
+
+fn disallowsName(tree: *const ast.Tree, function: ast.Function, ctx: *traverser.basic.Ctx) bool {
+    return switch (function.type) {
+        .function_expression => function.id != .null and !isMethodParent(tree, ctx),
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1055,6 +1055,7 @@ const BasicVisitor = struct {
             try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, switch (self.options.func_names_style) {
                 .always => .always,
                 .as_needed => .as_needed,
+                .never => .never,
             });
         }
         if (self.options.default_param_last) {

--- a/tests/rules/func_names.zig
+++ b/tests/rules/func_names.zig
@@ -128,6 +128,65 @@ test "reports func-names as-needed for non-inferable names" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_names.id));
 }
 
+test "reports func-names never for named function expressions" {
+    const source =
+        \\const first = function namedExpression() {
+        \\  return value;
+        \\};
+        \\const object = {
+        \\  property: function namedProperty() {
+        \\    return value;
+        \\  },
+        \\};
+        \\const generator = function* namedGenerator() {
+        \\  yield value;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_name_matching = false,
+        .func_names_style = .never,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_names.id));
+    try std.testing.expectEqualStrings("Unexpected named function.", result.diagnostics[0].message);
+}
+
+test "allows func-names never for anonymous expressions and declarations" {
+    const source =
+        \\function declaration() {
+        \\  return value;
+        \\}
+        \\export default function namedDefault() {
+        \\  return value;
+        \\}
+        \\const first = function () {
+        \\  return value;
+        \\};
+        \\const object = {
+        \\  method() {
+        \\    return value;
+        \\  },
+        \\};
+        \\const arrow = () => value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .func_name_matching = false,
+        .func_names_style = .never,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.func_names.id));
+}
+
 test "can disable func-names" {
     const source = "const value = function () { return 1; };\n";
 


### PR DESCRIPTION
## Summary
- add `func-names` `never` style support for named function expressions
- parse `func-names` string style from ESLint-style rule arrays and expose `--func-names=never`
- cover the new style in rule/config tests and update rule status docs

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/func_names.zig src/core.zig src/rules/root.zig src/main.zig tests/rules/func_names.zig`
- `git diff --check`
- CLI/config smoke for `func-names` `never` JSON diagnostics