### PR TITLE
fix: report no-eval references

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -87,6 +87,28 @@ const Visitor = struct {
 
         return .proceed;
     }
+
+    pub fn enter_identifier_reference(
+        self: *Visitor,
+        identifier: ast.IdentifierReference,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.check_no_eval) return .proceed;
+        if (!std.mem.eql(u8, ctx.tree.string(identifier.name), "eval")) return .proceed;
+        if (isCallCalleeReference(ctx.tree, index, ctx)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            no_eval.id,
+            "eval can be harmful.",
+            ctx.tree.span(index),
+        );
+
+        return .proceed;
+    }
 };
 
 fn isEvalCall(
@@ -124,6 +146,35 @@ fn isGlobalEvalMember(
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
     return isEvalGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+}
+
+fn isCallCalleeReference(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child) return false;
+                child = parent_index;
+            },
+            .sequence_expression => |sequence| {
+                if (!rangeContains(tree, sequence.expressions, child)) return false;
+                child = parent_index;
+            },
+            .call_expression => |call| return call.callee == child,
+            else => return false,
+        }
+    }
+
+    return false;
+}
+
+fn rangeContains(tree: *const ast.Tree, range: ast.IndexRange, needle: ast.NodeIndex) bool {
+    for (tree.extra(range)) |item| {
+        if (item == needle) return true;
+    }
+    return false;
 }
 
 fn alertCalleeName(

--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -47,6 +47,27 @@ const Visitor = struct {
 
         return .proceed;
     }
+
+    pub fn enter_identifier_reference(
+        self: *Visitor,
+        identifier: ast.IdentifierReference,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!std.mem.eql(u8, ctx.tree.string(identifier.name), "eval")) return .proceed;
+        if (isCallCalleeReference(ctx.tree, index, ctx)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "eval can be harmful.",
+            ctx.tree.span(index),
+        );
+
+        return .proceed;
+    }
 };
 
 fn isEvalCall(
@@ -84,6 +105,35 @@ fn isGlobalEvalMember(
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
     return isGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+}
+
+fn isCallCalleeReference(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child) return false;
+                child = parent_index;
+            },
+            .sequence_expression => |sequence| {
+                if (!rangeContains(tree, sequence.expressions, child)) return false;
+                child = parent_index;
+            },
+            .call_expression => |call| return call.callee == child,
+            else => return false,
+        }
+    }
+
+    return false;
+}
+
+fn rangeContains(tree: *const ast.Tree, range: ast.IndexRange, needle: ast.NodeIndex) bool {
+    for (tree.extra(range)) |item| {
+        if (item == needle) return true;
+    }
+    return false;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/no_eval.zig
+++ b/tests/rules/no_eval.zig
@@ -25,6 +25,29 @@ test "reports no-eval for direct indirect and global eval calls" {
     try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_eval.id));
 }
 
+test "reports no-eval for eval references outside call callees" {
+    const source =
+        \\var evalAlias = eval;
+        \\foo(eval);
+        \\const values = [eval];
+        \\const wrapped = (eval);
+        \\eval("code");
+        \\(0, eval)("code");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_sequences = false,
+        .no_var = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_eval.id));
+}
+
 test "does not report no-eval for non-global eval members" {
     const source =
         \\const object = { eval() {} };


### PR DESCRIPTION
## Summary

- align `no-eval` with ESLint by reporting direct `eval` references outside call callee positions
- keep direct and indirect `eval(...)` calls reported once
- cover the shared `global_call_checks` execution path and the standalone `no_eval` rule module

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_eval.zig src/rules/global_call_checks.zig tests/rules/no_eval.zig`
- `git diff --check`
