### PR TITLE
Align prefer-object-spread optional assign handling

### DIFF
--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -81,7 +81,6 @@ fn isGlobalObjectAssign(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional) return false;
     const property_name = memberPropertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, property_name, "assign")) return false;
     const object = unwrapTransparent(tree, member.object);

--- a/tests/rules/prefer_object_spread.zig
+++ b/tests/rules/prefer_object_spread.zig
@@ -8,6 +8,8 @@ test "reports prefer-object-spread for Object.assign into object literals" {
         \\const second = Object.assign({ value: 1 }, source, extra);
         \\const third = Object["assign"]({}, source);
         \\const fourth = Object[`assign`]({}, source);
+        \\const fifth = Object?.assign({}, source);
+        \\const sixth = Object?.["assign"]({}, source);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +21,7 @@ test "reports prefer-object-spread for Object.assign into object literals" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.prefer_object_spread.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.prefer_object_spread.id));
     try std.testing.expectEqualStrings("Use an object spread instead of Object.assign.", result.diagnostics[0].message);
 }
 
@@ -30,6 +32,7 @@ test "allows non-object targets shadowed Object and spread arguments" {
         \\Object.assign({}, ...sources);
         \\Object[assign]({}, source);
         \\Object[`assi${name}`]({}, source);
+        \\Object?.[`assi${name}`]({}, source);
         \\function local(Object) {
         \\  Object.assign({}, source);
         \\}


### PR DESCRIPTION
## Summary

- align `prefer-object-spread` with ESLint for optional `Object.assign` chains
- report `Object?.assign({}, source)` and optional static computed `Object?.["assign"]({}, source)`
- continue to ignore dynamic property names, shadowed `Object`, non-object targets, and spread arguments

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_object_spread.zig tests/rules/prefer_object_spread.zig`
- `git diff --check`
- focused ESLint comparison for `prefer-object-spread` reported the same lines as utoo-lint: `1, 2, 3, 4, 5, 6, 7`
