### PR TITLE
fix: detect constant logical conditions

### DIFF
--- a/src/rules/no_constant_condition.zig
+++ b/src/rules/no_constant_condition.zig
@@ -1,8 +1,9 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-constant-condition";
 
@@ -43,6 +44,7 @@ fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
         .class => |class| class.type == .class_expression,
         .unary_expression => |unary| isConstantUnaryExpression(tree, unary),
+        .logical_expression => |logical| isConstantLogicalExpression(tree, logical),
         else => false,
     };
 }
@@ -60,6 +62,82 @@ fn isConstantUnaryExpression(tree: *const ast.Tree, unary: ast.UnaryExpression) 
         .delete,
         => false,
     };
+}
+
+fn isConstantLogicalExpression(tree: *const ast.Tree, logical: ast.LogicalExpression) bool {
+    if (logical.operator == .nullish_coalescing) return false;
+
+    const left = staticTruthiness(tree, unwrapTransparent(tree, logical.left));
+    const right = staticTruthiness(tree, unwrapTransparent(tree, logical.right));
+
+    return switch (logical.operator) {
+        .@"or" => (left orelse false) or (right orelse false) or (left != null and right != null),
+        .@"and" => (left != null and !left.?) or (right != null and !right.?) or (left != null and right != null),
+        .nullish_coalescing => false,
+    };
+}
+
+fn staticTruthiness(tree: *const ast.Tree, index: ast.NodeIndex) ?bool {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .boolean_literal => |literal| literal.value,
+        .null_literal => false,
+        .numeric_literal => |literal| {
+            const value = literal.value(tree);
+            return value != 0 and value == value;
+        },
+        .bigint_literal => |literal| bigintTruthy(tree.string(literal.raw)),
+        .string_literal => |literal| tree.string(literal.value).len != 0,
+        .regexp_literal,
+        .array_expression,
+        .object_expression,
+        .arrow_function_expression,
+        => true,
+        .template_literal => |literal| templateLiteralTruthy(tree, literal),
+        .function => |function| if (function.type == .function_expression or function.type == .ts_empty_body_function_expression) true else null,
+        .class => |class| if (class.type == .class_expression) true else null,
+        .unary_expression => |unary| staticUnaryTruthiness(tree, unary),
+        else => null,
+    };
+}
+
+fn staticUnaryTruthiness(tree: *const ast.Tree, unary: ast.UnaryExpression) ?bool {
+    const argument = unwrapTransparent(tree, unary.argument);
+    return switch (unary.operator) {
+        .logical_not => if (staticTruthiness(tree, argument)) |truthy| !truthy else null,
+        .positive,
+        .negate,
+        => switch (tree.data(argument)) {
+            .numeric_literal => staticTruthiness(tree, argument),
+            else => null,
+        },
+        .bitwise_not => null,
+        .void => false,
+        .typeof,
+        .delete,
+        => null,
+    };
+}
+
+fn templateLiteralTruthy(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?bool {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked).len != 0,
+        else => null,
+    };
+}
+
+fn bigintTruthy(raw: []const u8) bool {
+    for (raw) |char| {
+        if (char == '_' or char == 'n') continue;
+        if (char != '0') return true;
+    }
+    return false;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/no_constant_condition.zig
+++ b/tests/rules/no_constant_condition.zig
@@ -75,6 +75,42 @@ test "does not report no-constant-condition for dynamic unary expressions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
 }
 
+test "reports no-constant-condition for constant logical expressions" {
+    const source =
+        \\if (true || ready) { use(); }
+        \\if (ready || true) { use(); }
+        \\if (false && ready) { use(); }
+        \\if (ready && false) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_constant_condition.id));
+}
+
+test "does not report no-constant-condition for dynamic logical expressions" {
+    const source =
+        \\if (true && ready) { use(); }
+        \\if (false || ready) { use(); }
+        \\if (ready && true) { use(); }
+        \\if (ready || false) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
+}
+
 test "can disable no-constant-condition" {
     const source =
         \\if (false) { use(); }


### PR DESCRIPTION
## Summary

- detect constant `&&` / `||` conditions when one side determines the result
- add static truthiness for literal and simple unary expressions used by logical short-circuiting
- keep dynamic logical expressions such as `true && ready` and `false || ready` ignored

## Why

ESLint reports logical expressions like `true || ready`, `ready || true`, `false && ready`, and `ready && false` as constant conditions by default. The previous implementation only recognized literal and unary constants, so these short-circuit cases were missed.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_constant_condition.zig tests/rules/no_constant_condition.zig`
- `git diff --check`
