### PR TITLE
Align no-multi-spaces property exception

### DIFF
--- a/src/rules/no_multi_spaces.zig
+++ b/src/rules/no_multi_spaces.zig
@@ -136,6 +136,12 @@ fn collectIgnoredSpans(allocator: Allocator, tree: *const ast.Tree) Allocator.Er
             .string_literal, .template_element, .regexp_literal => {
                 try ignored_spans.append(allocator, .{ .start = span.start, .end = span.end });
             },
+            .object_property => |property| {
+                const value_span = tree.span(property.value);
+                if (span.start < value_span.start) {
+                    try ignored_spans.append(allocator, .{ .start = span.start, .end = value_span.start });
+                }
+            },
             else => {},
         }
     }

--- a/tests/rules/no_multi_spaces.zig
+++ b/tests/rules/no_multi_spaces.zig
@@ -67,6 +67,41 @@ test "does not report no-multi-spaces for indentation or inside literals and com
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_spaces.id));
 }
 
+test "does not report no-multi-spaces for object property alignment" {
+    const source =
+        "const obj = {\n" ++
+        "  a  : 1,\n" ++
+        "  bb:  2,\n" ++
+        "  [key  ]: 3,\n" ++
+        "  async  method  () {},\n" ++
+        "};\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_spaces.id));
+}
+
+test "still reports no-multi-spaces inside object property values" {
+    const source =
+        "const obj = {\n" ++
+        "  a: fn(  1),\n" ++
+        "  b: 1 +  2,\n" ++
+        "};\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_multi_spaces.id));
+}
+
 test "can disable no-multi-spaces" {
     const source = "const value =  1;\n";
 


### PR DESCRIPTION
## Summary
- ignore `no-multi-spaces` gaps from an object property start through its value start
- align the default ESLint `Property` exception for key/colon/value alignment and object method spacing
- keep reporting multiple spaces inside object property value expressions

## Why
ESLint's default `no-multi-spaces` configuration allows object property alignment, including spaces around property colons, computed keys, and object method heads. utoo-lint previously scanned the raw line text and reported those default-allowed property gaps.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_multi_spaces.zig tests/rules/no_multi_spaces.zig`
- `git diff --check`
