### PR TITLE
Report prefer-rest-params with rest args

### DIFF
--- a/src/rules/prefer_rest_params.zig
+++ b/src/rules/prefer_rest_params.zig
@@ -21,7 +21,6 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     if (function.body == .null) return;
-    if (hasRestParameter(tree, function.params)) return;
     if (bindingNamed(tree, function.id, "arguments")) return;
     if (paramsContainBinding(tree, function.params, "arguments")) return;
     if (scanBodyArguments(tree, function.body) != .used) return;
@@ -34,11 +33,6 @@ pub fn check(
         "Use the rest parameters instead of 'arguments'.",
         tree.span(index),
     );
-}
-
-fn hasRestParameter(tree: *const ast.Tree, params_index: ast.NodeIndex) bool {
-    const params = formalParameters(tree, params_index) orelse return false;
-    return params.rest != .null;
 }
 
 fn paramsContainBinding(tree: *const ast.Tree, params_index: ast.NodeIndex, name: []const u8) bool {

--- a/tests/rules/prefer_rest_params.zig
+++ b/tests/rules/prefer_rest_params.zig
@@ -15,6 +15,14 @@ test "reports prefer-rest-params for current function arguments usage" {
         \\    return arguments[0];
         \\  }
         \\};
+        \\function withRest(...args) {
+        \\  return arguments[0];
+        \\}
+        \\function nestedOnly() {
+        \\  function inner(...args) {
+        \\    return arguments[0];
+        \\  }
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -24,16 +32,13 @@ test "reports prefer-rest-params for current function arguments usage" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_rest_params.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_rest_params.id));
 }
 
-test "does not report prefer-rest-params for rest params or nested rest usage" {
+test "does not report prefer-rest-params for nested or arrow arguments usage" {
     const source =
-        \\function withRest(...args) {
-        \\  return arguments[0];
-        \\}
         \\function nestedOnly() {
-        \\  function inner(...args) {
+        \\  function inner(arguments) {
         \\    return arguments[0];
         \\  }
         \\}


### PR DESCRIPTION
## Summary

- Align `prefer-rest-params` with ESLint when a function already has rest parameters.
- Continue reporting `arguments` usage in rest-parameter functions instead of skipping the function.
- Update coverage for direct and nested function cases that use rest parameters.

## Notes

This keeps the existing one-diagnostic-per-function behavior. ESLint reports each `arguments` reference individually; that is a separate alignment point.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_rest_params.zig tests/rules/prefer_rest_params.zig`
- `git diff --check`
