### PR TITLE
fix: detect static computed duplicate keys

### DIFF
--- a/src/rules/no_dupe_keys.zig
+++ b/src/rules/no_dupe_keys.zig
@@ -91,17 +91,56 @@ fn isDuplicate(
 }
 
 fn propertyName(allocator: Allocator, tree: *const ast.Tree, property: ast.ObjectProperty) Allocator.Error!?PropertyName {
-    if (property.computed or property.key == .null) return null;
+    if (property.key == .null) return null;
+    if (isPrototypeSetter(tree, property)) return null;
 
-    return switch (tree.data(property.key)) {
-        .identifier_name => |identifier| .{ .value = tree.string(identifier.name) },
+    const key = unwrapTransparent(tree, property.key);
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| if (property.computed) null else .{ .value = tree.string(identifier.name) },
         .string_literal => |literal| .{ .value = tree.string(literal.value) },
         .numeric_literal => |literal| .{ .value = try numericPropertyName(allocator, tree, literal), .owned = true },
+        .template_literal => |literal| templatePropertyName(tree, literal),
         else => null,
     };
+}
+
+fn isPrototypeSetter(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
+    if (property.computed or property.kind != .init or property.method) return false;
+    const key = unwrapTransparent(tree, property.key);
+    const name = switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, "__proto__");
 }
 
 fn numericPropertyName(allocator: Allocator, tree: *const ast.Tree, literal: ast.NumericLiteral) Allocator.Error![]const u8 {
     const value = literal.value(tree);
     return std.fmt.allocPrint(allocator, "{d}", .{value});
+}
+
+fn templatePropertyName(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?PropertyName {
+    if (tree.extra(literal.expressions).len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| .{ .value = tree.string(element.cooked) },
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/tests/rules/no_dupe_keys.zig
+++ b/tests/rules/no_dupe_keys.zig
@@ -23,7 +23,7 @@ test "reports no-dupe-keys for duplicate object literal keys" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_dupe_keys.id));
 }
 
-test "does not report no-dupe-keys for computed keys or getter setter pairs" {
+test "does not report no-dupe-keys for dynamic computed keys or getter setter pairs" {
     const source =
         \\const object = {
         \\  [alpha]: 1,
@@ -42,6 +42,51 @@ test "does not report no-dupe-keys for computed keys or getter setter pairs" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_dupe_keys.id));
+}
+
+test "reports no-dupe-keys for static computed object keys" {
+    const source =
+        \\const object = {
+        \\  alpha: 1,
+        \\  ["alpha"]: 2,
+        \\  [`beta`]: 1,
+        \\  beta: 2,
+        \\  [0x1]: 1,
+        \\  1: 2,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_useless_computed_key = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_dupe_keys.id));
+}
+
+test "does not compare prototype setters with computed __proto__ keys" {
+    const source =
+        \\const object = {
+        \\  "__proto__": proto,
+        \\  ["__proto__"]: value,
+        \\  [`__proto__`]: other,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_useless_computed_key = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_dupe_keys.id));
 }
 
 test "reports no-dupe-keys for equivalent numeric object keys" {


### PR DESCRIPTION
## Summary

- include static computed object keys in `no-dupe-keys` duplicate detection
- keep dynamic computed keys ignored
- preserve the `__proto__` prototype setter exception while still comparing computed `__proto__` keys with each other

## Why

Computed object keys with literal string, number, or no-substitution template values produce static property names and should participate in duplicate key detection. The previous implementation skipped all computed keys, so it missed duplicates like `alpha` with `["alpha"]` or `1` with `[0x1]`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_dupe_keys.zig tests/rules/no_dupe_keys.zig`
- `git diff --check`
