### PR TITLE
Handle optional Object defineProperty calls

### DIFF
--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -51,7 +51,6 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (call.optional) return .proceed;
         if (!isObjectDefinePropertyCall(ctx.tree, call.callee)) return .proceed;
 
         const arguments = ctx.tree.extra(call.arguments);
@@ -93,7 +92,6 @@ fn isObjectDefinePropertyCall(
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional) return false;
 
     const method = propertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, method, "defineProperty") and !std.mem.eql(u8, method, "defineProperties")) return false;

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -40,6 +40,12 @@ test "reports no-extend-native for Object defineProperty calls" {
         \\Object[`defineProperties`](Set.prototype, {
         \\  first: { value: function () {} },
         \\});
+        \\Object.defineProperty?.(Date.prototype, "day", {});
+        \\Object?.defineProperty(Array.prototype, "second", {});
+        \\Object?.["defineProperty"](Map.prototype, "second", {});
+        \\Object?.[`defineProperties`](Set.prototype, {
+        \\  second: { value: function () {} },
+        \\});
         \\const Object = {
         \\  defineProperty() {},
         \\};
@@ -62,7 +68,7 @@ test "reports no-extend-native for Object defineProperty calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_extend_native.id));
 }
 
 test "does not report no-extend-native for ordinary objects or dynamic members" {
@@ -71,6 +77,7 @@ test "does not report no-extend-native for ordinary objects or dynamic members" 
         \\local.prototype.trimLeft = function () {};
         \\Array[`proto${suffix}`].first = function () {};
         \\Object[`define${suffix}`](Array.prototype, "first", {});
+        \\Object?.[`define${suffix}`](Array.prototype, "first", {});
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- Allow `no-extend-native` to report optional-chain `Object.defineProperty` and `Object.defineProperties` calls.
- Cover optional call/member forms such as `Object.defineProperty?.(...)`, `Object?.defineProperty(...)`, and static optional computed members.
- Keep dynamic computed `Object` members ignored.

## Why

ESLint reports static optional-chain `Object.defineProperty` calls that extend native prototypes. utoo-lint skipped those calls because the rule returned early for optional calls and optional member links.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extend_native.zig tests/rules/no_extend_native.zig`
- `git diff --check`
