### PR TITLE
Align prefer-promise-reject-errors static Promise

### DIFF
--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -49,7 +49,7 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.check_prefer_promise_reject_errors and
-            isGlobalPromiseRejectCall(ctx.tree, self.symbol_table, call))
+            isPromiseRejectCall(ctx.tree, call))
         {
             try checkRejectArgument(self.allocator, self.diagnostics, ctx.tree, call.arguments, index);
         }
@@ -63,11 +63,11 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (!isGlobalPromiseReference(ctx.tree, self.symbol_table, expression.callee)) return .proceed;
-
         const executor = promiseExecutor(ctx.tree, expression.arguments);
+        const is_global_promise = isGlobalPromiseReference(ctx.tree, self.symbol_table, expression.callee);
 
-        if (self.check_no_async_promise_executor and
+        if (is_global_promise and
+            self.check_no_async_promise_executor and
             executor != null and
             isAsyncFunctionLike(ctx.tree, executor.?))
         {
@@ -81,11 +81,14 @@ const Visitor = struct {
             );
         }
 
-        if (self.check_no_promise_executor_return and executor != null) {
+        if (is_global_promise and self.check_no_promise_executor_return and executor != null) {
             try checkExecutorReturn(self.allocator, self.diagnostics, ctx.tree, executor.?);
         }
 
-        if (self.check_prefer_promise_reject_errors and executor != null) {
+        if (self.check_prefer_promise_reject_errors and
+            isPromiseReferenceName(ctx.tree, expression.callee) and
+            executor != null)
+        {
             const reject_name = executorRejectName(ctx.tree, executor.?) orelse return .proceed;
             try scanExecutorRejects(self.allocator, self.diagnostics, ctx.tree, reject_name, executor.?);
         }
@@ -94,9 +97,8 @@ const Visitor = struct {
     }
 };
 
-fn isGlobalPromiseRejectCall(
+fn isPromiseRejectCall(
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
     call: ast.CallExpression,
 ) bool {
     if (call.optional) return false;
@@ -109,7 +111,7 @@ fn isGlobalPromiseRejectCall(
 
     const property = staticMemberPropertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, property, "reject")) return false;
-    return isGlobalPromiseReference(tree, symbol_table, member.object);
+    return isPromiseReferenceName(tree, member.object);
 }
 
 fn promiseExecutor(tree: *const ast.Tree, arguments: ast.IndexRange) ?ast.NodeIndex {
@@ -379,9 +381,13 @@ fn isGlobalPromiseReference(
     symbol_table: traverser.semantic.SymbolTable,
     index: ast.NodeIndex,
 ) bool {
+    if (!isPromiseReferenceName(tree, index)) return false;
     const unwrapped = unwrapTransparent(tree, index);
-    if (!isIdentifierReferenceNamed(tree, unwrapped, "Promise")) return false;
     return isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn isPromiseReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return isIdentifierReferenceNamed(tree, index, "Promise");
 }
 
 fn isUnresolvedReference(

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -21,6 +21,14 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
         \\    reject(1);
         \\  }
         \\});
+        \\const Promise = {
+        \\  reject(value) {
+        \\    return value;
+        \\  }
+        \\};
+        \\Promise.reject("local");
+        \\Promise["reject"]("local");
+        \\Promise[`reject`]("local");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -30,7 +38,7 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
 test "does not report prefer-promise-reject-errors for error-like rejection reasons" {
@@ -50,16 +58,15 @@ test "does not report prefer-promise-reject-errors for error-like rejection reas
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
-test "does not report prefer-promise-reject-errors for shadowed Promise or nested reject calls" {
+test "does not report prefer-promise-reject-errors for dynamic Promise members or nested reject calls" {
     const source =
+        \\const suffix = "ject";
         \\const Promise = {
         \\  reject(value) {
         \\    return value;
         \\  }
         \\};
-        \\Promise.reject("local");
-        \\Promise["reject"]("local");
-        \\Promise[`reject`]("local");
+        \\Promise[`re${suffix}`]("dynamic");
         \\new Promise((resolve, reject) => {
         \\  function nested() {
         \\    reject("nested");


### PR DESCRIPTION
## Summary

- align `prefer-promise-reject-errors` with ESLint's static `Promise` matching
- report `Promise.reject(...)` even when `Promise` is locally shadowed
- keep `no-async-promise-executor` and `no-promise-executor-return` scoped to global `Promise`

## Why

ESLint's `prefer-promise-reject-errors` checks static `Promise.reject` and `new Promise(... reject(...))` shapes by name, including locally shadowed `Promise`. utoo-lint previously required `Promise` to be unresolved, so focused/default global handling could miss these cases.

## Validation

- compared `eslint@latest` and utoo-lint on static, computed, dynamic, and `new Promise` rejection cases
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/promise_checks.zig tests/rules/prefer_promise_reject_errors.zig`
- `git diff --check`
