### PR TITLE
fix: detect negated boolean casts

### DIFF
--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -86,7 +86,14 @@ const Visitor = struct {
         expression: ast.NodeIndex,
     ) Allocator.Error!void {
         const unwrapped = unwrapTransparent(tree, expression);
+        try self.checkBooleanExpression(tree, unwrapped);
+    }
 
+    fn checkBooleanExpression(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        unwrapped: ast.NodeIndex,
+    ) Allocator.Error!void {
         if (isBooleanCall(tree, self.symbol_table, unwrapped) or isDoubleNegation(tree, unwrapped)) {
             try core.addDiagnostic(
                 self.allocator,
@@ -97,6 +104,14 @@ const Visitor = struct {
                 tree.span(unwrapped),
             );
         }
+
+        const unary = switch (tree.data(unwrapped)) {
+            .unary_expression => |unary| unary,
+            else => return,
+        };
+        if (unary.operator != .logical_not) return;
+
+        try self.checkBooleanExpression(tree, unwrapTransparent(tree, unary.argument));
     }
 };
 

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -41,6 +41,38 @@ test "does not report no-extra-boolean-cast outside boolean contexts or for shad
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_boolean_cast.id));
 }
 
+test "reports no-extra-boolean-cast inside negated boolean contexts" {
+    const source =
+        \\if (!Boolean(value)) { use(value); }
+        \\while (!!!value) { break; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
+}
+
+test "does not report negated boolean casts outside boolean contexts" {
+    const source =
+        \\const a = !Boolean(value);
+        \\const b = !!!value;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_boolean_cast.id));
+}
+
 test "can disable no-extra-boolean-cast" {
     const source =
         \\if (Boolean(value)) { use(value); }


### PR DESCRIPTION
## Summary

- recurse through logical negation inside boolean contexts for `no-extra-boolean-cast`
- report `!Boolean(value)` as a redundant Boolean call
- report overlapping double negations in `!!!value`
- keep negated casts outside boolean contexts ignored

## Why

A logical negation still places its operand in a boolean context. The previous implementation only inspected the top-level test expression, so it missed redundant casts nested under `!` even though ESLint reports them by default.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_boolean_cast.zig tests/rules/no_extra_boolean_cast.zig`
- `git diff --check`
