### PR TITLE
fix: track computed Promise reject

### DIFF
--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -67,9 +67,10 @@ fn isGlobalPromiseRejectCall(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional or member.computed) return false;
+    if (member.optional) return false;
 
-    if (!isIdentifierNameNamed(tree, member.property, "reject")) return false;
+    const property = staticMemberPropertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "reject")) return false;
     return isGlobalPromiseReference(tree, symbol_table, member.object);
 }
 
@@ -251,11 +252,26 @@ fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name:
     };
 }
 
-fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(unwrapTransparent(tree, index))) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
-        else => false,
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
     };
 }
 

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -105,9 +105,10 @@ fn isGlobalPromiseRejectCall(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional or member.computed) return false;
+    if (member.optional) return false;
 
-    if (!isIdentifierNameNamed(tree, member.property, "reject")) return false;
+    const property = staticMemberPropertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, "reject")) return false;
     return isGlobalPromiseReference(tree, symbol_table, member.object);
 }
 
@@ -414,11 +415,26 @@ fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name:
     };
 }
 
-fn isIdentifierNameNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
-    if (index == .null) return false;
-    return switch (tree.data(unwrapTransparent(tree, index))) {
-        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
-        else => false,
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
     };
 }
 

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -4,7 +4,11 @@ const helpers = @import("../helpers.zig");
 
 test "reports prefer-promise-reject-errors for obvious non-error rejection reasons" {
     const source =
+        \\const suffix = "ject";
         \\Promise.reject("failed");
+        \\Promise["reject"]("failed");
+        \\Promise[`reject`]("failed");
+        \\Promise[`re${suffix}`]("dynamic");
         \\Promise.reject(1);
         \\Promise.reject(`failed`);
         \\Promise.reject(undefined);
@@ -26,7 +30,7 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
 test "does not report prefer-promise-reject-errors for error-like rejection reasons" {
@@ -54,6 +58,8 @@ test "does not report prefer-promise-reject-errors for shadowed Promise or neste
         \\  }
         \\};
         \\Promise.reject("local");
+        \\Promise["reject"]("local");
+        \\Promise[`reject`]("local");
         \\new Promise((resolve, reject) => {
         \\  function nested() {
         \\    reject("nested");


### PR DESCRIPTION
## Summary

- Treat static computed `Promise.reject` calls as `prefer-promise-reject-errors` targets.
- Cover string-literal and no-substitution template member names while leaving dynamic templates and shadowed Promise references ignored.
- Keep the standalone rule helper aligned with the active aggregated promise check implementation.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/promise_checks.zig src/rules/prefer_promise_reject_errors.zig tests/rules/prefer_promise_reject_errors.zig`
- `git diff --check`
