### PR TITLE
Allow empty generators in require-yield

### DIFF
--- a/src/rules/require_yield.zig
+++ b/src/rules/require_yield.zig
@@ -14,6 +14,7 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     if (!function.generator or function.body == .null) return;
+    if (functionBodyEmpty(tree, function.body)) return;
     if (containsYield(tree, function.body)) return;
 
     try core.addDiagnostic(
@@ -24,6 +25,13 @@ pub fn check(
         "This generator function does not have 'yield'.",
         tree.span(index),
     );
+}
+
+fn functionBodyEmpty(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .function_body => |body| body.body.len == 0,
+        else => false,
+    };
 }
 
 fn containsYield(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/require_yield.zig
+++ b/tests/rules/require_yield.zig
@@ -4,17 +4,23 @@ const helpers = @import("../helpers.zig");
 
 test "reports require-yield for generators without their own yield" {
     const source =
-        \\function* empty() {}
+        \\function* emptyStatement() {
+        \\  ;
+        \\}
         \\function* onlyNested() {
         \\  function* nested() {
         \\    yield value;
         \\  }
         \\}
         \\const obj = {
-        \\  *emptyMethod() {}
+        \\  *emptyMethod() {
+        \\    ;
+        \\  }
         \\};
         \\class Example {
-        \\  *emptyMethod() {}
+        \\  *emptyMethod() {
+        \\    ;
+        \\  }
         \\}
     ;
 
@@ -32,13 +38,17 @@ test "reports require-yield for generators without their own yield" {
 
 test "does not report require-yield for generators with yield or non-generators" {
     const source =
+        \\function* empty() {}
+        \\const obj = {
+        \\  *emptyMethod() {}
+        \\};
         \\function* values() {
         \\  yield value;
         \\}
         \\function* delegate() {
         \\  yield* values();
         \\}
-        \\const obj = {
+        \\const objWithYield = {
         \\  *method() {
         \\    if (ready) {
         \\      yield value;


### PR DESCRIPTION
## Summary

- skip `require-yield` diagnostics for empty generator bodies
- keep reporting non-empty generator bodies that still lack their own `yield`
- add coverage for empty function generators and generator methods

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/require_yield.zig tests/rules/require_yield.zig`
- `git diff --check`
