### PR TITLE
Report no-useless-rename assignment patterns

### DIFF
--- a/src/rules/no_useless_rename.zig
+++ b/src/rules/no_useless_rename.zig
@@ -60,6 +60,72 @@ pub fn checkObjectPattern(
     }
 }
 
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+) Allocator.Error!void {
+    if (expression.operator != .assign) return;
+
+    switch (tree.data(unwrapTransparent(tree, expression.left))) {
+        .object_pattern => |pattern| try checkAssignmentObjectPattern(allocator, diagnostics, tree, pattern),
+        else => {},
+    }
+}
+
+fn checkAssignmentObjectPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+) Allocator.Error!void {
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        if (property.shorthand or property.computed) continue;
+
+        switch (tree.data(unwrapTransparent(tree, property.value))) {
+            .object_pattern => |nested| {
+                try checkAssignmentObjectPattern(allocator, diagnostics, tree, nested);
+                continue;
+            },
+            else => {},
+        }
+
+        const key = propertyName(tree, property.key) orelse continue;
+        const value = referenceOrAssignmentName(tree, property.value) orelse continue;
+        if (!std.mem.eql(u8, key, value)) continue;
+
+        try addDiagnostic(allocator, diagnostics, tree, property_index);
+    }
+}
+
+fn referenceOrAssignmentName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .assignment_pattern => |pattern| referenceOrPropertyName(tree, pattern.left),
+        else => referenceOrPropertyName(tree, unwrapTransparent(tree, index)),
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
 fn addDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2098,6 +2098,9 @@ const BasicVisitor = struct {
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
+        if (self.options.no_useless_rename) {
+            try no_useless_rename.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -7,6 +7,9 @@ test "reports no-useless-rename for same-name import export and destructuring al
         \\import { foo as foo } from "mod";
         \\export { foo as foo };
         \\const { bar: bar, baz: baz = fallback } = source;
+        \\({ qux: qux } = source);
+        \\({ value: value = fallback } = source);
+        \\({ nested: { prop: prop } } = source);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -16,7 +19,7 @@ test "reports no-useless-rename for same-name import export and destructuring al
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_rename.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_rename.id));
 }
 
 test "does not report no-useless-rename for meaningful aliases or shorthand" {
@@ -24,6 +27,7 @@ test "does not report no-useless-rename for meaningful aliases or shorthand" {
         \\import { foo as bar, baz } from "mod";
         \\export { foo as bar };
         \\const { foo: bar, baz } = source;
+        \\({ qux: alias } = source);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- Align `no-useless-rename` with ESLint for assignment destructuring patterns.
- Report same-name aliases in `({ foo: foo } = source)` assignment targets.
- Cover default values and nested assignment destructuring.
- Keep meaningful aliases and computed properties ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_rename.zig src/rules/root.zig tests/rules/no_useless_rename.zig`
- `git diff --check`
