### PR TITLE
fix: narrow no-cond-assign default scope

### DIFF
--- a/src/rules/no_cond_assign.zig
+++ b/src/rules/no_cond_assign.zig
@@ -27,42 +27,10 @@ pub fn check(
 fn findAmbiguousAssignment(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
     if (index == .null) return null;
 
-    switch (tree.data(index)) {
-        .parenthesized_expression => return null,
-        .assignment_expression => return index,
+    return switch (tree.data(index)) {
+        .parenthesized_expression => null,
+        .assignment_expression => index,
         .chain_expression => |chain| return findAmbiguousAssignment(tree, chain.expression),
-        .binary_expression => |expression| {
-            if (findAmbiguousAssignment(tree, expression.left)) |assignment| return assignment;
-            return findAmbiguousAssignment(tree, expression.right);
-        },
-        .logical_expression => |expression| {
-            if (findAmbiguousAssignment(tree, expression.left)) |assignment| return assignment;
-            return findAmbiguousAssignment(tree, expression.right);
-        },
-        .unary_expression => |expression| return findAmbiguousAssignment(tree, expression.argument),
-        .conditional_expression => |expression| {
-            if (findAmbiguousAssignment(tree, expression.@"test")) |assignment| return assignment;
-            if (findAmbiguousAssignment(tree, expression.consequent)) |assignment| return assignment;
-            return findAmbiguousAssignment(tree, expression.alternate);
-        },
-        .sequence_expression => |expression| {
-            for (tree.extra(expression.expressions)) |item| {
-                if (findAmbiguousAssignment(tree, item)) |assignment| return assignment;
-            }
-            return null;
-        },
-        .call_expression => |call| {
-            if (findAmbiguousAssignment(tree, call.callee)) |assignment| return assignment;
-            for (tree.extra(call.arguments)) |argument| {
-                if (findAmbiguousAssignment(tree, argument)) |assignment| return assignment;
-            }
-            return null;
-        },
-        .member_expression => |member| {
-            if (findAmbiguousAssignment(tree, member.object)) |assignment| return assignment;
-            if (member.computed) return findAmbiguousAssignment(tree, member.property);
-            return null;
-        },
-        else => return null,
-    }
+        else => null,
+    };
 }

--- a/tests/rules/no_cond_assign.zig
+++ b/tests/rules/no_cond_assign.zig
@@ -26,6 +26,13 @@ test "does not report no-cond-assign for parenthesized assignments or comparison
         \\while ((node = node.parentNode) !== null) { use(node); }
         \\do { use(value); } while ((value += 1));
         \\for (; value === next; ) { use(value); }
+        \\if (use(value = next)) { use(value); }
+        \\if (other + (value = next)) { use(value); }
+        \\if (other || (value = next)) { use(value); }
+        \\if (other ? (value = next) : fallback) { use(value); }
+        \\if (!(value = next)) { use(value); }
+        \\if (value = next, other) { use(value); }
+        \\if ((value = next), other) { use(value); }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- narrow default `no-cond-assign` detection to the condition expression itself
- avoid reporting assignments nested in call, binary, logical, unary, conditional, or sequence expressions
- add regression coverage for ESLint-compatible default `except-parens` cases

## Why

ESLint's default `no-cond-assign` behavior reports conditions that are directly assignments, but allows assignments that are parenthesized or nested inside another expression. The previous implementation recursively searched the whole condition and could over-report cases like `if (use(value = next))`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_cond_assign.zig tests/rules/no_cond_assign.zig`
- `git diff --check`
