### PR TITLE
Align prefer-object-has-own optional chain handling

### DIFF
--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -54,17 +54,13 @@ fn isPreferableHasOwn(
     symbol_table: traverser.semantic.SymbolTable,
     call: ast.CallExpression,
 ) bool {
-    if (call.optional) return false;
-
     const arguments = tree.extra(call.arguments);
     if (arguments.len < 2) return false;
 
     const call_member = memberExpression(tree, call.callee) orelse return false;
-    if (call_member.optional) return false;
     if (!propertyNamed(tree, call_member, "call")) return false;
 
     const target_member = memberExpression(tree, call_member.object) orelse return false;
-    if (target_member.optional) return false;
     if (!propertyNamed(tree, target_member, "hasOwnProperty")) return false;
 
     return isPreferredTargetObject(tree, symbol_table, target_member.object);
@@ -84,7 +80,6 @@ fn isPreferredTargetObject(
     }
 
     const prototype_member = memberExpression(tree, object) orelse return false;
-    if (prototype_member.optional) return false;
     if (!propertyNamed(tree, prototype_member, "prototype")) return false;
 
     const prototype_object = unwrapTransparent(tree, prototype_member.object);

--- a/tests/rules/prefer_object_has_own.zig
+++ b/tests/rules/prefer_object_has_own.zig
@@ -9,6 +9,9 @@ test "reports prefer-object-has-own for hasOwnProperty call helpers" {
         \\({}).hasOwnProperty.call(object, "key");
         \\Object["prototype"]["hasOwnProperty"]["call"](object, "key");
         \\Object[`prototype`][`hasOwnProperty`][`call`](object, "key");
+        \\Object.prototype.hasOwnProperty.call?.(object, "key");
+        \\Object.prototype.hasOwnProperty?.call(object, "key");
+        \\Object?.prototype.hasOwnProperty.call(object, "key");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +23,7 @@ test "reports prefer-object-has-own for hasOwnProperty call helpers" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_object_has_own.id));
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.prefer_object_has_own.id));
     try std.testing.expectEqualStrings(
         "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
         result.diagnostics[0].message,


### PR DESCRIPTION
## Summary

- align `prefer-object-has-own` with ESLint for optional `hasOwnProperty.call` chains
- report `Object.prototype.hasOwnProperty.call?.(...)`, `Object.prototype.hasOwnProperty?.call(...)`, and `Object?.prototype.hasOwnProperty.call(...)`
- continue to ignore dynamic property names and shadowed `Object`

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_object_has_own.zig tests/rules/prefer_object_has_own.zig`
- `git diff --check`
- focused ESLint comparison for `prefer-object-has-own` reported the same lines as utoo-lint: `1, 2, 3, 4, 5, 6`
