### PR TITLE
fix: report template literal concat

### DIFF
--- a/src/rules/no_useless_concat.zig
+++ b/src/rules/no_useless_concat.zig
@@ -33,7 +33,7 @@ fn isStringLikeLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
-        .template_literal => |template| template.expressions.len == 0,
+        .template_literal => true,
         else => false,
     };
 }

--- a/tests/rules/no_useless_concat.zig
+++ b/tests/rules/no_useless_concat.zig
@@ -6,6 +6,9 @@ test "reports no-useless-concat for same line string literal concatenation" {
     const source =
         \\const first = "foo" + "bar";
         \\const second = `foo` + "bar";
+        \\const third = "foo" + `bar`;
+        \\const fourth = `foo` + `bar`;
+        \\const fifth = `foo ${value}` + "bar";
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -15,13 +18,12 @@ test "reports no-useless-concat for same line string literal concatenation" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_concat.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_concat.id));
 }
 
 test "does not report no-useless-concat for dynamic or multiline concatenation" {
     const source =
         \\const dynamic = "foo" + value;
-        \\const templated = `foo ${value}` + "bar";
         \\const multiline = "foo" +
         \\  "bar";
     ;


### PR DESCRIPTION
## Summary

- Treat all template literals as string-like literals for `no-useless-concat`, matching ESLint behavior.
- Add coverage for string/template, template/template, and interpolated-template concatenation.
- Keep multiline and non-literal concatenation ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_concat.zig tests/rules/no_useless_concat.zig`
- `git diff --check`
