### PR TITLE
Align no-regex-spaces focused constructors

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -159,6 +159,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_object_constructor or
         options.no_promise_executor_return or
         options.no_redeclare or
+        options.no_regex_spaces or
         options.no_shadow or
         options.no_undef or
         options.react_jsx_no_undef or

--- a/tests/rules/no_regex_spaces.zig
+++ b/tests/rules/no_regex_spaces.zig
@@ -22,6 +22,21 @@ test "reports no-regex-spaces for consecutive regex pattern spaces" {
     try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_regex_spaces.id));
 }
 
+test "reports no-regex-spaces constructors when only the rule is enabled" {
+    const source =
+        \\const first = RegExp("foo  bar");
+        \\const second = new RegExp("foo   bar");
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_regex_spaces = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_regex_spaces.id));
+}
+
 test "does not report no-regex-spaces for escaped, character class, or dynamic constructor spaces" {
     const source =
         \\const first = /foo bar/;


### PR DESCRIPTION
## Summary

- run semantic analysis when `no-regex-spaces` is the only enabled rule
- keep RegExp constructor checks active for focused rule sets such as `--rules=no-regex-spaces`
- add focused coverage for `RegExp("foo  bar")` and `new RegExp("foo   bar")`

## Why

`no-regex-spaces` checks RegExp constructors in its semantic visitor, but `hasSemanticRules` did not include the rule. Focused runs only enabled the basic pass, so regex literals were reported while static RegExp constructor patterns were missed.

## Validation

- compared `eslint@latest` and utoo-lint with `--rules=no-regex-spaces`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/root.zig tests/rules/no_regex_spaces.zig`
- `git diff --check`
