### PR TITLE
Align no-nested-ternary branch checks

### DIFF
--- a/src/rules/no_nested_ternary.zig
+++ b/src/rules/no_nested_ternary.zig
@@ -26,32 +26,30 @@ pub fn check(
 }
 
 fn hasNestedTernary(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {
-    return subtreeHasConditionalExpression(tree, expression.@"test") or
-        subtreeHasConditionalExpression(tree, expression.consequent) or
-        subtreeHasConditionalExpression(tree, expression.alternate);
+    return isConditionalExpression(tree, expression.@"test") or
+        isConditionalExpression(tree, expression.consequent) or
+        isConditionalExpression(tree, expression.alternate);
 }
 
-fn subtreeHasConditionalExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn isConditionalExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;
 
-    switch (tree.data(index)) {
-        .conditional_expression => return true,
-        inline else => |node| {
-            const Node = @TypeOf(node);
-            if (@typeInfo(Node) != .@"struct") return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .conditional_expression => true,
+        else => false,
+    };
+}
 
-            inline for (@typeInfo(Node).@"struct".fields) |field| {
-                if (field.type == ast.NodeIndex) {
-                    if (subtreeHasConditionalExpression(tree, @field(node, field.name))) return true;
-                } else if (field.type == ast.IndexRange) {
-                    const range = @field(node, field.name);
-                    for (tree.extra(range)) |child| {
-                        if (subtreeHasConditionalExpression(tree, child)) return true;
-                    }
-                }
-            }
-        },
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
     }
 
-    return false;
+    return current;
 }

--- a/tests/rules/no_nested_ternary.zig
+++ b/tests/rules/no_nested_ternary.zig
@@ -6,6 +6,7 @@ test "reports no-nested-ternary for conditional expressions inside branches" {
     const source =
         \\const first = foo ? bar ? a : b : c;
         \\const second = foo ? a : bar ? b : c;
+        \\const third = foo ? (bar ? a : b) : c;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,12 +18,14 @@ test "reports no-nested-ternary for conditional expressions inside branches" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_nested_ternary.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_nested_ternary.id));
 }
 
 test "does not report no-nested-ternary for simple conditional expressions" {
     const source =
         \\const value = ready ? a : b;
+        \\const called = foo ? call(bar ? a : b) : c;
+        \\const object = foo ? { value: bar ? a : b } : c;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary
- restrict `no-nested-ternary` to direct conditional expressions in ternary branches
- avoid reporting ternaries nested deeper inside call arguments or object literals
- add coverage for direct parenthesized nested ternaries and deeper non-nested cases

## Why
ESLint reports nested ternaries when a conditional expression appears directly in the test, consequent, or alternate of another conditional expression. utoo-lint previously walked entire branch subtrees, which caused false positives for expressions like `foo ? call(bar ? a : b) : c`.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_nested_ternary.zig tests/rules/no_nested_ternary.zig`
- `git diff --check`
