### PR TITLE
Handle optional native prototype arguments

### DIFF
--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -38,7 +38,7 @@ const Visitor = struct {
         };
         if (left_member.optional) return .proceed;
 
-        if (nativePrototypeName(ctx.tree, left_member.object)) |name| {
+        if (nativePrototypeName(ctx.tree, left_member.object, false)) |name| {
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 
@@ -56,7 +56,7 @@ const Visitor = struct {
         const arguments = ctx.tree.extra(call.arguments);
         if (arguments.len == 0) return .proceed;
 
-        if (nativePrototypeName(ctx.tree, arguments[0])) |name| {
+        if (nativePrototypeName(ctx.tree, arguments[0], true)) |name| {
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 
@@ -67,12 +67,13 @@ const Visitor = struct {
 fn nativePrototypeName(
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    allow_optional: bool,
 ) ?[]const u8 {
     const member = switch (tree.data(unwrapTransparent(tree, index))) {
         .member_expression => |member| member,
         else => return null,
     };
-    if (member.optional) return null;
+    if (member.optional and !allow_optional) return null;
 
     const property_name = propertyName(tree, member) orelse return null;
     if (!std.mem.eql(u8, property_name, "prototype")) return null;

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -46,6 +46,8 @@ test "reports no-extend-native for Object defineProperty calls" {
         \\Object?.[`defineProperties`](Set.prototype, {
         \\  second: { value: function () {} },
         \\});
+        \\Object.defineProperty(Array?.prototype, "maybe", {});
+        \\Object.defineProperty(Array?.["prototype"], "maybeComputed", {});
         \\const Object = {
         \\  defineProperty() {},
         \\};
@@ -68,7 +70,7 @@ test "reports no-extend-native for Object defineProperty calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_extend_native.id));
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.no_extend_native.id));
 }
 
 test "does not report no-extend-native for ordinary objects or dynamic members" {


### PR DESCRIPTION
## Summary

- Allow `no-extend-native` to report optional-chain native prototype arguments in `Object.defineProperty`.
- Cover `Object.defineProperty(Array?.prototype, ...)` and `Object.defineProperty(Array?.["prototype"], ...)`.
- Keep assignment-side optional member handling conservative.

## Why

ESLint reports static optional-chain native prototype references when they are passed to `Object.defineProperty`. utoo-lint still skipped optional prototype member references in that argument position, so it missed those cases.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extend_native.zig tests/rules/no_extend_native.zig`
- `git diff --check`
