### PR TITLE
fix: report template regex constructors

### DIFF
--- a/src/rules/prefer_regex_literals.zig
+++ b/src/rules/prefer_regex_literals.zig
@@ -77,9 +77,9 @@ fn isStaticRegExpConstructor(
     if (!isGlobalRegExpReference(tree, symbol_table, callee)) return false;
 
     const pattern = arguments[0];
-    if (!isStringLiteral(tree, pattern)) return false;
+    if (!isStaticLiteral(tree, pattern)) return false;
 
-    if (arguments.len == 2 and !isStringLiteral(tree, arguments[1])) return false;
+    if (arguments.len == 2 and !isStaticLiteral(tree, arguments[1])) return false;
     return true;
 }
 
@@ -93,9 +93,10 @@ fn isGlobalRegExpReference(
     return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
 }
 
-fn isStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn isStaticLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
+        .template_literal => |literal| literal.expressions.len == 0,
         else => false,
     };
 }

--- a/tests/rules/prefer_regex_literals.zig
+++ b/tests/rules/prefer_regex_literals.zig
@@ -5,8 +5,12 @@ const helpers = @import("../helpers.zig");
 test "reports prefer-regex-literals for static RegExp constructors" {
     const source =
         \\RegExp("abc");
+        \\RegExp(`abc`);
         \\new RegExp("abc");
         \\new RegExp("abc", "u");
+        \\new RegExp(`abc`, "u");
+        \\new RegExp("abc", `u`);
+        \\new RegExp(`abc`, `u`);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +22,7 @@ test "reports prefer-regex-literals for static RegExp constructors" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_regex_literals.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.prefer_regex_literals.id));
     try std.testing.expectEqualStrings(
         "Use a regular expression literal instead of the RegExp constructor.",
         result.diagnostics[0].message,
@@ -27,7 +31,9 @@ test "reports prefer-regex-literals for static RegExp constructors" {
 
 test "does not report prefer-regex-literals for dynamic patterns or shadowed RegExp" {
     const source =
+        \\const suffix = "bc";
         \\RegExp(pattern);
+        \\RegExp(`a${suffix}`);
         \\RegExp("abc", flags);
         \\RegExp("abc", "u", "extra");
         \\const RegExp = function () {};


### PR DESCRIPTION
## Summary

- Treat no-substitution template literals as static RegExp constructor pattern and flag arguments for `prefer-regex-literals`.
- Keep dynamic template patterns ignored.
- Add coverage for static template pattern/flag combinations.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_regex_literals.zig tests/rules/prefer_regex_literals.zig`
- `git diff --check`
