### PR TITLE
fix: track static computed Object descriptors

### DIFF
--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -320,24 +320,27 @@ fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name:
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.computed) return false;
 
+    const property = staticMemberPropertyName(tree, member) orelse return false;
     return isIdentifierReferenceNamed(tree, member.object, object_name) and
-        isIdentifierNameNamed(tree, member.property, property_name);
+        std.mem.eql(u8, property, property_name);
+}
+
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
 }
 
 fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
     if (index == .null) return false;
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
-        else => false,
-    };
-}
-
-fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(index)) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
         else => false,
     };
 }

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -75,7 +75,17 @@ test "reports accessor-pairs for computed setters without getters" {
 
 test "reports accessor-pairs for property descriptors without get" {
     const source =
+        \\const suffix = "Property";
         \\Object.defineProperty(target, "value", {
+        \\  set(next) {}
+        \\});
+        \\Object["defineProperty"](target, "fourth", {
+        \\  set(next) {}
+        \\});
+        \\Object[`defineProperty`](target, "fifth", {
+        \\  set(next) {}
+        \\});
+        \\Object[`define${suffix}`](target, "dynamic", {
         \\  set(next) {}
         \\});
         \\Object.defineProperties(target, {
@@ -87,8 +97,28 @@ test "reports accessor-pairs for property descriptors without get" {
         \\    set(next) {}
         \\  }
         \\});
+        \\Object["defineProperties"](target, {
+        \\  sixth: {
+        \\    set(next) {}
+        \\  }
+        \\});
+        \\Object[`defineProperties`](target, {
+        \\  seventh: {
+        \\    set(next) {}
+        \\  }
+        \\});
         \\Object.create(proto, {
         \\  third: {
+        \\    set(next) {}
+        \\  }
+        \\});
+        \\Object["create"](proto, {
+        \\  eighth: {
+        \\    set(next) {}
+        \\  }
+        \\});
+        \\Object[`create`](proto, {
+        \\  ninth: {
         \\    set(next) {}
         \\  }
         \\});
@@ -103,7 +133,7 @@ test "reports accessor-pairs for property descriptors without get" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.accessor_pairs.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.accessor_pairs.id));
 }
 
 test "does not report accessor-pairs for getters without setters by default" {


### PR DESCRIPTION
## Summary

- Treat static computed `Object` descriptor helper calls as `accessor-pairs` descriptor sources.
- Cover string-literal and no-substitution template calls for `defineProperty`, `defineProperties`, and `create` while leaving dynamic templates ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/accessor_pairs.zig tests/rules/accessor_pairs.zig`
- `git diff --check`
