### PR TITLE
feat: parse dot notation keyword option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -357,6 +357,11 @@ pub const CapitalizedCommentsIgnoreInlineComments = enum {
     no,
 };
 
+pub const DotNotationAllowKeywords = enum {
+    yes,
+    no,
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
@@ -373,6 +378,7 @@ pub const Options = struct {
     constructor_super: bool = true,
     curly: bool = true,
     dot_notation: bool = true,
+    dot_notation_allow_keywords: DotNotationAllowKeywords = .yes,
     typescript_eslint_dot_notation: bool = true,
     default_case: bool = true,
     default_case_last: bool = true,
@@ -821,6 +827,9 @@ pub const Options = struct {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
         }
+        if (enabled and (std.mem.eql(u8, cli_name, "dot-notation") or std.mem.eql(u8, cli_name, "@typescript-eslint/dot-notation"))) {
+            self.dot_notation_allow_keywords = try dotNotationAllowKeywordsFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
@@ -1042,6 +1051,24 @@ pub const Options = struct {
             return .insurance;
         }
         return .default;
+    }
+
+    fn dotNotationAllowKeywordsFromConfig(value: std.json.Value) RuleConfigError!DotNotationAllowKeywords {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .yes,
+        };
+        if (items.len < 2) return .yes;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allowKeywords") orelse return .yes) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (allow) .yes else .no;
     }
 
     fn noRestrictedDisableRestrictsNoNestedTernary(value: std.json.Value) bool {
@@ -2045,6 +2072,32 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.capitalized_comments);
     try std.testing.expectEqual(CapitalizedCommentsMode.never, options.capitalized_comments_mode);
     try std.testing.expectEqual(CapitalizedCommentsIgnoreInlineComments.yes, options.capitalized_comments_ignore_inline_comments);
+
+    var dot_notation_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowKeywords\":false}]",
+        .{},
+    );
+    defer dot_notation_config.deinit();
+    try options.setByRuleConfigValue("dot-notation", dot_notation_config.value);
+    try std.testing.expect(options.dot_notation);
+    try std.testing.expectEqual(DotNotationAllowKeywords.no, options.dot_notation_allow_keywords);
+
+    try options.setByRuleConfigValue("@typescript-eslint/dot-notation", .{ .string = "off" });
+    try std.testing.expect(!options.typescript_eslint_dot_notation);
+    try std.testing.expectEqual(DotNotationAllowKeywords.no, options.dot_notation_allow_keywords);
+
+    var typescript_dot_notation_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowKeywords\":true}]",
+        .{},
+    );
+    defer typescript_dot_notation_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/dot-notation", typescript_dot_notation_config.value);
+    try std.testing.expect(options.typescript_eslint_dot_notation);
+    try std.testing.expectEqual(DotNotationAllowKeywords.yes, options.dot_notation_allow_keywords);
 
     var ivy_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/dot_notation.zig
