### PR TITLE
fix: report template dot notation

### DIFF
--- a/src/rules/dot_notation.zig
+++ b/src/rules/dot_notation.zig
@@ -33,10 +33,7 @@ pub fn checkWithOptions(
 ) Allocator.Error!void {
     if (!member.computed or member.property == .null) return;
 
-    const property_name = switch (tree.data(member.property)) {
-        .string_literal => |literal| tree.string(literal.value),
-        else => return,
-    };
+    const property_name = staticPropertyName(tree, member.property) orelse return;
     if (!isAsciiIdentifierName(property_name)) return;
     if (!options.allow_keywords and isKeyword(property_name)) return;
 
@@ -49,6 +46,26 @@ pub fn checkWithOptions(
         "['{s}'] is better written in dot notation.",
         .{property_name},
     );
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
 }
 
 fn isAsciiIdentifierName(name: []const u8) bool {

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -5,6 +5,7 @@ const helpers = @import("../helpers.zig");
 test "reports dot-notation for computed string properties that can use dot access" {
     const source =
         \\object["property"];
+        \\object[`template`];
         \\object["_private"];
         \\object["$value"];
         \\object["property1"];
@@ -22,7 +23,7 @@ test "reports dot-notation for computed string properties that can use dot acces
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.dot_notation.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.dot_notation.id));
     try std.testing.expectEqualStrings(
         "['property'] is better written in dot notation.",
         result.diagnostics[0].message,
@@ -31,10 +32,13 @@ test "reports dot-notation for computed string properties that can use dot acces
 
 test "does not report dot-notation when bracket access is required" {
     const source =
+        \\const suffix = "erty";
         \\object["not-valid"];
+        \\object[`not-valid`];
         \\object["123"];
         \\object[""];
         \\object[property];
+        \\object[`prop${suffix}`];
         \\object[call()];
     ;
 

--- a/tests/rules/typescript_eslint_dot_notation.zig
+++ b/tests/rules/typescript_eslint_dot_notation.zig
@@ -5,6 +5,7 @@ const helpers = @import("../helpers.zig");
 test "reports @typescript-eslint/dot-notation for computed string properties" {
     const source =
         \\object["property"];
+        \\object[`template`];
         \\object["_private"];
         \\object["$value"];
         \\object["property1"];
@@ -21,7 +22,7 @@ test "reports @typescript-eslint/dot-notation for computed string properties" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.typescript_eslint_dot_notation.id));
     try std.testing.expect(!helpers.hasRule(result, lint.rules.dot_notation.id));
     for (result.diagnostics) |diagnostic| {
         if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_dot_notation.id)) {
@@ -32,10 +33,13 @@ test "reports @typescript-eslint/dot-notation for computed string properties" {
 
 test "does not report @typescript-eslint/dot-notation when bracket access is required" {
     const source =
+        \\const suffix = "erty";
         \\object["not-valid"];
+        \\object[`not-valid`];
         \\object["123"];
         \\object[""];
         \\object[property];
+        \\object[`prop${suffix}`];
         \\object[call()];
     ;
 


### PR DESCRIPTION
## Summary

- Report `dot-notation` for static no-substitution template member access such as ``object[`property`]``.
- Keep dynamic template member access ignored.
- Cover both core `dot-notation` and the `@typescript-eslint/dot-notation` wrapper path.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/dot_notation.zig tests/rules/dot_notation.zig tests/rules/typescript_eslint_dot_notation.zig`
- `git diff --check`
