### PR TITLE
Handle more promise rejection literals

### DIFF
--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -204,8 +204,12 @@ fn isInvalidRejectReason(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .boolean_literal,
         .null_literal,
         .template_literal,
+        .regexp_literal,
+        .object_expression,
+        .array_expression,
         => true,
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => true,
         .binary_expression => |expression| expression.operator == .add,
         else => false,
     };

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -365,8 +365,12 @@ fn isInvalidRejectReason(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .boolean_literal,
         .null_literal,
         .template_literal,
+        .regexp_literal,
+        .object_expression,
+        .array_expression,
         => true,
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => true,
         .binary_expression => |expression| expression.operator == .add,
         else => false,
     };

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -46,11 +46,35 @@ test "reports prefer-promise-reject-errors for obvious non-error rejection reaso
     try std.testing.expectEqual(@as(usize, 17), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
+test "reports prefer-promise-reject-errors for object regexp and unary reject reasons" {
+    const source =
+        \\Promise.reject({});
+        \\Promise.reject([]);
+        \\Promise.reject(/failed/);
+        \\Promise.reject(void 0);
+        \\Promise.reject(typeof failed);
+        \\Promise.reject(-1);
+        \\new Promise((resolve, reject) => {
+        \\  reject({});
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
 test "does not report prefer-promise-reject-errors for error-like rejection reasons" {
     const source =
         \\Promise.reject(new Error("failed"));
         \\Promise.reject(error);
         \\Promise.reject(Error("failed"));
+        \\Promise.reject(NaN);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary
- Treat object, array, regexp, and unary expressions as obvious non-Error Promise rejection reasons.
- Keep the standalone prefer-promise-reject-errors helper in sync with the shared promise checks path.
- Add focused coverage for `Promise.reject(...)` and executor `reject(...)` cases, plus `NaN` as an allowed dynamic identifier.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/prefer_promise_reject_errors.zig src/rules/promise_checks.zig tests/rules/prefer_promise_reject_errors.zig`
- `git diff --check`
