### PR TITLE
fix: allow globalThis shadowing

### DIFF
--- a/src/rules/no_shadow_restricted_names.zig
+++ b/src/rules/no_shadow_restricted_names.zig
@@ -125,6 +125,5 @@ fn isRestrictedName(name: []const u8) bool {
         std.mem.eql(u8, name, "NaN") or
         std.mem.eql(u8, name, "Infinity") or
         std.mem.eql(u8, name, "arguments") or
-        std.mem.eql(u8, name, "eval") or
-        std.mem.eql(u8, name, "globalThis");
+        std.mem.eql(u8, name, "eval");
 }

--- a/tests/rules/no_shadow_restricted_names.zig
+++ b/tests/rules/no_shadow_restricted_names.zig
@@ -8,7 +8,6 @@ test "reports no-shadow-restricted-names for restricted declarations" {
         \\!function(Infinity) {};
         \\const undefined = 5;
         \\try {} catch (eval) {}
-        \\import globalThis from "foo";
         \\import { undefined } from "bar";
         \\import * as arguments from "baz";
         \\class Infinity {}
@@ -25,13 +24,13 @@ test "reports no-shadow-restricted-names for restricted declarations" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
 }
 
 test "reports no-shadow-restricted-names inside binding patterns" {
     const source =
         \\function f({ NaN }, [Infinity], ...eval) {}
-        \\const { undefined: alias = 1, value: globalThis } = source;
+        \\const { undefined: alias = 1 } = source;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -42,7 +41,7 @@ test "reports no-shadow-restricted-names inside binding patterns" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_shadow_restricted_names.id));
 }
 
 test "does not report no-shadow-restricted-names for allowed names or uninitialized undefined" {
@@ -53,6 +52,9 @@ test "does not report no-shadow-restricted-names for allowed names or uninitiali
         \\var undefined;
         \\import { undefined as undef } from "bar";
         \\const foo = globalThis;
+        \\function global(globalThis) {}
+        \\const { value: globalThis } = source;
+        \\import globalThis from "foo";
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-shadow-restricted-names` with ESLint's restricted-name set
- stop treating `globalThis` bindings as restricted-name shadowing
- keep `undefined`, `NaN`, `Infinity`, `arguments`, and `eval` restricted

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_shadow_restricted_names.zig tests/rules/no_shadow_restricted_names.zig`
- `git diff --check`
