### PR TITLE
feat: support no unused expressions options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -144,7 +144,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
-| [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented |
+| [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Implemented |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -218,6 +218,21 @@ pub const NoPlusplusAllowForLoopAfterthoughts = enum {
     no,
 };
 
+pub const NoUnusedExpressionsAllowShortCircuit = enum {
+    yes,
+    no,
+};
+
+pub const NoUnusedExpressionsAllowTernary = enum {
+    yes,
+    no,
+};
+
+pub const NoUnusedExpressionsAllowTaggedTemplates = enum {
+    yes,
+    no,
+};
+
 pub const NoParamReassignProps = enum {
     yes,
     no,
@@ -585,6 +600,9 @@ pub const Options = struct {
     no_useless_escape: bool = true,
     no_useless_rename: bool = true,
     no_unused_expressions: bool = true,
+    no_unused_expressions_allow_short_circuit: NoUnusedExpressionsAllowShortCircuit = .no,
+    no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .no,
+    no_unused_expressions_allow_tagged_templates: NoUnusedExpressionsAllowTaggedTemplates = .yes,
     typescript_eslint_no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
     no_warning_comments_location: NoWarningCommentsLocation = .start,
@@ -832,6 +850,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-useless-computed-key")) {
             self.no_useless_computed_key_enforce_for_class_members = try noUselessComputedKeyEnforceForClassMembersFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-unused-expressions")) {
+            self.no_unused_expressions_allow_short_circuit = try noUnusedExpressionsAllowShortCircuitFromConfig(value);
+            self.no_unused_expressions_allow_ternary = try noUnusedExpressionsAllowTernaryFromConfig(value);
+            self.no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-warning-comments")) {
             self.no_warning_comments_location = try noWarningCommentsLocationFromConfig(value);
@@ -1212,6 +1235,60 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enforce) .yes else .no;
+    }
+
+    fn noUnusedExpressionsAllowShortCircuitFromConfig(value: std.json.Value) RuleConfigError!NoUnusedExpressionsAllowShortCircuit {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowShortCircuit") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
+    }
+
+    fn noUnusedExpressionsAllowTernaryFromConfig(value: std.json.Value) RuleConfigError!NoUnusedExpressionsAllowTernary {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowTernary") orelse return .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
+    }
+
+    fn noUnusedExpressionsAllowTaggedTemplatesFromConfig(value: std.json.Value) RuleConfigError!NoUnusedExpressionsAllowTaggedTemplates {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .yes,
+        };
+        if (items.len < 2) return .yes;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowTaggedTemplates") orelse return .yes) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
     }
 
     fn noWarningCommentsLocationFromConfig(value: std.json.Value) RuleConfigError!NoWarningCommentsLocation {
@@ -1884,6 +1961,19 @@ test "Options can apply ESLint-style rule config values" {
         NoUselessComputedKeyEnforceForClassMembers.no,
         options.no_useless_computed_key_enforce_for_class_members,
     );
+
+    var no_unused_expressions_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowShortCircuit\":true,\"allowTernary\":true,\"allowTaggedTemplates\":false}]",
+        .{},
+    );
+    defer no_unused_expressions_config.deinit();
+    try options.setByRuleConfigValue("no-unused-expressions", no_unused_expressions_config.value);
+    try std.testing.expect(options.no_unused_expressions);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowShortCircuit.yes, options.no_unused_expressions_allow_short_circuit);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowTernary.yes, options.no_unused_expressions_allow_ternary);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
 
     var no_warning_comments_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -583,6 +583,12 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_rename = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-expressions=off")) {
             options.no_unused_expressions = false;
+        } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-short-circuit=on")) {
+            options.no_unused_expressions_allow_short_circuit = .yes;
+        } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-ternary=on")) {
+            options.no_unused_expressions_allow_ternary = .yes;
+        } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-tagged-templates=off")) {
+            options.no_unused_expressions_allow_tagged_templates = .no;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments=off")) {
             options.no_warning_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments-location=anywhere")) {
@@ -1691,6 +1697,9 @@ fn printHelp() void {
         \\  --no-useless-escape=off   Disable no-useless-escape
         \\  --no-useless-rename=off   Disable no-useless-rename
         \\  --no-unused-expressions=off Disable no-unused-expressions
+        \\  --no-unused-expressions-allow-short-circuit=on Allow short-circuit expressions
+        \\  --no-unused-expressions-allow-ternary=on Allow ternary expressions
+        \\  --no-unused-expressions-allow-tagged-templates=off Report tagged template expressions
         \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-warning-comments-location=anywhere Report warning terms anywhere in comments
         \\  --no-warning-comments-decoration=asterisk Ignore leading * comment decorations

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1322,7 +1322,11 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_unused_expressions and !self.options.typescript_eslint_no_unused_expressions) {
-            try no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try no_unused_expressions.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, .{
+                .allow_short_circuit = self.options.no_unused_expressions_allow_short_circuit == .yes,
+                .allow_ternary = self.options.no_unused_expressions_allow_ternary == .yes,
+                .allow_tagged_templates = self.options.no_unused_expressions_allow_tagged_templates == .yes,
+            });
         }
         if (self.options.typescript_eslint_no_unused_expressions) {
             try typescript_eslint_no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);

--- a/tests/rules/no_unused_expressions.zig
+++ b/tests/rules/no_unused_expressions.zig
@@ -59,6 +59,27 @@ test "does not report no-unused-expressions for expressions with side effects" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_expressions.id));
 }
 
+test "honors no-unused-expressions allow options" {
+    const source =
+        \\foo && bar();
+        \\foo ? bar() : baz();
+        \\tag`template`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions_allow_short_circuit = .yes,
+        .no_unused_expressions_allow_ternary = .yes,
+        .no_unused_expressions_allow_tagged_templates = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_expressions.id));
+}
+
 test "can disable no-unused-expressions" {
     const source =
         \\foo;


### PR DESCRIPTION
## Summary
- wire core `no-unused-expressions` options through lint Options and rule execution
- parse `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` from ESLint-style rule arrays
- expose CLI switches for the same options and document rule status

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/root.zig tests/rules/no_unused_expressions.zig`
- `git diff --check`
- CLI/config smoke for `no-unused-expressions` options JSON diagnostics