### PR TITLE
fix: align no-implied-eval globals

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -189,7 +189,7 @@ fn isImpliedEvalCallee(
 
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
-    return isEvalGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+    return isImpliedEvalGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
@@ -277,4 +277,8 @@ fn isEvalGlobalObjectName(name: []const u8) bool {
     return std.mem.eql(u8, name, "window") or
         std.mem.eql(u8, name, "globalThis") or
         std.mem.eql(u8, name, "global");
+}
+
+fn isImpliedEvalGlobalObjectName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "globalThis");
 }

--- a/src/rules/no_implied_eval.zig
+++ b/src/rules/no_implied_eval.zig
@@ -81,7 +81,7 @@ fn isImpliedEvalCallee(
 
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
-    return isGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+    return isImpliedEvalGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
@@ -140,10 +140,8 @@ fn isImpliedEvalName(name: []const u8) bool {
         std.mem.eql(u8, name, "execScript");
 }
 
-fn isGlobalObjectName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "window") or
-        std.mem.eql(u8, name, "globalThis") or
-        std.mem.eql(u8, name, "global");
+fn isImpliedEvalGlobalObjectName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "globalThis");
 }
 
 fn isUnresolvedReference(

--- a/tests/rules/no_implied_eval.zig
+++ b/tests/rules/no_implied_eval.zig
@@ -7,7 +7,7 @@ test "reports no-implied-eval for string timer and execScript calls" {
         \\setTimeout("alert(1)", 100);
         \\setInterval(`tick()`, 100);
         \\execScript("alert(1)");
-        \\window.setTimeout("alert(1)");
+        \\globalThis.setTimeout("alert(1)");
         \\globalThis["setInterval"]("tick()", 100);
         \\globalThis[`setInterval`]("tick()", 100);
     ;
@@ -32,6 +32,9 @@ test "does not report no-implied-eval for function arguments or shadowed calls" 
         \\setTimeout("not global");
         \\const window = sandbox;
         \\window.setTimeout("not global");
+        \\window.setInterval("not global");
+        \\global.setTimeout("not global");
+        \\self.setTimeout("not global");
         \\object.setInterval("not global");
         \\globalThis[`set${suffix}`]("not static");
     ;
@@ -51,7 +54,7 @@ test "does not report no-implied-eval for function arguments or shadowed calls" 
 test "can disable no-implied-eval" {
     const source =
         \\setTimeout("alert(1)", 100);
-        \\window.setInterval("tick()", 100);
+        \\globalThis.setInterval("tick()", 100);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-implied-eval` global member detection with ESLint defaults
- continue reporting bare timer/`execScript` string calls and `globalThis.*` calls
- stop reporting `window.*`, `global.*`, and `self.*` timer members as implied eval

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_implied_eval.zig src/rules/global_call_checks.zig tests/rules/no_implied_eval.zig`
- `git diff --check`
