### PR TITLE
fix: align no-useless-escape class escapes

### DIFF
--- a/src/rules/no_useless_escape.zig
+++ b/src/rules/no_useless_escape.zig
@@ -112,11 +112,18 @@ fn checkRegExpPattern(
 ) Allocator.Error!void {
     var offset: usize = 0;
     var in_class = false;
+    var class_start: ?usize = null;
 
     while (offset < pattern.len) {
         const char = pattern[offset];
-        if (char == '[') in_class = true;
-        if (char == ']' and in_class) in_class = false;
+        if (char == '[' and !in_class) {
+            in_class = true;
+            class_start = offset;
+        }
+        if (char == ']' and in_class) {
+            in_class = false;
+            class_start = null;
+        }
 
         if (char != '\\' or offset + 1 >= pattern.len) {
             offset += 1;
@@ -124,7 +131,7 @@ fn checkRegExpPattern(
         }
 
         const escaped = pattern[offset + 1];
-        if (!isNecessaryRegExpEscape(escaped, in_class)) {
+        if (!isNecessaryRegExpEscape(pattern, offset, escaped, in_class, class_start)) {
             try addDiagnostic(allocator, diagnostics, span, escaped);
         }
 
@@ -132,16 +139,22 @@ fn checkRegExpPattern(
     }
 }
 
-fn isNecessaryRegExpEscape(escaped: u8, in_class: bool) bool {
+fn isNecessaryRegExpEscape(
+    pattern: []const u8,
+    offset: usize,
+    escaped: u8,
+    in_class: bool,
+    class_start: ?usize,
+) bool {
     if (std.ascii.isAlphanumeric(escaped)) return true;
 
     if (in_class) {
         return switch (escaped) {
             '\\',
             ']',
-            '^',
-            '-',
             => true,
+            '^' => class_start != null and offset == class_start.? + 1,
+            '-' => isEscapedHyphenRangeOperator(pattern, offset, class_start),
             else => false,
         };
     }
@@ -165,6 +178,18 @@ fn isNecessaryRegExpEscape(escaped: u8, in_class: bool) bool {
         => true,
         else => false,
     };
+}
+
+fn isEscapedHyphenRangeOperator(pattern: []const u8, offset: usize, class_start: ?usize) bool {
+    const start = class_start orelse return false;
+    if (offset <= start + 1) return false;
+
+    var first_element = start + 1;
+    if (first_element < pattern.len and pattern[first_element] == '^') first_element += 1;
+    if (first_element >= offset) return false;
+
+    const after_escape = offset + 2;
+    return after_escape < pattern.len and pattern[after_escape] != ']';
 }
 
 fn addDiagnostic(

--- a/tests/rules/no_useless_escape.zig
+++ b/tests/rules/no_useless_escape.zig
@@ -25,6 +25,13 @@ test "reports no-useless-escape for unnecessary regular expression escapes" {
         \\const a = /\#/;
         \\const b = /[\#]/;
         \\const c = /\-/;
+        \\const d = /[\-]/;
+        \\const e = /[a\-]/;
+        \\const f = /[\-a]/;
+        \\const g = /[a\-z\-]/;
+        \\const h = /[^\^]/;
+        \\const i = /[a\^]/;
+        \\const j = /[\]\-\^]/;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -33,7 +40,7 @@ test "reports no-useless-escape for unnecessary regular expression escapes" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_useless_escape.id));
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_useless_escape.id));
 }
 
 test "does not report no-useless-escape for necessary escapes" {
@@ -44,7 +51,9 @@ test "does not report no-useless-escape for necessary escapes" {
         \\const d = "\n\t\x20\u0020";
         \\const e = `\`${value}\${literal}`;
         \\const f = /\d+\.\w+\/x/;
-        \\const g = /[\]\-\^]/;
+        \\const h = /[a\-z]/;
+        \\const i = /[\^]/;
+        \\const j = /[\^a]/;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-useless-escape` with ESLint for position-sensitive escapes inside regular expression character classes
- report unnecessary escaped hyphens at the start/end of character classes while preserving range cases such as `[a\-z]`
- report unnecessary escaped carets when they are not the leading literal caret in a non-negated character class

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_escape.zig tests/rules/no_useless_escape.zig`
- `git diff --check`
