### PR TITLE
fix: allow bound args on arrow bind

### DIFF
--- a/src/rules/no_extra_bind.zig
+++ b/src/rules/no_extra_bind.zig
@@ -29,7 +29,7 @@ pub fn check(
     const has_bound_arguments = call.arguments.len > 1;
 
     const is_extra = switch (tree.data(target)) {
-        .arrow_function_expression => true,
+        .arrow_function_expression => !has_bound_arguments,
         .function => |function| !has_bound_arguments and !functionUsesThis(tree, function),
         else => false,
     };

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -49,6 +49,7 @@ test "does not report no-extra-bind when this or bound arguments are used" {
         \\const second = function (value) {
         \\  return value + 1;
         \\}.bind(context, value);
+        \\const third = ((value) => value + 1).bind(context, value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- stop reporting arrow-function `.bind()` calls when extra bound arguments are present
- add regression coverage for arrow-function partial application

## Why

ESLint's `no-extra-bind` allows `.bind(thisArg, ...args)` when the extra arguments are meaningful partial application inputs. The previous implementation reported every arrow-function `.bind()` call, including cases like `((value) => value + 1).bind(context, value)`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_bind.zig tests/rules/no_extra_bind.zig`
- `git diff --check`
