### PR TITLE
Align prefer-exponentiation-operator arity

### DIFF
--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -34,7 +34,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (call.arguments.len == 2 and isGlobalMathPowCall(ctx.tree, self.symbol_table, call.callee)) {
+        if (isGlobalMathPowCall(ctx.tree, self.symbol_table, call.callee)) {
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -5,6 +5,9 @@ const helpers = @import("../helpers.zig");
 test "reports prefer-exponentiation-operator for Math.pow calls" {
     const source =
         \\Math.pow(base, exponent);
+        \\Math.pow();
+        \\Math.pow(base);
+        \\Math.pow(base, exponent, modulo);
         \\(Math).pow(2, 8);
         \\Math["pow"](2, 8);
         \\Math[`pow`](2, 8);
@@ -21,7 +24,7 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_exponentiation_operator.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.prefer_exponentiation_operator.id));
     try std.testing.expectEqualStrings(
         "Use the exponentiation operator (**) instead of Math.pow.",
         result.diagnostics[0].message,
@@ -31,8 +34,6 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
 test "does not report prefer-exponentiation-operator for other calls or shadowed Math" {
     const source =
         \\Math.max(base, exponent);
-        \\Math.pow(base);
-        \\Math.pow(base, exponent, modulo);
         \\Math[`po${letter}`](base, exponent);
         \\const Math = { pow() {} };
         \\Math.pow(base, exponent);


### PR DESCRIPTION
## Summary

- report `Math.pow` calls in `prefer-exponentiation-operator` regardless of argument count
- keep the existing static member matching for `Math.pow`, `Math["pow"]`, and ``Math[`pow`]``
- continue to ignore shadowed `Math` bindings and dynamic property names

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_exponentiation_operator.zig tests/rules/prefer_exponentiation_operator.zig`
- `git diff --check`
- focused ESLint comparison for `prefer-exponentiation-operator` reported the same lines as utoo-lint: `1, 2, 3, 4, 5, 6`
