### PR TITLE
Align func-name-matching dynamic computed keys

### DIFF
--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -197,7 +197,6 @@ fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]co
 
     return if (computed)
         switch (tree.data(unwrapTransparent(tree, key))) {
-            .identifier_reference => |identifier| tree.string(identifier.name),
             .string_literal => |literal| tree.string(literal.value),
             .numeric_literal => |literal| tree.string(literal.raw),
             else => null,

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -58,12 +58,14 @@ test "does not report func-name-matching for matching or unsupported cases" {
         \\const unnamed = function () {};
         \\const arrow = () => {};
         \\object.value = function value() {};
+        \\object[value] = function otherValue() {};
         \\object[getName()] = function dynamic() {};
         \\module.exports = function exported() {};
         \\exports.value = function exportedValue() {};
         \\const object = {
         \\  method() {},
         \\  value: function value() {},
+        \\  [value]: function otherValue() {},
         \\};
         \\class Example {
         \\  field = function field() {};


### PR DESCRIPTION
## Summary

Align `func-name-matching` with ESLint for dynamic computed property keys.

## What changed

- Stop treating computed identifier keys as static property names.
- Keep static computed string and numeric keys supported.
- Add allowed cases for `object[value] = function otherValue() {}` and `{ [value]: function otherValue() {} }`.

## Why

ESLint only checks `func-name-matching` when the property name is statically known. utoo-lint previously used the identifier inside a dynamic computed key as the target name, which produced false positives for dynamic property access.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/func_name_matching.zig tests/rules/func_name_matching.zig`
- `git diff --check`
