### PR TITLE
Align no-useless-call void thisArg

### DIFF
--- a/src/rules/no_useless_call.zig
+++ b/src/rules/no_useless_call.zig
@@ -68,6 +68,7 @@ fn isNullOrUndefined(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .null_literal => true,
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => |expression| expression.operator == .void,
         else => false,
     };
 }

--- a/tests/rules/no_useless_call.zig
+++ b/tests/rules/no_useless_call.zig
@@ -10,6 +10,7 @@ test "reports no-useless-call for unnecessary call expressions" {
         \\this.foo.call(this, a);
         \\obj.foo.bar.call(obj.foo, a);
         \\foo["call"](undefined, a);
+        \\foo.call(void 0, a);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +20,7 @@ test "reports no-useless-call for unnecessary call expressions" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_useless_call.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_call.id));
 }
 
 test "reports no-useless-call for unnecessary apply expressions with array arguments" {
@@ -30,6 +31,7 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
         \\this.foo.apply(this, [a]);
         \\obj.foo["apply"](obj, [a]);
         \\foo.apply(undefined, [, a]);
+        \\foo.apply(void 0, [a]);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -39,7 +41,7 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_useless_call.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_call.id));
 }
 
 test "does not report no-useless-call when this binding or arguments are meaningful" {


### PR DESCRIPTION
## Summary

Align `no-useless-call` with ESLint for `void` this arguments.

## What changed

- Treat `void` unary expressions as undefined-like `thisArg` values.
- Report `foo.call(void 0, ...)`.
- Report `foo.apply(void 0, [...])`.

## Why

ESLint reports `call` and `apply` usages with `void 0` as an unnecessary undefined `thisArg`. utoo-lint previously only recognized direct `undefined` and `null`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_call.zig tests/rules/no_useless_call.zig`
- `git diff --check`
