### PR TITLE
Report valid-typeof non-string values

### DIFF
--- a/src/rules/valid_typeof.zig
+++ b/src/rules/valid_typeof.zig
@@ -20,9 +20,11 @@ pub fn check(
     const right_typeof = isTypeofExpression(tree, expression.right);
     if (left_typeof == right_typeof) return;
 
-    const literal_index = if (left_typeof) expression.right else expression.left;
-    const value = stringLiteralValue(tree, literal_index) orelse return;
-    if (isValidTypeofValue(value)) return;
+    const value_index = if (left_typeof) expression.right else expression.left;
+    switch (comparisonValueState(tree, value_index)) {
+        .valid, .unknown => return,
+        .invalid => {},
+    }
 
     try core.addDiagnostic(
         allocator,
@@ -33,6 +35,12 @@ pub fn check(
         tree.span(index),
     );
 }
+
+const ComparisonValueState = enum {
+    valid,
+    invalid,
+    unknown,
+};
 
 fn isTypeofComparisonOperator(operator: ast.BinaryOperator) bool {
     return switch (operator) {
@@ -61,6 +69,26 @@ fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
         .string_literal => |literal| tree.string(literal.value),
         .template_literal => |literal| templateStringValue(tree, literal),
         else => null,
+    };
+}
+
+fn comparisonValueState(tree: *const ast.Tree, index: ast.NodeIndex) ComparisonValueState {
+    if (index == .null) return .unknown;
+
+    const unwrapped = unwrapTransparent(tree, index);
+    if (stringLiteralValue(tree, unwrapped)) |value| {
+        return if (isValidTypeofValue(value)) .valid else .invalid;
+    }
+
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined")) .invalid else .unknown,
+        .null_literal,
+        .boolean_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .regexp_literal,
+        => .invalid,
+        else => .unknown,
     };
 }
 

--- a/tests/rules/valid_typeof.zig
+++ b/tests/rules/valid_typeof.zig
@@ -8,6 +8,10 @@ test "reports valid-typeof for invalid typeof comparison strings" {
         \\if (typeof value === `strnig`) { use(value); }
         \\if ("undefimed" !== typeof value) { use(value); }
         \\if ((typeof value) == ("bool")) { use(value); }
+        \\if (typeof value === undefined) { use(value); }
+        \\if (typeof value === null) { use(value); }
+        \\if (typeof value === 1) { use(value); }
+        \\if (typeof value === true) { use(value); }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +22,7 @@ test "reports valid-typeof for invalid typeof comparison strings" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.valid_typeof.id));
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.valid_typeof.id));
 }
 
 test "does not report valid-typeof for valid values or unrelated comparisons" {
@@ -35,6 +39,7 @@ test "does not report valid-typeof for valid values or unrelated comparisons" {
         \\if (typeof value === "symbol") { use(value); }
         \\if (typeof value === "bigint") { use(value); }
         \\if (typeof value === expectedType) { use(value); }
+        \\if (typeof value === typeof other) { use(value); }
         \\if (value === "strnig") { use(value); }
     ;
 


### PR DESCRIPTION
## Summary

- Align `valid-typeof` with ESLint for definite non-string comparison values.
- Report comparisons such as `typeof value === undefined`, `null`, numbers, booleans, bigint, and regexp literals.
- Keep dynamic comparison values such as identifiers and interpolated templates ignored.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/valid_typeof.zig tests/rules/valid_typeof.zig`
- `git diff --check`
