### PR TITLE
Align no-labels labeled jumps

### DIFF
--- a/src/rules/no_labels.zig
+++ b/src/rules/no_labels.zig
@@ -6,7 +6,7 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-labels";
 
-pub fn check(
+pub fn checkLabeledStatement(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
@@ -18,6 +18,44 @@ pub fn check(
         .warning,
         id,
         "Labels are not allowed.",
+        tree.span(index),
+    );
+}
+
+pub fn checkBreakStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.BreakStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (statement.label == .null) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected label in break statement.",
+        tree.span(index),
+    );
+}
+
+pub fn checkContinueStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ContinueStatement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (statement.label == .null) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected label in continue statement.",
         tree.span(index),
     );
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1749,12 +1749,27 @@ const BasicVisitor = struct {
 
     pub fn enter_continue_statement(
         self: *BasicVisitor,
-        _: ast.ContinueStatement,
+        statement: ast.ContinueStatement,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_continue) {
             try no_continue.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.no_labels) {
+            try no_labels.checkContinueStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_break_statement(
+        self: *BasicVisitor,
+        statement: ast.BreakStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_labels) {
+            try no_labels.checkBreakStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         return .proceed;
     }
@@ -1772,7 +1787,7 @@ const BasicVisitor = struct {
             try no_unused_labels.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.no_labels) {
-            try no_labels.check(self.allocator, self.diagnostics, ctx.tree, index);
+            try no_labels.checkLabeledStatement(self.allocator, self.diagnostics, ctx.tree, index);
         }
         return .proceed;
     }

--- a/tests/rules/no_labels.zig
+++ b/tests/rules/no_labels.zig
@@ -8,6 +8,10 @@ test "reports no-labels for labeled statements" {
         \\for (const item of items) {
         \\  if (item) break start;
         \\}
+        \\again:
+        \\while (ready) {
+        \\  continue again;
+        \\}
         \\done:
         \\use(value);
     ;
@@ -19,13 +23,14 @@ test "reports no-labels for labeled statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_labels.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_labels.id));
 }
 
-test "does not report no-labels for unlabeled loops" {
+test "does not report no-labels for unlabeled break and continue" {
     const source =
         \\for (const item of items) {
         \\  if (item) break;
+        \\  continue;
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- report labeled `break` statements for `no-labels`
- report labeled `continue` statements for `no-labels`
- keep unlabeled `break` and `continue` statements ignored

## Why

ESLint reports both the labeled statement itself and any `break` or `continue` that targets a label. utoo-lint previously only reported the label declaration, so `break foo;` and `continue foo;` were missed.

## Validation

- compared `eslint@latest` and utoo-lint on labeled statements, labeled jumps, and unlabeled jumps
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_labels.zig src/rules/root.zig tests/rules/no_labels.zig`
- `git diff --check`
