### PR TITLE
Report useless returns in catch blocks

### DIFF
--- a/src/rules/no_useless_return.zig
+++ b/src/rules/no_useless_return.zig
@@ -52,7 +52,12 @@ fn isRedundantReturn(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverse
                 child = ancestor;
             },
             .try_statement => |statement| {
-                if (statement.block != child) return false;
+                if (statement.block != child and (statement.handler == .null or statement.handler != child)) return false;
+                if (statement.handler == child and statement.finalizer != .null) return false;
+                child = ancestor;
+            },
+            .catch_clause => |clause| {
+                if (clause.body != child) return false;
                 child = ancestor;
             },
             .while_statement,
@@ -60,7 +65,6 @@ fn isRedundantReturn(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverse
             .for_statement,
             .for_in_statement,
             .for_of_statement,
-            .catch_clause,
             => return false,
             .function,
             .arrow_function_expression,

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -66,6 +66,13 @@ test "reports no-useless-return in final try blocks" {
         \\    cleanup();
         \\  }
         \\}
+        \\function third() {
+        \\  try {
+        \\    work();
+        \\  } catch (error) {
+        \\    return;
+        \\  }
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -76,7 +83,7 @@ test "reports no-useless-return in final try blocks" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_return.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_useless_return.id));
 }
 
 test "does not report no-useless-return when return changes control flow" {
@@ -106,15 +113,17 @@ test "does not report no-useless-return when return changes control flow" {
         \\function fifth() {
         \\  try {
         \\    work();
-        \\  } catch (error) {
+        \\  } finally {
         \\    return;
         \\  }
         \\}
         \\function sixth() {
         \\  try {
         \\    work();
-        \\  } finally {
+        \\  } catch (error) {
         \\    return;
+        \\  } finally {
+        \\    cleanup();
         \\  }
         \\}
     ;


### PR DESCRIPTION
## Summary
- Treat bare `return;` statements in final `catch` blocks as redundant when the `try` statement has no `finally` block.
- Keep `catch` returns with a `finally` block conservative, matching ESLint's default behavior for cleanup finalizers.
- Add coverage for final catch returns and finalizer cases.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_useless_return.zig tests/rules/no_useless_return.zig`
- `git diff --check`
