### PR TITLE
Align no-compare-neg-zero wrapped zeroes

### DIFF
--- a/src/rules/no_compare_neg_zero.zig
+++ b/src/rules/no_compare_neg_zero.zig
@@ -46,14 +46,28 @@ fn isComparisonOperator(operator: ast.BinaryOperator) bool {
 fn isNegativeZero(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;
 
-    const unary = switch (tree.data(index)) {
+    const unary = switch (tree.data(unwrapTransparent(tree, index))) {
         .unary_expression => |unary| unary,
         else => return false,
     };
     if (unary.operator != .negate) return false;
 
-    return switch (tree.data(unary.argument)) {
-        .numeric_literal => |literal| std.mem.eql(u8, tree.string(literal.raw), "0"),
+    return switch (tree.data(unwrapTransparent(tree, unary.argument))) {
+        .numeric_literal => |literal| literal.value(tree) == 0,
         else => false,
     };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/tests/rules/no_compare_neg_zero.zig
+++ b/tests/rules/no_compare_neg_zero.zig
@@ -8,6 +8,9 @@ test "reports no-compare-neg-zero for comparisons against negative zero" {
         \\-0 == x;
         \\x < -0;
         \\-0 >= x;
+        \\x === -(0);
+        \\(-0) === x;
+        \\x === -0.0;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +21,7 @@ test "reports no-compare-neg-zero for comparisons against negative zero" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_compare_neg_zero.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_compare_neg_zero.id));
 }
 
 test "does not report no-compare-neg-zero for non-comparisons" {


### PR DESCRIPTION
## Summary
- detect parenthesized negative zero comparisons like `x === -(0)` and `(-0) === x`
- treat numeric zero spellings such as `-0.0` as negative zero
- add coverage for wrapped and decimal negative zero comparisons

## Why
ESLint reports `no-compare-neg-zero` for wrapped zero expressions and decimal zero spellings. utoo-lint previously only recognized a raw `-0` numeric literal.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_compare_neg_zero.zig tests/rules/no_compare_neg_zero.zig`
- `git diff --check`
