### PR TITLE
Report no-self-assign destructuring

### DIFF
--- a/src/rules/no_self_assign.zig
+++ b/src/rules/no_self_assign.zig
@@ -29,10 +29,26 @@ pub fn check(
     defer arena.deinit();
     const arena_allocator = arena.allocator();
 
-    const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
-    const right = (try referenceFromExpression(arena_allocator, tree, expression.right)) orelse return;
-    if (!referencesEqual(left, right)) return;
+    if (try referenceFromExpression(arena_allocator, tree, expression.left)) |left| {
+        if (try referenceFromExpression(arena_allocator, tree, expression.right)) |right| {
+            if (referencesEqual(left, right)) {
+                try addDiagnostic(allocator, diagnostics, tree, index);
+                return;
+            }
+        }
+    }
 
+    if (expression.operator == .assign) {
+        try checkPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, expression.left, expression.right);
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -76,6 +92,122 @@ fn referenceFromExpression(
         },
         else => return null,
     }
+}
+
+fn checkPatternSelfAssign(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    arena_allocator: Allocator,
+    left_index: ast.NodeIndex,
+    right_index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (left_index == .null or right_index == .null) return;
+
+    switch (tree.data(unwrapTransparent(tree, left_index))) {
+        .array_pattern => |left| {
+            const right = switch (tree.data(unwrapTransparent(tree, right_index))) {
+                .array_expression => |right| right,
+                else => return,
+            };
+            try checkArrayPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, left, right);
+        },
+        .object_pattern => |left| {
+            const right = switch (tree.data(unwrapTransparent(tree, right_index))) {
+                .object_expression => |right| right,
+                else => return,
+            };
+            try checkObjectPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, left, right);
+        },
+        .assignment_pattern => {},
+        else => {
+            const left = (try referenceFromExpression(arena_allocator, tree, left_index)) orelse return;
+            const right = (try referenceFromExpression(arena_allocator, tree, right_index)) orelse return;
+            if (!referencesEqual(left, right)) return;
+            try addDiagnostic(allocator, diagnostics, tree, right_index);
+        },
+    }
+}
+
+fn checkArrayPatternSelfAssign(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    arena_allocator: Allocator,
+    left: ast.ArrayPattern,
+    right: ast.ArrayExpression,
+) Allocator.Error!void {
+    const left_elements = tree.extra(left.elements);
+    const right_elements = tree.extra(right.elements);
+    const len = @min(left_elements.len, right_elements.len);
+
+    for (left_elements[0..len], right_elements[0..len]) |left_element, right_element| {
+        try checkPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, left_element, right_element);
+    }
+}
+
+fn checkObjectPatternSelfAssign(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    arena_allocator: Allocator,
+    left: ast.ObjectPattern,
+    right: ast.ObjectExpression,
+) Allocator.Error!void {
+    for (tree.extra(left.properties)) |left_property_index| {
+        const left_property = switch (tree.data(left_property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const key = patternPropertyName(tree, left_property.key, left_property.computed) orelse continue;
+        const right_value = objectPropertyValueByName(tree, right, key) orelse continue;
+        try checkPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, left_property.value, right_value);
+    }
+}
+
+fn objectPropertyValueByName(tree: *const ast.Tree, object: ast.ObjectExpression, name: []const u8) ?ast.NodeIndex {
+    for (tree.extra(object.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        const key = patternPropertyName(tree, property.key, property.computed) orelse continue;
+        if (std.mem.eql(u8, key, name)) return property.value;
+    }
+
+    return null;
+}
+
+fn patternPropertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null) return null;
+
+    return if (computed)
+        switch (tree.data(index)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .numeric_literal => |literal| tree.string(literal.raw),
+            .template_literal => |literal| templateStringValue(tree, literal),
+            else => null,
+        }
+    else switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }
 
 fn newReference(allocator: Allocator, reference: Reference) Allocator.Error!*const Reference {

--- a/tests/rules/no_self_assign.zig
+++ b/tests/rules/no_self_assign.zig
@@ -9,6 +9,11 @@ test "reports no-self-assign for equivalent assignment references" {
         \\object.value = object.value;
         \\this.value = this["value"];
         \\object[`value`] = object[`value`];
+        \\({ property: property } = { property: property });
+        \\({ alias: renamed } = { alias: renamed });
+        \\({ outer: { inner: inner } } = { outer: { inner: inner } });
+        \\({ ["computed"]: computed } = { computed: computed });
+        \\[first, second] = [other, second];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +23,7 @@ test "reports no-self-assign for equivalent assignment references" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_self_assign.id));
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_self_assign.id));
 }
 
 test "does not report no-self-assign for different references or effectful objects" {
@@ -28,6 +33,11 @@ test "does not report no-self-assign for different references or effectful objec
         \\object.value = object.other;
         \\getObject().value = getObject().value;
         \\object[`val${suffix}`] = object[`val${suffix}`];
+        \\({ property: property } = { other: property });
+        \\({ property: property } = { property: other });
+        \\({ property: property = fallback } = { property: property });
+        \\({ [dynamic]: property } = { [dynamic]: property });
+        \\[first] = [second];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- Align `no-self-assign` with ESLint for destructuring assignments.
- Report self-assignments in object and array assignment patterns.
- Match object destructuring by static property key, including static computed keys.
- Keep aliases, defaults, dynamic computed keys, and different RHS values ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_self_assign.zig tests/rules/no_self_assign.zig`
- `git diff --check`
