### PR TITLE
Align no-implicit-coercion optional indexOf handling

### DIFF
--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -140,13 +140,11 @@ fn isIndexOfCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .call_expression => |call| call,
         else => return false,
     };
-    if (call.optional) return false;
 
     const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional) return false;
 
     const name = propertyName(tree, member) orelse return false;
     return std.mem.eql(u8, name, "indexOf") or std.mem.eql(u8, name, "lastIndexOf");

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -9,6 +9,10 @@ test "reports no-implicit-coercion for boolean coercion" {
         \\const third = ~items.lastIndexOf(value);
         \\const fourth = ~items[`indexOf`](value);
         \\const fifth = ~items[`lastIndexOf`](value);
+        \\const sixth = ~items?.indexOf(value);
+        \\const seventh = ~items.indexOf?.(value);
+        \\const eighth = ~items?.[`indexOf`](value);
+        \\const ninth = ~items.lastIndexOf?.(value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +23,7 @@ test "reports no-implicit-coercion for boolean coercion" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
     try std.testing.expectEqualStrings("Use `Boolean()` instead of double negation.", result.diagnostics[0].message);
 }
 
@@ -78,6 +82,7 @@ test "does not report no-implicit-coercion for explicit conversions" {
         \\const twelfth = ~items[`index${suffix}`](value);
         \\const thirteenth = "" + `${value}`;
         \\const fourteenth = `${value}` + "";
+        \\const fifteenth = ~items?.[`index${suffix}`](value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-implicit-coercion` with ESLint for optional `indexOf` and `lastIndexOf` chains
- report `~items?.indexOf(value)`, `~items.indexOf?.(value)`, and static computed optional calls
- continue to ignore dynamic property names such as ``~items?.[`index${suffix}`](value)``

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_implicit_coercion.zig tests/rules/no_implicit_coercion.zig`
- `git diff --check`
- focused ESLint comparison for `no-implicit-coercion` reported the same lines as utoo-lint: `1, 2, 3, 4, 5, 7, 8`
