### PR TITLE
Report redundant loop labels

### DIFF
--- a/src/rules/no_extra_label.zig
+++ b/src/rules/no_extra_label.zig
@@ -15,6 +15,7 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     const label_name = labelName(tree, statement.label) orelse return;
+    try reportRedundantLoopLabelReferences(allocator, diagnostics, tree, statement.body, label_name);
     if (containsLabelReference(tree, statement.body, label_name)) return;
 
     try core.addDiagnostic(
@@ -24,6 +25,107 @@ pub fn check(
         id,
         "This label is unnecessary.",
         tree.span(index),
+    );
+}
+
+fn reportRedundantLoopLabelReferences(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    label_name: []const u8,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .for_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        .for_in_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        .for_of_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        .while_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        .do_while_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        else => {},
+    }
+}
+
+fn reportRedundantLoopBodyReferences(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    label_name: []const u8,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .break_statement => |statement| {
+            if (sameLabel(tree, statement.label, label_name)) {
+                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, statement.label, label_name);
+            }
+        },
+        .continue_statement => |statement| {
+            if (sameLabel(tree, statement.label, label_name)) {
+                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, statement.label, label_name);
+            }
+        },
+        .block_statement => |block| try reportRedundantReferencesInRange(allocator, diagnostics, tree, block.body, label_name),
+        .static_block => |block| try reportRedundantReferencesInRange(allocator, diagnostics, tree, block.body, label_name),
+        .if_statement => |statement| {
+            try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.consequent, label_name);
+            try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.alternate, label_name);
+        },
+        .try_statement => |statement| {
+            try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.block, label_name);
+            if (statement.handler != .null) {
+                const handler = switch (tree.data(statement.handler)) {
+                    .catch_clause => |handler| handler,
+                    else => return,
+                };
+                try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, handler.body, label_name);
+            }
+            try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.finalizer, label_name);
+        },
+        .labeled_statement => |statement| try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, statement.body, label_name),
+        .function,
+        .arrow_function_expression,
+        .class,
+        .for_statement,
+        .for_in_statement,
+        .for_of_statement,
+        .while_statement,
+        .do_while_statement,
+        .switch_statement,
+        => {},
+        else => {},
+    }
+}
+
+fn reportRedundantReferencesInRange(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    label_name: []const u8,
+) Allocator.Error!void {
+    for (tree.extra(range)) |child| {
+        try reportRedundantLoopBodyReferences(allocator, diagnostics, tree, child, label_name);
+    }
+}
+
+fn addRedundantReferenceDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    label: ast.NodeIndex,
+    label_name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(label),
+        "This label '{s}' is unnecessary.",
+        .{label_name},
     );
 }
 

--- a/tests/rules/no_extra_label.zig
+++ b/tests/rules/no_extra_label.zig
@@ -24,13 +24,66 @@ test "reports no-extra-label for labels without labeled break or continue" {
     try std.testing.expectEqualStrings("This label is unnecessary.", result.diagnostics[0].message);
 }
 
-test "does not report no-extra-label when labeled break or continue uses the label" {
+test "reports no-extra-label for redundant labeled break or continue" {
     const source =
         \\outer: while (ready) {
         \\  break outer;
         \\}
         \\loop: while (ready) {
         \\  continue loop;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_label.id));
+}
+
+test "reports no-extra-label through nested labeled blocks" {
+    const source =
+        \\outer: while (ready) {
+        \\  block: {
+        \\    break outer;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_label.id));
+
+    var found_redundant_reference = false;
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, "This label 'outer' is unnecessary.")) {
+            found_redundant_reference = true;
+        }
+    }
+    try std.testing.expect(found_redundant_reference);
+}
+
+test "does not report no-extra-label when nested break or continue needs the label" {
+    const source =
+        \\outer: while (ready) {
+        \\  while (inner) {
+        \\    break outer;
+        \\  }
+        \\}
+        \\loop: while (ready) {
+        \\  while (inner) {
+        \\    continue loop;
+        \\  }
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- report redundant `break label` and `continue label` references when they target the immediately labeled loop
- keep labeled references in nested loops and switches valid
- add coverage for direct loop references, nested labeled blocks, and nested loop escapes

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_extra_label.zig tests/rules/no_extra_label.zig`
- `git diff --check`
