### PR TITLE
feat: parse prefer const destructuring option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -881,6 +881,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "prefer-const")) {
+            self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
         }
@@ -1456,6 +1459,26 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn preferConstDestructuringFromConfig(value: std.json.Value) RuleConfigError!PreferConstDestructuring {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .any,
+        };
+        if (items.len < 2) return .any;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const destructuring = switch (config.get("destructuring") orelse return .any) {
+            .string => |destructuring| destructuring,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, destructuring, "any")) return .any;
+        if (std.mem.eql(u8, destructuring, "all")) return .all;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
@@ -2361,6 +2384,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-plusplus", no_plusplus_config.value);
     try std.testing.expect(options.no_plusplus);
     try std.testing.expectEqual(NoPlusplusAllowForLoopAfterthoughts.yes, options.no_plusplus_allow_for_loop_afterthoughts);
+
+    var prefer_const_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"destructuring\":\"all\"}]",
+        .{},
+    );
+    defer prefer_const_config.deinit();
+    try options.setByRuleConfigValue("prefer-const", prefer_const_config.value);
+    try std.testing.expect(options.prefer_const);
+    try std.testing.expectEqual(PreferConstDestructuring.all, options.prefer_const_destructuring);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/prefer_const.zig
+++ b/tests/rules/prefer_const.zig
@@ -73,6 +73,32 @@ test "reports prefer-const for destructuring only when all bindings qualify in a
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_const.id));
 }
 
+test "uses configured prefer-const destructuring all mode" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"destructuring\":\"all\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("prefer-const", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\let { a, b } = obj;
+        \\b = 2;
+        \\let [c, d] = list;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_const.id));
+}
+
 test "can disable prefer-const" {
     const source =
         \\let a = 1;


### PR DESCRIPTION
## Summary
- Parse ESLint-style `prefer-const` `destructuring` options from native rule config
- Wire `destructuring: "all"` into the existing runtime option
- Add config parser and lint behavior coverage for the `all` mode

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig tests/rules/prefer_const.zig`
- `git diff --check`
- CLI smoke: `prefer-const: ["error", { "destructuring": "all" }]` only reports destructuring groups where every binding qualifies
