### PR TITLE
Align no-process-env member access

### DIFF
--- a/src/rules/no_process_env.zig
+++ b/src/rules/no_process_env.zig
@@ -35,13 +35,9 @@ fn isProcessEnvAccess(tree: *const ast.Tree, member: ast.MemberExpression) bool 
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
     if (member.property == .null) return null;
+    if (member.computed) return null;
 
-    return if (member.computed)
-        switch (tree.data(member.property)) {
-            .string_literal => |literal| tree.string(literal.value),
-            else => null,
-        }
-    else switch (tree.data(member.property)) {
+    return switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         else => null,
     };

--- a/tests/rules/no_process_env.zig
+++ b/tests/rules/no_process_env.zig
@@ -6,7 +6,6 @@ test "reports no-process-env for process env member access" {
     const source =
         \\const nodeEnv = process.env.NODE_ENV;
         \\process.env.DEBUG = "1";
-        \\const env = process["env"];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -16,13 +15,16 @@ test "reports no-process-env for process env member access" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_process_env.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_process_env.id));
 }
 
 test "does not report no-process-env for other objects or dynamic properties" {
     const source =
         \\const env = config.env;
+        \\const bracket = process["env"];
+        \\const template = process[`env`];
         \\const env2 = process[envName];
+        \\const computed = process[`${envName}`];
         \\const value = process.envName;
     ;
 


### PR DESCRIPTION
## Summary
- limit `no-process-env` reporting to direct `process.env` member access
- stop reporting computed `process["env"]`, `process[`env`]`, and dynamic `process[...]` access
- update rule tests to lock the ESLint-compatible computed-member behavior

## Why
ESLint's deprecated core `no-process-env` rule reports direct `process.env` access only. utoo-lint previously treated computed string access as equivalent, which produced extra diagnostics for bracket and template member expressions.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_process_env.zig tests/rules/no_process_env.zig`
- `git diff --check`
