### PR TITLE
feat: parse no use before define options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -233,6 +233,11 @@ pub const NoUnusedExpressionsAllowTaggedTemplates = enum {
     no,
 };
 
+pub const NoUseBeforeDefineCheck = enum {
+    yes,
+    no,
+};
+
 pub const NoParamReassignProps = enum {
     yes,
     no,
@@ -625,6 +630,8 @@ pub const Options = struct {
     use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_use_before_define: bool = true,
+    no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
+    no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     no_undef: bool = true,
     prefer_const: bool = true,
     prefer_const_destructuring: PreferConstDestructuring = .any,
@@ -725,6 +732,8 @@ pub const Options = struct {
     typescript_eslint_no_useless_empty_export: bool = true,
     typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_use_before_define: bool = true,
+    typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
+    typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_no_wrapper_object_types: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
@@ -897,6 +906,14 @@ pub const Options = struct {
             self.no_unused_expressions_allow_short_circuit = try noUnusedExpressionsAllowShortCircuitFromConfig(value);
             self.no_unused_expressions_allow_ternary = try noUnusedExpressionsAllowTernaryFromConfig(value);
             self.no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
+            self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
+            self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-use-before-define")) {
+            self.typescript_eslint_no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", false);
+            self.typescript_eslint_no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
         }
         if (std.mem.eql(u8, cli_name, "no-void")) {
             self.no_void_allow_as_statement = try noVoidAllowAsStatementFromConfig(value);
@@ -1585,6 +1602,24 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noUseBeforeDefineCheckFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!NoUseBeforeDefineCheck {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return if (default) .yes else .no,
+        };
+        if (items.len < 2) return if (default) .yes else .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const enabled = switch (config.get(key) orelse return if (default) .yes else .no) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (enabled) .yes else .no;
     }
 
     fn noVoidAllowAsStatementFromConfig(value: std.json.Value) RuleConfigError!NoVoidAllowAsStatement {
@@ -2444,6 +2479,30 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedExpressionsAllowShortCircuit.yes, options.no_unused_expressions_allow_short_circuit);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTernary.yes, options.no_unused_expressions_allow_ternary);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
+
+    var no_use_before_define_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":false,\"classes\":false}]",
+        .{},
+    );
+    defer no_use_before_define_config.deinit();
+    try options.setByRuleConfigValue("no-use-before-define", no_use_before_define_config.value);
+    try std.testing.expect(options.no_use_before_define);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_classes);
+
+    var typescript_no_use_before_define_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":true,\"classes\":false}]",
+        .{},
+    );
+    defer typescript_no_use_before_define_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", typescript_no_use_before_define_config.value);
+    try std.testing.expect(options.typescript_eslint_no_use_before_define);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.typescript_eslint_no_use_before_define_check_functions);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_classes);
 
     var no_void_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -884,11 +884,17 @@ pub fn runSemantic(
     }
 
     if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {
-        try no_use_before_define.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .check_functions = options.no_use_before_define_check_functions == .yes,
+            .check_classes = options.no_use_before_define_check_classes == .yes,
+        });
     }
 
     if (options.typescript_eslint_no_use_before_define) {
-        try typescript_eslint_no_use_before_define.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try typescript_eslint_no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .check_functions = options.typescript_eslint_no_use_before_define_check_functions == .yes,
+            .check_classes = options.typescript_eslint_no_use_before_define_check_classes == .yes,
+        });
     }
 
     if (options.no_undef) {

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -13,10 +13,23 @@ pub fn run(
     tree: *const parser.ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+        .check_functions = false,
+        .check_classes = true,
+    });
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: no_use_before_define.Options,
+) Allocator.Error!void {
     try no_use_before_define.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
-        .check_functions = false,
-        .check_classes = true,
+        .check_functions = options.check_functions,
+        .check_classes = options.check_classes,
     });
 }

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -69,6 +69,45 @@ test "reports no-use-before-define for repeated initializer self references" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "uses configured no-use-before-define function and class checks" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":false,\"classes\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-use-before-define", config.value);
+    options.eol_last = false;
+    options.no_empty_block_statements = false;
+    options.no_empty_function = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.no_new = false;
+    options.no_var = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.vars_on_top = false;
+    options.typescript_eslint_no_use_before_define = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\f();
+        \\function f() {}
+        \\new C();
+        \\class C {}
+        \\a;
+        \\var a = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "can disable no-use-before-define" {
     const source =
         \\a;

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -46,6 +46,44 @@ test "does not report @typescript-eslint/no-use-before-define for type reference
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
 }
 
+test "uses configured @typescript-eslint/no-use-before-define function and class checks" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":true,\"classes\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", config.value);
+    options.eol_last = false;
+    options.no_empty_block_statements = false;
+    options.no_empty_function = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.no_new = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\f();
+        \\function f() {}
+        \\
+        \\new C();
+        \\class C {}
+        \\
+        \\a;
+        \\let a = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+}
+
 test "can disable @typescript-eslint/no-use-before-define and fall back to core rule" {
     const source =
         \\f();


### PR DESCRIPTION
## Summary
- Parse `functions` and `classes` options for `no-use-before-define`
- Parse the same options for `@typescript-eslint/no-use-before-define` while preserving the existing TypeScript defaults
- Pass the parsed options through semantic rule dispatch and add config-driven behavior coverage

## Validation
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_use_before_define.zig tests/rules/no_use_before_define.zig tests/rules/typescript_eslint_no_use_before_define.zig`
- `git diff --check`
- CLI smoke for `no-use-before-define: ["error", { "functions": false, "classes": false }]`
- CLI smoke for `@typescript-eslint/no-use-before-define: ["error", { "functions": true, "classes": false }]`
