### PR TITLE
fix: track static computed getter descriptors

### DIFF
--- a/src/rules/getter_return.zig
+++ b/src/rules/getter_return.zig
@@ -179,10 +179,33 @@ fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name:
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.computed) return false;
 
+    const property = staticMemberPropertyName(tree, member) orelse return false;
     return isIdentifierReferenceNamed(tree, member.object, object_name) and
-        isIdentifierNameNamed(tree, member.property, property_name);
+        std.mem.eql(u8, property, property_name);
+}
+
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
 }
 
 fn isPropertyNamed(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
@@ -199,14 +222,6 @@ fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name:
     if (index == .null) return false;
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
-        else => false,
-    };
-}
-
-fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(index)) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
         else => false,
     };
 }

--- a/tests/rules/getter_return.zig
+++ b/tests/rules/getter_return.zig
@@ -45,8 +45,18 @@ test "reports getter-return for getters that do not return a value" {
 
 test "reports getter-return for descriptor getters that do not return a value" {
     const source =
+        \\const suffix = "Property";
         \\Object.defineProperty(target, "x", {
         \\  get: function () {}
+        \\});
+        \\Object["defineProperty"](target, "string", {
+        \\  get() {}
+        \\});
+        \\Object[`defineProperty`](target, "template", {
+        \\  get() {}
+        \\});
+        \\Object[`define${suffix}`](target, "dynamic", {
+        \\  get() {}
         \\});
         \\Object.defineProperties(target, {
         \\  y: {
@@ -57,11 +67,31 @@ test "reports getter-return for descriptor getters that do not return a value" {
         \\    }
         \\  }
         \\});
+        \\Object["defineProperties"](target, {
+        \\  string: {
+        \\    get() {}
+        \\  }
+        \\});
+        \\Object[`defineProperties`](target, {
+        \\  template: {
+        \\    get() {}
+        \\  }
+        \\});
         \\Object.create(proto, {
         \\  z: {
         \\    get: function () {
         \\      return;
         \\    }
+        \\  }
+        \\});
+        \\Object["create"](proto, {
+        \\  string: {
+        \\    get() {}
+        \\  }
+        \\});
+        \\Object[`create`](proto, {
+        \\  template: {
+        \\    get() {}
         \\  }
         \\});
     ;
@@ -74,7 +104,7 @@ test "reports getter-return for descriptor getters that do not return a value" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.getter_return.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.getter_return.id));
 }
 
 test "does not report getter-return when all getter paths return or throw" {


### PR DESCRIPTION
## Summary

- Treat static computed `Object` descriptor helper calls as descriptor contexts for `getter-return`.
- Cover string-literal and no-substitution template calls for `defineProperty`, `defineProperties`, and `create` while leaving dynamic templates ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/getter_return.zig tests/rules/getter_return.zig`
- `git diff --check`
