### PR TITLE
Tighten spaced comment markers

### DIFF
--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -48,19 +48,18 @@ fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, style: Style)
     const value = tree.string(comment.value);
     if (value.len == 0) return true;
 
-    if (isMarker(value[0], comment.type)) return true;
+    const index = spacingIndex(value, comment.type);
+    if (index >= value.len) return true;
 
     return switch (style) {
-        .always => isWhitespace(value[0]),
-        .never => !isWhitespace(value[0]),
+        .always => isWhitespace(value[index]),
+        .never => !isWhitespace(value[index]),
     };
 }
 
-fn isMarker(char: u8, comment_type: ast.Comment.Type) bool {
-    return switch (comment_type) {
-        .line => char == '/',
-        .block => char == '*' or char == '!',
-    };
+fn spacingIndex(value: []const u8, comment_type: ast.Comment.Type) usize {
+    if (comment_type == .block and value[0] == '*') return 1;
+    return 0;
 }
 
 fn message(style: Style) []const u8 {

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -5,7 +5,10 @@ const helpers = @import("../helpers.zig");
 test "reports spaced-comment for comments without spacing" {
     const source =
         \\//missing space
+        \\/// <reference path="types.d.ts" />
         \\/*missing space */
+        \\/**missing space */
+        \\/*! license */
         \\const value = 1; //inline missing space
     ;
 
@@ -17,20 +20,17 @@ test "reports spaced-comment for comments without spacing" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.spaced_comment.id));
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.spaced_comment.id));
 }
 
-test "does not report spaced-comment for spaced comments and common markers" {
+test "does not report spaced-comment for spaced comments and jsdoc markers" {
     const source =
         \\// line comment
         \\// another line comment
-        \\///
-        \\/// <reference path="types.d.ts" />
         \\/* block comment */
         \\/**
         \\ * jsdoc
         \\ */
-        \\/*! license */
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -48,10 +48,12 @@ test "reports spaced-comment for spaced comments in never mode" {
     const source =
         \\// space is disallowed
         \\/* block space is disallowed */
+        \\/** jsdoc marker space is disallowed */
         \\//nospace
         \\/*nospace */
         \\/// common marker
-        \\/** jsdoc */
+        \\/**jsdoc */
+        \\/*! license */
         \\const value = 1;
     ;
 
@@ -64,7 +66,7 @@ test "reports spaced-comment for spaced comments in never mode" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.spaced_comment.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.spaced_comment.id));
 }
 
 test "can disable spaced-comment" {


### PR DESCRIPTION
## Summary

- tighten `spaced-comment` marker handling to match ESLint defaults
- report `///...`, `/**nospace */`, and `/*! ... */` in `always` mode
- report whitespace after the JSDoc `*` marker in `never` mode while keeping marker forms without spacing valid

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/spaced_comment.zig tests/rules/spaced_comment.zig`
- `git diff --check`
