### PR TITLE
fix: allow template console methods

### DIFF
--- a/src/rules/no_console.zig
+++ b/src/rules/no_console.zig
@@ -63,10 +63,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_console.zig
+++ b/tests/rules/no_console.zig
@@ -21,6 +21,8 @@ test "allows configured no-console methods" {
     const source =
         \\console.warn(value);
         \\console["error"](value);
+        \\console[`warn`](value);
+        \\console[`wa${suffix}`](value);
         \\console.log(value);
     ;
 
@@ -36,7 +38,7 @@ test "allows configured no-console methods" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_console.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_console.id));
 }
 
 test "can disable no-console" {


### PR DESCRIPTION
## Summary

- read no-substitution template property names in `no-console`
- allow configured console methods such as ``console[`warn`]()``
- keep dynamic computed console methods reported

## Why

ESLint treats ``console[`warn`]()`` as the statically named `warn` method for the `no-console` `allow` option. The previous implementation only resolved dotted methods and string-literal computed methods, so the template form was reported even when `warn` was configured as allowed.

## Validation

- `zig fmt --check src/rules/no_console.zig tests/rules/no_console.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
