### PR TITLE
fix: report no-obj-calls for sequence callees

### DIFF
--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -112,6 +112,11 @@ fn globalObjectName(
 
     const member = switch (tree.data(unwrapped)) {
         .member_expression => |member| member,
+        .sequence_expression => |sequence| {
+            const expressions = tree.extra(sequence.expressions);
+            if (expressions.len == 0) return null;
+            return globalObjectName(tree, symbol_table, expressions[expressions.len - 1]);
+        },
         else => return null,
     };
 

--- a/tests/rules/no_obj_calls.zig
+++ b/tests/rules/no_obj_calls.zig
@@ -38,6 +38,23 @@ test "reports no-obj-calls for globalThis object member calls" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
+test "reports no-obj-calls for sequence call callees" {
+    const source =
+        \\(0, Math)();
+        \\(foo, globalThis.JSON)();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
 test "reports no-obj-calls for global object constructors" {
     const source =
         \\new Math();
@@ -74,6 +91,24 @@ test "reports no-obj-calls for globalThis object member constructors" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_obj_calls.id));
+}
+
+test "reports no-obj-calls for sequence constructor callees" {
+    const source =
+        \\new (0, Math)();
+        \\new (foo, globalThis.JSON)();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_comma_operator = false,
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_obj_calls.id));
 }
 
 test "does not report no-obj-calls for member calls allowed globals or shadowed names" {


### PR DESCRIPTION
## Summary

- report `no-obj-calls` when a sequence expression callee resolves to a forbidden global object
- cover both call and constructor forms, such as `(0, Math)()` and `new (foo, globalThis.JSON)()`

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/native_object_checks.zig tests/rules/no_obj_calls.zig`
- `git diff --check`
