### PR TITLE
fix: report no-import-assign for template Object.assign

### DIFF
--- a/src/rules/reassignment_rules.zig
+++ b/src/rules/reassignment_rules.zig
@@ -317,10 +317,20 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
     return if (member.computed)
         switch (tree.data(member.property)) {
             .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
             else => null,
         }
     else switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0 or literal.quasis.len != 1) return null;
+    const quasi_index = tree.extra(literal.quasis)[0];
+    return switch (tree.data(quasi_index)) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/tests/rules/no_import_assign.zig
+++ b/tests/rules/no_import_assign.zig
@@ -28,6 +28,7 @@ test "reports no-import-assign for namespace import mutation" {
         \\ns.value = replacement;
         \\ns["value"]++;
         \\Object.assign(ns, { value: replacement });
+        \\Object[`assign`](ns, { value: replacement });
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -38,7 +39,7 @@ test "reports no-import-assign for namespace import mutation" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_import_assign.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_import_assign.id));
 }
 
 test "reports no-import-assign for imported bindings in destructuring assignment targets" {
@@ -72,6 +73,7 @@ test "does not report no-import-assign for local shadowing or imported object pr
         \\function local(named) {
         \\  ({ x: named } = obj);
         \\}
+        \\Object[`ass${suffix}`](ns, { value: replacement });
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- report `no-import-assign` for namespace mutations through static template `Object.assign`
- keep dynamic template member names ignored, matching ESLint's static behavior

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/reassignment_rules.zig tests/rules/no_import_assign.zig`
- `git diff --check`
