### PR TITLE
Allow no-else-return else-if chains

### DIFF
--- a/src/rules/no_else_return.zig
+++ b/src/rules/no_else_return.zig
@@ -13,6 +13,10 @@ pub fn check(
     statement: ast.IfStatement,
 ) Allocator.Error!void {
     if (statement.alternate == .null) return;
+    switch (tree.data(statement.alternate)) {
+        .if_statement => return,
+        else => {},
+    }
     if (!alwaysExits(tree, statement.consequent)) return;
 
     try core.addDiagnostic(

--- a/tests/rules/no_else_return.zig
+++ b/tests/rules/no_else_return.zig
@@ -52,6 +52,31 @@ test "does not report no-else-return when consequent can continue" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_else_return.id));
 }
 
+test "does not report no-else-return for else-if alternate" {
+    const source =
+        \\function first(value) {
+        \\  if (value) {
+        \\    return 1;
+        \\  } else if (value > 1) {
+        \\    return 2;
+        \\  }
+        \\}
+        \\function second(value) {
+        \\  if (value) return 1;
+        \\  else if (value > 1) return 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_else_return.id));
+}
+
 test "can disable no-else-return" {
     const source =
         \\function first(value) {


### PR DESCRIPTION
## Summary

- allow `no-else-return` to skip `else if` alternates, matching ESLint's default `allowElseIf` behavior
- add coverage for braced and inline `else if` chains

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_else_return.zig tests/rules/no_else_return.zig`
- `git diff --check`
