### PR TITLE
Align no-extend-native native names

### DIFF
--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -12,12 +12,11 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
+    _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
-        .symbol_table = symbol_table,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -26,7 +25,6 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
-    symbol_table: traverser.semantic.SymbolTable,
 
     pub fn enter_assignment_expression(
         self: *Visitor,
@@ -40,7 +38,7 @@ const Visitor = struct {
         };
         if (left_member.optional) return .proceed;
 
-        if (nativePrototypeName(ctx.tree, self.symbol_table, left_member.object)) |name| {
+        if (nativePrototypeName(ctx.tree, left_member.object)) |name| {
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 
@@ -54,12 +52,12 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (call.optional) return .proceed;
-        if (!isObjectDefinePropertyCall(ctx.tree, self.symbol_table, call.callee)) return .proceed;
+        if (!isObjectDefinePropertyCall(ctx.tree, call.callee)) return .proceed;
 
         const arguments = ctx.tree.extra(call.arguments);
         if (arguments.len == 0) return .proceed;
 
-        if (nativePrototypeName(ctx.tree, self.symbol_table, arguments[0])) |name| {
+        if (nativePrototypeName(ctx.tree, arguments[0])) |name| {
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 
@@ -69,7 +67,6 @@ const Visitor = struct {
 
 fn nativePrototypeName(
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
     index: ast.NodeIndex,
 ) ?[]const u8 {
     const member = switch (tree.data(unwrapTransparent(tree, index))) {
@@ -83,14 +80,13 @@ fn nativePrototypeName(
 
     const object = unwrapTransparent(tree, member.object);
     const name = identifierReferenceName(tree, object) orelse return null;
-    if (!isNativeConstructor(name) or !isUnresolvedReference(symbol_table, object)) return null;
+    if (!isNativeConstructor(name)) return null;
 
     return name;
 }
 
 fn isObjectDefinePropertyCall(
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
     callee: ast.NodeIndex,
 ) bool {
     const member = switch (tree.data(unwrapTransparent(tree, callee))) {
@@ -104,7 +100,7 @@ fn isObjectDefinePropertyCall(
 
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
-    return std.mem.eql(u8, object_name, "Object") and isUnresolvedReference(symbol_table, object);
+    return std.mem.eql(u8, object_name, "Object");
 }
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
@@ -185,20 +181,6 @@ fn isNativeConstructor(name: []const u8) bool {
     for (constructors) |constructor| {
         if (std.mem.eql(u8, name, constructor)) return true;
     }
-    return false;
-}
-
-fn isUnresolvedReference(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
     return false;
 }
 

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -4,9 +4,12 @@ const helpers = @import("../helpers.zig");
 
 test "reports no-extend-native for native prototype assignments" {
     const source =
+        \\Object.prototype.toJSON = function () {};
         \\String.prototype.trimLeft = function () {};
         \\Array.prototype["first"] = function () {};
         \\Array[`prototype`].first = function () {};
+        \\const Boolean = CustomBoolean;
+        \\Boolean.prototype.value = function () {};
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -23,8 +26,8 @@ test "reports no-extend-native for native prototype assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_extend_native.id));
-    try std.testing.expectEqualStrings("String prototype is read only, properties should not be added.", result.diagnostics[0].message);
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqualStrings("Object prototype is read only, properties should not be added.", result.diagnostics[0].message);
 }
 
 test "reports no-extend-native for Object defineProperty calls" {
@@ -37,6 +40,12 @@ test "reports no-extend-native for Object defineProperty calls" {
         \\Object[`defineProperties`](Set.prototype, {
         \\  first: { value: function () {} },
         \\});
+        \\const Object = {
+        \\  defineProperty() {},
+        \\};
+        \\Object.defineProperty(Array.prototype, "last", {});
+        \\const Array = CustomArray;
+        \\Object.defineProperty(Array.prototype, "shadowed", {});
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -53,19 +62,13 @@ test "reports no-extend-native for Object defineProperty calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_extend_native.id));
 }
 
-test "does not report no-extend-native for shadowed constructors or ordinary objects" {
+test "does not report no-extend-native for ordinary objects or dynamic members" {
     const source =
-        \\const String = {};
-        \\String.prototype.trimLeft = function () {};
         \\const local = { prototype: {} };
         \\local.prototype.trimLeft = function () {};
-        \\const Object = {
-        \\  defineProperty() {},
-        \\};
-        \\Object.defineProperty(Array.prototype, "first", {});
         \\Array[`proto${suffix}`].first = function () {};
         \\Object[`define${suffix}`](Array.prototype, "first", {});
     ;


### PR DESCRIPTION
## Summary

- align `no-extend-native` with ESLint's syntax-based native constructor matching
- report `Object.prototype` extensions and shadowed native constructor names
- keep ordinary objects and dynamic member names ignored

## Why

ESLint's `no-extend-native` does not use scope resolution to skip locally shadowed native constructor names. utoo-lint previously skipped those cases, and also missed `Object.prototype` when the parser resolved `Object` as a built-in binding.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extend_native.zig tests/rules/no_extend_native.zig`
- `git diff --check`
