### PR TITLE
Align no-invalid-regexp static RegExp

### DIFF
--- a/src/rules/no_invalid_regexp.zig
+++ b/src/rules/no_invalid_regexp.zig
@@ -12,12 +12,11 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
+    _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
-        .symbol_table = symbol_table,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -26,7 +25,6 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
-    symbol_table: traverser.semantic.SymbolTable,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -57,7 +55,7 @@ const Visitor = struct {
     ) Allocator.Error!void {
         const arguments = tree.extra(argument_range);
         if (arguments.len == 0) return;
-        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+        if (!isRegExpReferenceName(tree, callee)) return;
 
         const flags = if (arguments.len >= 2) stringLiteralValue(tree, arguments[1]) else null;
         if (flags) |value| {
@@ -151,14 +149,10 @@ fn validatePattern(pattern: []const u8) ?[]const u8 {
     return null;
 }
 
-fn isGlobalRegExpReference(
-    tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
-    index: ast.NodeIndex,
-) bool {
+fn isRegExpReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const unwrapped = unwrapTransparent(tree, index);
     const name = identifierReferenceName(tree, unwrapped) orelse return false;
-    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+    return std.mem.eql(u8, name, "RegExp");
 }
 
 fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
@@ -189,18 +183,4 @@ fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const
         .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
     };
-}
-
-fn isUnresolvedReference(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
 }

--- a/tests/rules/no_invalid_regexp.zig
+++ b/tests/rules/no_invalid_regexp.zig
@@ -11,6 +11,9 @@ test "reports no-invalid-regexp for invalid RegExp constructor arguments" {
         \\RegExp("abc", "uv");
         \\RegExp(pattern, "z");
         \\RegExp(`abc`, "z");
+        \\function local(RegExp) {
+        \\  RegExp("(", "z");
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +23,22 @@ test "reports no-invalid-regexp for invalid RegExp constructor arguments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
+}
+
+test "reports no-invalid-regexp when only the rule is enabled" {
+    const source =
+        \\RegExp("[");
+        \\new RegExp("[", "z");
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_invalid_regexp = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
 }
 
 test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
@@ -30,9 +48,7 @@ test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
         \\RegExp(pattern, flags);
         \\RegExp(`[`, `z`);
         \\RegExp(pattern, `z`);
-        \\function local(RegExp) {
-        \\  RegExp("(", "z");
-        \\}
+        \\globalThis.RegExp("(", "z");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-invalid-regexp` with ESLint's direct `RegExp` constructor matching
- report invalid `RegExp(...)` and `new RegExp(...)` even when `RegExp` is locally shadowed
- keep member calls such as `globalThis.RegExp(...)` ignored

## Why

ESLint's `no-invalid-regexp` validates direct `RegExp` constructor calls by static name. utoo-lint previously required `RegExp` to be unresolved, which missed focused/default known-global runs and shadowed direct calls.

## Validation

- compared `eslint@latest` and utoo-lint with direct, `new`, shadowed, and `globalThis.RegExp` cases
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_invalid_regexp.zig tests/rules/no_invalid_regexp.zig`
- `git diff --check`
