### PR TITLE
Align prefer-template dynamic templates

### DIFF
--- a/src/rules/prefer_template.zig
+++ b/src/rules/prefer_template.zig
@@ -35,7 +35,7 @@ fn isStaticStringLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
-        .template_literal => |template| template.expressions.len == 0,
+        .template_literal => true,
         else => false,
     };
 }

--- a/tests/rules/prefer_template.zig
+++ b/tests/rules/prefer_template.zig
@@ -7,6 +7,7 @@ test "reports prefer-template for string concatenation with expressions" {
         \\const a = "hello " + name;
         \\const b = name + "!";
         \\const c = `hello ` + name;
+        \\const d = `hello ${name}` + suffix;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -16,7 +17,7 @@ test "reports prefer-template for string concatenation with expressions" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_template.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_template.id));
 }
 
 test "does not report prefer-template for non-string or static-only concatenation" {
@@ -25,6 +26,7 @@ test "does not report prefer-template for non-string or static-only concatenatio
         \\const b = "hello " + "world";
         \\const c = `hello ` + "world";
         \\const d = `hello ${name}`;
+        \\const e = `hello ${name}` + "!";
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

Align `prefer-template` handling for dynamic template literals.

## What changed

- Treat any template literal as string-like when deciding whether `+` is string concatenation.
- Report dynamic template plus non-string expressions, such as `` `hello ${name}` + suffix ``.
- Avoid reporting dynamic template plus a string literal, matching ESLint's existing behavior.

## Why

ESLint reports concatenation between a template literal and a non-string expression, even when the template contains expressions. utoo-lint only treated static template literals as string-like, which missed those cases and reported some template-plus-string expressions.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_template.zig tests/rules/prefer_template.zig`
- `git diff --check`
