### PR TITLE
fix: align no-global-assign readonly globals

### DIFF
--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -106,24 +106,32 @@ fn isReadonlyGlobal(name: []const u8) bool {
     if (name.len == 0) return false;
 
     return switch (name[0]) {
-        'A' => isOneOf(name, .{ "Array", "ArrayBuffer", "Atomics" }),
+        'A' => isOneOf(name, .{ "AggregateError", "Array", "ArrayBuffer", "AsyncDisposableStack", "Atomics" }),
         'B' => isOneOf(name, .{ "BigInt", "BigInt64Array", "BigUint64Array", "Boolean" }),
-        'D' => isOneOf(name, .{ "DataView", "Date" }),
+        'D' => isOneOf(name, .{ "DataView", "Date", "DisposableStack" }),
         'E' => isOneOf(name, .{ "Error", "EvalError" }),
-        'F' => isOneOf(name, .{ "Float32Array", "Float64Array", "Function" }),
-        'I' => isOneOf(name, .{ "Infinity", "Int8Array", "Int16Array", "Int32Array", "Intl" }),
+        'F' => isOneOf(name, .{ "FinalizationRegistry", "Float16Array", "Float32Array", "Float64Array", "Function" }),
+        'I' => isOneOf(name, .{ "Infinity", "Int8Array", "Int16Array", "Int32Array", "Intl", "Iterator" }),
         'J' => std.mem.eql(u8, name, "JSON"),
         'M' => isOneOf(name, .{ "Map", "Math" }),
         'N' => isOneOf(name, .{ "NaN", "Number" }),
         'O' => std.mem.eql(u8, name, "Object"),
-        'P' => std.mem.eql(u8, name, "Promise"),
+        'P' => isOneOf(name, .{ "Promise", "Proxy" }),
         'R' => isOneOf(name, .{ "RangeError", "ReferenceError", "Reflect", "RegExp" }),
-        'S' => isOneOf(name, .{ "Set", "String", "Symbol", "SyntaxError" }),
-        'T' => std.mem.eql(u8, name, "TypeError"),
+        'S' => isOneOf(name, .{ "Set", "SharedArrayBuffer", "String", "SuppressedError", "Symbol", "SyntaxError" }),
+        'T' => isOneOf(name, .{ "Temporal", "TypeError" }),
         'U' => isOneOf(name, .{ "Uint8Array", "Uint8ClampedArray", "Uint16Array", "Uint32Array", "URIError" }),
-        'W' => isOneOf(name, .{ "WeakMap", "WeakSet" }),
+        'W' => isOneOf(name, .{ "WeakMap", "WeakRef", "WeakSet" }),
+        'c' => std.mem.eql(u8, name, "constructor"),
+        'd' => isOneOf(name, .{ "decodeURI", "decodeURIComponent" }),
+        'e' => isOneOf(name, .{ "encodeURI", "encodeURIComponent", "escape", "eval" }),
         'g' => std.mem.eql(u8, name, "globalThis"),
-        'u' => std.mem.eql(u8, name, "undefined"),
+        'h' => std.mem.eql(u8, name, "hasOwnProperty"),
+        'i' => isOneOf(name, .{ "isFinite", "isNaN", "isPrototypeOf" }),
+        'p' => isOneOf(name, .{ "parseFloat", "parseInt", "propertyIsEnumerable" }),
+        't' => isOneOf(name, .{ "toLocaleString", "toString" }),
+        'u' => isOneOf(name, .{ "undefined", "unescape" }),
+        'v' => std.mem.eql(u8, name, "valueOf"),
         else => false,
     };
 }
@@ -146,7 +154,7 @@ fn isUnresolvedReference(
         }
     }
 
-    return false;
+    return true;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/no_global_assign.zig
+++ b/tests/rules/no_global_assign.zig
@@ -40,13 +40,60 @@ test "reports no-global-assign for updates and destructuring assignments" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_global_assign.id));
 }
 
+test "reports no-global-assign for ESLint default read-only globals" {
+    const source =
+        \\AggregateError = 1;
+        \\AsyncDisposableStack = 2;
+        \\DisposableStack = 3;
+        \\FinalizationRegistry = 4;
+        \\Float16Array = 5;
+        \\Iterator = 6;
+        \\Proxy = 7;
+        \\SharedArrayBuffer = 8;
+        \\SuppressedError = 9;
+        \\Temporal = 10;
+        \\WeakRef = 11;
+        \\decodeURI = 12;
+        \\decodeURIComponent = 13;
+        \\encodeURI = 14;
+        \\encodeURIComponent = 15;
+        \\escape = 16;
+        \\isFinite = 17;
+        \\isNaN = 18;
+        \\isPrototypeOf = 19;
+        \\parseFloat = 20;
+        \\parseInt = 21;
+        \\propertyIsEnumerable = 22;
+        \\constructor = 23;
+        \\hasOwnProperty = 24;
+        \\toLocaleString = 25;
+        \\toString = 26;
+        \\unescape = 27;
+        \\valueOf = 28;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 28), helpers.countRule(result, lint.rules.no_global_assign.id));
+}
+
 test "does not report no-global-assign for shadowed names or property writes" {
     const source =
         \\let Object = null;
         \\Object = {};
+        \\let Temporal = null;
+        \\Temporal = value;
+        \\let parseFloat = null;
+        \\parseFloat = fn;
+        \\let constructor = null;
+        \\constructor = value;
         \\globalThis.Object = {};
         \\Number.value = 1;
-        \\Temporal = value;
         \\window = value;
     ;
 


### PR DESCRIPTION
## Summary

- align `no-global-assign` with ESLint's default read-only global scope
- add newer built-ins such as `AggregateError`, `Temporal`, `WeakRef`, and global function/prototype names such as `parseFloat`, `decodeURI`, and `toString`
- treat missing assignment-target reference entries as unresolved so these read-only globals are still reported while local shadows stay allowed

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_global_assign.zig tests/rules/no_global_assign.zig`
- `git diff --check`
