### PR TITLE
Align no-undef typeof default

### DIFF
--- a/src/rules/no_undef.zig
+++ b/src/rules/no_undef.zig
@@ -14,12 +14,19 @@ pub fn run(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    var allowed_typeof_refs = std.AutoHashMap(ast.NodeIndex, void).init(allocator);
+    defer allowed_typeof_refs.deinit();
+
+    var visitor = TypeofVisitor{ .allowed_refs = &allowed_typeof_refs };
+    try traverser.basic.traverse(TypeofVisitor, tree, &visitor);
+
     var iter = symbol_table.iterUnresolved();
 
     while (iter.next()) |entry| {
         const reference = entry.reference;
         if (reference.kind != .value) continue;
         if (tree.data(reference.node) == .jsx_identifier) continue;
+        if (allowed_typeof_refs.contains(reference.node)) continue;
 
         const name = tree.string(reference.name);
         if (core.isKnownGlobal(name)) continue;
@@ -34,4 +41,38 @@ pub fn run(
             .{name},
         );
     }
+}
+
+const TypeofVisitor = struct {
+    allowed_refs: *std.AutoHashMap(ast.NodeIndex, void),
+
+    pub fn enter_unary_expression(
+        self: *TypeofVisitor,
+        expression: ast.UnaryExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (expression.operator != .typeof) return .proceed;
+
+        const argument = unwrapTransparent(ctx.tree, expression.argument);
+        if (argument == .null) return .proceed;
+        if (ctx.tree.data(argument) != .identifier_reference) return .proceed;
+
+        try self.allowed_refs.put(argument, {});
+        return .proceed;
+    }
+};
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/tests/rules/no_undef.zig
+++ b/tests/rules/no_undef.zig
@@ -13,3 +13,35 @@ test "reports no-undef for missing references" {
 
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_undef.id));
 }
+
+test "does not report no-undef for direct typeof identifier operands by default" {
+    const source =
+        \\typeof missing;
+        \\typeof (alsoMissing);
+        \\typeof missing === "undefined";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_undef.id));
+}
+
+test "reports no-undef for unresolved member objects inside typeof" {
+    const source =
+        \\typeof missing.prop;
+        \\typeof (alsoMissing.prop);
+        \\missing.prop;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_undef.id));
+}


### PR DESCRIPTION
## Summary
- skip `no-undef` diagnostics for unresolved identifiers used as direct `typeof` operands
- keep reporting unresolved objects in `typeof missing.prop` and normal unresolved references
- add tests for direct, parenthesized, and member-expression `typeof` cases

## Why
ESLint's default `no-undef` behavior allows `typeof missing` checks without reporting the missing identifier. utoo-lint previously reported unresolved identifiers in all `typeof` expressions, which produced extra diagnostics for common existence checks.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_undef.zig tests/rules/no_undef.zig`
- `git diff --check`
