### PR TITLE
Align object-shorthand method cases

### DIFF
--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -14,25 +14,36 @@ pub fn check(
     property: ast.ObjectProperty,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (property.computed or property.shorthand or property.kind != .init) return;
+    if (property.shorthand or property.kind != .init or property.method) return;
 
-    if (!canUseShorthand(tree, property)) return;
+    const shorthand_kind = shorthandKind(tree, property) orelse return;
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Expected property shorthand.",
+        switch (shorthand_kind) {
+            .property => "Expected property shorthand.",
+            .method => "Expected method shorthand.",
+        },
         tree.span(index),
     );
 }
 
-fn canUseShorthand(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
-    const key_name = propertyKeyName(tree, property.key) orelse return false;
+const ShorthandKind = enum {
+    property,
+    method,
+};
 
-    if (identifierReferenceNamed(tree, property.value, key_name)) return true;
-    return isAnonymousFunctionExpression(tree, property.value);
+fn shorthandKind(tree: *const ast.Tree, property: ast.ObjectProperty) ?ShorthandKind {
+    if (!property.computed) {
+        const key_name = propertyKeyName(tree, property.key);
+        if (key_name != null and identifierReferenceNamed(tree, property.value, key_name.?)) return .property;
+    }
+
+    if (isAnonymousFunctionExpression(tree, property.value)) return .method;
+    return null;
 }
 
 fn propertyKeyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -17,6 +17,9 @@ test "reports object-shorthand for redundant property and method forms" {
         \\  "quoted-method": function () {
         \\    return 3;
         \\  },
+        \\  [computedMethod]: function () {
+        \\    return 4;
+        \\  },
         \\};
     ;
 
@@ -27,7 +30,7 @@ test "reports object-shorthand for redundant property and method forms" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.object_shorthand.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.object_shorthand.id));
 }
 
 test "does not report object-shorthand for non-shorthandable properties" {
@@ -38,6 +41,12 @@ test "does not report object-shorthand for non-shorthandable properties" {
         \\  foo: bar,
         \\  "foo": bar,
         \\  [foo]: foo,
+        \\  method() {
+        \\    return foo;
+        \\  },
+        \\  async asyncMethod() {
+        \\    return foo;
+        \\  },
         \\  bar: function named() {
         \\    return 1;
         \\  },


### PR DESCRIPTION
## Summary

- Align `object-shorthand` with ESLint for method shorthand cases.
- Stop reporting properties that are already written as shorthand methods.
- Report anonymous function values, including computed keys, as method shorthand opportunities.
- Use ESLint-compatible property vs method shorthand messages.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/object_shorthand.zig tests/rules/object_shorthand.zig`
- `git diff --check`
