### PR TITLE
Skip static arguments members

### DIFF
--- a/src/rules/prefer_rest_params.zig
+++ b/src/rules/prefer_rest_params.zig
@@ -74,6 +74,7 @@ fn collectBodyArguments(
     return switch (tree.data(index)) {
         .variable_declaration => |declaration| try collectVariableDeclarationArguments(allocator, tree, declaration, references),
         .function => |function| if (function.type == .function_declaration and bindingNamed(tree, function.id, "arguments")) .declared else .none,
+        .member_expression => |member| try collectMemberExpressionArguments(allocator, tree, member, references),
         .identifier_reference => |identifier| {
             if (std.mem.eql(u8, tree.string(identifier.name), "arguments")) {
                 try references.append(allocator, index);
@@ -119,6 +120,29 @@ fn collectArrowArguments(
     return .none;
 }
 
+fn collectMemberExpressionArguments(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    references: *std.ArrayList(ast.NodeIndex),
+) Allocator.Error!ArgumentsScanResult {
+    if (!member.computed and isIdentifierReferenceNamed(tree, member.object, "arguments")) return .none;
+
+    switch (try collectBodyArguments(allocator, tree, member.object, references)) {
+        .declared => return .declared,
+        .none => {},
+    }
+
+    if (member.computed) {
+        switch (try collectBodyArguments(allocator, tree, member.property, references)) {
+            .declared => return .declared,
+            .none => {},
+        }
+    }
+
+    return .none;
+}
+
 fn collectNodeArguments(
     allocator: Allocator,
     tree: *const ast.Tree,
@@ -145,6 +169,15 @@ fn collectNodeArguments(
     }
 
     return .none;
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        else => false,
+    };
 }
 
 fn bindingNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const u8) bool {

--- a/tests/rules/prefer_rest_params.zig
+++ b/tests/rules/prefer_rest_params.zig
@@ -8,7 +8,7 @@ test "reports prefer-rest-params for current function arguments usage" {
         \\  return arguments[0];
         \\}
         \\const second = function () {
-        \\  return arguments.length;
+        \\  return arguments[1];
         \\};
         \\const obj = {
         \\  method() {
@@ -62,7 +62,7 @@ test "reports prefer-rest-params for each arguments reference" {
         \\  return arguments[0];
         \\}
         \\function arrowInside() {
-        \\  const read = () => arguments.length;
+        \\  const read = () => arguments[0];
         \\  return read;
         \\}
     ;
@@ -75,6 +75,30 @@ test "reports prefer-rest-params for each arguments reference" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_rest_params.id));
+}
+
+test "does not report prefer-rest-params for static arguments members" {
+    const source =
+        \\function first() {
+        \\  return arguments.length;
+        \\}
+        \\function second() {
+        \\  return arguments.callee;
+        \\}
+        \\function arrowInside() {
+        \\  const read = () => arguments.length;
+        \\  return read;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_rest_params.id));
 }
 
 test "does not report prefer-rest-params when arguments is shadowed in scripts" {


### PR DESCRIPTION
## Summary

- skip `prefer-rest-params` reports for static `arguments.<property>` reads such as `arguments.length`
- keep reports for computed `arguments[...]` reads, including inside arrow functions that close over the function's arguments object

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_rest_params.zig tests/rules/prefer_rest_params.zig`
- `git diff --check`
