### PR TITLE
fix: detect template native extensions

### DIFF
--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -113,10 +113,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -6,6 +6,7 @@ test "reports no-extend-native for native prototype assignments" {
     const source =
         \\String.prototype.trimLeft = function () {};
         \\Array.prototype["first"] = function () {};
+        \\Array[`prototype`].first = function () {};
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -22,14 +23,18 @@ test "reports no-extend-native for native prototype assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_extend_native.id));
     try std.testing.expectEqualStrings("String prototype is read only, properties should not be added.", result.diagnostics[0].message);
 }
 
 test "reports no-extend-native for Object defineProperty calls" {
     const source =
         \\Object.defineProperty(Date.prototype, "week", { value: function () {} });
+        \\Object[`defineProperty`](Array.prototype, "first", {});
         \\Object.defineProperties(Map.prototype, {
+        \\  first: { value: function () {} },
+        \\});
+        \\Object[`defineProperties`](Set.prototype, {
         \\  first: { value: function () {} },
         \\});
     ;
@@ -48,7 +53,7 @@ test "reports no-extend-native for Object defineProperty calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_extend_native.id));
 }
 
 test "does not report no-extend-native for shadowed constructors or ordinary objects" {
@@ -61,6 +66,8 @@ test "does not report no-extend-native for shadowed constructors or ordinary obj
         \\  defineProperty() {},
         \\};
         \\Object.defineProperty(Array.prototype, "first", {});
+        \\Array[`proto${suffix}`].first = function () {};
+        \\Object[`define${suffix}`](Array.prototype, "first", {});
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-extend-native`
- cover native prototype access such as ``Array[`prototype`]``
- cover `Object` helpers such as ``Object[`defineProperty`]`` and ``Object[`defineProperties`]``
- keep dynamic computed property names ignored

## Why

ESLint reports static computed forms of native prototype extensions because they are equivalent to dotted member access. The previous implementation only handled dotted properties and string-literal computed properties.

## Validation

- `zig fmt --check src/rules/no_extend_native.zig tests/rules/no_extend_native.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
