### PR TITLE
Align no-buffer-constructor shadowed calls

### DIFF
--- a/src/rules/no_buffer_constructor.zig
+++ b/src/rules/no_buffer_constructor.zig
@@ -12,12 +12,11 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
+    _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
-        .symbol_table = symbol_table,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -26,7 +25,6 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
-    symbol_table: traverser.semantic.SymbolTable,
 
     pub fn enter_new_expression(
         self: *Visitor,
@@ -34,7 +32,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isGlobalBufferReference(ctx.tree, self.symbol_table, expression.callee)) {
+        if (isBufferConstructorCallee(ctx.tree, expression.callee)) {
             try self.addDiagnostic(ctx.tree, index);
         }
 
@@ -47,7 +45,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isGlobalBufferReference(ctx.tree, self.symbol_table, call.callee)) {
+        if (isBufferConstructorCallee(ctx.tree, call.callee)) {
             try self.addDiagnostic(ctx.tree, index);
         }
 
@@ -66,15 +64,11 @@ const Visitor = struct {
     }
 };
 
-fn isGlobalBufferReference(
-    tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
-    index: ast.NodeIndex,
-) bool {
+fn isBufferConstructorCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const unwrapped = unwrapTransparent(tree, index);
     const name = identifierReferenceName(tree, unwrapped) orelse return false;
 
-    return std.mem.eql(u8, name, "Buffer") and isUnresolvedReference(symbol_table, unwrapped);
+    return std.mem.eql(u8, name, "Buffer");
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
@@ -98,18 +92,4 @@ fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const
         .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
     };
-}
-
-fn isUnresolvedReference(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
 }

--- a/tests/rules/no_buffer_constructor.zig
+++ b/tests/rules/no_buffer_constructor.zig
@@ -2,11 +2,15 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports no-buffer-constructor for global Buffer calls and constructors" {
+test "reports no-buffer-constructor for Buffer calls and constructors" {
     const source =
         \\const first = Buffer("abc");
         \\const second = new Buffer("abc");
         \\const third = new (Buffer)("abc");
+        \\function local(Buffer) {
+        \\  const fourth = Buffer("abc");
+        \\  const fifth = new Buffer("abc");
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -16,17 +20,13 @@ test "reports no-buffer-constructor for global Buffer calls and constructors" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_buffer_constructor.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_buffer_constructor.id));
 }
 
-test "does not report no-buffer-constructor for safe APIs or shadowed Buffer" {
+test "does not report no-buffer-constructor for safe APIs" {
     const source =
         \\const first = Buffer.from("abc");
         \\const second = Buffer.alloc(10);
-        \\function local(Buffer) {
-        \\  const third = Buffer("abc");
-        \\  const fourth = new Buffer("abc");
-        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

Align `no-buffer-constructor` with ESLint for shadowed `Buffer` calls.

## What changed

- Report direct `Buffer()` and `new Buffer()` even when `Buffer` is locally shadowed.
- Keep the rule limited to direct `Buffer` callees, without adding `globalThis.Buffer` or sequence callee handling.
- Update tests to cover shadowed `Buffer` calls as reported cases.

## Why

ESLint's deprecated core `no-buffer-constructor` rule is syntax-based and reports direct `Buffer` constructor calls regardless of local scope. utoo-lint previously required the `Buffer` reference to be unresolved, which missed those shadowed cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_buffer_constructor.zig tests/rules/no_buffer_constructor.zig`
- `git diff --check`
