### PR TITLE
Align no-sparse-arrays hole counts

### DIFF
--- a/src/rules/no_sparse_arrays.zig
+++ b/src/rules/no_sparse_arrays.zig
@@ -14,22 +14,26 @@ pub fn check(
     expression: ast.ArrayExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (!hasHole(tree, expression.elements)) return;
+    const holes = countHoles(tree, expression.elements);
+    if (holes == 0) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Unexpected sparse array.",
-        tree.span(index),
-    );
+    for (0..holes) |_| {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unexpected sparse array.",
+            tree.span(index),
+        );
+    }
 }
 
-fn hasHole(tree: *const ast.Tree, elements: ast.IndexRange) bool {
+fn countHoles(tree: *const ast.Tree, elements: ast.IndexRange) usize {
+    var holes: usize = 0;
     for (tree.extra(elements)) |element| {
-        if (element == .null) return true;
+        if (element == .null) holes += 1;
     }
 
-    return false;
+    return holes;
 }

--- a/tests/rules/no_sparse_arrays.zig
+++ b/tests/rules/no_sparse_arrays.zig
@@ -7,6 +7,7 @@ test "reports no-sparse-arrays for array holes" {
         \\const first = [1,, 2];
         \\const second = [,];
         \\const third = [,,];
+        \\const fourth = [,,...items];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +18,7 @@ test "reports no-sparse-arrays for array holes" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_sparse_arrays.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_sparse_arrays.id));
 }
 
 test "does not report no-sparse-arrays for explicit values" {


### PR DESCRIPTION
## Summary
- report one `no-sparse-arrays` diagnostic per array hole instead of one per sparse array
- cover multiple holes before a spread element in the rule test

## Why
ESLint reports each sparse array hole separately, so arrays like `[,,]` produce two `no-sparse-arrays` diagnostics. utoo-lint previously collapsed those into one diagnostic for the whole array.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_sparse_arrays.zig tests/rules/no_sparse_arrays.zig`
- `git diff --check`
