### PR TITLE
fix: detect template logical assignments

### DIFF
--- a/src/rules/logical_assignment_operators.zig
+++ b/src/rules/logical_assignment_operators.zig
@@ -285,11 +285,24 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
             .identifier_reference => |identifier| tree.string(identifier.name),
             .string_literal => |literal| tree.string(literal.value),
             .numeric_literal => |literal| tree.string(literal.raw),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/logical_assignment_operators.zig
+++ b/tests/rules/logical_assignment_operators.zig
@@ -12,6 +12,7 @@ test "reports logical-assignment-operators for self logical assignments" {
         \\third = third ?? fallback;
         \\object.value = object.value || fallback;
         \\this.ready = this.ready && fallback;
+        \\object[`value`] = object[`value`] || fallback;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -21,7 +22,7 @@ test "reports logical-assignment-operators for self logical assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
 }
 
 test "reports logical-assignment-operators for short-circuit assignment expressions" {
@@ -96,6 +97,7 @@ test "does not report logical-assignment-operators when shorthand would change m
         \\value ||= fallback;
         \\value || (other = fallback);
         \\object[getKey()] = object[getKey()] || fallback;
+        \\object[`val${suffix}`] = object[`val${suffix}`] || fallback;
         \\object.value = other.value || fallback;
         \\if (value) other = fallback;
         \\if (value != null) value = fallback;


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `logical-assignment-operators`
- cover assignments such as ``object[`value`] = object[`value`] || fallback``
- keep dynamic template member names ignored

## Why

ESLint treats static computed member names as equivalent to string-literal member access for `logical-assignment-operators`. The previous implementation handled identifiers, string literals, and numeric literals, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/logical_assignment_operators.zig tests/rules/logical_assignment_operators.zig`
- `zig build test --summary all -- logical_assignment_operators`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
