### PR TITLE
Align object-shorthand string keys

### DIFF
--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -29,13 +29,18 @@ pub fn check(
 }
 
 fn canUseShorthand(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
-    const key_name = switch (tree.data(property.key)) {
-        .identifier_name => |identifier| tree.string(identifier.name),
-        else => return false,
-    };
+    const key_name = propertyKeyName(tree, property.key) orelse return false;
 
     if (identifierReferenceNamed(tree, property.value, key_name)) return true;
     return isAnonymousFunctionExpression(tree, property.value);
+}
+
+fn propertyKeyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
 }
 
 fn identifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -13,6 +13,10 @@ test "reports object-shorthand for redundant property and method forms" {
         \\  asyncValue: async function () {
         \\    return 2;
         \\  },
+        \\  "quoted": quoted,
+        \\  "quoted-method": function () {
+        \\    return 3;
+        \\  },
         \\};
     ;
 
@@ -23,7 +27,7 @@ test "reports object-shorthand for redundant property and method forms" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.object_shorthand.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.object_shorthand.id));
 }
 
 test "does not report object-shorthand for non-shorthandable properties" {
@@ -32,7 +36,7 @@ test "does not report object-shorthand for non-shorthandable properties" {
         \\const obj = {
         \\  foo,
         \\  foo: bar,
-        \\  "foo": foo,
+        \\  "foo": bar,
         \\  [foo]: foo,
         \\  bar: function named() {
         \\    return 1;


### PR DESCRIPTION
## Summary

Align `object-shorthand` with ESLint for string literal property keys.

## What changed

- Treat string literal object keys as shorthand candidates.
- Report cases such as `"foo": foo`.
- Report anonymous function values on string keys, including keys that must remain quoted in method shorthand.

## Why

ESLint's default `object-shorthand` rule reports both identifier keys and string literal keys when the property can be written in shorthand or method shorthand form. utoo-lint previously only considered identifier keys.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/object_shorthand.zig tests/rules/object_shorthand.zig`
- `git diff --check`
