### PR TITLE
Align no-nested-ternary test expressions

### DIFF
--- a/src/rules/no_nested_ternary.zig
+++ b/src/rules/no_nested_ternary.zig
@@ -26,8 +26,7 @@ pub fn check(
 }
 
 fn hasNestedTernary(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {
-    return isConditionalExpression(tree, expression.@"test") or
-        isConditionalExpression(tree, expression.consequent) or
+    return isConditionalExpression(tree, expression.consequent) or
         isConditionalExpression(tree, expression.alternate);
 }
 

--- a/tests/rules/no_nested_ternary.zig
+++ b/tests/rules/no_nested_ternary.zig
@@ -24,6 +24,7 @@ test "reports no-nested-ternary for conditional expressions inside branches" {
 test "does not report no-nested-ternary for simple conditional expressions" {
     const source =
         \\const value = ready ? a : b;
+        \\const tested = (foo ? a : b) ? c : d;
         \\const called = foo ? call(bar ? a : b) : c;
         \\const object = foo ? { value: bar ? a : b } : c;
     ;


### PR DESCRIPTION
## Summary

- stop reporting `no-nested-ternary` when a conditional expression appears only in the test position
- keep reporting nested ternaries in the consequent or alternate branches

## Why

ESLint reports nested ternaries only when the nested conditional is in one of the branch expressions. utoo-lint previously also reported `(a ? b : c) ? d : e`, where the nested conditional is the test expression.

## Validation

- compared `eslint@latest` and utoo-lint on branch-nested and test-position conditional expressions
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_nested_ternary.zig tests/rules/no_nested_ternary.zig`
- `git diff --check`
