### PR TITLE
fix: detect template array callbacks

### DIFF
--- a/src/rules/array_callback_return.zig
+++ b/src/rules/array_callback_return.zig
@@ -367,10 +367,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/array_callback_return.zig
+++ b/tests/rules/array_callback_return.zig
@@ -12,6 +12,9 @@ test "reports array-callback-return when callbacks can fall through" {
         \\items.filter(function(item) {
         \\  return void item;
         \\});
+        \\items[`map`](function(item) {
+        \\  item.value;
+        \\});
         \\Array.from(items, function(item) {
         \\  item.toString();
         \\});
@@ -27,7 +30,7 @@ test "reports array-callback-return when callbacks can fall through" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.array_callback_return.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.array_callback_return.id));
 }
 
 test "does not report array-callback-return for callbacks that return on all paths" {
@@ -90,6 +93,9 @@ test "ignores forEach callbacks and non-function callback references" {
         \\  item.toString();
         \\});
         \\items.map(callback);
+        \\items[`ma${suffix}`](function(item) {
+        \\  item.value;
+        \\});
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -114,6 +120,9 @@ test "reports array-callback-return for forEach return values when checkForEach 
         \\items.forEach((item) => {
         \\  return void item.touch();
         \\});
+        \\items[`forEach`](function(item) {
+        \\  return item.id;
+        \\});
         \\items.forEach((item) => {
         \\  item.touch();
         \\});
@@ -130,7 +139,7 @@ test "reports array-callback-return for forEach return values when checkForEach 
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.array_callback_return.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.array_callback_return.id));
     try std.testing.expectEqualStrings(
         "Array.prototype.forEach() expects no useless return value from callback.",
         result.diagnostics[0].message,


### PR DESCRIPTION
## Summary

- detect no-substitution template method names in `array-callback-return`
- cover value-returning array callbacks such as ``items[`map`](...)``
- cover `checkForEach` with ``items[`forEach`](...)``
- keep dynamic computed method names ignored

## Why

ESLint treats static computed array method names as equivalent to dotted method calls for `array-callback-return`. The previous implementation only handled dotted method names and string-literal computed names.

## Validation

- `zig fmt --check src/rules/array_callback_return.zig tests/rules/array_callback_return.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
