### PR TITLE
fix: detect template Function members

### DIFF
--- a/src/rules/no_new_func.zig
+++ b/src/rules/no_new_func.zig
@@ -125,10 +125,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_new_func.zig
+++ b/tests/rules/no_new_func.zig
@@ -9,6 +9,7 @@ test "reports no-new-func for Function constructor usage" {
         \\const c = Function.call(null, "return 1");
         \\const d = Function.apply(null, ["return 1"]);
         \\const e = Function.bind(null, "return 1");
+        \\const f = Function[`call`](null, "return 1");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,16 +20,18 @@ test "reports no-new-func for Function constructor usage" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_new_func.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_new_func.id));
 }
 
-test "does not report no-new-func for shadowed Function" {
+test "does not report no-new-func for shadowed Function or dynamic member names" {
     const source =
         \\function local(Function) {
         \\  const a = new Function("return 1");
         \\  const b = Function("return 1");
         \\  const c = Function.call(null, "return 1");
+        \\  const d = Function[`call`](null, "return 1");
         \\}
+        \\const d = Function[`ca${suffix}`](null, "return 1");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-new-func`
- cover `Function` helper calls such as ``Function[`call`](...)``
- keep dynamic computed member names and shadowed `Function` bindings ignored

## Why

ESLint treats static computed `Function.call/apply/bind` member names as equivalent to string-literal member access for `no-new-func`. The previous implementation handled dotted and string-literal members, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_new_func.zig tests/rules/no_new_func.zig`
- `zig build test --summary all -- no_new_func`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
