### PR TITLE
fix: detect template iterator property

### DIFF
--- a/src/rules/no_iterator.zig
+++ b/src/rules/no_iterator.zig
@@ -33,10 +33,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_iterator.zig
+++ b/tests/rules/no_iterator.zig
@@ -8,6 +8,8 @@ test "reports no-iterator for iterator member access" {
         \\foo["__iterator__"] = bar;
         \\const iterator = foo.__iterator__;
         \\const iterator2 = foo["__iterator__"];
+        \\foo[`__iterator__`] = bar;
+        \\const iterator3 = foo[`__iterator__`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +19,7 @@ test "reports no-iterator for iterator member access" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_iterator.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_iterator.id));
 }
 
 test "does not report no-iterator for object literal properties or other members" {
@@ -27,6 +29,7 @@ test "does not report no-iterator for object literal properties or other members
         \\  other: foo.__iter__,
         \\};
         \\foo[iterator] = bar;
+        \\foo[`__${name}__`] = bar;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names for `no-iterator`
- keep dynamic computed property names ignored

## Why

ESLint reports ``foo[`__iterator__`]`` for `no-iterator` because the computed template property is statically equivalent to `foo.__iterator__`. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/no_iterator.zig tests/rules/no_iterator.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
