### PR TITLE
Align no-extra-boolean-cast static Boolean matching

### DIFF
--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -12,12 +12,11 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
+    _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
-        .symbol_table = symbol_table,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -26,7 +25,6 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
-    symbol_table: traverser.semantic.SymbolTable,
 
     pub fn enter_if_statement(
         self: *Visitor,
@@ -94,7 +92,7 @@ const Visitor = struct {
         tree: *const ast.Tree,
         unwrapped: ast.NodeIndex,
     ) Allocator.Error!void {
-        if (isBooleanCall(tree, self.symbol_table, unwrapped) or isDoubleNegation(tree, unwrapped)) {
+        if (isBooleanCall(tree, unwrapped) or isDoubleNegation(tree, unwrapped)) {
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,
@@ -115,11 +113,7 @@ const Visitor = struct {
     }
 };
 
-fn isBooleanCall(
-    tree: *const ast.Tree,
-    symbol_table: traverser.semantic.SymbolTable,
-    index: ast.NodeIndex,
-) bool {
+fn isBooleanCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const call = switch (tree.data(index)) {
         .call_expression => |call| call,
         else => return false,
@@ -127,7 +121,7 @@ fn isBooleanCall(
 
     const callee = unwrapTransparent(tree, call.callee);
     const name = identifierReferenceName(tree, callee) orelse return false;
-    return std.mem.eql(u8, name, "Boolean") and isUnresolvedReference(symbol_table, callee);
+    return std.mem.eql(u8, name, "Boolean");
 }
 
 fn isDoubleNegation(tree: *const ast.Tree, index: ast.NodeIndex) bool {
@@ -166,18 +160,4 @@ fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const
         .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
     };
-}
-
-fn isUnresolvedReference(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
 }

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -9,6 +9,10 @@ test "reports no-extra-boolean-cast in boolean contexts" {
         \\do { value++; } while (Boolean(value));
         \\for (; !!value; value++) { break; }
         \\const selected = Boolean(value) ? 1 : 2;
+        \\function local(Boolean) {
+        \\  if (Boolean(value)) { use(value); }
+        \\}
+        \\if (Boolean?.(value)) { use(value); }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,16 +22,15 @@ test "reports no-extra-boolean-cast in boolean contexts" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
 }
 
-test "does not report no-extra-boolean-cast outside boolean contexts or for shadowed Boolean" {
+test "does not report no-extra-boolean-cast outside boolean contexts or member calls" {
     const source =
         \\const a = Boolean(value);
         \\const b = !!value;
-        \\function local(Boolean) {
-        \\  if (Boolean(value)) { use(value); }
-        \\}
+        \\if (globalThis.Boolean(value)) { use(value); }
+        \\if (obj.Boolean(value)) { use(value); }
         \\if (!value) { use(value); }
     ;
 


### PR DESCRIPTION
## Summary

- align `no-extra-boolean-cast` with ESLint's static `Boolean(...)` callee matching
- report redundant `Boolean` calls in boolean contexts even when `Boolean` is locally shadowed
- keep member calls such as `globalThis.Boolean(...)` and `obj.Boolean(...)` out of scope

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_boolean_cast.zig tests/rules/no_extra_boolean_cast.zig`
- `git diff --check`
- focused ESLint comparison for `no-extra-boolean-cast` reported the same lines as utoo-lint: `1, 2, 3, 4, 8, 9, 10, 10`
