### PR TITLE
fix: detect template new-cap members

### DIFF
--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -65,10 +65,23 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -9,6 +9,8 @@ test "reports new-cap for lowercase constructors and uppercase function calls" {
         \\Foo();
         \\namespace.Foo();
         \\namespace["Foo"]();
+        \\new namespace[`foo`]();
+        \\namespace[`Foo`]();
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,14 +21,16 @@ test "reports new-cap for lowercase constructors and uppercase function calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.new_cap.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.new_cap.id));
 }
 
-test "does not report new-cap for conventional constructor usage or callable builtins" {
+test "does not report new-cap for conventional constructor usage callable builtins or dynamic members" {
     const source =
         \\new Foo();
         \\foo();
         \\new namespace.Foo();
+        \\new namespace[`fo${suffix}`]();
+        \\namespace[`Fo${suffix}`]();
         \\Array();
         \\Boolean();
         \\Date();


### PR DESCRIPTION
## Summary

- detect no-substitution template property names in `new-cap`
- cover lowercase constructor members such as ``new namespace[`foo`]()``
- cover uppercase function-call members such as ``namespace[`Foo`]()``
- keep dynamic template member names ignored

## Why

ESLint treats static computed member names as equivalent to string-literal member access for `new-cap`. The previous implementation handled dotted and string-literal members, but missed no-substitution template member names.

## Validation

- `zig fmt --check src/rules/new_cap.zig tests/rules/new_cap.zig`
- `zig build test --summary all -- new_cap`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
