### PR TITLE
Align no-lone-blocks function bodies

### DIFF
--- a/src/rules/no_lone_blocks.zig
+++ b/src/rules/no_lone_blocks.zig
@@ -15,7 +15,7 @@ pub fn check(
     parent: ast.NodeIndex,
 ) Allocator.Error!void {
     if (!isStatementListParent(tree.data(parent))) return;
-    if (hasBlockScopedBinding(tree, block)) return;
+    if (tree.data(parent) == .program and hasBlockScopedBinding(tree, block)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -31,6 +31,7 @@ fn isStatementListParent(data: ast.NodeData) bool {
     return switch (data) {
         .program,
         .block_statement,
+        .function_body,
         => true,
         else => false,
     };

--- a/tests/rules/no_lone_blocks.zig
+++ b/tests/rules/no_lone_blocks.zig
@@ -12,6 +12,12 @@ test "reports no-lone-blocks for unnecessary block statements" {
         \\    run();
         \\  }
         \\}
+        \\function scoped() {
+        \\  { let value = getValue(); }
+        \\  { const value = getValue(); }
+        \\  { class Scoped {} }
+        \\  { function nested() {} }
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -22,7 +28,7 @@ test "reports no-lone-blocks for unnecessary block statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_lone_blocks.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_lone_blocks.id));
 }
 
 test "does not report no-lone-blocks for scoped declarations" {


### PR DESCRIPTION
## Summary

- align `no-lone-blocks` with ESLint for nested blocks inside function bodies
- treat Yuku `function_body` as a statement-list parent for lone block checks
- keep top-level scoped declaration blocks ignored

## Why

ESLint reports redundant nested blocks inside function bodies, including blocks that contain `let`, `const`, `class`, or function declarations. utoo-lint previously skipped those because nested blocks under Yuku `function_body` were not considered statement-list children.

## Validation

- compared `eslint@latest` and utoo-lint on a fixture with top-level blocks, function-body nested blocks, and switch case blocks
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_lone_blocks.zig tests/rules/no_lone_blocks.zig`
- `git diff --check`
