### PR TITLE
fix: check template typeof values

### DIFF
--- a/src/rules/valid_typeof.zig
+++ b/src/rules/valid_typeof.zig
@@ -59,6 +59,19 @@ fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/valid_typeof.zig
+++ b/tests/rules/valid_typeof.zig
@@ -5,6 +5,7 @@ const helpers = @import("../helpers.zig");
 test "reports valid-typeof for invalid typeof comparison strings" {
     const source =
         \\if (typeof value === "strnig") { use(value); }
+        \\if (typeof value === `strnig`) { use(value); }
         \\if ("undefimed" !== typeof value) { use(value); }
         \\if ((typeof value) == ("bool")) { use(value); }
     ;
@@ -17,12 +18,15 @@ test "reports valid-typeof for invalid typeof comparison strings" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.valid_typeof.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.valid_typeof.id));
 }
 
 test "does not report valid-typeof for valid values or unrelated comparisons" {
     const source =
+        \\const suffix = "nig";
         \\if (typeof value === "undefined") { use(value); }
+        \\if (typeof value === `string`) { use(value); }
+        \\if (typeof value === `str${suffix}`) { use(value); }
         \\if (typeof value !== "object") { use(value); }
         \\if (typeof value === "boolean") { use(value); }
         \\if (typeof value === "number") { use(value); }


### PR DESCRIPTION
## Summary

- Treat no-substitution template literals as literal comparison values for `valid-typeof`.
- Keep dynamic template typeof comparisons ignored.
- Add coverage for invalid static templates and valid/dynamic template cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/valid_typeof.zig tests/rules/valid_typeof.zig`
- `git diff --check`
