### PR TITLE
Align no-multi-assign declarations

### DIFF
--- a/src/rules/no_multi_assign.zig
+++ b/src/rules/no_multi_assign.zig
@@ -25,6 +25,24 @@ pub fn check(
     );
 }
 
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!void {
+    if (!isAssignmentExpression(tree, declarator.init)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Unexpected chained assignment.",
+        tree.span(declarator.init),
+    );
+}
+
 fn isAssignmentExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1407,6 +1407,9 @@ const BasicVisitor = struct {
                 .allow_in_object_destructuring = self.options.no_underscore_dangle_allow_in_object_destructuring == .yes,
             });
         }
+        if (self.options.no_multi_assign) {
+            try no_multi_assign.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
         if (self.options.func_name_matching) {
             try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, .{
                 .style = funcNameMatchingStyle(self.options.func_name_matching_style),

--- a/tests/rules/no_multi_assign.zig
+++ b/tests/rules/no_multi_assign.zig
@@ -8,6 +8,9 @@ test "reports no-multi-assign for chained assignments" {
         \\a = b = c;
         \\a = (b = c);
         \\a = b = c = d;
+        \\let x = y = z;
+        \\const p = q = r;
+        \\var m = n = o;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +20,7 @@ test "reports no-multi-assign for chained assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_multi_assign.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_multi_assign.id));
 }
 
 test "does not report no-multi-assign for single assignments" {
@@ -26,6 +29,7 @@ test "does not report no-multi-assign for single assignments" {
         \\a = b;
         \\a += b;
         \\a = condition ? b = c : c;
+        \\let ok = b;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- report chained assignments used as variable declaration initializers
- cover `let`, `const`, and `var` declaration forms
- keep ordinary declaration initializers ignored

## Why

ESLint reports `let x = y = z` as `no-multi-assign` because the initializer is itself an assignment expression. utoo-lint previously only checked assignment expressions whose right-hand side was another assignment, so declaration initializers were missed.

## Validation

- compared `eslint@latest` and utoo-lint on assignment expressions and declaration initializers
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_multi_assign.zig src/rules/root.zig tests/rules/no_multi_assign.zig`
- `git diff --check`
