### PR TITLE
Handle try exits in no-unreachable

### DIFF
--- a/src/rules/no_unreachable.zig
+++ b/src/rules/no_unreachable.zig
@@ -45,6 +45,8 @@ fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .if_statement => |statement| statement.alternate != .null and
             alwaysExits(tree, statement.consequent) and
             alwaysExits(tree, statement.alternate),
+        .try_statement => |statement| alwaysExits(tree, statement.block) or
+            alwaysExits(tree, statement.finalizer),
         else => false,
     };
 }

--- a/tests/rules/no_unreachable.zig
+++ b/tests/rules/no_unreachable.zig
@@ -58,6 +58,33 @@ test "reports no-unreachable after if statements where both branches exit" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unreachable.id));
 }
 
+test "reports no-unreachable after try statements that exit" {
+    const source =
+        \\function first() {
+        \\  try { return value; } catch (error) { recover(error); }
+        \\  call();
+        \\}
+        \\function second() {
+        \\  try { use(); } finally { return cleanup(); }
+        \\  call();
+        \\}
+        \\function third() {
+        \\  try { throw error; } finally { cleanup(); }
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_unreachable.id));
+}
+
 test "does not report no-unreachable for reachable statements or hoisted declarations" {
     const source =
         \\function first(value) {
@@ -70,6 +97,10 @@ test "does not report no-unreachable for reachable statements or hoisted declara
         \\  return;
         \\  function later() {}
         \\  var hoisted = 1;
+        \\}
+        \\function third() {
+        \\  try { call(); } catch (error) { return recover(error); }
+        \\  call();
         \\}
     ;
 


### PR DESCRIPTION
## Summary

- treat final `try` statements as exiting for `no-unreachable` when the `try` block exits
- also treat exiting `finally` blocks as making following statements unreachable
- keep statements reachable when only the `catch` block exits

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_unreachable.zig tests/rules/no_unreachable.zig`
- `git diff --check`
