### PR TITLE
Report no-extra-semi class members

### DIFF
--- a/src/rules/no_extra_semi.zig
+++ b/src/rules/no_extra_semi.zig
@@ -1,9 +1,10 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-extra-semi";
 
@@ -24,6 +25,49 @@ pub fn check(
         "Unnecessary semicolon.",
         tree.span(index),
     );
+}
+
+pub fn checkClassBody(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.ClassBody,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    var current: usize = @intCast(tree.span(index).start + 1);
+
+    for (tree.extra(body.body)) |member_index| {
+        const member_span = tree.span(member_index);
+        try reportSemicolonsInRange(allocator, diagnostics, tree, current, @intCast(member_span.start));
+        current = @intCast(member_span.end);
+    }
+
+    const body_span = tree.span(index);
+    if (body_span.end == 0) return;
+    try reportSemicolonsInRange(allocator, diagnostics, tree, current, @intCast(body_span.end - 1));
+}
+
+fn reportSemicolonsInRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    start: usize,
+    end: usize,
+) Allocator.Error!void {
+    if (start >= end or end > tree.source.len) return;
+
+    for (tree.source[start..end], start..) |byte, offset| {
+        if (byte != ';') continue;
+        const semicolon: u32 = @intCast(offset);
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary semicolon.",
+            .{ .start = semicolon, .end = semicolon + 1 },
+        );
+    }
 }
 
 pub fn isStatementBody(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2772,9 +2772,12 @@ const BasicVisitor = struct {
     pub fn enter_class_body(
         self: *BasicVisitor,
         body: ast.ClassBody,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_extra_semi and !self.options.typescript_eslint_no_extra_semi) {
+            try no_extra_semi.checkClassBody(self.allocator, self.diagnostics, ctx.tree, body, index);
+        }
         if (self.options.accessor_pairs) {
             try accessor_pairs.checkClassBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, body, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,

--- a/tests/rules/no_extra_semi.zig
+++ b/tests/rules/no_extra_semi.zig
@@ -7,6 +7,7 @@ test "reports no-extra-semi for unnecessary empty statements" {
         \\const value = 1;;
         \\function run() {}
         \\;
+        \\class Example { ; method() {} ; field; }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +18,7 @@ test "reports no-extra-semi for unnecessary empty statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_semi.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_extra_semi.id));
 }
 
 test "does not report no-extra-semi for empty statement bodies" {


### PR DESCRIPTION
## Summary

- Align `no-extra-semi` with ESLint for class body stray semicolons.
- Report semicolons between class members, including leading, repeated, and trailing class member semicolons.
- Keep statement-body semicolon allowances unchanged.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_semi.zig src/rules/root.zig tests/rules/no_extra_semi.zig`
- `git diff --check`
