### PR TITLE
Handle commutative operator assignment

### DIFF
--- a/src/rules/operator_assignment.zig
+++ b/src/rules/operator_assignment.zig
@@ -37,7 +37,11 @@ pub fn check(
 
     const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
     const right_left = (try referenceFromExpression(arena_allocator, tree, binary.left)) orelse return;
-    if (!referencesEqual(left, right_left)) return;
+    if (!referencesEqual(left, right_left)) {
+        if (!hasCommutativeAssignmentOperator(binary.operator)) return;
+        const right_right = (try referenceFromExpression(arena_allocator, tree, binary.right)) orelse return;
+        if (!referencesEqual(left, right_right)) return;
+    }
 
     try core.addDiagnostic(
         allocator,
@@ -63,6 +67,17 @@ fn hasAssignmentOperator(operator: ast.BinaryOperator) bool {
         .left_shift,
         .right_shift,
         .unsigned_right_shift,
+        => true,
+        else => false,
+    };
+}
+
+fn hasCommutativeAssignmentOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .multiply,
+        .bitwise_or,
+        .bitwise_xor,
+        .bitwise_and,
         => true,
         else => false,
     };

--- a/tests/rules/operator_assignment.zig
+++ b/tests/rules/operator_assignment.zig
@@ -17,6 +17,10 @@ test "reports operator-assignment for assignable binary self updates" {
         \\this.total = this.total - amount;
         \\obj["count"] = obj["count"] | mask;
         \\obj[0] = obj[0] & mask;
+        \\value = amount * value;
+        \\value = amount | value;
+        \\value = amount ^ value;
+        \\value = amount & value;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -28,13 +32,14 @@ test "reports operator-assignment for assignable binary self updates" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.operator_assignment.id));
+    try std.testing.expectEqual(@as(usize, 16), helpers.countRule(result, lint.rules.operator_assignment.id));
 }
 
 test "does not report operator-assignment when shorthand would change the expression" {
     const source =
         \\let value = 1;
         \\value = amount + value;
+        \\value = amount - value;
         \\value = value && amount;
         \\value = value < amount;
         \\value += amount;


### PR DESCRIPTION
## Summary

- report `operator-assignment` when a commutative binary expression keeps the assigned reference on the right side
- cover `*`, `|`, `^`, and `&` while leaving non-commutative `+` and `-` right-side cases unreported
- add regression coverage matching ESLint's behavior for right-side self references

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/operator_assignment.zig tests/rules/operator_assignment.zig`
- `git diff --check`
