### PR TITLE
Align no-regex-spaces constructors

### DIFF
--- a/src/rules/no_regex_spaces.zig
+++ b/src/rules/no_regex_spaces.zig
@@ -1,10 +1,70 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-regex-spaces";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, call.callee, call.arguments, index);
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, expression.callee, expression.arguments, index);
+        return .proceed;
+    }
+
+    fn checkConstructor(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+        argument_range: ast.IndexRange,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(argument_range);
+        if (arguments.len == 0) return;
+        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+
+        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
+        if (!hasConsecutiveSpaces(pattern)) return;
+
+        try addDiagnostic(self.allocator, self.diagnostics, tree, index);
+    }
+};
 
 pub fn check(
     allocator: Allocator,
@@ -15,6 +75,15 @@ pub fn check(
 ) Allocator.Error!void {
     if (!hasConsecutiveSpaces(tree.string(literal.pattern))) return;
 
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -23,6 +92,60 @@ pub fn check(
         "Avoid multiple spaces in regular expression literals.",
         tree.span(index),
     );
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
 }
 
 fn hasConsecutiveSpaces(pattern: []const u8) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -764,6 +764,10 @@ pub fn runSemantic(
         try no_invalid_regexp.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
+    if (options.no_regex_spaces) {
+        try no_regex_spaces.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.no_misleading_character_class) {
         try no_misleading_character_class.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/tests/rules/no_regex_spaces.zig
+++ b/tests/rules/no_regex_spaces.zig
@@ -6,28 +6,39 @@ test "reports no-regex-spaces for consecutive regex pattern spaces" {
     const source =
         \\const first = /foo  bar/;
         \\const second = /foo   bar/;
+        \\const third = new RegExp("foo  bar");
+        \\const fourth = RegExp("foo   bar", "g");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_console = false,
+        .prefer_regex_literals = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_regex_spaces.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_regex_spaces.id));
 }
 
-test "does not report no-regex-spaces for escaped or character class spaces" {
+test "does not report no-regex-spaces for escaped, character class, or dynamic constructor spaces" {
     const source =
         \\const first = /foo bar/;
         \\const second = /foo\ \ bar/;
         \\const third = /[  ]/;
+        \\const fourth = new RegExp(`foo  bar`);
+        \\const fifth = new RegExp(`foo ${value}  bar`);
+        \\const sixth = new RegExp(pattern);
+        \\const seventh = new globalThis.RegExp("foo  bar");
+        \\function local(RegExp) {
+        \\  const eighth = new RegExp("foo  bar");
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_console = false,
+        .prefer_regex_literals = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary
- report `no-regex-spaces` for static string patterns passed to direct global `RegExp` constructors
- keep template, dynamic, `globalThis.RegExp`, and shadowed `RegExp` constructor calls ignored
- reuse the existing regex-space diagnostic for literal and constructor paths

## Why
ESLint checks direct `RegExp("...")` and `new RegExp("...")` string patterns for consecutive spaces. utoo-lint previously only checked regex literals, so constructor string patterns were missed.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_regex_spaces.zig src/rules/root.zig tests/rules/no_regex_spaces.zig`
- `git diff --check`
