### PR TITLE
fix: avoid nested no-return-assign false positives

### DIFF
--- a/src/rules/no_return_assign.zig
+++ b/src/rules/no_return_assign.zig
@@ -43,7 +43,7 @@ fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesiz
 
     switch (tree.data(index)) {
         .parenthesized_expression => |expression| {
-            if (!allow_parenthesized) return null;
+            if (!allow_parenthesized and tree.data(expression.expression) == .assignment_expression) return null;
             return findAssignment(tree, expression.expression, allow_parenthesized);
         },
         .assignment_expression => return index,
@@ -69,6 +69,7 @@ fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesiz
             return null;
         },
         .call_expression => |call| {
+            if (!allow_parenthesized) return null;
             if (findAssignment(tree, call.callee, allow_parenthesized)) |assignment| return assignment;
             for (tree.extra(call.arguments)) |argument| {
                 if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
@@ -76,6 +77,7 @@ fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesiz
             return null;
         },
         .new_expression => |new| {
+            if (!allow_parenthesized) return null;
             if (findAssignment(tree, new.callee, allow_parenthesized)) |assignment| return assignment;
             for (tree.extra(new.arguments)) |argument| {
                 if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
@@ -83,6 +85,7 @@ fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesiz
             return null;
         },
         .member_expression => |member| {
+            if (!allow_parenthesized) return null;
             if (findAssignment(tree, member.object, allow_parenthesized)) |assignment| return assignment;
             if (member.computed) return findAssignment(tree, member.property, allow_parenthesized);
             return null;

--- a/tests/rules/no_return_assign.zig
+++ b/tests/rules/no_return_assign.zig
@@ -8,6 +8,12 @@ test "reports no-return-assign for returned assignments" {
         \\  return value = next;
         \\}
         \\const assign = (value, next) => value += next;
+        \\function sequence(value, next) {
+        \\  return other, value = next;
+        \\}
+        \\function parenthesizedSequence(value, next) {
+        \\  return (other, value = next);
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +23,7 @@ test "reports no-return-assign for returned assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_assign.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_return_assign.id));
 }
 
 test "does not report no-return-assign for comparisons or parenthesized assignments" {
@@ -29,6 +35,24 @@ test "does not report no-return-assign for comparisons or parenthesized assignme
         \\  return (value = next);
         \\}
         \\const assign = (value, next) => (value += next);
+        \\function callArgument(value, next) {
+        \\  return use(value = next);
+        \\}
+        \\function binary(value, next) {
+        \\  return other + (value = next);
+        \\}
+        \\function logical(value, next) {
+        \\  return other && (value = next);
+        \\}
+        \\function conditional(value, next) {
+        \\  return other ? (value = next) : fallback;
+        \\}
+        \\function unary(value, next) {
+        \\  return !(value = next);
+        \\}
+        \\function sequence(value, next) {
+        \\  return other, (value = next);
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -47,6 +71,18 @@ test "reports parenthesized returned assignments in always mode" {
         \\  return (value = next);
         \\}
         \\const assign = (value, next) => (value += next);
+        \\function callArgument(value, next) {
+        \\  return use(value = next);
+        \\}
+        \\function binary(value, next) {
+        \\  return other + (value = next);
+        \\}
+        \\function logical(value, next) {
+        \\  return other && (value = next);
+        \\}
+        \\function conditional(value, next) {
+        \\  return other ? (value = next) : fallback;
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -57,7 +93,7 @@ test "reports parenthesized returned assignments in always mode" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_assign.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_return_assign.id));
 }
 
 test "can disable no-return-assign" {


### PR DESCRIPTION
## Summary

- avoid reporting assignments nested in call/new/member expressions for default `no-return-assign`
- keep parenthesized assignments ignored in `except-parens` mode while still reporting assignment sequence expressions
- preserve `always` mode coverage for nested parenthesized assignments

## Why

ESLint's default `no-return-assign` behavior reports assignments that are effectively returned, but it does not flag assignments nested in call arguments or parenthesized operands. The previous implementation recursed through every nested expression and could over-report cases like `return use(value = next)`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_return_assign.zig tests/rules/no_return_assign.zig`
- `git diff --check`
