### PR TITLE
Align func-name-matching CommonJS exports

### DIFF
--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -167,29 +167,14 @@ fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8
 }
 
 fn memberTargetName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
-    if (isCommonJsExportTarget(tree, member)) return null;
+    if (isModuleExportsTarget(tree, member)) return null;
     return propertyName(tree, member.property, member.computed);
 }
 
-fn isCommonJsExportTarget(tree: *const ast.Tree, member: ast.MemberExpression) bool {
-    if (isIdentifierReferenceNamed(tree, member.object, "exports")) return true;
-    if (!member.computed and
-        isIdentifierReferenceNamed(tree, member.object, "module") and
-        propertyName(tree, member.property, member.computed) != null and
-        std.mem.eql(u8, propertyName(tree, member.property, member.computed).?, "exports"))
-    {
-        return true;
-    }
-
-    const object = switch (tree.data(unwrapTransparent(tree, member.object))) {
-        .member_expression => |object| object,
-        else => return false,
-    };
-    if (object.computed) return false;
-
-    return isIdentifierReferenceNamed(tree, object.object, "module") and
-        propertyName(tree, object.property, object.computed) != null and
-        std.mem.eql(u8, propertyName(tree, object.property, object.computed).?, "exports");
+fn isModuleExportsTarget(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    const name = propertyName(tree, member.property, member.computed) orelse return false;
+    return isIdentifierReferenceNamed(tree, member.object, "module") and
+        std.mem.eql(u8, name, "exports");
 }
 
 fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]const u8 {

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -9,6 +9,8 @@ test "reports func-name-matching for mismatched variable and assignment targets"
         \\third = function fourth() {};
         \\object.value = function other() {};
         \\this.ready = function done() {};
+        \\module.exports.value = function exportedValue() {};
+        \\exports.value = function exportedValue() {};
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -21,7 +23,7 @@ test "reports func-name-matching for mismatched variable and assignment targets"
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.func_name_matching.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.func_name_matching.id));
     try std.testing.expectEqualStrings(
         "Function name `second` should match target name `first`.",
         result.diagnostics[0].message,
@@ -61,7 +63,7 @@ test "does not report func-name-matching for matching or unsupported cases" {
         \\object[value] = function otherValue() {};
         \\object[getName()] = function dynamic() {};
         \\module.exports = function exported() {};
-        \\exports.value = function exportedValue() {};
+        \\module["exports"] = function exportedComputed() {};
         \\const object = {
         \\  method() {},
         \\  value: function value() {},


### PR DESCRIPTION
## Summary

Align `func-name-matching` CommonJS export handling with ESLint.

## What changed

- Only skip direct `module.exports = function ...` assignments.
- Also skip direct computed `module["exports"] = function ...` assignments.
- Report property assignments such as `module.exports.value = function exportedValue() ...` and `exports.value = function exportedValue() ...`.

## Why

ESLint treats the direct CommonJS export object assignment as a special case, but still checks named properties under `module.exports` and `exports`. utoo-lint previously skipped those property assignments and reported computed `module["exports"]` direct assignments.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/func_name_matching.zig tests/rules/func_name_matching.zig`
- `git diff --check`
