### PR TITLE
fix: detect template alert members

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -221,10 +221,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_alert.zig
+++ b/tests/rules/no_alert.zig
@@ -10,6 +10,8 @@ test "reports no-alert for global alert APIs" {
         \\window.alert("hello");
         \\globalThis.prompt("name");
         \\window["confirm"]("continue?");
+        \\window[`alert`]("hello");
+        \\globalThis[`prompt`]("name");
         \\(alert)("wrapped");
     ;
 
@@ -21,13 +23,30 @@ test "reports no-alert for global alert APIs" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_alert.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.no_alert.id));
 }
 
 test "does not report no-alert for shadowed alert" {
     const source =
         \\const alert = customAlert;
         \\alert("custom");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_alert.id));
+}
+
+test "does not report no-alert for dynamic global member names" {
+    const source =
+        \\window[`al${suffix}`]("hello");
+        \\globalThis[name]("name");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names for `no-alert` global member calls
- keep dynamic computed member names ignored
- cover `window` and `globalThis` template member forms

## Why

ESLint reports calls such as ``window[`alert`]("hello")`` and ``globalThis[`prompt`]("name")`` for `no-alert` because the property names are statically equivalent to dotted member calls. The shared global call checker previously only resolved dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/global_call_checks.zig src/rules/no_alert.zig tests/rules/no_alert.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
