### PR TITLE
fix: report all literal path concats

### DIFF
--- a/src/rules/no_path_concat.zig
+++ b/src/rules/no_path_concat.zig
@@ -44,26 +44,11 @@ fn isPathMetaIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 
 fn isStringLikePathPart(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
-        .string_literal => |literal| containsPathSeparator(tree.string(literal.value)),
-        .template_literal => |template| template.expressions.len == 0 and containsPathSeparator(sourceSlice(tree, index) orelse ""),
+        .string_literal,
+        .template_literal,
+        => true,
         else => false,
     };
-}
-
-fn containsPathSeparator(value: []const u8) bool {
-    return std.mem.indexOfScalar(u8, value, '/') != null or
-        std.mem.indexOfScalar(u8, value, '\\') != null;
-}
-
-fn sourceSlice(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
-    if (index == .null) return null;
-
-    const span = tree.span(unwrapTransparent(tree, index));
-    const start: usize = @intCast(span.start);
-    const end: usize = @intCast(span.end);
-
-    if (start >= end or end > tree.source.len) return null;
-    return tree.source[start..end];
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/no_path_concat.zig
+++ b/tests/rules/no_path_concat.zig
@@ -8,6 +8,8 @@ test "reports no-path-concat for dirname and filename path string concatenation"
         \\const second = __filename + "\\foo.js";
         \\const third = "/tmp/" + __dirname;
         \\const fourth = (__dirname) + `/foo.js`;
+        \\const fifth = __filename + ".bak";
+        \\const sixth = __dirname + `${name}.js`;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,15 +20,13 @@ test "reports no-path-concat for dirname and filename path string concatenation"
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_path_concat.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_path_concat.id));
 }
 
 test "does not report no-path-concat for non-path concatenation or path helpers" {
     const source =
         \\const name = __dirname + suffix;
-        \\const label = __filename + ".bak";
         \\const joined = path.join(__dirname, "foo.js");
-        \\const dynamic = __dirname + `${name}.js`;
         \\const ordinary = dirname + "/foo.js";
     ;
 


### PR DESCRIPTION
## Summary

- Match ESLint `no-path-concat` by reporting `__dirname`/`__filename` concatenated with any string or template literal.
- Cover suffix-only strings and dynamic templates that were previously ignored.
- Keep non-literal concatenation, path helpers, and ordinary identifiers ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_path_concat.zig tests/rules/no_path_concat.zig`
- `git diff --check`
