### PR TITLE
fix: detect useless returns in try blocks

### DIFF
--- a/src/rules/no_useless_return.zig
+++ b/src/rules/no_useless_return.zig
@@ -51,12 +51,15 @@ fn isRedundantReturn(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverse
                 if (statement.consequent != child and statement.alternate != child) return false;
                 child = ancestor;
             },
+            .try_statement => |statement| {
+                if (statement.block != child) return false;
+                child = ancestor;
+            },
             .while_statement,
             .do_while_statement,
             .for_statement,
             .for_in_statement,
             .for_of_statement,
-            .try_statement,
             .catch_clause,
             => return false,
             .function,

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -49,6 +49,36 @@ test "reports no-useless-return in final switch cases" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_useless_return.id));
 }
 
+test "reports no-useless-return in final try blocks" {
+    const source =
+        \\function first() {
+        \\  try {
+        \\    work();
+        \\    return;
+        \\  } catch (error) {
+        \\    recover(error);
+        \\  }
+        \\}
+        \\function second() {
+        \\  try {
+        \\    return;
+        \\  } finally {
+        \\    cleanup();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_return.id));
+}
+
 test "does not report no-useless-return when return changes control flow" {
     const source =
         \\function first(flag) {
@@ -72,6 +102,20 @@ test "does not report no-useless-return when return changes control flow" {
         \\}
         \\function fourth() {
         \\  return value;
+        \\}
+        \\function fifth() {
+        \\  try {
+        \\    work();
+        \\  } catch (error) {
+        \\    return;
+        \\  }
+        \\}
+        \\function sixth() {
+        \\  try {
+        \\    work();
+        \\  } finally {
+        \\    return;
+        \\  }
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- allow `no-useless-return` to analyze final `return;` statements inside `try` blocks
- keep `catch` and `finally` returns treated as control-flow-changing
- add coverage for try/catch and try/finally behavior

## Why

ESLint reports a bare `return;` at the natural end of a `try` block as unnecessary when the surrounding statement is also at function exit. The previous implementation stopped at `try_statement`, so it missed these cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_return.zig tests/rules/no_useless_return.zig`
- `git diff --check`
