### PR TITLE
fix: detect template proto property

### DIFF
--- a/src/rules/no_proto.zig
+++ b/src/rules/no_proto.zig
@@ -33,10 +33,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_proto.zig
+++ b/tests/rules/no_proto.zig
@@ -8,6 +8,8 @@ test "reports no-proto for proto member access" {
         \\obj["__proto__"] = b;
         \\const c = obj.__proto__;
         \\const d = obj["__proto__"];
+        \\obj[`__proto__`] = e;
+        \\const f = obj[`__proto__`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +20,7 @@ test "reports no-proto for proto member access" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(helpers.hasRule(result, lint.rules.no_proto.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_proto.id));
 }
 
 test "does not report no-proto for object literal proto property" {
@@ -27,6 +29,7 @@ test "does not report no-proto for object literal proto property" {
         \\  __proto__: null,
         \\  a: 1,
         \\};
+        \\const value = obj[`__${name}__`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names for `no-proto`
- keep dynamic computed property names ignored

## Why

ESLint reports ``obj[`__proto__`]`` for `no-proto` because the computed template property is statically equivalent to `obj.__proto__`. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/no_proto.zig tests/rules/no_proto.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
