### PR TITLE
fix: handle template enum duplicate values

### DIFF
--- a/src/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/src/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -56,7 +56,20 @@ fn literalEnumValue(tree: *const ast.Tree, index: ast.NodeIndex) ?EnumValue {
 
     return switch (tree.data(index)) {
         .string_literal => |literal| .{ .string = tree.string(literal.value) },
+        .template_literal => |literal| templateLiteralValue(tree, literal),
         .numeric_literal => |literal| .{ .number = literal.value(tree) },
+        else => null,
+    };
+}
+
+fn templateLiteralValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?EnumValue {
+    if (tree.extra(literal.expressions).len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| .{ .string = tree.string(element.cooked) },
         else => null,
     };
 }

--- a/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -49,6 +49,41 @@ test "ignores implicit and computed enum initializers" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
 }
 
+test "reports @typescript-eslint/no-duplicate-enum-values for template literal enum values" {
+    const source =
+        \\enum Status {
+        \\  Pending = "pending",
+        \\  Waiting = `pending`,
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+}
+
+test "ignores interpolated template enum initializers" {
+    const source =
+        \\const suffix = "ing";
+        \\enum Status {
+        \\  Pending = "pending",
+        \\  Waiting = `pend${suffix}`,
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+}
+
 test "can disable @typescript-eslint/no-duplicate-enum-values" {
     const source =
         \\enum Status {


### PR DESCRIPTION
## Summary

- treat no-substitution template literals as string enum values in `@typescript-eslint/no-duplicate-enum-values`
- keep interpolated template enum initializers ignored as computed values
- add coverage for both cases

## Why

Static template literal enum initializers are literal values and should participate in duplicate enum value detection alongside string literals. Interpolated templates are computed and should remain outside this rule's literal-only check.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/typescript_eslint_no_duplicate_enum_values.zig tests/rules/typescript_eslint_no_duplicate_enum_values.zig`
- `git diff --check`
