### PR TITLE
Align no-useless-call optional chain handling

### DIFF
--- a/src/rules/no_useless_call.zig
+++ b/src/rules/no_useless_call.zig
@@ -14,15 +14,12 @@ pub fn check(
     call: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (call.optional) return;
-
     const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
         .member_expression => |member| member,
         else => return,
     };
-    if (callee_member.optional) return;
 
-    const method = propertyName(tree, callee_member) orelse return;
+    const method = nonComputedPropertyName(tree, callee_member) orelse return;
     if (!std.mem.eql(u8, method, "call") and !std.mem.eql(u8, method, "apply")) return;
 
     const arguments = tree.extra(call.arguments);
@@ -49,7 +46,6 @@ fn hasUselessThisArg(tree: *const ast.Tree, target: ast.NodeIndex, this_arg: ast
         else => return isNullOrUndefined(tree, this_arg),
     };
 
-    if (target_member.optional) return false;
     if (!isSimpleReference(tree, target_member.object)) return false;
 
     return sameSource(tree, target_member.object, this_arg);
@@ -78,8 +74,17 @@ fn isSimpleReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .identifier_reference,
         .this_expression,
         => true,
-        .member_expression => |member| !member.optional and isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
+        .member_expression => |member| isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
         else => false,
+    };
+}
+
+fn nonComputedPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed or member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
     };
 }
 

--- a/tests/rules/no_useless_call.zig
+++ b/tests/rules/no_useless_call.zig
@@ -7,10 +7,14 @@ test "reports no-useless-call for unnecessary call expressions" {
         \\foo.call(undefined);
         \\foo.call(null, a, b);
         \\obj.foo.call(obj, a);
+        \\obj.foo?.call(obj, a);
+        \\obj?.foo.call(obj, a);
+        \\obj["foo"].call(obj, a);
         \\this.foo.call(this, a);
         \\obj.foo.bar.call(obj.foo, a);
-        \\foo["call"](undefined, a);
         \\foo.call(void 0, a);
+        \\foo.call?.(undefined, a);
+        \\foo?.call(undefined, a);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +24,7 @@ test "reports no-useless-call for unnecessary call expressions" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_call.id));
+    try std.testing.expectEqual(@as(usize, 11), helpers.countRule(result, lint.rules.no_useless_call.id));
 }
 
 test "reports no-useless-call for unnecessary apply expressions with array arguments" {
@@ -28,10 +32,14 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
         \\foo.apply(undefined, []);
         \\foo.apply(null, [a, b]);
         \\obj.foo.apply(obj, [a]);
+        \\obj.foo?.apply(obj, [a]);
+        \\obj?.foo.apply(obj, [a]);
+        \\obj["foo"].apply(obj, [a]);
         \\this.foo.apply(this, [a]);
-        \\obj.foo["apply"](obj, [a]);
         \\foo.apply(undefined, [, a]);
         \\foo.apply(void 0, [a]);
+        \\foo.apply?.(undefined, [a]);
+        \\foo?.apply(undefined, [a]);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -41,7 +49,7 @@ test "reports no-useless-call for unnecessary apply expressions with array argum
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_call.id));
+    try std.testing.expectEqual(@as(usize, 11), helpers.countRule(result, lint.rules.no_useless_call.id));
 }
 
 test "does not report no-useless-call when this binding or arguments are meaningful" {
@@ -52,6 +60,10 @@ test "does not report no-useless-call when this binding or arguments are meaning
         \\foo.apply(undefined, args);
         \\obj.foo.apply(obj, args);
         \\foo.apply(obj, [a]);
+        \\foo["call"](undefined, a);
+        \\foo[`call`](undefined, a);
+        \\foo["apply"](undefined, []);
+        \\foo[`apply`](undefined, []);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- align `no-useless-call` with ESLint for optional `.call()` and `.apply()` chains
- report unnecessary `foo.call?.(...)`, `foo?.call(...)`, `foo.apply?.(...)`, and `foo?.apply(...)`
- stop treating computed `foo["call"](...)` / `foo["apply"](...)` as `.call()` / `.apply()` for this rule

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_call.zig tests/rules/no_useless_call.zig`
- `git diff --check`
- focused ESLint comparison for `no-useless-call` reported the same lines as utoo-lint: `1, 2, 3, 6, 7, 8, 11, 12, 13, 14, 15`
