### PR TITLE
fix: flag apply calls with array holes

### DIFF
--- a/src/rules/no_useless_call.zig
+++ b/src/rules/no_useless_call.zig
@@ -58,16 +58,10 @@ fn hasUselessThisArg(tree: *const ast.Tree, target: ast.NodeIndex, this_arg: ast
 fn hasArrayLiteralArguments(tree: *const ast.Tree, arguments: []const ast.NodeIndex) bool {
     if (arguments.len < 2) return false;
 
-    const array = switch (tree.data(unwrapTransparent(tree, arguments[1]))) {
-        .array_expression => |array| array,
+    return switch (tree.data(unwrapTransparent(tree, arguments[1]))) {
+        .array_expression => true,
         else => return false,
     };
-
-    for (tree.extra(array.elements)) |element| {
-        if (element == .null) return false;
-    }
-
-    return true;
 }
 
 fn isNullOrUndefined(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/no_useless_call.zig
+++ b/tests/rules/no_useless_call.zig
@@ -29,6 +29,7 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
         \\obj.foo.apply(obj, [a]);
         \\this.foo.apply(this, [a]);
         \\obj.foo["apply"](obj, [a]);
+        \\foo.apply(undefined, [, a]);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -38,7 +39,7 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_call.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_useless_call.id));
 }
 
 test "does not report no-useless-call when this binding or arguments are meaningful" {
@@ -48,7 +49,6 @@ test "does not report no-useless-call when this binding or arguments are meaning
         \\getObj().foo.call(getObj(), a);
         \\foo.apply(undefined, args);
         \\obj.foo.apply(obj, args);
-        \\foo.apply(undefined, [, a]);
         \\foo.apply(obj, [a]);
     ;
 


### PR DESCRIPTION
## Summary

- report `no-useless-call` for `.apply()` calls whose second argument is an array literal with holes
- move the array-hole regression into the reporting coverage

## Why

ESLint treats array holes in an `.apply()` array literal as safely expressible by direct call arguments, so `foo.apply(undefined, [, a])` is still a useless `.apply()` call. The previous implementation skipped array literals containing holes and missed that diagnostic.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_call.zig tests/rules/no_useless_call.zig`
- `git diff --check`
