### PR TITLE
Require explicit array callback returns

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -372,7 +372,7 @@ pub const Options = struct {
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
     accessor_pairs_set_without_get: AccessorPairsSetWithoutGet = .yes,
     array_callback_return: bool = true,
-    array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .yes,
+    array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .no,
     array_callback_return_check_for_each: ArrayCallbackReturnCheckForEach = .no,
     array_callback_return_allow_void: ArrayCallbackReturnAllowVoid = .no,
     block_scoped_var: bool = true,
@@ -972,7 +972,7 @@ pub const Options = struct {
     }
 
     fn arrayCallbackReturnAllowImplicitFromConfig(value: std.json.Value) RuleConfigError!ArrayCallbackReturnAllowImplicit {
-        const enabled = try arrayCallbackReturnOptionFromConfig(value, "allowImplicit", true);
+        const enabled = try arrayCallbackReturnOptionFromConfig(value, "allowImplicit", false);
         return if (enabled) .yes else .no;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -118,6 +118,8 @@ pub fn main(init: std.process.Init) !void {
             options.constructor_super = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
             options.array_callback_return = false;
+        } else if (std.mem.eql(u8, arg, "--array-callback-return-allow-implicit=on")) {
+            options.array_callback_return_allow_implicit = .yes;
         } else if (std.mem.eql(u8, arg, "--array-callback-return-allow-implicit=off")) {
             options.array_callback_return_allow_implicit = .no;
         } else if (std.mem.eql(u8, arg, "--array-callback-return-check-for-each=on")) {
@@ -1460,6 +1462,7 @@ fn printHelp() void {
         \\  --accessor-pairs-get-without-set=on Enable accessor-pairs getWithoutSet
         \\  --accessor-pairs-set-without-get=off Disable accessor-pairs setWithoutGet
         \\  --array-callback-return=off Disable array-callback-return
+        \\  --array-callback-return-allow-implicit=on Allow bare return statements in array callbacks
         \\  --array-callback-return-allow-implicit=off Require explicit values from array callbacks
         \\  --array-callback-return-check-for-each=on Check forEach callbacks for return values
         \\  --array-callback-return-allow-void=on Allow void returns in checked forEach callbacks

--- a/src/rules/array_callback_return.zig
+++ b/src/rules/array_callback_return.zig
@@ -8,7 +8,7 @@ const Allocator = std.mem.Allocator;
 pub const id = "array-callback-return";
 
 pub const Options = struct {
-    allow_implicit: bool = true,
+    allow_implicit: bool = false,
     check_for_each: bool = false,
     allow_void: bool = false,
 };

--- a/tests/rules/array_callback_return.zig
+++ b/tests/rules/array_callback_return.zig
@@ -40,7 +40,7 @@ test "does not report array-callback-return for callbacks that return on all pat
         \\  if (item) {
         \\    return item;
         \\  }
-        \\  return;
+        \\  return fallback;
         \\});
         \\items.some((item) => {
         \\  if (item) {
@@ -62,7 +62,7 @@ test "does not report array-callback-return for callbacks that return on all pat
     try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
 }
 
-test "reports array-callback-return for implicit returns when allowImplicit is disabled" {
+test "reports array-callback-return for implicit returns by default" {
     const source =
         \\items.filter(function(item) {
         \\  if (item) {
@@ -73,7 +73,6 @@ test "reports array-callback-return for implicit returns when allowImplicit is d
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
-        .array_callback_return_allow_implicit = .no,
         .no_undef = false,
         .no_unused_vars = false,
         .no_useless_return = false,
@@ -82,6 +81,28 @@ test "reports array-callback-return for implicit returns when allowImplicit is d
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.array_callback_return.id));
+}
+
+test "allows implicit returns when allowImplicit is enabled" {
+    const source =
+        \\items.filter(function(item) {
+        \\  if (item) {
+        \\    return item;
+        \\  }
+        \\  return;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .array_callback_return_allow_implicit = .yes,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_useless_return = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.array_callback_return.id));
 }
 
 test "ignores forEach callbacks and non-function callback references" {


### PR DESCRIPTION
## Summary

- Align `array-callback-return` with ESLint by requiring explicit callback return values by default.
- Keep an escape hatch for `allowImplicit: true` through config and add `--array-callback-return-allow-implicit=on` for the CLI.
- Update tests so bare `return;` reports by default and only passes when `allowImplicit` is enabled.

## Validation

- `zig build test -- tests/rules/array_callback_return.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/array_callback_return.zig src/core.zig src/main.zig tests/rules/array_callback_return.zig`
- `git diff --check`
