### PR TITLE
fix: align no-eval global members

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -325,9 +325,7 @@ fn isAlertGlobalObjectName(name: []const u8) bool {
 }
 
 fn isEvalGlobalObjectName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "window") or
-        std.mem.eql(u8, name, "globalThis") or
-        std.mem.eql(u8, name, "global");
+    return std.mem.eql(u8, name, "globalThis");
 }
 
 fn isImpliedEvalGlobalObjectName(name: []const u8) bool {

--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -187,9 +187,7 @@ fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]c
 }
 
 fn isGlobalObjectName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "window") or
-        std.mem.eql(u8, name, "globalThis") or
-        std.mem.eql(u8, name, "global");
+    return std.mem.eql(u8, name, "globalThis");
 }
 
 fn isUnresolvedReference(

--- a/tests/rules/no_eval.zig
+++ b/tests/rules/no_eval.zig
@@ -7,10 +7,8 @@ test "reports no-eval for direct indirect and global eval calls" {
         \\eval("code");
         \\(eval)("code");
         \\(0, eval)("code");
-        \\window.eval("code");
         \\globalThis["eval"]("code");
         \\globalThis[`eval`]("code");
-        \\global.eval("code");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -22,7 +20,7 @@ test "reports no-eval for direct indirect and global eval calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_eval.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_eval.id));
 }
 
 test "reports no-eval for eval references outside call callees" {
@@ -57,6 +55,11 @@ test "does not report no-eval for non-global eval members" {
         \\globalThis[`ev${suffix}`]("code");
         \\const window = sandbox;
         \\window.eval("code");
+        \\global.eval("code");
+        \\self.eval("code");
+        \\this.eval("code");
+        \\window["eval"]("code");
+        \\global[`eval`]("code");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-eval` global member detection with ESLint defaults
- keep reporting `globalThis.eval`, `globalThis["eval"]`, and static template `globalThis[\`eval\`]`
- stop reporting `window.eval`, `global.eval`, `self.eval`, and `this.eval`

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_eval.zig src/rules/global_call_checks.zig tests/rules/no_eval.zig`
- `git diff --check`
