### PR TITLE
Handle try exits in no-fallthrough

### DIFF
--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -87,6 +87,8 @@ fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .if_statement => |statement| statement.alternate != .null and
             alwaysExits(tree, statement.consequent) and
             alwaysExits(tree, statement.alternate),
+        .try_statement => |statement| alwaysExits(tree, statement.block) or
+            alwaysExits(tree, statement.finalizer),
 
         else => false,
     };

--- a/tests/rules/no_fallthrough.zig
+++ b/tests/rules/no_fallthrough.zig
@@ -61,6 +61,54 @@ test "does not report no-fallthrough for break, return, throw, adjacent empty ca
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
 }
 
+test "does not report no-fallthrough when final try statements exit" {
+    const source =
+        \\function run(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      try { return one(); } catch (error) { recover(error); }
+        \\    case 2:
+        \\      try { one(); } finally { return cleanup(); }
+        \\    case 3:
+        \\      try { return three(); } finally { cleanup(); }
+        \\    default:
+        \\      done();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
+}
+
+test "reports no-fallthrough when only catch exits" {
+    const source =
+        \\function run(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      try { one(); } catch (error) { return recover(error); }
+        \\    default:
+        \\      done();
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_fallthrough.id));
+}
+
 test "reports no-fallthrough for separated empty cases by default" {
     const source =
         \\switch (value) {


### PR DESCRIPTION
## Summary

- treat final `try` statements as exiting for `no-fallthrough` when the `try` block exits
- also treat `finally` blocks that exit as preventing switch fallthrough
- keep reporting when only the `catch` block exits and the `try` block can fall through

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_fallthrough.zig tests/rules/no_fallthrough.zig`
- `git diff --check`
