### PR TITLE
Report more constant conditions

### DIFF
--- a/src/rules/no_constant_condition.zig
+++ b/src/rules/no_constant_condition.zig
@@ -56,7 +56,9 @@ fn isConstantExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
         .class => |class| class.type == .class_expression,
         .unary_expression => |unary| isConstantUnaryExpression(tree, unary),
+        .binary_expression => |binary| isConstantBinaryExpression(tree, binary),
         .logical_expression => |logical| isConstantLogicalExpression(tree, logical),
+        .assignment_expression => |assignment| isConstantAssignmentExpression(tree, assignment),
         else => false,
     };
 }
@@ -81,6 +83,18 @@ fn isConstantUnaryExpression(tree: *const ast.Tree, unary: ast.UnaryExpression) 
         .delete,
         => false,
     };
+}
+
+fn isConstantBinaryExpression(tree: *const ast.Tree, binary: ast.BinaryExpression) bool {
+    if (binary.operator == .in or binary.operator == .instanceof) return false;
+
+    return isConstantExpression(tree, unwrapTransparent(tree, binary.left)) and
+        isConstantExpression(tree, unwrapTransparent(tree, binary.right));
+}
+
+fn isConstantAssignmentExpression(tree: *const ast.Tree, assignment: ast.AssignmentExpression) bool {
+    if (assignment.operator != .assign) return false;
+    return isConstantExpression(tree, unwrapTransparent(tree, assignment.right));
 }
 
 fn isConstantLogicalExpression(tree: *const ast.Tree, logical: ast.LogicalExpression) bool {

--- a/tests/rules/no_constant_condition.zig
+++ b/tests/rules/no_constant_condition.zig
@@ -127,6 +127,25 @@ test "reports no-constant-condition for constant logical expressions" {
     try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_constant_condition.id));
 }
 
+test "reports no-constant-condition for constant binary and assignment expressions" {
+    const source =
+        \\if (1 + 2) { use(); }
+        \\if ("a" === "b") { use(); }
+        \\if (value = 1) { use(); }
+        \\if (value = {}) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_cond_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_constant_condition.id));
+}
+
 test "does not report no-constant-condition for dynamic logical expressions" {
     const source =
         \\if (true && ready) { use(); }
@@ -136,6 +155,26 @@ test "does not report no-constant-condition for dynamic logical expressions" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_constant_condition.id));
+}
+
+test "does not report no-constant-condition for dynamic binary or assignment expressions" {
+    const source =
+        \\if (1 + ready) { use(); }
+        \\if (value = ready) { use(); }
+        \\if (value += 1) { use(); }
+        \\if ("key" in {}) { use(); }
+        \\if ({} instanceof Object) { use(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_cond_assign = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary

- report `no-constant-condition` for binary expressions whose operands are both constant
- report simple assignment conditions when the assigned value is constant
- keep dynamic binary expressions, compound assignments, and `in`/`instanceof` conditions unreported

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_constant_condition.zig tests/rules/no_constant_condition.zig`
- `git diff --check`
