### PR TITLE
Allow await in for initializers

### DIFF
--- a/src/rules/no_await_in_loop.zig
+++ b/src/rules/no_await_in_loop.zig
@@ -14,7 +14,7 @@ pub fn check(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
-    if (!isInsideLoop(tree, ctx)) return;
+    if (!isInsideLoop(tree, index, ctx)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -26,20 +26,27 @@ pub fn check(
     );
 }
 
-fn isInsideLoop(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+fn isInsideLoop(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child = index;
     var depth: usize = 1;
     while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
         switch (tree.data(ancestor)) {
             .arrow_function_expression,
             .function,
             => return false,
-            .for_statement,
+            .for_statement => |statement| {
+                if (statement.init == child) {
+                    child = ancestor;
+                    continue;
+                }
+                return true;
+            },
             .for_in_statement,
             .for_of_statement,
             .while_statement,
             .do_while_statement,
             => return true,
-            else => {},
+            else => child = ancestor,
         }
     }
 

--- a/tests/rules/no_await_in_loop.zig
+++ b/tests/rules/no_await_in_loop.zig
@@ -27,10 +27,32 @@ test "reports no-await-in-loop for await expressions inside loop bodies" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_await_in_loop.id));
 }
 
+test "reports no-await-in-loop for await in for test and update" {
+    const source =
+        \\async function run() {
+        \\  for (; await ready(); step()) {}
+        \\  for (; ready; await step()) {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_await_in_loop.id));
+}
+
 test "does not report no-await-in-loop outside loops or across nested functions" {
     const source =
         \\async function run(items) {
         \\  await setup();
+        \\  for (await setup(); ready; step()) {
+        \\    use();
+        \\  }
         \\  for (const item of items) {
         \\    async function nested() {
         \\      await work(item);
@@ -54,6 +76,26 @@ test "does not report no-await-in-loop outside loops or across nested functions"
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_await_in_loop.id));
+}
+
+test "reports no-await-in-loop for for-init await inside an outer loop" {
+    const source =
+        \\async function run() {
+        \\  while (ready) {
+        \\    for (await setup(); active; step()) {}
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_await_in_loop.id));
 }
 
 test "can disable no-await-in-loop" {


### PR DESCRIPTION
## Summary

- align `no-await-in-loop` with ESLint by allowing `await` in a `for` statement initializer
- keep reporting awaits in `for` test, update, and loop bodies
- still report a `for` initializer await when the whole `for` statement is nested inside an outer loop

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_await_in_loop.zig tests/rules/no_await_in_loop.zig`
- `git diff --check`
