### PR TITLE
fix: detect template implied eval members

### DIFF
--- a/src/rules/no_implied_eval.zig
+++ b/src/rules/no_implied_eval.zig
@@ -113,10 +113,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_implied_eval.zig
+++ b/tests/rules/no_implied_eval.zig
@@ -9,6 +9,7 @@ test "reports no-implied-eval for string timer and execScript calls" {
         \\execScript("alert(1)");
         \\window.setTimeout("alert(1)");
         \\globalThis["setInterval"]("tick()", 100);
+        \\globalThis[`setInterval`]("tick()", 100);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +21,7 @@ test "reports no-implied-eval for string timer and execScript calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_implied_eval.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_implied_eval.id));
 }
 
 test "does not report no-implied-eval for function arguments or shadowed calls" {
@@ -32,6 +33,7 @@ test "does not report no-implied-eval for function arguments or shadowed calls" 
         \\const window = sandbox;
         \\window.setTimeout("not global");
         \\object.setInterval("not global");
+        \\globalThis[`set${suffix}`]("not static");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-implied-eval`
- cover global timer calls such as ``globalThis[`setInterval`](...)``
- keep dynamic computed callee names ignored

## Why

ESLint treats static computed global timer names as equivalent to string-literal member access for `no-implied-eval`. The previous implementation handled dotted and string-literal members, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_implied_eval.zig tests/rules/no_implied_eval.zig`
- `zig build test --summary all -- no_implied_eval`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
