### PR TITLE
Align no-process-exit member access

### DIFF
--- a/src/rules/no_process_exit.zig
+++ b/src/rules/no_process_exit.zig
@@ -40,13 +40,9 @@ fn isProcessExitCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
     if (member.property == .null) return null;
+    if (member.computed) return null;
 
-    return if (member.computed)
-        switch (tree.data(member.property)) {
-            .string_literal => |literal| tree.string(literal.value),
-            else => null,
-        }
-    else switch (tree.data(member.property)) {
+    return switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         else => null,
     };

--- a/tests/rules/no_process_exit.zig
+++ b/tests/rules/no_process_exit.zig
@@ -5,7 +5,6 @@ const helpers = @import("../helpers.zig");
 test "reports no-process-exit for process exit calls" {
     const source =
         \\process.exit(1);
-        \\process["exit"](0);
         \\(process.exit)();
     ;
 
@@ -16,14 +15,17 @@ test "reports no-process-exit for process exit calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_process_exit.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_process_exit.id));
 }
 
 test "does not report no-process-exit for references or other objects" {
     const source =
         \\const exit = process.exit;
         \\runner.exit(1);
+        \\process["exit"](0);
+        \\process[`exit`](0);
         \\process[method](0);
+        \\process[`${method}`](0);
         \\process.exitCode = 1;
     ;
 


### PR DESCRIPTION
## Summary
- limit `no-process-exit` reporting to direct `process.exit()` calls
- stop reporting computed `process["exit"]()`, `process[`exit`]()`, and dynamic `process[...]()` calls
- keep parenthesized direct `process.exit` calls covered

## Why
ESLint's deprecated core `no-process-exit` rule reports direct `process.exit()` calls only. utoo-lint previously treated computed string access as equivalent, which produced extra diagnostics for bracket and template member calls.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_process_exit.zig tests/rules/no_process_exit.zig`
- `git diff --check`
