### PR TITLE
Align no-extra-bind optional chain handling

### DIFF
--- a/src/rules/no_extra_bind.zig
+++ b/src/rules/no_extra_bind.zig
@@ -14,13 +14,10 @@ pub fn check(
     call: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (call.optional) return;
-
     const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
         .member_expression => |member| member,
         else => return,
     };
-    if (callee_member.optional) return;
 
     const method = propertyName(tree, callee_member) orelse return;
     if (!std.mem.eql(u8, method, "bind")) return;

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -13,6 +13,12 @@ test "reports no-extra-bind for functions that do not use this" {
         \\const third = function () {
         \\  return value;
         \\}[`bind`](context);
+        \\const fourth = function () {
+        \\  return value;
+        \\}.bind?.(context);
+        \\const fifth = function () {
+        \\  return value;
+        \\}?.bind(context);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -23,7 +29,7 @@ test "reports no-extra-bind for functions that do not use this" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_extra_bind.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_extra_bind.id));
     try std.testing.expectEqualStrings("The function binding is unnecessary.", result.diagnostics[0].message);
 }
 


### PR DESCRIPTION
## Summary

- align `no-extra-bind` with ESLint for optional `.bind()` chains
- report unnecessary `function() {}.bind?.(...)` and `function() {}?.bind(...)`
- keep dynamic property names, `this`-using functions, and bound-argument cases out of scope

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_bind.zig tests/rules/no_extra_bind.zig`
- `git diff --check`
- focused ESLint comparison for `no-extra-bind` reported the same lines as utoo-lint: `1, 2, 3, 4, 5`
