### PR TITLE
fix: allow parenthesized void statements

### DIFF
--- a/src/rules/no_void.zig
+++ b/src/rules/no_void.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-void";
@@ -27,11 +28,11 @@ pub fn checkWithOptions(
     tree: *const ast.Tree,
     expression: ast.UnaryExpression,
     index: ast.NodeIndex,
-    parent: ?ast.NodeIndex,
+    path: ?*const traverser.NodePath,
     options: Options,
 ) Allocator.Error!void {
     if (expression.operator != .void) return;
-    if (options.allow_as_statement and isExpressionStatementParent(tree, index, parent)) return;
+    if (options.allow_as_statement and isExpressionStatementUse(tree, index, path)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -43,10 +44,25 @@ pub fn checkWithOptions(
     );
 }
 
-fn isExpressionStatementParent(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
-    const parent_index = parent orelse return false;
-    return switch (tree.data(parent_index)) {
-        .expression_statement => |statement| statement.expression == index,
-        else => false,
-    };
+fn isExpressionStatementUse(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: ?*const traverser.NodePath,
+) bool {
+    const node_path = path orelse return false;
+    var current = index;
+    var depth: usize = 1;
+
+    while (node_path.ancestor(depth)) |parent| : (depth += 1) {
+        switch (tree.data(parent)) {
+            .parenthesized_expression => |expression| {
+                if (expression.expression != current) return false;
+                current = parent;
+            },
+            .expression_statement => |statement| return statement.expression == current,
+            else => return false,
+        }
+    }
+
+    return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2182,7 +2182,7 @@ const BasicVisitor = struct {
             try no_delete_var.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_void) {
-            try no_void.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx.path.ancestor(1), .{
+            try no_void.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, &ctx.path, .{
                 .allow_as_statement = self.options.no_void_allow_as_statement == .yes,
             });
         }

--- a/tests/rules/no_void.zig
+++ b/tests/rules/no_void.zig
@@ -43,6 +43,8 @@ test "does not report no-void for delete or property names" {
 test "allows void expression statements when allowAsStatement is enabled" {
     const source =
         \\void doSideEffect();
+        \\(void doSideEffect());
+        \\((void doSideEffect()));
         \\function f() {
         \\  return void doSideEffect();
         \\}


### PR DESCRIPTION
## Summary

- allow parenthesized `void` expression statements when `allowAsStatement` is enabled
- add regression coverage for one and two parenthesis layers

## Why

ESLint's `no-void` option `allowAsStatement` allows `void foo();`, `(void foo());`, and `((void foo()));` because the `void` expression is still used as a statement. The previous implementation only checked the direct parent node, so it still reported parenthesized statement forms.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_void.zig src/rules/root.zig tests/rules/no_void.zig`
- `git diff --check`
