### PR TITLE
fix: detect template bind members

### DIFF
--- a/src/rules/no_extra_bind.zig
+++ b/src/rules/no_extra_bind.zig
@@ -152,10 +152,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -10,6 +10,9 @@ test "reports no-extra-bind for functions that do not use this" {
         \\const second = function () {
         \\  return value;
         \\}.bind();
+        \\const third = function () {
+        \\  return value;
+        \\}[`bind`](context);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +23,7 @@ test "reports no-extra-bind for functions that do not use this" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_bind.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_extra_bind.id));
     try std.testing.expectEqualStrings("The function binding is unnecessary.", result.diagnostics[0].message);
 }
 
@@ -50,6 +53,9 @@ test "does not report no-extra-bind when this or bound arguments are used" {
         \\  return value + 1;
         \\}.bind(context, value);
         \\const third = ((value) => value + 1).bind(context, value);
+        \\const fourth = function () {
+        \\  return value;
+        \\}[`bi${suffix}`](context);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-extra-bind`
- cover unnecessary bindings such as ``function () {}[`bind`](context)``
- keep dynamic computed bind names ignored

## Why

ESLint treats static computed `bind` member names as equivalent to string-literal member access for `no-extra-bind`. The previous implementation handled dotted and string-literal members, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_extra_bind.zig tests/rules/no_extra_bind.zig`
- `zig build test --summary all -- no_extra_bind`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
