### PR TITLE
Ignore nonalphabetic new-cap names

### DIFF
--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -15,7 +15,7 @@ pub fn checkNewExpression(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     const name = constructorName(tree, expression.callee) orelse return;
-    if (startsWithUppercase(name)) return;
+    if (nameCase(name) != .lower) return;
 
     try core.addDiagnostic(
         allocator,
@@ -36,7 +36,7 @@ pub fn checkCallExpression(
 ) Allocator.Error!void {
     const callee = unwrapTransparent(tree, expression.callee);
     const name = constructorName(tree, callee) orelse return;
-    if (!startsWithUppercase(name)) return;
+    if (nameCase(name) != .upper) return;
     if (isAllowedCallableBuiltin(tree, callee, name)) return;
 
     try core.addDiagnostic(
@@ -109,8 +109,17 @@ fn isAllowedCallableBuiltin(tree: *const ast.Tree, callee: ast.NodeIndex, name: 
     return false;
 }
 
-fn startsWithUppercase(name: []const u8) bool {
-    return name.len > 0 and std.ascii.isUpper(name[0]);
+const NameCase = enum {
+    upper,
+    lower,
+    other,
+};
+
+fn nameCase(name: []const u8) NameCase {
+    if (name.len == 0) return .other;
+    if (std.ascii.isUpper(name[0])) return .upper;
+    if (std.ascii.isLower(name[0])) return .lower;
+    return .other;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -28,7 +28,15 @@ test "does not report new-cap for conventional constructor usage callable builti
     const source =
         \\new Foo();
         \\foo();
+        \\new _foo();
+        \\new $foo();
+        \\_Foo();
+        \\$Foo();
         \\new namespace.Foo();
+        \\new namespace._foo();
+        \\new namespace.$foo();
+        \\namespace._Foo();
+        \\namespace.$Foo();
         \\new namespace[`fo${suffix}`]();
         \\namespace[`Fo${suffix}`]();
         \\Array();


### PR DESCRIPTION
## Summary

- align `new-cap` with ESLint for names that start with non-alphabetic characters
- ignore constructor and call names such as `_foo`, `$foo`, `_Foo`, and `$Foo`
- keep existing lowercase constructor and uppercase call checks for alphabetic names

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/new_cap.zig tests/rules/new_cap.zig`
- `git diff --check`
