### PR TITLE
fix: detect template self assignments

### DIFF
--- a/src/rules/no_self_assign.zig
+++ b/src/rules/no_self_assign.zig
@@ -107,11 +107,24 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
             .identifier_reference => |identifier| tree.string(identifier.name),
             .string_literal => |literal| tree.string(literal.value),
             .numeric_literal => |literal| tree.string(literal.raw),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_self_assign.zig
+++ b/tests/rules/no_self_assign.zig
@@ -8,6 +8,7 @@ test "reports no-self-assign for equivalent assignment references" {
         \\foo ||= foo;
         \\object.value = object.value;
         \\this.value = this["value"];
+        \\object[`value`] = object[`value`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +18,7 @@ test "reports no-self-assign for equivalent assignment references" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_self_assign.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_self_assign.id));
 }
 
 test "does not report no-self-assign for different references or effectful objects" {
@@ -26,6 +27,7 @@ test "does not report no-self-assign for different references or effectful objec
         \\foo += foo;
         \\object.value = object.other;
         \\getObject().value = getObject().value;
+        \\object[`val${suffix}`] = object[`val${suffix}`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `no-self-assign`
- cover self assignments such as ``object[`value`] = object[`value`]``
- keep dynamic template member names ignored

## Why

ESLint treats static computed member names as equivalent to string-literal member access for `no-self-assign`. The previous implementation handled identifiers, string literals, and numeric literals, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/no_self_assign.zig tests/rules/no_self_assign.zig`
- `zig build test --summary all -- no_self_assign`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
