### PR TITLE
fix: track computed accessor pairs

### DIFF
--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -275,8 +275,33 @@ fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]co
         .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
         .string_literal => |literal| tree.string(literal.value),
         .numeric_literal => |literal| tree.string(literal.raw),
+        .identifier_reference => if (computed) sourceSlice(tree, key) else null,
+        .template_literal => |literal| templateStringValue(tree, literal) orelse if (computed) sourceSlice(tree, key) else null,
         else => null,
     };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return null;
+
+    return tree.source[start..end];
 }
 
 fn propertyKeyEquals(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -45,6 +45,34 @@ test "reports accessor-pairs for class setters without getters" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.accessor_pairs.id));
 }
 
+test "reports accessor-pairs for computed setters without getters" {
+    const source =
+        \\const object = {
+        \\  set [`template`](next) {},
+        \\  set [dynamic](next) {},
+        \\  get [paired]() { return 1; },
+        \\  set [paired](next) {},
+        \\};
+        \\class Example {
+        \\  set [`template`](next) {}
+        \\  set [dynamic](next) {}
+        \\  get [paired]() { return 1; }
+        \\  set [paired](next) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.accessor_pairs.id));
+}
+
 test "reports accessor-pairs for property descriptors without get" {
     const source =
         \\Object.defineProperty(target, "value", {


### PR DESCRIPTION
## Summary

- track computed accessor keys in `accessor-pairs`
- cover static template setters such as ``set [`template`](next) {}``
- cover dynamic computed setters such as `set [dynamic](next) {}` while pairing matching computed getters/setters

## Why

ESLint reports missing getter/setter counterparts for computed accessors, including dynamic computed keys. The previous implementation skipped dynamic computed accessor names, so those setters were ignored entirely.

## Validation

- `zig fmt --check src/rules/accessor_pairs.zig tests/rules/accessor_pairs.zig`
- `zig build test --summary all -- accessor_pairs`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
