### PR TITLE
Align no-unneeded-ternary boolean branches

### DIFF
--- a/src/rules/no_unneeded_ternary.zig
+++ b/src/rules/no_unneeded_ternary.zig
@@ -13,9 +13,8 @@ pub fn check(
     expression: ast.ConditionalExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    const consequent = booleanLiteralValue(tree, expression.consequent) orelse return;
-    const alternate = booleanLiteralValue(tree, expression.alternate) orelse return;
-    if (consequent == alternate) return;
+    _ = booleanLiteralValue(tree, expression.consequent) orelse return;
+    _ = booleanLiteralValue(tree, expression.alternate) orelse return;
 
     try core.addDiagnostic(
         allocator,

--- a/tests/rules/no_unneeded_ternary.zig
+++ b/tests/rules/no_unneeded_ternary.zig
@@ -6,6 +6,8 @@ test "reports no-unneeded-ternary for boolean literal branches" {
     const source =
         \\const first = enabled ? true : false;
         \\const second = enabled ? false : true;
+        \\const third = enabled ? true : true;
+        \\const fourth = enabled ? false : false;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +19,7 @@ test "reports no-unneeded-ternary for boolean literal branches" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unneeded_ternary.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unneeded_ternary.id));
 }
 
 test "does not report no-unneeded-ternary for non-boolean branches or default assignments" {


### PR DESCRIPTION
## Summary
- report `no-unneeded-ternary` whenever both conditional branches are boolean literals
- add coverage for same-value boolean branches like `cond ? true : true` and `cond ? false : false`

## Why
ESLint reports boolean literal ternaries even when both branches have the same boolean value. utoo-lint previously skipped those cases because it returned early when the branch values matched.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_unneeded_ternary.zig tests/rules/no_unneeded_ternary.zig`
- `git diff --check`
