### PR TITLE
fix: detect unary constant conditions

### DIFF
--- a/src/rules/no_constant_condition.zig
+++ b/src/rules/no_constant_condition.zig
@@ -42,8 +42,23 @@ fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .template_literal => |literal| literal.expressions.len == 0,
         .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
         .class => |class| class.type == .class_expression,
-        .unary_expression => |unary| unary.operator == .logical_not and isConstantExpression(tree, unwrapTransparent(tree, unary.argument)),
+        .unary_expression => |unary| isConstantUnaryExpression(tree, unary),
         else => false,
+    };
+}
+
+fn isConstantUnaryExpression(tree: *const ast.Tree, unary: ast.UnaryExpression) bool {
+    const argument = unwrapTransparent(tree, unary.argument);
+    return switch (unary.operator) {
+        .logical_not,
+        .positive,
+        .negate,
+        .bitwise_not,
+        => isConstantExpression(tree, argument),
+        .void => true,
+        .typeof,
+        .delete,
+        => false,
     };
 }
 

--- a/tests/rules/no_constant_condition.zig
+++ b/tests/rules/no_constant_condition.zig
@@ -39,6 +39,42 @@ test "does not report no-constant-condition for dynamic conditions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
 }
 
+test "reports no-constant-condition for constant unary expressions" {
+    const source =
+        \\if (void 0) { use(); }
+        \\if (!void 0) { use(); }
+        \\if (+1) { use(); }
+        \\if (-1) { use(); }
+        \\if (~0) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_constant_condition.id));
+}
+
+test "does not report no-constant-condition for dynamic unary expressions" {
+    const source =
+        \\if (+ready) { use(); }
+        \\if (-ready) { use(); }
+        \\if (~ready) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
+}
+
 test "can disable no-constant-condition" {
     const source =
         \\if (false) { use(); }


### PR DESCRIPTION
## Summary

- treat constant unary expressions as constant conditions in `no-constant-condition`
- cover `void`, unary plus/minus, bitwise not, and nested logical not
- keep dynamic unary operands ignored

## Why

ESLint reports unary expressions such as `void 0`, `+1`, `-1`, and `~0` as constant conditions by default. The previous implementation only treated literal expressions and logical-not-wrapped constants as constant, so these cases were missed.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_constant_condition.zig tests/rules/no_constant_condition.zig`
- `git diff --check`
