### PR TITLE
fix: detect template apply for spread

### DIFF
--- a/src/rules/prefer_spread.zig
+++ b/src/rules/prefer_spread.zig
@@ -84,10 +84,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/prefer_spread.zig
+++ b/tests/rules/prefer_spread.zig
@@ -9,6 +9,7 @@ test "reports prefer-spread for apply calls that can use spread syntax" {
         \\obj.method.apply(obj, args);
         \\this.method.apply(this, args);
         \\obj.nested.method.apply(obj.nested, args);
+        \\fn[`apply`](undefined, args);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +19,7 @@ test "reports prefer-spread for apply calls that can use spread syntax" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_spread.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.prefer_spread.id));
 }
 
 test "does not report prefer-spread when spread conversion is unsafe or covered by no-useless-call" {
@@ -30,6 +31,7 @@ test "does not report prefer-spread when spread conversion is unsafe or covered 
         \\fn.apply(null, ...args);
         \\fn?.apply(null, args);
         \\obj.method.apply?.(obj, args);
+        \\fn[`ap${suffix}`](undefined, args);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names for `prefer-spread`
- keep dynamic computed property names ignored

## Why

ESLint reports calls such as ``fn[`apply`](undefined, args)`` for `prefer-spread` because the computed template property is statically equivalent to `fn.apply(...)`. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/prefer_spread.zig tests/rules/prefer_spread.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
