### PR TITLE
Report builtin global redeclarations

### DIFF
--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -70,9 +70,16 @@ pub fn runWithOptions(
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
 
+        const name = tree.string(symbol.name);
+        if (isBuiltinGlobalRedeclaration(tree, symbol, name, options)) {
+            for (decls) |decl| {
+                try addBuiltinGlobalRedeclaration(allocator, diagnostics, tree, decl, name, options);
+            }
+            continue;
+        }
+
         if (decls.len <= 1) continue;
 
-        const name = tree.string(symbol.name);
         if (options.mode == .typescript) {
             try checkTypescriptRedeclarations(allocator, diagnostics, tree, decls, name, decl_info, options);
         } else {
@@ -92,6 +99,18 @@ fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bo
     if (flags.ambient) return false;
     if (flags.type_import or flags.interface or flags.type_alias or flags.type_parameter) return false;
     return flags.inValueSpace() or flags.import;
+}
+
+fn isBuiltinGlobalRedeclaration(
+    tree: *const ast.Tree,
+    symbol: traverser.semantic.Symbol,
+    name: []const u8,
+    options: Options,
+) bool {
+    return options.mode == .javascript and
+        tree.source_type == .script and
+        symbol.scope == .root and
+        core.isKnownGlobal(name);
 }
 
 fn checkTypescriptRedeclarations(
@@ -173,6 +192,25 @@ fn addAlreadyDefined(
         options.rule_id,
         tree.span(decl),
         "'{s}' is already defined.",
+        .{name},
+    );
+}
+
+fn addBuiltinGlobalRedeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    decl: ast.NodeIndex,
+    name: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        options.severity,
+        options.rule_id,
+        tree.span(decl),
+        "'{s}' is already defined as a built-in global variable.",
         .{name},
     );
 }

--- a/tests/rules/no_redeclare.zig
+++ b/tests/rules/no_redeclare.zig
@@ -24,14 +24,35 @@ test "reports no-redeclare for repeated declarations" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_redeclare.id));
 }
 
-test "does not report no-redeclare for script built-in globals by default" {
+test "reports no-redeclare for script built-in globals by default" {
     const source =
         \\var Object = 1;
-        \\var Array = 1;
+        \\let undefinedValue = undefined;
+        \\let undefined = 1;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", .{
         .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_redeclare.id));
+}
+
+test "does not report no-redeclare for module or local built-in shadows" {
+    const source =
+        \\var Object = 1;
+        \\function demo() {
+        \\  var Array = 1;
+        \\  return Array;
+        \\}
+        \\console.log(Object, demo());
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);


### PR DESCRIPTION
## Summary

- report `no-redeclare` diagnostics when a script top-level declaration shadows a known built-in global
- keep module top-level and local function shadows out of this built-in redeclaration path
- use the dedicated built-in global message for each matching declaration

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_redeclare.zig tests/rules/no_redeclare.zig`
- `git diff --check`
