### PR TITLE
fix: track static computed setter descriptors

### DIFF
--- a/src/rules/no_setter_return.zig
+++ b/src/rules/no_setter_return.zig
@@ -123,10 +123,33 @@ fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name:
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.computed) return false;
 
+    const property = staticMemberPropertyName(tree, member) orelse return false;
     return isIdentifierReferenceNamed(tree, member.object, object_name) and
-        isIdentifierNameNamed(tree, member.property, property_name);
+        std.mem.eql(u8, property, property_name);
+}
+
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
 }
 
 fn isPropertyNamed(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
@@ -143,14 +166,6 @@ fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name:
     if (index == .null) return false;
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
-        else => false,
-    };
-}
-
-fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(index)) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
         else => false,
     };
 }

--- a/tests/rules/no_setter_return.zig
+++ b/tests/rules/no_setter_return.zig
@@ -28,7 +28,23 @@ test "reports no-setter-return for returning values from class and object setter
 
 test "reports no-setter-return for common property descriptor setters" {
     const source =
+        \\const suffix = "Property";
         \\Object.defineProperty(object, "value", {
+        \\  set(next) {
+        \\    return next;
+        \\  },
+        \\});
+        \\Object["defineProperty"](object, "string", {
+        \\  set(next) {
+        \\    return next;
+        \\  },
+        \\});
+        \\Object[`defineProperty`](object, "template", {
+        \\  set(next) {
+        \\    return next;
+        \\  },
+        \\});
+        \\Object[`define${suffix}`](object, "dynamic", {
         \\  set(next) {
         \\    return next;
         \\  },
@@ -40,9 +56,37 @@ test "reports no-setter-return for common property descriptor setters" {
         \\    },
         \\  },
         \\});
+        \\Object["defineProperties"](object, {
+        \\  string: {
+        \\    set(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
+        \\Object[`defineProperties`](object, {
+        \\  template: {
+        \\    set(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
         \\Object.create(proto, {
         \\  value: {
         \\    set: function(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
+        \\Object["create"](proto, {
+        \\  string: {
+        \\    set(next) {
+        \\      return next;
+        \\    },
+        \\  },
+        \\});
+        \\Object[`create`](proto, {
+        \\  template: {
+        \\    set(next) {
         \\      return next;
         \\    },
         \\  },
@@ -56,7 +100,7 @@ test "reports no-setter-return for common property descriptor setters" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_setter_return.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.no_setter_return.id));
 }
 
 test "does not report no-setter-return for bare returns methods or nested functions" {


### PR DESCRIPTION
## Summary

- Treat static computed `Object` descriptor helper calls as descriptor contexts for `no-setter-return`.
- Cover string-literal and no-substitution template calls for `defineProperty`, `defineProperties`, and `create` while leaving dynamic templates ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_setter_return.zig tests/rules/no_setter_return.zig`
- `git diff --check`
