### PR TITLE
Report prefer-const loop bindings

### DIFF
--- a/src/rules/prefer_const.zig
+++ b/src/rules/prefer_const.zig
@@ -159,6 +159,26 @@ const Visitor = struct {
         return .proceed;
     }
 
+    pub fn enter_for_in_statement(
+        self: *Visitor,
+        statement: ast.ForInStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.collectForLoopLeft(ctx.tree, statement.left);
+        return .proceed;
+    }
+
+    pub fn enter_for_of_statement(
+        self: *Visitor,
+        statement: ast.ForOfStatement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.collectForLoopLeft(ctx.tree, statement.left);
+        return .proceed;
+    }
+
     pub fn enter_update_expression(
         self: *Visitor,
         expression: ast.UpdateExpression,
@@ -167,6 +187,30 @@ const Visitor = struct {
     ) Allocator.Error!traverser.Action {
         try self.markReassigned(ctx.tree, expression.argument);
         return .proceed;
+    }
+
+    fn collectForLoopLeft(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        const declaration = switch (tree.data(index)) {
+            .variable_declaration => |declaration| declaration,
+            else => return,
+        };
+        if (declaration.kind != .let) return;
+
+        for (tree.extra(declaration.declarators)) |declarator_index| {
+            const declarator = switch (tree.data(declarator_index)) {
+                .variable_declarator => |declarator| declarator,
+                else => continue,
+            };
+
+            const group = if (self.options.destructuring == .all and isDestructuringPattern(tree, declarator.id)) group: {
+                const group_id = self.next_destructuring_group;
+                self.next_destructuring_group += 1;
+                try self.destructuring_groups.put(group_id, false);
+                break :group group_id;
+            } else null;
+
+            try self.collectCandidate(tree, declarator.id, group);
+        }
     }
 
     fn collectCandidate(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex, group: ?usize) Allocator.Error!void {

--- a/tests/rules/prefer_const.zig
+++ b/tests/rules/prefer_const.zig
@@ -7,6 +7,12 @@ test "reports prefer-const for initialized let declarations that are never reass
         \\let a = 1;
         \\let { b } = obj;
         \\let [c] = list;
+        \\for (let key in obj) {
+        \\  console.log(key);
+        \\}
+        \\for (let value of list) {
+        \\  console.log(value);
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -15,7 +21,7 @@ test "reports prefer-const for initialized let declarations that are never reass
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_const.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_const.id));
 }
 
 test "does not report prefer-const for reassigned let bindings or uninitialized declarations" {
@@ -26,6 +32,9 @@ test "does not report prefer-const for reassigned let bindings or uninitialized 
         \\b++;
         \\let c;
         \\c = 1;
+        \\for (let key in obj) {
+        \\  key = "other";
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -43,6 +52,9 @@ test "reports prefer-const for destructuring any by default" {
         \\b = 2;
         \\let [c, d] = list;
         \\d++;
+        \\for (let [e, f] of entries) {
+        \\  f = 2;
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -51,7 +63,7 @@ test "reports prefer-const for destructuring any by default" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_const.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_const.id));
 }
 
 test "reports prefer-const for destructuring only when all bindings qualify in all mode" {


### PR DESCRIPTION
## Summary

- Align `prefer-const` with ESLint for `for-in` and `for-of` loop bindings.
- Report `let` bindings in loop headers when they are never reassigned.
- Preserve reassignment handling for loop bodies and existing destructuring options.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_const.zig tests/rules/prefer_const.zig`
- `git diff --check`
