### PR TITLE
Align prefer-spread optional chain handling

### DIFF
--- a/src/rules/prefer_spread.zig
+++ b/src/rules/prefer_spread.zig
@@ -14,13 +14,10 @@ pub fn check(
     call: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (call.optional) return;
-
     const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
         .member_expression => |member| member,
         else => return,
     };
-    if (callee_member.optional) return;
 
     const method = propertyName(tree, callee_member) orelse return;
     if (!std.mem.eql(u8, method, "apply")) return;
@@ -46,7 +43,6 @@ fn canPreserveThisArg(tree: *const ast.Tree, target: ast.NodeIndex, this_arg: as
         else => return isNullOrUndefined(tree, this_arg),
     };
 
-    if (target_member.optional) return false;
     if (!isSimpleReference(tree, target_member.object)) return false;
     return sameSource(tree, target_member.object, this_arg);
 }
@@ -73,7 +69,7 @@ fn isSimpleReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .identifier_reference,
         .this_expression,
         => true,
-        .member_expression => |member| !member.optional and isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
+        .member_expression => |member| isSimpleReference(tree, member.object) and propertyName(tree, member) != null,
         else => false,
     };
 }

--- a/tests/rules/prefer_spread.zig
+++ b/tests/rules/prefer_spread.zig
@@ -6,7 +6,12 @@ test "reports prefer-spread for apply calls that can use spread syntax" {
     const source =
         \\fn.apply(null, args);
         \\fn.apply(undefined, args);
+        \\fn.apply?.(null, args);
+        \\fn?.apply(null, args);
         \\obj.method.apply(obj, args);
+        \\obj.method.apply?.(obj, args);
+        \\obj?.method.apply(obj, args);
+        \\obj.method?.apply(obj, args);
         \\this.method.apply(this, args);
         \\obj.nested.method.apply(obj.nested, args);
         \\fn[`apply`](undefined, args);
@@ -19,7 +24,7 @@ test "reports prefer-spread for apply calls that can use spread syntax" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.prefer_spread.id));
+    try std.testing.expectEqual(@as(usize, 11), helpers.countRule(result, lint.rules.prefer_spread.id));
 }
 
 test "does not report prefer-spread when spread conversion is unsafe or covered by no-useless-call" {
@@ -29,8 +34,6 @@ test "does not report prefer-spread when spread conversion is unsafe or covered 
         \\fn.call(null, first, second);
         \\fn.apply(null, [first, second]);
         \\fn.apply(null, ...args);
-        \\fn?.apply(null, args);
-        \\obj.method.apply?.(obj, args);
         \\fn[`ap${suffix}`](undefined, args);
     ;
 


### PR DESCRIPTION
## Summary

- align `prefer-spread` with ESLint for optional `.apply()` chains
- report `fn.apply?.(...)`, `fn?.apply(...)`, and optional member target chains when spread conversion is safe
- keep dynamic property names and unsafe `this`/argument cases out of scope

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_spread.zig tests/rules/prefer_spread.zig`
- `git diff --check`
- focused ESLint comparison for `prefer-spread` reported the same lines as utoo-lint: `1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12`
