### PR TITLE
Align no-inner-declarations default

### DIFF
--- a/src/rules/no_inner_declarations.zig
+++ b/src/rules/no_inner_declarations.zig
@@ -9,46 +9,10 @@ const Allocator = std.mem.Allocator;
 pub const id = "no-inner-declarations";
 
 pub fn checkFunction(
-    allocator: Allocator,
-    diagnostics: *core.DiagnosticList,
-    tree: *const ast.Tree,
-    function: ast.Function,
-    index: ast.NodeIndex,
-    ctx: *traverser.basic.Ctx,
-) Allocator.Error!void {
-    if (function.type != .function_declaration) return;
-    if (!isInnerDeclaration(tree, ctx)) return;
-
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Move function declaration to program root or function body root.",
-        tree.span(index),
-    );
-}
-
-fn isInnerDeclaration(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
-    const parent = ctx.path.parent() orelse return false;
-
-    switch (tree.data(parent)) {
-        .program,
-        .function_body,
-        => return false,
-
-        .export_named_declaration,
-        .export_default_declaration,
-        => {
-            const grandparent = ctx.path.ancestor(2) orelse return true;
-            return switch (tree.data(grandparent)) {
-                .program,
-                .function_body,
-                => false,
-                else => true,
-            };
-        },
-
-        else => return true,
-    }
-}
+    _: Allocator,
+    _: *core.DiagnosticList,
+    _: *const ast.Tree,
+    _: ast.Function,
+    _: ast.NodeIndex,
+    _: *traverser.basic.Ctx,
+) Allocator.Error!void {}

--- a/tests/rules/no_inner_declarations.zig
+++ b/tests/rules/no_inner_declarations.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports no-inner-declarations for function declarations inside blocks" {
+test "does not report no-inner-declarations for block-scoped function declarations by default" {
     const source =
         \\if (foo) {
         \\  function bar() {}
@@ -24,7 +24,7 @@ test "reports no-inner-declarations for function declarations inside blocks" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_inner_declarations.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inner_declarations.id));
 }
 
 test "does not report no-inner-declarations for root function declarations" {


### PR DESCRIPTION
## Summary
- stop reporting block-scoped function declarations from `no-inner-declarations` by default
- keep the rule entrypoint available while matching ESLint 9's modern default behavior
- update the block function declaration test to assert no diagnostics

## Why
ESLint 9's default `no-inner-declarations` behavior no longer reports function declarations inside blocks for modern JavaScript. utoo-lint previously reported those declarations unconditionally, producing extra diagnostics compared with ESLint defaults.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_inner_declarations.zig tests/rules/no_inner_declarations.zig`
- `git diff --check`
