### PR TITLE
Ignore computed arguments caller keys

### DIFF
--- a/src/rules/no_caller.zig
+++ b/src/rules/no_caller.zig
@@ -16,7 +16,7 @@ pub fn check(
 ) Allocator.Error!void {
     if (!isArgumentsObject(tree, member.object)) return;
 
-    const name = propertyName(tree, member) orelse return;
+    const name = nonComputedPropertyName(tree, member) orelse return;
     if (!isForbiddenProperty(name)) return;
 
     try core.addDiagnostic(
@@ -52,15 +52,10 @@ fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex 
     return current;
 }
 
-fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
-    if (member.property == .null) return null;
+fn nonComputedPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed or member.property == .null) return null;
 
-    return if (member.computed)
-        switch (tree.data(member.property)) {
-            .string_literal => |literal| tree.string(literal.value),
-            else => null,
-        }
-    else switch (tree.data(member.property)) {
+    return switch (tree.data(member.property)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         else => null,
     };

--- a/tests/rules/no_caller.zig
+++ b/tests/rules/no_caller.zig
@@ -7,8 +7,8 @@ test "reports no-caller for arguments caller and callee access" {
         \\function f() {
         \\  arguments.callee;
         \\  arguments.caller;
-        \\  arguments["callee"];
-        \\  arguments["caller"];
+        \\  arguments?.callee;
+        \\  arguments.callee = fn;
         \\}
     ;
 
@@ -28,6 +28,9 @@ test "does not report no-caller for other objects or properties" {
         \\object.callee;
         \\arguments.length;
         \\arguments[name];
+        \\arguments["callee"];
+        \\arguments["caller"];
+        \\arguments[`callee`];
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary

- Align `no-caller` with ESLint by only reporting non-computed `arguments.caller` and `arguments.callee` member access.
- Keep optional chaining and assignment coverage for direct member access.
- Add non-reporting coverage for computed string and template property keys.

## Validation

- `zig build test -- tests/rules/no_caller.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_caller.zig tests/rules/no_caller.zig`
- `git diff --check`
