### PR TITLE
Align func-names destructuring defaults

### DIFF
--- a/src/rules/func_names.zig
+++ b/src/rules/func_names.zig
@@ -83,6 +83,7 @@ fn allowsInferredName(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *travers
         .variable_declarator => |declarator| declarator.init == index,
         .object_property => |property| property.value == index,
         .property_definition => |property| property.value == index,
+        .assignment_pattern => |pattern| pattern.right == index,
         .assignment_expression => |assignment| assignment.right == index and isInferredAssignment(tree, assignment),
         else => false,
     };

--- a/tests/rules/func_names.zig
+++ b/tests/rules/func_names.zig
@@ -91,6 +91,18 @@ test "allows func-names as-needed for inferable names" {
         \\quux ??= function () {
         \\  return value;
         \\};
+        \\const { local = function () {
+        \\  return value;
+        \\} } = object;
+        \\const [item = function () {
+        \\  return value;
+        \\}] = array;
+        \\({ assigned = function () {
+        \\  return value;
+        \\} } = object);
+        \\[assignedItem = function () {
+        \\  return value;
+        \\}] = array;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

Align `func-names` `as-needed` behavior for destructuring default functions.

## What changed

- Treat anonymous functions in assignment pattern defaults as name-inferable.
- Cover object and array destructuring defaults in declarations and assignments.

## Why

ESLint's `func-names` rule in `as-needed` mode allows anonymous functions in destructuring default initializers because JavaScript can infer a name for them. utoo-lint previously reported those functions as non-inferable.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/func_names.zig tests/rules/func_names.zig`
- `git diff --check`
