### PR TITLE
fix: align no-obj-calls forbidden globals

### DIFF
--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -118,8 +118,7 @@ fn isForbiddenObject(name: []const u8) bool {
         std.mem.eql(u8, name, "JSON") or
         std.mem.eql(u8, name, "Reflect") or
         std.mem.eql(u8, name, "Atomics") or
-        std.mem.eql(u8, name, "Intl") or
-        std.mem.eql(u8, name, "Temporal");
+        std.mem.eql(u8, name, "Intl");
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/no_obj_calls.zig
+++ b/src/rules/no_obj_calls.zig
@@ -105,8 +105,7 @@ fn isForbiddenObject(name: []const u8) bool {
         std.mem.eql(u8, name, "JSON") or
         std.mem.eql(u8, name, "Reflect") or
         std.mem.eql(u8, name, "Atomics") or
-        std.mem.eql(u8, name, "Intl") or
-        std.mem.eql(u8, name, "Temporal");
+        std.mem.eql(u8, name, "Intl");
 }
 
 fn isUnresolvedReference(

--- a/tests/rules/no_obj_calls.zig
+++ b/tests/rules/no_obj_calls.zig
@@ -9,7 +9,6 @@ test "reports no-obj-calls for global object calls" {
         \\Reflect();
         \\Atomics();
         \\Intl();
-        \\Temporal();
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +18,7 @@ test "reports no-obj-calls for global object calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_obj_calls.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
 test "reports no-obj-calls for global object constructors" {
@@ -29,7 +28,6 @@ test "reports no-obj-calls for global object constructors" {
         \\new Reflect();
         \\new Atomics();
         \\new Intl();
-        \\new Temporal();
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -40,13 +38,15 @@ test "reports no-obj-calls for global object constructors" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_obj_calls.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
-test "does not report no-obj-calls for member calls or shadowed names" {
+test "does not report no-obj-calls for member calls allowed globals or shadowed names" {
     const source =
         \\Math.max(1, 2);
         \\JSON.parse("{}");
+        \\Temporal();
+        \\new Temporal();
         \\function run(Math, JSON) {
         \\  Math();
         \\  new JSON();


### PR DESCRIPTION
## Summary

- align `no-obj-calls` with ESLint's default forbidden global object list
- stop reporting `Temporal()` and `new Temporal()` as `no-obj-calls`
- update the shared native-object check path and the standalone rule helper list

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_obj_calls.zig src/rules/native_object_checks.zig tests/rules/no_obj_calls.zig`
- `git diff --check`
