### PR TITLE
Align no-throw-literal unary throws

### DIFF
--- a/src/rules/no_throw_literal.zig
+++ b/src/rules/no_throw_literal.zig
@@ -41,6 +41,7 @@ fn isInvalidThrowArgument(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .array_expression,
         => true,
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => true,
         .binary_expression => |expression| expression.operator == .add,
         else => false,
     };

--- a/tests/rules/no_throw_literal.zig
+++ b/tests/rules/no_throw_literal.zig
@@ -14,6 +14,13 @@ test "reports no-throw-literal for literal throw arguments" {
         \\throw /error/;
         \\throw {};
         \\throw [];
+        \\throw void 0;
+        \\throw -1;
+        \\throw +1;
+        \\throw !error;
+        \\throw ~error;
+        \\throw typeof error;
+        \\throw delete error.value;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -23,7 +30,7 @@ test "reports no-throw-literal for literal throw arguments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_throw_literal.id));
+    try std.testing.expectEqual(@as(usize, 17), helpers.countRule(result, lint.rules.no_throw_literal.id));
 }
 
 test "does not report no-throw-literal for error objects or references" {


### PR DESCRIPTION
## Summary

Align `no-throw-literal` with ESLint for unary throw arguments.

## What changed

- Report unary expressions used as throw arguments.
- Cover `void`, numeric sign, logical not, bitwise not, `typeof`, and `delete` throw cases.

## Why

ESLint reports unary throw arguments because they evaluate to non-Error primitive values. utoo-lint previously only reported direct literals, `undefined`, and string concatenation-style binary expressions.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_throw_literal.zig tests/rules/no_throw_literal.zig`
- `git diff --check`