+++ b/src/rules/dot_notation.zig
@@ -10,6 +10,7 @@ pub const id = "dot-notation";
 pub const Options = struct {
     rule_id: []const u8 = id,
     severity: core.Severity = .warning,
+    allow_keywords: bool = true,
 };
 
 pub fn check(
@@ -37,6 +38,7 @@ pub fn checkWithOptions(
         else => return,
     };
     if (!isAsciiIdentifierName(property_name)) return;
+    if (!options.allow_keywords and isKeyword(property_name)) return;
 
     try core.addDiagnosticFmt(
         allocator,
@@ -65,4 +67,73 @@ fn isIdentifierStart(char: u8) bool {
 
 fn isIdentifierPart(char: u8) bool {
     return isIdentifierStart(char) or std.ascii.isDigit(char);
+}
+
+fn isKeyword(name: []const u8) bool {
+    const keywords = [_][]const u8{
+        "abstract",
+        "boolean",
+        "break",
+        "byte",
+        "case",
+        "catch",
+        "char",
+        "class",
+        "const",
+        "continue",
+        "debugger",
+        "default",
+        "delete",
+        "do",
+        "double",
+        "else",
+        "enum",
+        "export",
+        "extends",
+        "false",
+        "final",
+        "finally",
+        "float",
+        "for",
+        "function",
+        "goto",
+        "if",
+        "implements",
+        "import",
+        "in",
+        "instanceof",
+        "int",
+        "interface",
+        "long",
+        "native",
+        "new",
+        "null",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "return",
+        "short",
+        "static",
+        "super",
+        "switch",
+        "synchronized",
+        "this",
+        "throw",
+        "throws",
+        "transient",
+        "true",
+        "try",
+        "typeof",
+        "var",
+        "void",
+        "volatile",
+        "while",
+        "with",
+    };
+
+    for (keywords) |keyword| {
+        if (std.mem.eql(u8, name, keyword)) return true;
+    }
+    return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2409,10 +2409,14 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.dot_notation and !self.options.typescript_eslint_dot_notation) {
-            try dot_notation.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+            try dot_notation.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, member, index, .{
+                .allow_keywords = self.options.dot_notation_allow_keywords == .yes,
+            });
         }
         if (self.options.typescript_eslint_dot_notation) {
-            try typescript_eslint_dot_notation.check(self.allocator, self.diagnostics, ctx.tree, member, index);
+            try typescript_eslint_dot_notation.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, member, index, .{
+                .allow_keywords = self.options.dot_notation_allow_keywords == .yes,
+            });
         }
         if (self.options.no_caller) {
             try no_caller.check(self.allocator, self.diagnostics, ctx.tree, member, index);

--- a/src/rules/typescript_eslint_dot_notation.zig
+++ b/src/rules/typescript_eslint_dot_notation.zig
@@ -13,8 +13,20 @@ pub fn check(
     member: parser.ast.MemberExpression,
     index: parser.ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, member, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    member: parser.ast.MemberExpression,
+    index: parser.ast.NodeIndex,
+    options: dot_notation.Options,
+) Allocator.Error!void {
     try dot_notation.checkWithOptions(allocator, diagnostics, tree, member, index, .{
         .rule_id = id,
         .severity = .@"error",
+        .allow_keywords = options.allow_keywords,
     });
 }

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -8,6 +8,7 @@ test "reports dot-notation for computed string properties that can use dot acces
         \\object["_private"];
         \\object["$value"];
         \\object["property1"];
+        \\object["default"];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -21,7 +22,7 @@ test "reports dot-notation for computed string properties that can use dot acces
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.dot_notation.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.dot_notation.id));
     try std.testing.expectEqualStrings(
         "['property'] is better written in dot notation.",
         result.diagnostics[0].message,
@@ -47,6 +48,32 @@ test "does not report dot-notation when bracket access is required" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
+}
+
+test "allows keyword properties when allowKeywords is false" {
+    const source =
+        \\object["default"];
+        \\object["class"];
+        \\object["property"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation_allow_keywords = .no,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.dot_notation.id));
+    try std.testing.expectEqualStrings(
+        "['property'] is better written in dot notation.",
+        result.diagnostics[0].message,
+    );
 }
 
 test "can disable dot-notation" {

--- a/tests/rules/typescript_eslint_dot_notation.zig
+++ b/tests/rules/typescript_eslint_dot_notation.zig
@@ -8,6 +8,7 @@ test "reports @typescript-eslint/dot-notation for computed string properties" {
         \\object["_private"];
         \\object["$value"];
         \\object["property1"];
+        \\object["default"];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
@@ -20,7 +21,7 @@ test "reports @typescript-eslint/dot-notation for computed string properties" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
     try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
     for (result.diagnostics) |diagnostic| {
         if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_dot_notation.id)) {
@@ -47,6 +48,31 @@ test "does not report @typescript-eslint/dot-notation when bracket access is req
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_dot_notation.id));
+}
+
+test "allows keyword properties for @typescript-eslint/dot-notation when allowKeywords is false" {
+    const source =
+        \\object["default"];
+        \\object["class"];
+        \\object["property"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .dot_notation_allow_keywords = .no,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
+    try std.testing.expectEqualStrings(
+        "['property'] is better written in dot notation.",
+        result.diagnostics[0].message,
+    );
 }
 
 test "can disable @typescript-eslint/dot-notation and fall back to core rule" {


### PR DESCRIPTION
## Summary
- Parse `dot-notation` and `@typescript-eslint/dot-notation` `allowKeywords` options from native rule config
- Pass the option through core and TypeScript rule dispatch
- Skip keyword property diagnostics when `allowKeywords` is false while preserving default reporting

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/dot_notation.zig src/rules/typescript_eslint_dot_notation.zig src/rules/root.zig tests/rules/dot_notation.zig tests/rules/typescript_eslint_dot_notation.zig`
- `git diff --check`
- CLI smoke: `dot-notation: ["error", { "allowKeywords": false }]` only reports non-keyword property access
