### PR TITLE
fix: detect computed Object.assign calls

### DIFF
--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -81,8 +81,9 @@ fn isGlobalObjectAssign(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.computed or member.optional) return false;
-    if (!isIdentifierName(tree, member.property, "assign")) return false;
+    if (member.optional) return false;
+    const property_name = memberPropertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property_name, "assign")) return false;
     const object = unwrapTransparent(tree, member.object);
     if (!isIdentifierReference(tree, object, "Object")) return false;
     return isUnresolvedReference(symbol_table, object);
@@ -102,11 +103,30 @@ fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex 
     return current;
 }
 
-fn isIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(index)) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
-        else => false,
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    if (!member.computed) {
+        return switch (tree.data(member.property)) {
+            .identifier_name => |identifier| tree.string(identifier.name),
+            else => null,
+        };
+    }
+
+    return switch (tree.data(unwrapTransparent(tree, member.property))) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
     };
 }
 

--- a/tests/rules/prefer_object_spread.zig
+++ b/tests/rules/prefer_object_spread.zig
@@ -6,16 +6,20 @@ test "reports prefer-object-spread for Object.assign into object literals" {
     const source =
         \\const first = Object.assign({}, source);
         \\const second = Object.assign({ value: 1 }, source, extra);
+        \\const third = Object["assign"]({}, source);
+        \\const fourth = Object[`assign`]({}, source);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
+        .dot_notation = false,
+        .typescript_eslint_dot_notation = false,
         .no_undef = false,
         .no_unused_vars = false,
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_object_spread.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_object_spread.id));
     try std.testing.expectEqualStrings("Use an object spread instead of Object.assign.", result.diagnostics[0].message);
 }
 
@@ -24,7 +28,8 @@ test "allows non-object targets shadowed Object and spread arguments" {
         \\const target = {};
         \\Object.assign(target, source);
         \\Object.assign({}, ...sources);
-        \\Object["assign"]({}, source);
+        \\Object[assign]({}, source);
+        \\Object[`assi${name}`]({}, source);
         \\function local(Object) {
         \\  Object.assign({}, source);
         \\}


### PR DESCRIPTION
## Summary

- detect static computed `Object["assign"]` calls in `prefer-object-spread`
- detect no-substitution template property names such as ``Object[`assign`]``
- keep dynamic computed properties ignored

## Why

ESLint reports `Object["assign"]({}, source)` and ``Object[`assign`]({}, source)`` as `prefer-object-spread` violations because both are statically equivalent to `Object.assign`. The previous implementation only handled the non-computed `.assign` form.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_object_spread.zig tests/rules/prefer_object_spread.zig`
- `git diff --check`
