### PR TITLE
fix: detect template eval members

### DIFF
--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -115,10 +115,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_eval.zig
+++ b/tests/rules/no_eval.zig
@@ -9,6 +9,7 @@ test "reports no-eval for direct indirect and global eval calls" {
         \\(0, eval)("code");
         \\window.eval("code");
         \\globalThis["eval"]("code");
+        \\globalThis[`eval`]("code");
         \\global.eval("code");
     ;
 
@@ -21,7 +22,7 @@ test "reports no-eval for direct indirect and global eval calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_eval.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_eval.id));
 }
 
 test "does not report no-eval for non-global eval members" {
@@ -29,6 +30,8 @@ test "does not report no-eval for non-global eval members" {
         \\const object = { eval() {} };
         \\object.eval("code");
         \\object["eval"]("code");
+        \\object[`eval`]("code");
+        \\globalThis[`ev${suffix}`]("code");
         \\const window = sandbox;
         \\window.eval("code");
     ;


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-eval`
- cover global eval calls such as ``globalThis[`eval`](...)``
- keep dynamic computed property names ignored

## Why

ESLint treats static computed property names as equivalent to dotted or string-literal member access for `no-eval`. The previous implementation handled dotted and string-literal global eval calls, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_eval.zig tests/rules/no_eval.zig`
- `zig build test --summary all -- no_eval`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
