### PR TITLE
Honor default-case comment position

### DIFF
--- a/src/rules/default_case.zig
+++ b/src/rules/default_case.zig
@@ -40,10 +40,22 @@ fn hasDefaultCase(tree: *const ast.Tree, statement: ast.SwitchStatement) bool {
 }
 
 fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex) bool {
-    const span = tree.span(index);
-    const start: usize = @intCast(span.start);
-    const end: usize = @intCast(span.end);
-    if (start >= end or end > tree.source.len) return false;
+    const switch_statement = switch (tree.data(index)) {
+        .switch_statement => |statement| statement,
+        else => return false,
+    };
 
-    return std.mem.indexOf(u8, tree.source[start..end], "no default") != null;
+    const cases = tree.extra(switch_statement.cases);
+    if (cases.len == 0) return false;
+
+    const last_case_end = tree.span(cases[cases.len - 1]).end;
+    const switch_end = tree.span(index).end;
+
+    for (tree.comments) |comment| {
+        if (comment.start < last_case_end or comment.end > switch_end) continue;
+        const value = std.mem.trim(u8, tree.string(comment.value), &std.ascii.whitespace);
+        if (std.ascii.eqlIgnoreCase(value, "no default")) return true;
+    }
+
+    return false;
 }

--- a/tests/rules/default_case.zig
+++ b/tests/rules/default_case.zig
@@ -9,6 +9,16 @@ test "reports default-case for switch statements without default" {
         \\    runOne();
         \\    break;
         \\}
+        \\switch (commentBeforeCase) {
+        \\  // no default
+        \\  case 1:
+        \\    runOne();
+        \\}
+        \\switch (commentWithExplanation) {
+        \\  case 1:
+        \\    runOne();
+        \\  // no default: handled elsewhere
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,7 +28,7 @@ test "reports default-case for switch statements without default" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.default_case.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.default_case.id));
 }
 
 test "does not report default-case when default exists or comment opts out" {
@@ -31,9 +41,14 @@ test "does not report default-case when default exists or comment opts out" {
         \\    runDefault();
         \\}
         \\switch (second) {
-        \\  // no default
         \\  case 1:
         \\    runOne();
+        \\  // no default
+        \\}
+        \\switch (third) {
+        \\  case 1:
+        \\    runOne();
+        \\  /* No Default */
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- only honor `default-case` opt-out comments after the final switch case and before the switch closes
- require the trimmed comment text to match `no default` case-insensitively
- add coverage for comments before cases, explanatory comments, line comments, and block comments

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/default_case.zig tests/rules/default_case.zig`
- `git diff --check`
