### PR TITLE
Align no-implicit-coercion dynamic templates

### DIFF
--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -208,7 +208,7 @@ fn isStringType(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 fn isStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
-        .template_literal => |literal| literal.expressions.len == 0,
+        .template_literal => true,
         else => false,
     };
 }

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -76,6 +76,8 @@ test "does not report no-implicit-coercion for explicit conversions" {
         \\const tenth = "" + "value";
         \\const eleventh = `value` + "";
         \\const twelfth = ~items[`index${suffix}`](value);
+        \\const thirteenth = "" + `${value}`;
+        \\const fourteenth = `${value}` + "";
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

Align `no-implicit-coercion` string checks for dynamic template literals.

## What changed

- Treat any template literal as a string value when checking empty-string concatenation.
- Allow `"" + `${value}`` and `` `${value}` + "" `` without reporting string coercion.

## Why

ESLint treats dynamic template literals as string-like operands. utoo-lint previously only treated static template literals as strings, which caused false positives for empty-string concatenation with dynamic templates.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_implicit_coercion.zig tests/rules/no_implicit_coercion.zig`
- `git diff --check`
