### PR TITLE
fix: validate regexp flags first

### DIFF
--- a/src/rules/no_invalid_regexp.zig
+++ b/src/rules/no_invalid_regexp.zig
@@ -59,10 +59,25 @@ const Visitor = struct {
         if (arguments.len == 0) return;
         if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
 
-        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
-        const flags = if (arguments.len >= 2) stringLiteralValue(tree, arguments[1]) orelse return else "";
+        const flags = if (arguments.len >= 2) stringLiteralValue(tree, arguments[1]) else null;
+        if (flags) |value| {
+            if (validateFlags(value)) |message| {
+                try self.addDiagnostic(tree, index, message);
+                return;
+            }
+        }
 
-        const message = validateRegExp(pattern, flags) orelse return;
+        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
+        const message = validatePattern(pattern) orelse return;
+        try self.addDiagnostic(tree, index, message);
+    }
+
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        message: []const u8,
+    ) Allocator.Error!void {
         try core.addDiagnosticFmt(
             self.allocator,
             self.diagnostics,
@@ -74,11 +89,6 @@ const Visitor = struct {
         );
     }
 };
-
-fn validateRegExp(pattern: []const u8, flags: []const u8) ?[]const u8 {
-    if (validateFlags(flags)) |message| return message;
-    return validatePattern(pattern);
-}
 
 fn validateFlags(flags: []const u8) ?[]const u8 {
     var seen: u32 = 0;

--- a/tests/rules/no_invalid_regexp.zig
+++ b/tests/rules/no_invalid_regexp.zig
@@ -9,6 +9,8 @@ test "reports no-invalid-regexp for invalid RegExp constructor arguments" {
         \\RegExp("abc", "zz");
         \\RegExp("abc", "gg");
         \\RegExp("abc", "uv");
+        \\RegExp(pattern, "z");
+        \\RegExp(`abc`, "z");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +20,7 @@ test "reports no-invalid-regexp for invalid RegExp constructor arguments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
 }
 
 test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
@@ -26,6 +28,8 @@ test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
         \\RegExp("abc", "gi");
         \\new RegExp("[abc]", "u");
         \\RegExp(pattern, flags);
+        \\RegExp(`[`, `z`);
+        \\RegExp(pattern, `z`);
         \\function local(RegExp) {
         \\  RegExp("(", "z");
         \\}


### PR DESCRIPTION
## Summary

- Validate static string RegExp flags before requiring a static pattern.
- Match ESLint behavior for invalid flags with dynamic or template patterns, while keeping template flags ignored.
- Add regression coverage for dynamic patterns and template-pattern/template-flag cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_invalid_regexp.zig tests/rules/no_invalid_regexp.zig`
- `git diff --check`
