### PR TITLE
Report console member usage

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -123,6 +123,7 @@ fn hasSemanticRules(options: Options) bool {
         options.alipay_ant_exhaustive_deps or
         options.alipay_ant_prefer_click_with_debounce or
         options.no_buffer_constructor or
+        options.no_console or
         options.alipay_ant_no_spread_params or
         options.alipay_ant_prefer_import_from_stdlib or
         options.no_class_assign or

--- a/src/rules/no_console.zig
+++ b/src/rules/no_console.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-console";
@@ -11,50 +12,61 @@ pub const Options = struct {
     allow: core.NoConsoleAllow = .{},
 };
 
-pub fn check(
+pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    call: ast.CallExpression,
-    index: ast.NodeIndex,
-) Allocator.Error!void {
-    try checkWithOptions(allocator, diagnostics, tree, call, index, .{});
-}
-
-pub fn checkWithOptions(
-    allocator: Allocator,
-    diagnostics: *core.DiagnosticList,
-    tree: *const ast.Tree,
-    call: ast.CallExpression,
-    index: ast.NodeIndex,
+    symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
-    const member = consoleMemberCall(tree, call.callee) orelse return;
-    const method = propertyName(tree, member);
-    if (method != null and options.allow.contains(method.?)) return;
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .options = options,
+    };
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Unexpected console call.",
-        tree.span(index),
-    );
+    try traverser.basic.traverse(Visitor, tree, &visitor);
 }
 
-fn consoleMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex) ?ast.MemberExpression {
-    var current = callee;
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 
-    switch (tree.data(current)) {
-        .chain_expression => |chain| current = chain.expression,
-        else => {},
+    pub fn enter_member_expression(
+        self: *Visitor,
+        member: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isGlobalConsoleReference(ctx.tree, self.symbol_table, member.object)) return .proceed;
+
+        const method = propertyName(ctx.tree, member);
+        if (method != null and self.options.allow.contains(method.?)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Unexpected console statement.",
+            ctx.tree.span(index),
+        );
+
+        return .proceed;
     }
+};
 
-    return switch (tree.data(current)) {
-        .member_expression => |member| if (isIdentifierNamed(tree, member.object, "console")) member else null,
-        else => null,
-    };
+fn isGlobalConsoleReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    if (!isIdentifierNamed(tree, unwrapped, "console")) return false;
+    return isUnresolvedReference(symbol_table, unwrapped);
 }
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
@@ -91,4 +103,32 @@ fn isIdentifierNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: []const 
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
         else => false,
     };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -693,6 +693,12 @@ pub fn runSemantic(
         try no_buffer_constructor.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
+    if (options.no_console) {
+        try no_console.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .allow = options.no_console_allow,
+        });
+    }
+
     if (options.no_extra_boolean_cast) {
         try no_extra_boolean_cast.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
@@ -2277,11 +2283,6 @@ const BasicVisitor = struct {
         }
         if (self.options.import_no_amd) {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
-        }
-        if (self.options.no_console) {
-            try no_console.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, call, index, .{
-                .allow = self.options.no_console_allow,
-            });
         }
         if (self.options.no_prototype_builtins) {
             try no_prototype_builtins.check(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/tests/rules/no_console.zig
+++ b/tests/rules/no_console.zig
@@ -2,24 +2,37 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports no-console for console calls" {
+test "reports no-console for console member usage" {
     const source =
         \\console.log(value);
+        \\console.log;
+        \\console.log = value;
+        \\delete console.log;
+        \\console["log"](value);
+        \\console[`log`](value);
+        \\console[`lo${suffix}`](value);
+        \\console.log?.(value);
+        \\console?.log(value);
+        \\console?.["log"](value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(helpers.hasRule(result, lint.rules.no_console.id));
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_console.id));
 }
 
 test "allows configured no-console methods" {
     const source =
         \\console.warn(value);
+        \\console.warn;
+        \\console.warn = value;
         \\console["error"](value);
         \\console[`warn`](value);
         \\console[`wa${suffix}`](value);
@@ -32,6 +45,8 @@ test "allows configured no-console methods" {
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_console_allow = allow,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -39,6 +54,24 @@ test "allows configured no-console methods" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_console.id));
+}
+
+test "does not report no-console for shadowed console" {
+    const source =
+        \\function local(console) {
+        \\  console.log(value);
+        \\  console.log = value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_console.id));
 }
 
 test "can disable no-console" {


### PR DESCRIPTION
## Summary
- Move `no-console` to semantic traversal so shadowed `console` bindings are ignored.
- Report `console.*` member usage for calls, reads, writes, deletes, optional chains, and computed members instead of only call expressions.
- Keep configured allowed methods working for calls and non-call member usage.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/root.zig src/rules/root.zig src/rules/no_console.zig tests/rules/no_console.zig`
- `git diff --check`
