### PR TITLE
fix: detect static Number.parseInt literals

### DIFF
--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -130,17 +130,41 @@ fn isGlobalParseIntCall(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.computed or member.optional or member.property == .null) return false;
+    if (member.optional or member.property == .null) return false;
 
-    const property = switch (tree.data(member.property)) {
-        .identifier_name => |identifier| tree.string(identifier.name),
-        else => return false,
-    };
+    const property = propertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, property, "parseInt")) return false;
 
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
     return std.mem.eql(u8, object_name, "Number") and isUnresolvedReference(symbol_table, object);
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/prefer_numeric_literals.zig
+++ b/tests/rules/prefer_numeric_literals.zig
@@ -7,18 +7,22 @@ test "reports prefer-numeric-literals for parseInt calls that can be numeric lit
         \\parseInt("101", 2);
         \\parseInt("755", 8);
         \\Number.parseInt("ff", 16);
+        \\Number["parseInt"]("ff", 16);
+        \\Number[`parseInt`]("ff", 16);
         \\parseInt(`a0`, 16);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
+        .typescript_eslint_dot_notation = false,
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
     try std.testing.expectEqualStrings("Use a binary literal instead of parseInt().", result.diagnostics[0].message);
 }
 
@@ -49,7 +53,7 @@ test "allows parseInt calls without static string and binary octal or hexadecima
         \\parseInt(`a${value}`, 16);
         \\parseInt("101", radix);
         \\parseInt("101", 2, extra);
-        \\Number["parseInt"]("ff", 16);
+        \\Number[`parse${suffix}`]("ff", 16);
         \\function local(parseInt, Number) {
         \\  parseInt("101", 2);
         \\  Number.parseInt("ff", 16);


### PR DESCRIPTION
## Summary

- report `Number["parseInt"](...)` in `prefer-numeric-literals`
- report no-substitution template property names such as ``Number[`parseInt`](...)``
- keep dynamic computed property names ignored

## Why

ESLint reports `Number["parseInt"]("ff", 16)` and ``Number[`parseInt`]("ff", 16)`` for `prefer-numeric-literals` because both properties are statically equivalent to `Number.parseInt`. The previous implementation only handled dotted `Number.parseInt`.

## Validation

- `zig fmt --check src/rules/prefer_numeric_literals.zig tests/rules/prefer_numeric_literals.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
