### PR TITLE
feat: support yoda always

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -184,7 +184,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Implemented |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
-| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented |
+| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented for `never` and optional `always` behavior |
 
 ## Import plugin rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -307,6 +307,11 @@ pub const FuncNameMatchingStyle = enum {
     never,
 };
 
+pub const YodaStyle = enum {
+    never,
+    always,
+};
+
 pub const PreferConstDestructuring = enum {
     any,
     all,
@@ -707,6 +712,7 @@ pub const Options = struct {
     wrap_iife: bool = true,
     wrap_iife_style: WrapIifeStyle = .outside,
     yoda: bool = true,
+    yoda_style: YodaStyle = .never,
 
     pub fn allDisabled() Options {
         var options = Options{};
@@ -837,6 +843,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "wrap-iife")) {
             self.wrap_iife_style = try wrapIifeStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "yoda")) {
+            self.yoda_style = try yodaStyleFromConfig(value);
         }
     }
 
@@ -1323,6 +1332,22 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "outside")) return .outside;
         if (std.mem.eql(u8, style, "inside")) return .inside;
         if (std.mem.eql(u8, style, "any")) return .any;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn yodaStyleFromConfig(value: std.json.Value) RuleConfigError!YodaStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .never,
+        };
+        if (items.len < 2) return .never;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "never")) return .never;
+        if (std.mem.eql(u8, style, "always")) return .always;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -1896,6 +1921,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("wrap-iife", wrap_iife_config.value);
     try std.testing.expect(options.wrap_iife);
     try std.testing.expectEqual(WrapIifeStyle.inside, options.wrap_iife_style);
+
+    var yoda_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer yoda_config.deinit();
+    try options.setByRuleConfigValue("yoda", yoda_config.value);
+    try std.testing.expect(options.yoda);
+    try std.testing.expectEqual(YodaStyle.always, options.yoda_style);
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/main.zig
+++ b/src/main.zig
@@ -855,6 +855,8 @@ pub fn main(init: std.process.Init) !void {
             options.parser_semantic_errors = false;
         } else if (std.mem.eql(u8, arg, "--yoda=off")) {
             options.yoda = false;
+        } else if (std.mem.eql(u8, arg, "--yoda=always")) {
+            options.yoda_style = .always;
         } else {
             try targets.append(allocator, arg);
         }
@@ -1814,6 +1816,7 @@ fn printHelp() void {
         \\  --wrap-iife=off|outside|inside|any Configure wrap-iife
         \\  --semantic-errors=off     Disable parser semantic errors
         \\  --yoda=off                Disable yoda
+        \\  --yoda=always             Require yoda comparison style
         \\
     , .{});
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2148,7 +2148,10 @@ const BasicVisitor = struct {
             try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.yoda) {
-            try yoda.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try yoda.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, expression, index, switch (self.options.yoda_style) {
+                .never => .never,
+                .always => .always,
+            });
         }
         if (self.options.typescript_eslint_no_confusing_non_null_assertion) {
             try typescript_eslint_no_confusing_non_null_assertion.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/src/rules/yoda.zig
+++ b/src/rules/yoda.zig
@@ -6,6 +6,11 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "yoda";
 
+pub const Style = enum {
+    never,
+    always,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -13,17 +18,47 @@ pub fn check(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithStyle(allocator, diagnostics, tree, expression, index, .never);
+}
+
+pub fn checkWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    style: Style,
+) Allocator.Error!void {
     if (!isComparisonOperator(expression.operator)) return;
-    if (!isLiteralLike(tree, expression.left) or isLiteralLike(tree, expression.right)) return;
+
+    const left_literal = isLiteralLike(tree, expression.left);
+    const right_literal = isLiteralLike(tree, expression.right);
+    if (hasExpectedYodaStyle(style, left_literal, right_literal)) return;
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Expected literal to be on the right side of comparison.",
+        message(style),
         tree.span(index),
     );
+}
+
+fn hasExpectedYodaStyle(style: Style, left_literal: bool, right_literal: bool) bool {
+    if (left_literal == right_literal) return true;
+
+    return switch (style) {
+        .never => !left_literal,
+        .always => left_literal,
+    };
+}
+
+fn message(style: Style) []const u8 {
+    return switch (style) {
+        .never => "Expected literal to be on the right side of comparison.",
+        .always => "Expected literal to be on the left side of comparison.",
+    };
 }
 
 fn isComparisonOperator(operator: ast.BinaryOperator) bool {

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -46,6 +46,55 @@ test "does not report yoda when literals are on the right side or both sides" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.yoda.id));
 }
 
+test "reports yoda always when literals are on the right side" {
+    const source =
+        \\if (color === "red") {}
+        \\if (count > 0) {}
+        \\if (enabled !== true) {}
+        \\if (state == `ready`) {}
+        \\if (value <= -1) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .yoda_style = .always,
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.yoda.id));
+    try std.testing.expectEqualStrings("Expected literal to be on the left side of comparison.", result.diagnostics[0].message);
+}
+
+test "allows yoda always when literals are on the left side or both sides" {
+    const source =
+        \\if ("red" === color) {}
+        \\if (0 < count) {}
+        \\if (true !== enabled) {}
+        \\if ("red" === "blue") {}
+        \\if (value in object) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .yoda_style = .always,
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.yoda.id));
+}
+
 test "can disable yoda" {
     const source =
         \\if ("red" === color) {}


### PR DESCRIPTION
## Summary
- add `yoda` `always` style support for literal-left comparisons
- parse `yoda` string style from ESLint-style rule arrays and expose `--yoda=always`
- cover the new style in rule/config tests and update rule status docs

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/yoda.zig src/rules/root.zig src/main.zig tests/rules/yoda.zig`
- `git diff --check`
- CLI/config smoke for `yoda` `always` JSON diagnostics