### PR TITLE
fix: track computed accessor grouping

### DIFF
--- a/src/rules/grouped_accessor_pairs.zig
+++ b/src/rules/grouped_accessor_pairs.zig
@@ -163,6 +163,31 @@ fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]co
         .private_identifier => |identifier| if (computed) null else tree.string(identifier.name),
         .string_literal => |literal| tree.string(literal.value),
         .numeric_literal => |literal| tree.string(literal.raw),
+        .identifier_reference => if (computed) sourceSlice(tree, key) else null,
+        .template_literal => |literal| templateStringValue(tree, literal) orelse if (computed) sourceSlice(tree, key) else null,
         else => null,
     };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return null;
+
+    return tree.source[start..end];
 }

--- a/tests/rules/grouped_accessor_pairs.zig
+++ b/tests/rules/grouped_accessor_pairs.zig
@@ -54,6 +54,45 @@ test "reports grouped-accessor-pairs for class accessors separated by other memb
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
 }
 
+test "reports grouped-accessor-pairs for computed accessors separated by other members" {
+    const source =
+        \\const object = {
+        \\  get [`template`]() {
+        \\    return 1;
+        \\  },
+        \\  other: 1,
+        \\  set [`template`](next) {},
+        \\  get [dynamic]() {
+        \\    return 2;
+        \\  },
+        \\  other2: 2,
+        \\  set [dynamic](next) {},
+        \\};
+        \\class Example {
+        \\  get [`template`]() {
+        \\    return 1;
+        \\  }
+        \\  method() {}
+        \\  set [`template`](next) {}
+        \\  get [dynamic]() {
+        \\    return 2;
+        \\  }
+        \\  method2() {}
+        \\  set [dynamic](next) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.grouped_accessor_pairs.id));
+}
+
 test "allows adjacent accessors in either order and distinct static pairs" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary

- track computed accessor keys in `grouped-accessor-pairs`
- cover static template accessors such as ``get [`template`]()``
- cover dynamic computed accessors such as `get [dynamic]()` while pairing matching getter/setter expressions

## Why

ESLint enforces grouping for computed getter/setter pairs, including dynamic computed keys. The previous implementation skipped dynamic computed accessor names, so separated computed accessor pairs were ignored.

## Validation

- `zig fmt --check src/rules/grouped_accessor_pairs.zig tests/rules/grouped_accessor_pairs.zig`
- `zig build test --summary all -- grouped_accessor_pairs`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
