### PR TITLE
Handle optional TS Array constructor calls

### DIFF
--- a/src/rules/typescript_eslint_no_array_constructor.zig
+++ b/src/rules/typescript_eslint_no_array_constructor.zig
@@ -16,7 +16,6 @@ pub fn checkCallExpression(
 ) Allocator.Error!void {
     if (call.arguments.len == 1) return;
     if (call.type_arguments != .null) return;
-    if (call.optional) return;
     if (!isArrayIdentifier(tree, call.callee)) return;
 
     try addDiagnostic(allocator, diagnostics, tree, index);

--- a/tests/rules/typescript_eslint_no_array_constructor.zig
+++ b/tests/rules/typescript_eslint_no_array_constructor.zig
@@ -8,8 +8,10 @@ test "reports @typescript-eslint/no-array-constructor for generic Array construc
         \\const b = new Array();
         \\const c = Array(1, 2);
         \\const d = new Array("a", "b");
+        \\const e = Array?.();
+        \\const f = Array?.(1, 2);
         \\function local(Array: (...args: unknown[]) => unknown) {
-        \\  const e = Array();
+        \\  const g = Array();
         \\}
     ;
 
@@ -20,7 +22,7 @@ test "reports @typescript-eslint/no-array-constructor for generic Array construc
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_array_constructor.id));
     for (result.diagnostics) |diagnostic| {
         if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_array_constructor.id)) {
@@ -36,7 +38,8 @@ test "does not report @typescript-eslint/no-array-constructor for single argumen
         \\const c = Array(...items);
         \\const d = Array<string>();
         \\const e = new Array<string>();
-        \\const f = Array?.();
+        \\const f = Array?.(length);
+        \\const g = Array?.(...items);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{


### PR DESCRIPTION
## Summary

- Report `@typescript-eslint/no-array-constructor` for optional `Array` calls with disallowed arity.
- Cover `Array?.()` and `Array?.(1, 2)`.
- Keep single-argument optional calls and optional spread calls ignored.

## Why

`@typescript-eslint/no-array-constructor` reports optional `Array` calls the same way it reports direct calls when the call has zero or multiple arguments. utoo-lint skipped all optional calls, so it missed those cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/typescript_eslint_no_array_constructor.zig tests/rules/typescript_eslint_no_array_constructor.zig`
- `git diff --check`
