### PR TITLE
Align no-lone-blocks switch cases

### DIFF
--- a/src/rules/no_lone_blocks.zig
+++ b/src/rules/no_lone_blocks.zig
@@ -31,7 +31,6 @@ fn isStatementListParent(data: ast.NodeData) bool {
     return switch (data) {
         .program,
         .block_statement,
-        .switch_case,
         => true,
         else => false,
     };

--- a/tests/rules/no_lone_blocks.zig
+++ b/tests/rules/no_lone_blocks.zig
@@ -12,12 +12,6 @@ test "reports no-lone-blocks for unnecessary block statements" {
         \\    run();
         \\  }
         \\}
-        \\switch (value) {
-        \\  case 1:
-        \\    {
-        \\      run();
-        \\    }
-        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -28,7 +22,7 @@ test "reports no-lone-blocks for unnecessary block statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_lone_blocks.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_lone_blocks.id));
 }
 
 test "does not report no-lone-blocks for scoped declarations" {
@@ -66,6 +60,18 @@ test "does not report no-lone-blocks for structured statement bodies" {
         \\if (ready) { run(); } else { stop(); }
         \\while (ready) { run(); }
         \\for (let i = 0; i < 1; i++) { run(); }
+        \\switch (value) {
+        \\  case 1:
+        \\    {
+        \\      run();
+        \\    }
+        \\}
+        \\switch (value) {
+        \\  default:
+        \\    {
+        \\      run();
+        \\    }
+        \\}
         \\try { run(); } catch (error) { handle(error); } finally { cleanup(); }
     ;
 


### PR DESCRIPTION
## Summary
- stop reporting `no-lone-blocks` for blocks directly inside switch cases
- move switch case block coverage into the allowed-structured-statements test

## Why
ESLint does not treat switch case body blocks as redundant lone blocks. utoo-lint previously reported those blocks because `switch_case` was included as a statement-list parent.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_lone_blocks.zig tests/rules/no_lone_blocks.zig`
- `git diff --check`
