### PR TITLE
Ignore base constructor super calls

### DIFF
--- a/src/rules/constructor_super.zig
+++ b/src/rules/constructor_super.zig
@@ -25,19 +25,7 @@ pub fn checkClass(
         else => return,
     };
 
-    if (class.super_class == .null) {
-        if (containsSuperCall(tree, function.body)) {
-            try core.addDiagnostic(
-                allocator,
-                diagnostics,
-                .warning,
-                id,
-                "Unexpected 'super()'.",
-                tree.span(constructor.index),
-            );
-        }
-        return;
-    }
+    if (class.super_class == .null) return;
 
     var super_calls: std.ArrayList(ast.NodeIndex) = .empty;
     defer super_calls.deinit(allocator);

--- a/tests/rules/constructor_super.zig
+++ b/tests/rules/constructor_super.zig
@@ -33,10 +33,16 @@ test "reports constructor-super when derived constructors omit super" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.constructor_super.id));
 }
 
-test "reports constructor-super for super calls in base constructors" {
+test "does not report constructor-super for base constructors" {
     const source =
         \\class Base {
         \\  constructor() {
+        \\    super();
+        \\  }
+        \\}
+        \\class DuplicateBase {
+        \\  constructor() {
+        \\    super();
         \\    super();
         \\  }
         \\}
@@ -50,7 +56,7 @@ test "reports constructor-super for super calls in base constructors" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.constructor_super.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.constructor_super.id));
 }
 
 test "reports constructor-super for duplicate super calls" {


### PR DESCRIPTION
## Summary

- skip `constructor-super` diagnostics for constructors on classes without `extends`
- keep derived-class checks for missing and duplicate `super()` calls
- update coverage for base constructors that call `super()`

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/constructor_super.zig tests/rules/constructor_super.zig`
- `git diff --check`
