### PR TITLE
Align no-redeclare builtins default

### DIFF
--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -70,24 +70,9 @@ pub fn runWithOptions(
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
 
-        const name = tree.string(symbol.name);
-        if (tree.source_type == .script and symbol.scope == .root and core.isKnownGlobal(name)) {
-            for (decls) |decl| {
-                try core.addDiagnosticFmt(
-                    allocator,
-                    diagnostics,
-                    options.severity,
-                    options.rule_id,
-                    tree.span(decl),
-                    "'{s}' is already defined as a built-in global variable.",
-                    .{name},
-                );
-            }
-            continue;
-        }
-
         if (decls.len <= 1) continue;
 
+        const name = tree.string(symbol.name);
         if (options.mode == .typescript) {
             try checkTypescriptRedeclarations(allocator, diagnostics, tree, decls, name, decl_info, options);
         } else {

--- a/tests/rules/no_redeclare.zig
+++ b/tests/rules/no_redeclare.zig
@@ -24,9 +24,10 @@ test "reports no-redeclare for repeated declarations" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_redeclare.id));
 }
 
-test "reports no-redeclare for script built-in globals" {
+test "does not report no-redeclare for script built-in globals by default" {
     const source =
         \\var Object = 1;
+        \\var Array = 1;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", .{
@@ -35,7 +36,7 @@ test "reports no-redeclare for script built-in globals" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_redeclare.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
 }
 
 test "does not report no-redeclare for distinct scopes and type declarations" {


### PR DESCRIPTION
## Summary
- stop reporting `no-redeclare` for script top-level declarations of known built-in globals by default
- keep ordinary repeated declarations on the existing `decls.len > 1` path
- update the built-in global test to match ESLint's default behavior

## Why
ESLint's default `no-redeclare` configuration does not report declarations such as `var Object` or `var Array` as built-in global redeclarations. utoo-lint previously reported those declarations unconditionally in script files, producing extra diagnostics.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_redeclare.zig tests/rules/no_redeclare.zig`
- `git diff --check`
