### PR TITLE
Report unused catch parameters

### DIFF
--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -107,7 +107,6 @@ pub fn runWithOptions(
 
         if (!isLintableSymbol(flags, options)) continue;
         if (flags.exported or flags.ambient) continue;
-        if (flags.catch_var) continue;
         if (flags.parameter) {
             if (!options.check_parameters) continue;
             if (options.args_after_used and !shouldCheckParameter(entry.id, symbol.scope, parameters.items)) continue;
@@ -136,6 +135,7 @@ pub fn runWithOptions(
 
 fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
     return flags.inValueSpace() or
+        flags.catch_var or
         flags.import or
         flags.type_import or
         flags.interface or

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -16,3 +16,30 @@ test "reports no-unused-vars for unused declarations" {
 
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "reports no-unused-vars for unused catch parameters" {
+    const source =
+        \\try {
+        \\  run();
+        \\} catch (unusedError) {
+        \\}
+        \\try {
+        \\  run();
+        \\} catch (usedError) {
+        \\  console.log(usedError);
+        \\}
+        \\try {
+        \\  run();
+        \\} catch {
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -13,6 +13,11 @@ test "reports @typescript-eslint/no-unused-vars for unused variables and after-u
         \\}
         \\demo("before", "used", "after");
         \\
+        \\try {
+        \\  demo("before", "used", "after");
+        \\} catch (unusedError) {
+        \\}
+        \\
         \\type UnusedType = string;
     ;
 
@@ -22,7 +27,7 @@ test "reports @typescript-eslint/no-unused-vars for unused variables and after-u
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
     for (result.diagnostics) |diagnostic| {
         if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.typescript_eslint_no_unused_vars.id)) {


### PR DESCRIPTION
## Summary

- report unused catch parameters in `no-unused-vars`
- carry the same behavior through `@typescript-eslint/no-unused-vars`, which reuses the core unused-vars implementation
- add coverage for unused, used, and optional catch bindings

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `git diff --check`
