### PR TITLE
Handle optional Number parseInt calls

### DIFF
--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -123,7 +123,7 @@ fn isParseIntCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
         .member_expression => |member| member,
         else => return false,
     };
-    if (member.optional or member.property == .null) return false;
+    if (member.property == .null) return false;
 
     const property = propertyName(tree, member) orelse return false;
     if (!std.mem.eql(u8, property, "parseInt")) return false;

--- a/tests/rules/prefer_numeric_literals.zig
+++ b/tests/rules/prefer_numeric_literals.zig
@@ -9,6 +9,11 @@ test "reports prefer-numeric-literals for parseInt calls that can be numeric lit
         \\Number.parseInt("ff", 16);
         \\Number["parseInt"]("ff", 16);
         \\Number[`parseInt`]("ff", 16);
+        \\parseInt?.("101", 2);
+        \\Number.parseInt?.("ff", 16);
+        \\Number?.parseInt("ff", 16);
+        \\Number?.["parseInt"]("ff", 16);
+        \\Number?.[`parseInt`]("ff", 16);
         \\parseInt(`a0`, 16);
         \\function local(parseInt, Number) {
         \\  parseInt("101", 2);
@@ -28,7 +33,7 @@ test "reports prefer-numeric-literals for parseInt calls that can be numeric lit
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+    try std.testing.expectEqual(@as(usize, 15), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
     try std.testing.expectEqualStrings("Use a binary literal instead of parseInt().", result.diagnostics[0].message);
 }
 
@@ -60,6 +65,7 @@ test "allows parseInt calls without static string and binary octal or hexadecima
         \\parseInt("101", radix);
         \\parseInt("101", 2, extra);
         \\Number[`parse${suffix}`]("ff", 16);
+        \\Number?.[`parse${suffix}`]("ff", 16);
         \\other.parseInt("ff", 16);
     ;
 


### PR DESCRIPTION
## Summary

- Allow `prefer-numeric-literals` to report optional-chain `Number.parseInt` calls.
- Cover `Number?.parseInt(...)`, `Number?.["parseInt"](...)`, and static optional template members.
- Keep dynamic computed `Number` members ignored.

## Why

ESLint reports static optional-chain `Number.parseInt` calls when they can be replaced with numeric literals. utoo-lint skipped optional member links, so it missed those cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_numeric_literals.zig tests/rules/prefer_numeric_literals.zig`
- `git diff --check`
