### PR TITLE
fix: detect template Math.pow property

### DIFF
--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -97,10 +97,21 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -7,6 +7,7 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
         \\Math.pow(base, exponent);
         \\(Math).pow(2, 8);
         \\Math["pow"](2, 8);
+        \\Math[`pow`](2, 8);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +21,7 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_exponentiation_operator.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_exponentiation_operator.id));
     try std.testing.expectEqualStrings(
         "Use the exponentiation operator (**) instead of Math.pow.",
         result.diagnostics[0].message,
@@ -32,6 +33,7 @@ test "does not report prefer-exponentiation-operator for other calls or shadowed
         \\Math.max(base, exponent);
         \\Math.pow(base);
         \\Math.pow(base, exponent, modulo);
+        \\Math[`po${letter}`](base, exponent);
         \\const Math = { pow() {} };
         \\Math.pow(base, exponent);
     ;


### PR DESCRIPTION
## Summary

- detect no-substitution template property names such as ``Math[`pow`]``
- keep dynamic computed property names ignored

## Why

ESLint reports ``Math[`pow`](base, exponent)`` as `prefer-exponentiation-operator` because the property name is statically equivalent to `pow`. The previous implementation only handled `.pow` and `["pow"]`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_exponentiation_operator.zig tests/rules/prefer_exponentiation_operator.zig`
- `git diff --check`
