### PR TITLE
fix: flag parenthesized no-new calls

### DIFF
--- a/src/rules/no_new.zig
+++ b/src/rules/no_new.zig
@@ -2,6 +2,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-new";
@@ -11,9 +12,9 @@ pub fn check(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
-    parent: ast.NodeIndex,
+    path: *const traverser.NodePath,
 ) Allocator.Error!void {
-    if (tree.data(parent) != .expression_statement) return;
+    if (!isExpressionStatementUse(tree, index, path)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -23,4 +24,26 @@ pub fn check(
         "Do not use 'new' for side effects.",
         tree.span(index),
     );
+}
+
+fn isExpressionStatementUse(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+) bool {
+    var current = index;
+    var depth: usize = 1;
+
+    while (path.ancestor(depth)) |parent| : (depth += 1) {
+        switch (tree.data(parent)) {
+            .parenthesized_expression => |expression| {
+                if (expression.expression != current) return false;
+                current = parent;
+            },
+            .expression_statement => |statement| return statement.expression == current,
+            else => return false,
+        }
+    }
+
+    return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2377,9 +2377,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_new) {
-            if (ctx.path.parent()) |parent| {
-                try no_new.check(self.allocator, self.diagnostics, ctx.tree, index, parent);
-            }
+            try no_new.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path);
         }
         if (self.options.no_new_require) {
             try no_new_require.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/rules/no_new.zig
+++ b/tests/rules/no_new.zig
@@ -6,6 +6,8 @@ test "reports no-new for constructor calls used as statements" {
     const source =
         \\new Widget();
         \\new namespace.Widget(value);
+        \\(new Widget());
+        \\((new Widget()));
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -15,7 +17,7 @@ test "reports no-new for constructor calls used as statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_new.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_new.id));
 }
 
 test "does not report no-new when constructed values are used" {


### PR DESCRIPTION
## Summary

- report `no-new` for parenthesized constructor calls used as expression statements
- add regression coverage for one and two layers of parentheses

## Why

ESLint reports `(new Foo());` and `((new Foo()));` as `no-new` violations because the constructed value is still unused. The previous implementation only checked when the `new` expression was the direct child of an expression statement, so it missed those parenthesized forms.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_new.zig src/rules/root.zig tests/rules/no_new.zig`
- `git diff --check`
