### PR TITLE
fix: normalize numeric duplicate keys

### DIFF
--- a/src/rules/no_dupe_keys.zig
+++ b/src/rules/no_dupe_keys.zig
@@ -9,9 +9,15 @@ pub const id = "no-dupe-keys";
 
 const SeenKey = struct {
     name: []const u8,
+    owned: bool = false,
     init: bool = false,
     get: bool = false,
     set: bool = false,
+};
+
+const PropertyName = struct {
+    value: []const u8,
+    owned: bool = false,
 };
 
 pub fn check(
@@ -21,7 +27,12 @@ pub fn check(
     expression: ast.ObjectExpression,
 ) Allocator.Error!void {
     var seen: std.ArrayList(SeenKey) = .empty;
-    defer seen.deinit(allocator);
+    defer {
+        for (seen.items) |entry| {
+            if (entry.owned) allocator.free(entry.name);
+        }
+        seen.deinit(allocator);
+    }
 
     for (tree.extra(expression.properties)) |property_index| {
         const property = switch (tree.data(property_index)) {
@@ -29,7 +40,7 @@ pub fn check(
             else => continue,
         };
 
-        const name = propertyName(tree, property) orelse continue;
+        const name = try propertyName(allocator, tree, property) orelse continue;
         if (try isDuplicate(allocator, &seen, name, property.kind)) {
             try core.addDiagnosticFmt(
                 allocator,
@@ -38,7 +49,7 @@ pub fn check(
                 id,
                 tree.span(property_index),
                 "Duplicate key `{s}`.",
-                .{name},
+                .{name.value},
             );
         }
     }
@@ -47,11 +58,12 @@ pub fn check(
 fn isDuplicate(
     allocator: Allocator,
     seen: *std.ArrayList(SeenKey),
-    name: []const u8,
+    name: PropertyName,
     kind: ast.PropertyKind,
 ) Allocator.Error!bool {
     for (seen.items) |*entry| {
-        if (!std.mem.eql(u8, entry.name, name)) continue;
+        if (!std.mem.eql(u8, entry.name, name.value)) continue;
+        if (name.owned) allocator.free(name.value);
 
         return switch (kind) {
             .init => true,
@@ -69,7 +81,8 @@ fn isDuplicate(
     }
 
     try seen.append(allocator, .{
-        .name = name,
+        .name = name.value,
+        .owned = name.owned,
         .init = kind == .init,
         .get = kind == .get,
         .set = kind == .set,
@@ -77,13 +90,18 @@ fn isDuplicate(
     return false;
 }
 
-fn propertyName(tree: *const ast.Tree, property: ast.ObjectProperty) ?[]const u8 {
+fn propertyName(allocator: Allocator, tree: *const ast.Tree, property: ast.ObjectProperty) Allocator.Error!?PropertyName {
     if (property.computed or property.key == .null) return null;
 
     return switch (tree.data(property.key)) {
-        .identifier_name => |identifier| tree.string(identifier.name),
-        .string_literal => |literal| tree.string(literal.value),
-        .numeric_literal => |literal| tree.string(literal.raw),
+        .identifier_name => |identifier| .{ .value = tree.string(identifier.name) },
+        .string_literal => |literal| .{ .value = tree.string(literal.value) },
+        .numeric_literal => |literal| .{ .value = try numericPropertyName(allocator, tree, literal), .owned = true },
         else => null,
     };
+}
+
+fn numericPropertyName(allocator: Allocator, tree: *const ast.Tree, literal: ast.NumericLiteral) Allocator.Error![]const u8 {
+    const value = literal.value(tree);
+    return std.fmt.allocPrint(allocator, "{d}", .{value});
 }

--- a/tests/rules/no_dupe_keys.zig
+++ b/tests/rules/no_dupe_keys.zig
@@ -44,6 +44,31 @@ test "does not report no-dupe-keys for computed keys or getter setter pairs" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_keys.id));
 }
 
+test "reports no-dupe-keys for equivalent numeric object keys" {
+    const source =
+        \\const object = {
+        \\  0x1: "hex",
+        \\  1: "decimal",
+        \\  1_0: "separated",
+        \\  10: "ten",
+        \\  "2": "string",
+        \\  2: "number",
+        \\  1.5: "fraction",
+        \\  1.50: "sameFraction",
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_dupe_keys.id));
+}
+
 test "can disable no-dupe-keys" {
     const source =
         \\const object = { alpha: 1, alpha: 2 };


### PR DESCRIPTION
## Summary

- normalize numeric object literal keys before `no-dupe-keys` comparison
- report duplicates for equivalent key spellings like `0x1`/`1`, `1_0`/`10`, and `1.5`/`1.50`
- keep string keys comparable with numeric keys, e.g. `"2"` and `2`

## Why

Object literal numeric keys are property names, so equivalent numeric spellings should compare by their property key value instead of raw source text. The previous implementation compared numeric literal `raw` strings and missed duplicate keys that JavaScript normalizes to the same property name.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_dupe_keys.zig tests/rules/no_dupe_keys.zig`
- `git diff --check`
