### PR TITLE
fix: report tagged unused expressions by default

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -613,7 +613,7 @@ pub const Options = struct {
     no_unused_expressions: bool = true,
     no_unused_expressions_allow_short_circuit: NoUnusedExpressionsAllowShortCircuit = .no,
     no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .no,
-    no_unused_expressions_allow_tagged_templates: NoUnusedExpressionsAllowTaggedTemplates = .yes,
+    no_unused_expressions_allow_tagged_templates: NoUnusedExpressionsAllowTaggedTemplates = .no,
     typescript_eslint_no_unused_expressions: bool = true,
     no_warning_comments: bool = true,
     no_warning_comments_location: NoWarningCommentsLocation = .start,
@@ -1589,15 +1589,15 @@ pub const Options = struct {
     fn noUnusedExpressionsAllowTaggedTemplatesFromConfig(value: std.json.Value) RuleConfigError!NoUnusedExpressionsAllowTaggedTemplates {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return .yes,
+            else => return .no,
         };
-        if (items.len < 2) return .yes;
+        if (items.len < 2) return .no;
 
         const config = switch (items[1]) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        const allow = switch (config.get("allowTaggedTemplates") orelse return .yes) {
+        const allow = switch (config.get("allowTaggedTemplates") orelse return .no) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -2478,6 +2478,16 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_unused_expressions);
     try std.testing.expectEqual(NoUnusedExpressionsAllowShortCircuit.yes, options.no_unused_expressions_allow_short_circuit);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTernary.yes, options.no_unused_expressions_allow_ternary);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
+
+    var no_unused_expressions_default_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\"]",
+        .{},
+    );
+    defer no_unused_expressions_default_config.deinit();
+    try options.setByRuleConfigValue("no-unused-expressions", no_unused_expressions_default_config.value);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
 
     var no_use_before_define_config = try std.json.parseFromSlice(

--- a/src/main.zig
+++ b/src/main.zig
@@ -587,8 +587,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unused_expressions_allow_short_circuit = .yes;
         } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-ternary=on")) {
             options.no_unused_expressions_allow_ternary = .yes;
-        } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-tagged-templates=off")) {
-            options.no_unused_expressions_allow_tagged_templates = .no;
+        } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-tagged-templates=on")) {
+            options.no_unused_expressions_allow_tagged_templates = .yes;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments=off")) {
             options.no_warning_comments = false;
         } else if (std.mem.eql(u8, arg, "--no-warning-comments-location=anywhere")) {
@@ -1699,7 +1699,7 @@ fn printHelp() void {
         \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-unused-expressions-allow-short-circuit=on Allow short-circuit expressions
         \\  --no-unused-expressions-allow-ternary=on Allow ternary expressions
-        \\  --no-unused-expressions-allow-tagged-templates=off Report tagged template expressions
+        \\  --no-unused-expressions-allow-tagged-templates=on  Allow tagged template expressions
         \\  --no-warning-comments=off Disable no-warning-comments
         \\  --no-warning-comments-location=anywhere Report warning terms anywhere in comments
         \\  --no-warning-comments-decoration=asterisk Ignore leading * comment decorations

--- a/src/rules/no_unused_expressions.zig
+++ b/src/rules/no_unused_expressions.zig
@@ -12,7 +12,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     allow_short_circuit: bool = false,
     allow_ternary: bool = false,
-    allow_tagged_templates: bool = true,
+    allow_tagged_templates: bool = false,
 };
 
 pub fn check(

--- a/tests/rules/no_unused_expressions.zig
+++ b/tests/rules/no_unused_expressions.zig
@@ -7,6 +7,7 @@ test "reports no-unused-expressions for expressions without side effects" {
         \\foo;
         \\1;
         \\`text`;
+        \\tag`template`;
         \\foo + bar;
         \\foo && bar();
         \\foo ? bar() : baz();
@@ -22,7 +23,7 @@ test "reports no-unused-expressions for expressions without side effects" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_unused_expressions.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.no_unused_expressions.id));
 }
 
 test "does not report no-unused-expressions for expressions with side effects" {
@@ -33,7 +34,6 @@ test "does not report no-unused-expressions for expressions with side effects" {
         \\value = 1;
         \\value += 1;
         \\value++;
-        \\tag`template`;
         \\import("mod");
         \\(foo());
         \\(0, foo());
@@ -69,7 +69,7 @@ test "honors no-unused-expressions allow options" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_unused_expressions_allow_short_circuit = .yes,
         .no_unused_expressions_allow_ternary = .yes,
-        .no_unused_expressions_allow_tagged_templates = .no,
+        .no_unused_expressions_allow_tagged_templates = .yes,
         .no_undef = false,
         .no_unused_vars = false,
         .typescript_eslint_no_unused_expressions = false,
@@ -77,7 +77,7 @@ test "honors no-unused-expressions allow options" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_expressions.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_expressions.id));
 }
 
 test "can disable no-unused-expressions" {


### PR DESCRIPTION
## Summary

- report tagged template expression statements in core `no-unused-expressions` by default
- keep explicit `allowTaggedTemplates` support for configs and CLI usage
- preserve the TypeScript/fishlint wrapper rule's tagged-template allowance

## Why

ESLint's default `no-unused-expressions` rule reports `tag\`template\`;` unless `allowTaggedTemplates` is explicitly enabled. The previous core default allowed tagged templates, so projects using the core rule could miss an ESLint-compatible diagnostic.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/main.zig src/rules/no_unused_expressions.zig tests/rules/no_unused_expressions.zig`
- `git diff --check`
