### PR TITLE
fix: report more readonly globals

### DIFF
--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -106,7 +106,7 @@ fn isReadonlyGlobal(name: []const u8) bool {
     if (name.len == 0) return false;
 
     return switch (name[0]) {
-        'A' => isOneOf(name, .{ "Array", "ArrayBuffer" }),
+        'A' => isOneOf(name, .{ "Array", "ArrayBuffer", "Atomics" }),
         'B' => isOneOf(name, .{ "BigInt", "BigInt64Array", "BigUint64Array", "Boolean" }),
         'D' => isOneOf(name, .{ "DataView", "Date" }),
         'E' => isOneOf(name, .{ "Error", "EvalError" }),
@@ -122,6 +122,7 @@ fn isReadonlyGlobal(name: []const u8) bool {
         'T' => std.mem.eql(u8, name, "TypeError"),
         'U' => isOneOf(name, .{ "Uint8Array", "Uint8ClampedArray", "Uint16Array", "Uint32Array", "URIError" }),
         'W' => isOneOf(name, .{ "WeakMap", "WeakSet" }),
+        'g' => std.mem.eql(u8, name, "globalThis"),
         'u' => std.mem.eql(u8, name, "undefined"),
         else => false,
     };

--- a/tests/rules/no_global_assign.zig
+++ b/tests/rules/no_global_assign.zig
@@ -7,6 +7,8 @@ test "reports no-global-assign for assignments to read-only globals" {
         \\Object = null;
         \\NaN = 1;
         \\undefined = 2;
+        \\globalThis = 3;
+        \\Atomics = value;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +19,7 @@ test "reports no-global-assign for assignments to read-only globals" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_global_assign.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_global_assign.id));
     try std.testing.expectEqualStrings("Read-only global 'Object' should not be modified.", result.diagnostics[0].message);
 }
 
@@ -44,6 +46,8 @@ test "does not report no-global-assign for shadowed names or property writes" {
         \\Object = {};
         \\globalThis.Object = {};
         \\Number.value = 1;
+        \\Temporal = value;
+        \\window = value;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-global-assign` with ESLint's readonly global list for default globals
- report assignments to `globalThis` and `Atomics`
- keep `Temporal` and `window` unreported for this rule

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_global_assign.zig tests/rules/no_global_assign.zig`
- `git diff --check`
