### PR TITLE
fix: detect template indexOf coercions

### DIFF
--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -158,10 +158,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -7,6 +7,8 @@ test "reports no-implicit-coercion for boolean coercion" {
         \\const first = !!value;
         \\const second = ~items.indexOf(value);
         \\const third = ~items.lastIndexOf(value);
+        \\const fourth = ~items[`indexOf`](value);
+        \\const fifth = ~items[`lastIndexOf`](value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +19,7 @@ test "reports no-implicit-coercion for boolean coercion" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
     try std.testing.expectEqualStrings("Use `Boolean()` instead of double negation.", result.diagnostics[0].message);
 }
 
@@ -73,6 +75,7 @@ test "does not report no-implicit-coercion for explicit conversions" {
         \\const ninth = 1 * Number(value);
         \\const tenth = "" + "value";
         \\const eleventh = `value` + "";
+        \\const twelfth = ~items[`index${suffix}`](value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-implicit-coercion`
- cover bitwise coercions such as ``~items[`indexOf`](value)``
- cover static template `lastIndexOf` calls while keeping dynamic template member names ignored

## Why

ESLint treats static computed `indexOf` and `lastIndexOf` member names as equivalent to string-literal member access for `no-implicit-coercion`. The previous implementation handled dotted and string-literal members, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_implicit_coercion.zig tests/rules/no_implicit_coercion.zig`
- `zig build test --summary all -- no_implicit_coercion`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
