### PR TITLE
fix: detect template prototype builtins

### DIFF
--- a/src/rules/no_prototype_builtins.zig
+++ b/src/rules/no_prototype_builtins.zig
@@ -54,12 +54,25 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     if (member.computed) {
         return switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         };
     }
 
     return switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_prototype_builtins.zig
+++ b/tests/rules/no_prototype_builtins.zig
@@ -8,6 +8,9 @@ test "reports no-prototype-builtins for direct object prototype method calls" {
         \\foo.isPrototypeOf(bar);
         \\foo.propertyIsEnumerable("bar");
         \\foo["hasOwnProperty"]("bar");
+        \\foo[`hasOwnProperty`]("bar");
+        \\foo[`isPrototypeOf`](bar);
+        \\foo[`propertyIsEnumerable`]("bar");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,15 +20,17 @@ test "reports no-prototype-builtins for direct object prototype method calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_prototype_builtins.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_prototype_builtins.id));
 }
 
 test "does not report no-prototype-builtins for safe prototype calls or other members" {
     const source =
         \\Object.prototype.hasOwnProperty.call(foo, "bar");
         \\Object.prototype.propertyIsEnumerable.call(foo, "bar");
+        \\Object[`prototype`].hasOwnProperty.call(foo, "bar");
         \\foo.hasOwn("bar");
         \\foo[method]("bar");
+        \\foo[`has${suffix}`]("bar");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names for `no-prototype-builtins`
- keep dynamic computed property names ignored
- continue allowing safe `Object.prototype` helper calls

## Why

ESLint reports calls such as ``foo[`hasOwnProperty`]("bar")`` because the computed template property is statically equivalent to `foo.hasOwnProperty("bar")`. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/no_prototype_builtins.zig tests/rules/no_prototype_builtins.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
