### PR TITLE
Align no-implied-eval direct calls

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -226,10 +226,6 @@ fn isImpliedEvalCallee(
 ) bool {
     const unwrapped = unwrapTransparent(tree, callee);
 
-    if (identifierReferenceName(tree, unwrapped)) |name| {
-        return isImpliedEvalName(name) and isUnresolvedReference(symbol_table, unwrapped);
-    }
-
     const member = switch (tree.data(unwrapped)) {
         .member_expression => |member| member,
         else => return false,

--- a/tests/rules/no_implied_eval.zig
+++ b/tests/rules/no_implied_eval.zig
@@ -4,12 +4,10 @@ const helpers = @import("../helpers.zig");
 
 test "reports no-implied-eval for string timer and execScript calls" {
     const source =
-        \\setTimeout("alert(1)", 100);
-        \\setInterval(`tick()`, 100);
-        \\execScript("alert(1)");
         \\globalThis.setTimeout("alert(1)");
         \\globalThis["setInterval"]("tick()", 100);
         \\globalThis[`setInterval`]("tick()", 100);
+        \\globalThis.execScript("alert(1)");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -21,11 +19,14 @@ test "reports no-implied-eval for string timer and execScript calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_implied_eval.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_implied_eval.id));
 }
 
-test "does not report no-implied-eval for function arguments or shadowed calls" {
+test "does not report no-implied-eval for direct calls function arguments or shadowed calls" {
     const source =
+        \\setTimeout("alert(1)", 100);
+        \\setInterval(`tick()`, 100);
+        \\execScript("alert(1)");
         \\setTimeout(() => alert(1), 100);
         \\setInterval(handler, 100);
         \\const setTimeout = customTimer;


### PR DESCRIPTION
## Summary
- stop reporting `no-implied-eval` for direct `setTimeout`, `setInterval`, and `execScript` calls by default
- keep reporting static `globalThis.*` timer and `execScript` member calls with string first arguments
- update tests to lock the ESLint-compatible direct-call behavior

## Why
ESLint 10's default `no-implied-eval` behavior does not report bare `setTimeout("...")`, `setInterval("...")`, or `execScript("...")` calls without configured globals. utoo-lint previously reported those direct unresolved calls, producing extra diagnostics compared with ESLint defaults.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/global_call_checks.zig tests/rules/no_implied_eval.zig`
- `git diff --check`
