### PR TITLE
Align no-new-require result construction

### DIFF
--- a/src/rules/no_new_require.zig
+++ b/src/rules/no_new_require.zig
@@ -28,17 +28,10 @@ pub fn check(
 
 fn isRequireConstructorCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const unwrapped = unwrapTransparent(tree, index);
-    switch (tree.data(unwrapped)) {
-        .identifier_reference => |identifier| return std.mem.eql(u8, tree.string(identifier.name), "require"),
-        .call_expression => |call| {
-            const callee = unwrapTransparent(tree, call.callee);
-            return switch (tree.data(callee)) {
-                .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "require"),
-                else => false,
-            };
-        },
-        else => return false,
-    }
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "require"),
+        else => false,
+    };
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/no_new_require.zig
+++ b/tests/rules/no_new_require.zig
@@ -6,7 +6,6 @@ test "reports no-new-require for constructing require calls" {
     const source =
         \\const foo = new require("foo");
         \\const bar = new (require)("bar");
-        \\const baz = new (require("baz"));
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -16,13 +15,14 @@ test "reports no-new-require for constructing require calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_new_require.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_new_require.id));
 }
 
 test "does not report no-new-require for ordinary require or constructed values" {
     const source =
         \\const Foo = require("foo");
         \\const foo = new Foo();
+        \\const baz = new (require("baz"));
         \\const resolved = require.resolve("foo");
         \\const custom = new require.resolve("foo");
     ;


### PR DESCRIPTION
## Summary

Align `no-new-require` with ESLint for constructors around `require()` call results.

## What changed

- Stop reporting `new (require("pkg"))`.
- Keep reporting direct `new require("pkg")` and `new (require)("pkg")`.
- Move the `new (require("pkg"))` fixture into the allowed test cases.

## Why

ESLint's `no-new-require` targets use of `new` with the `require` function itself. Constructing the value returned by `require("pkg")` is not reported by ESLint.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_new_require.zig tests/rules/no_new_require.zig`
- `git diff --check`
