### PR TITLE
Handle optional Promise rejection calls

### DIFF
--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -101,13 +101,10 @@ fn isPromiseRejectCall(
     tree: *const ast.Tree,
     call: ast.CallExpression,
 ) bool {
-    if (call.optional) return false;
-
     const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional) return false;
 
     const property = staticMemberPropertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, property, "reject")) return false;
@@ -334,7 +331,6 @@ fn scanRejectChildren(
 }
 
 fn isRejectCall(tree: *const ast.Tree, reject_name: []const u8, call: ast.CallExpression) bool {
-    if (call.optional) return false;
     return isIdentifierReferenceNamed(tree, call.callee, reject_name);
 }
 

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -8,6 +8,10 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
         \\Promise.reject("failed");
         \\Promise["reject"]("failed");
         \\Promise[`reject`]("failed");
+        \\Promise.reject?.("failed");
+        \\Promise?.reject("failed");
+        \\Promise?.["reject"]("failed");
+        \\Promise?.[`reject`]("failed");
         \\Promise[`re${suffix}`]("dynamic");
         \\Promise.reject(1);
         \\Promise.reject(`failed`);
@@ -15,6 +19,7 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
         \\Promise.reject("failed " + code);
         \\new Promise((resolve, reject) => {
         \\  reject("failed");
+        \\  reject?.("failed");
         \\});
         \\new Promise(function (resolve, reject) {
         \\  if (failed) {
@@ -38,7 +43,7 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+    try std.testing.expectEqual(@as(usize, 17), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
 test "does not report prefer-promise-reject-errors for error-like rejection reasons" {
@@ -67,6 +72,7 @@ test "does not report prefer-promise-reject-errors for dynamic Promise members o
         \\  }
         \\};
         \\Promise[`re${suffix}`]("dynamic");
+        \\Promise?.[`re${suffix}`]("dynamic");
         \\new Promise((resolve, reject) => {
         \\  function nested() {
         \\    reject("nested");


### PR DESCRIPTION
## Summary

- Allow `prefer-promise-reject-errors` to report optional-chain `Promise.reject` calls.
- Cover `Promise.reject?.(...)`, `Promise?.reject(...)`, static optional computed members, and executor `reject?.(...)`.
- Keep dynamic computed Promise members ignored.

## Why

ESLint reports these static optional-chain rejection calls the same way it reports direct `Promise.reject(...)`. The combined promise rule path still skipped optional calls and optional members, so utoo-lint missed those cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/promise_checks.zig tests/rules/prefer_promise_reject_errors.zig`
- `git diff --check`
