### PR TITLE
fix: report no-obj-calls on globalThis members

### DIFF
--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -58,24 +58,25 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         const callee = unwrapTransparent(ctx.tree, expression.callee);
-        const name = identifierReferenceName(ctx.tree, callee) orelse return .proceed;
 
-        if (self.check_no_new_native_nonconstructor and isNativeNonconstructorName(name)) {
-            if (isUnresolvedReference(self.symbol_table, callee)) {
-                try core.addDiagnosticFmt(
-                    self.allocator,
-                    self.diagnostics,
-                    .@"error",
-                    no_new_native_nonconstructor.id,
-                    ctx.tree.span(index),
-                    "`{s}` cannot be called as a constructor.",
-                    .{name},
-                );
+        if (identifierReferenceName(ctx.tree, callee)) |name| {
+            if (self.check_no_new_native_nonconstructor and isNativeNonconstructorName(name)) {
+                if (isUnresolvedReference(self.symbol_table, callee)) {
+                    try core.addDiagnosticFmt(
+                        self.allocator,
+                        self.diagnostics,
+                        .@"error",
+                        no_new_native_nonconstructor.id,
+                        ctx.tree.span(index),
+                        "`{s}` cannot be called as a constructor.",
+                        .{name},
+                    );
+                }
             }
         }
 
-        if (self.check_no_obj_calls and isForbiddenObject(name)) {
-            if (isUnresolvedReference(self.symbol_table, callee)) {
+        if (self.check_no_obj_calls) {
+            if (globalObjectName(ctx.tree, self.symbol_table, expression.callee)) |name| {
                 try self.reportNoObjCalls(ctx.tree, index, name);
             }
         }
@@ -102,10 +103,27 @@ fn globalObjectName(
     callee: ast.NodeIndex,
 ) ?[]const u8 {
     const unwrapped = unwrapTransparent(tree, callee);
-    const name = identifierReferenceName(tree, unwrapped) orelse return null;
-    if (!isForbiddenObject(name)) return null;
-    if (!isUnresolvedReference(symbol_table, unwrapped)) return null;
-    return name;
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        if (!isForbiddenObject(name)) return null;
+        if (!isUnresolvedReference(symbol_table, unwrapped)) return null;
+        return name;
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = identifierReferenceName(tree, object) orelse return null;
+    if (!std.mem.eql(u8, object_name, "globalThis") or !isUnresolvedReference(symbol_table, object)) {
+        return null;
+    }
+
+    const property_name = propertyName(tree, member) orelse return null;
+    if (!isForbiddenObject(property_name)) return null;
+    return property_name;
 }
 
 fn isNativeNonconstructorName(name: []const u8) bool {
@@ -140,6 +158,30 @@ fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const
 
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0 or literal.quasis.len != 1) return null;
+    const quasi_index = tree.extra(literal.quasis)[0];
+    return switch (tree.data(quasi_index)) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_obj_calls.zig
+++ b/tests/rules/no_obj_calls.zig
@@ -21,6 +21,23 @@ test "reports no-obj-calls for global object calls" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
+test "reports no-obj-calls for globalThis object member calls" {
+    const source =
+        \\globalThis.Math();
+        \\globalThis["JSON"]();
+        \\globalThis[`Reflect`]();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
 test "reports no-obj-calls for global object constructors" {
     const source =
         \\new Math();
@@ -41,15 +58,38 @@ test "reports no-obj-calls for global object constructors" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
+test "reports no-obj-calls for globalThis object member constructors" {
+    const source =
+        \\new globalThis.Math();
+        \\new globalThis["JSON"]();
+        \\new globalThis[`Reflect`]();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
 test "does not report no-obj-calls for member calls allowed globals or shadowed names" {
     const source =
         \\Math.max(1, 2);
         \\JSON.parse("{}");
         \\Temporal();
         \\new Temporal();
+        \\window.Math();
+        \\globalThis[`Ma${suffix}`]();
         \\function run(Math, JSON) {
         \\  Math();
         \\  new JSON();
+        \\}
+        \\function local(globalThis) {
+        \\  globalThis.Math();
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- report `no-obj-calls` for `globalThis` static member calls such as `globalThis.Math()`
- cover static computed members, including `globalThis["JSON"]()` and ``globalThis[`Reflect`]()``
- apply the same behavior to `new globalThis.Math()` while keeping dynamic templates, `window.Math()`, and locally shadowed `globalThis` allowed

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/native_object_checks.zig tests/rules/no_obj_calls.zig`
- `git diff --check`
