### PR TITLE
fix: ignore overload signatures in no-dupe-class-members

### DIFF
--- a/src/rules/no_dupe_class_members.zig
+++ b/src/rules/no_dupe_class_members.zig
@@ -88,6 +88,12 @@ fn memberInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?Member {
 }
 
 fn methodInfo(tree: *const ast.Tree, method: ast.MethodDefinition) ?Member {
+    const function = switch (tree.data(method.value)) {
+        .function => |function| function,
+        else => return null,
+    };
+    if (function.body == .null) return null;
+
     const name = if (method.kind == .constructor and !method.static)
         "constructor"
     else

--- a/tests/rules/typescript_eslint_no_dupe_class_members.zig
+++ b/tests/rules/typescript_eslint_no_dupe_class_members.zig
@@ -54,6 +54,56 @@ test "does not report @typescript-eslint/no-dupe-class-members for getter setter
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
 }
 
+test "does not report @typescript-eslint/no-dupe-class-members for overload signatures" {
+    const source =
+        \\class Example {
+        \\  value(input: string): string;
+        \\  value(input: number): string;
+        \\  value(input: string | number) {
+        \\    return String(input);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_adjacent_overload_signatures = false,
+        .typescript_eslint_unified_signatures = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
+}
+
+test "reports @typescript-eslint/no-dupe-class-members for duplicate overload implementations" {
+    const source =
+        \\class Example {
+        \\  value(input: string): string;
+        \\  value(input: string) {
+        \\    return input;
+        \\  }
+        \\  value(input: number) {
+        \\    return String(input);
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_adjacent_overload_signatures = false,
+        .typescript_eslint_unified_signatures = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_dupe_class_members.id));
+}
+
 test "can disable @typescript-eslint/no-dupe-class-members and fall back to core rule" {
     const source =
         \\class Example {


### PR DESCRIPTION
## Summary

- skip body-less class methods when collecting members for `no-dupe-class-members`
- cover TypeScript overload signatures so `@typescript-eslint/no-dupe-class-members` reports duplicate implementations, not overload declarations

## Why

TypeScript overload signatures are represented as class methods without a function body. They should not count as duplicate class members; only implemented members should participate in duplicate detection.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_dupe_class_members.zig tests/rules/typescript_eslint_no_dupe_class_members.zig`
- `git diff --check`
