### PR TITLE
Allow void delete unused expressions

### DIFF
--- a/src/rules/no_unused_expressions.zig
+++ b/src/rules/no_unused_expressions.zig
@@ -59,6 +59,7 @@ fn hasSideEffect(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) 
         => true,
 
         .tagged_template_expression => options.allow_tagged_templates,
+        .unary_expression => |unary| unary.operator == .delete or unary.operator == .void,
 
         .chain_expression => |chain| hasSideEffect(tree, chain.expression, options),
         .conditional_expression => |conditional| options.allow_ternary and

--- a/tests/rules/no_unused_expressions.zig
+++ b/tests/rules/no_unused_expressions.zig
@@ -34,6 +34,8 @@ test "does not report no-unused-expressions for expressions with side effects" {
         \\value = 1;
         \\value += 1;
         \\value++;
+        \\delete object.value;
+        \\void object.value;
         \\import("mod");
         \\(foo());
         \\(0, foo());


### PR DESCRIPTION
## Summary

- Treat `delete` and `void` unary expression statements as allowed by `no-unused-expressions`.
- Add regression coverage matching ESLint behavior where `delete obj.prop;` and `void obj.prop;` are not reported by this rule.

## Validation

- `zig build test -- tests/rules/no_unused_expressions.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_unused_expressions.zig tests/rules/no_unused_expressions.zig`
- `git diff --check`
