### PR TITLE
fix: detect template hasOwnProperty helpers

### DIFF
--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -117,10 +117,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/prefer_object_has_own.zig
+++ b/tests/rules/prefer_object_has_own.zig
@@ -8,6 +8,7 @@ test "reports prefer-object-has-own for hasOwnProperty call helpers" {
         \\Object.hasOwnProperty.call(object, "key");
         \\({}).hasOwnProperty.call(object, "key");
         \\Object["prototype"]["hasOwnProperty"]["call"](object, "key");
+        \\Object[`prototype`][`hasOwnProperty`][`call`](object, "key");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +20,7 @@ test "reports prefer-object-has-own for hasOwnProperty call helpers" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_object_has_own.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_object_has_own.id));
     try std.testing.expectEqualStrings(
         "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
         result.diagnostics[0].message,
@@ -32,6 +33,7 @@ test "does not report prefer-object-has-own for other calls or shadowed Object" 
         \\Object.prototype.propertyIsEnumerable.call(object, "key");
         \\object.hasOwnProperty("key");
         \\Object.prototype.hasOwnProperty.apply(object, ["key"]);
+        \\Object[`proto${suffix}`][`hasOwnProperty`][`call`](object, "key");
         \\function local(Object) {
         \\  Object.prototype.hasOwnProperty.call(object, "key");
         \\  Object.hasOwnProperty.call(object, "key");


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `Object.prototype.hasOwnProperty.call()` helper chains
- keep dynamic computed property names ignored

## Why

ESLint reports helper calls such as ``Object[`prototype`][`hasOwnProperty`][`call`](object, "key")`` for `prefer-object-has-own`, because each property name is statically equivalent to the dotted form. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/prefer_object_has_own.zig tests/rules/prefer_object_has_own.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
