### PR TITLE
fix: handle signed enum duplicate values

### DIFF
--- a/src/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/src/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -58,6 +58,20 @@ fn literalEnumValue(tree: *const ast.Tree, index: ast.NodeIndex) ?EnumValue {
         .string_literal => |literal| .{ .string = tree.string(literal.value) },
         .template_literal => |literal| templateLiteralValue(tree, literal),
         .numeric_literal => |literal| .{ .number = literal.value(tree) },
+        .unary_expression => |expression| signedNumericLiteralValue(tree, expression),
+        else => null,
+    };
+}
+
+fn signedNumericLiteralValue(tree: *const ast.Tree, expression: ast.UnaryExpression) ?EnumValue {
+    const number = switch (tree.data(expression.argument)) {
+        .numeric_literal => |literal| literal.value(tree),
+        else => return null,
+    };
+
+    return switch (expression.operator) {
+        .negate => .{ .number = -number },
+        .positive => .{ .number = number },
         else => null,
     };
 }

--- a/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
+++ b/tests/rules/typescript_eslint_no_duplicate_enum_values.zig
@@ -66,6 +66,27 @@ test "reports @typescript-eslint/no-duplicate-enum-values for template literal e
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
 }
 
+test "reports @typescript-eslint/no-duplicate-enum-values for signed numeric enum values" {
+    const source =
+        \\enum Status {
+        \\  Failed = -1,
+        \\  AlsoFailed = -1,
+        \\  Started = 1,
+        \\  PositiveStarted = +1,
+        \\  NegativeTwo = -2,
+        \\  PositiveTwo = 2,
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_duplicate_enum_values.id));
+}
+
 test "ignores interpolated template enum initializers" {
     const source =
         \\const suffix = "ing";


### PR DESCRIPTION
## Summary

- fold unary `+` and `-` numeric enum initializers into literal enum values
- report duplicate signed numeric enum values in `@typescript-eslint/no-duplicate-enum-values`
- add coverage for duplicate `-1`, duplicate `+1`/`1`, and distinct `-2`/`2`

## Why

Signed numeric enum initializers are represented as unary expressions in the AST, but they still produce literal numeric enum values. They should participate in duplicate enum value detection while computed expressions remain ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/typescript_eslint_no_duplicate_enum_values.zig tests/rules/typescript_eslint_no_duplicate_enum_values.zig`
- `git diff --check`
