### PR TITLE
Allow while true constant conditions

### DIFF
--- a/src/rules/no_constant_condition.zig
+++ b/src/rules/no_constant_condition.zig
@@ -26,6 +26,18 @@ pub fn check(
     );
 }
 
+pub fn checkWhile(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+) Allocator.Error!void {
+    const unwrapped = unwrapTransparent(tree, expression);
+    if (isBooleanTrue(tree, unwrapped)) return;
+
+    try check(allocator, diagnostics, tree, expression);
+}
+
 fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;
 
@@ -45,6 +57,13 @@ fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .class => |class| class.type == .class_expression,
         .unary_expression => |unary| isConstantUnaryExpression(tree, unary),
         .logical_expression => |logical| isConstantLogicalExpression(tree, logical),
+        else => false,
+    };
+}
+
+fn isBooleanTrue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .boolean_literal => |literal| literal.value,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1230,7 +1230,7 @@ const BasicVisitor = struct {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
         if (self.options.no_constant_condition) {
-            try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+            try no_constant_condition.checkWhile(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
         return .proceed;
     }

--- a/tests/rules/no_constant_condition.zig
+++ b/tests/rules/no_constant_condition.zig
@@ -39,6 +39,40 @@ test "does not report no-constant-condition for dynamic conditions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
 }
 
+test "does not report no-constant-condition for while true loops" {
+    const source =
+        \\while (true) { break; }
+        \\while ((true)) { break; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
+}
+
+test "still reports no-constant-condition for other loop constants" {
+    const source =
+        \\while (false) { break; }
+        \\while (1) { break; }
+        \\do { break; } while (true);
+        \\for (; true; ) { break; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_constant_condition.id));
+}
+
 test "reports no-constant-condition for constant unary expressions" {
     const source =
         \\if (void 0) { use(); }


### PR DESCRIPTION
## Summary

- skip `no-constant-condition` diagnostics for `while (true)` loops
- keep reporting other constant loop conditions such as `while (false)`, `do ... while (true)`, and `for (; true;)`
- add focused coverage for the ESLint default loop behavior

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_constant_condition.zig src/rules/root.zig tests/rules/no_constant_condition.zig`
- `git diff --check`
