### PR TITLE
Default no-redeclare builtin globals off

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -218,6 +218,11 @@ pub const NoPlusplusAllowForLoopAfterthoughts = enum {
     no,
 };
 
+pub const NoRedeclareBuiltinGlobals = enum {
+    yes,
+    no,
+};
+
 pub const NoUnusedExpressionsAllowShortCircuit = enum {
     yes,
     no,
@@ -565,6 +570,7 @@ pub const Options = struct {
     no_process_exit: bool = true,
     no_prototype_builtins: bool = true,
     no_redeclare: bool = true,
+    no_redeclare_builtin_globals: NoRedeclareBuiltinGlobals = .no,
     no_regex_spaces: bool = true,
     no_return_await: bool = true,
     no_return_assign: bool = true,
@@ -886,6 +892,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-param-reassign")) {
             self.no_param_reassign_props = try noParamReassignPropsFromConfig(value);
             self.no_param_reassign_ignore_property_modifications_for = try noParamReassignIgnoredNamesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-redeclare")) {
+            self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
@@ -1476,6 +1485,24 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noRedeclareBuiltinGlobalsFromConfig(value: std.json.Value) RuleConfigError!NoRedeclareBuiltinGlobals {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no,
+        };
+        if (items.len < 2) return .no;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const enabled = switch (config.get("builtinGlobals") orelse return .no) {
+            .bool => |bool_value| bool_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return if (enabled) .yes else .no;
     }
 
     fn preferConstDestructuringFromConfig(value: std.json.Value) RuleConfigError!PreferConstDestructuring {
@@ -2408,6 +2435,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("req"));
     try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("res"));
     try std.testing.expect(!options.no_param_reassign_ignore_property_modifications_for.contains("ctx"));
+
+    var no_redeclare_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"builtinGlobals\":true}]",
+        .{},
+    );
+    defer no_redeclare_config.deinit();
+    try options.setByRuleConfigValue("no-redeclare", no_redeclare_config.value);
+    try std.testing.expect(options.no_redeclare);
+    try std.testing.expectEqual(NoRedeclareBuiltinGlobals.yes, options.no_redeclare_builtin_globals);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -493,6 +493,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_prototype_builtins = false;
         } else if (std.mem.eql(u8, arg, "--no-redeclare=off")) {
             options.no_redeclare = false;
+        } else if (std.mem.eql(u8, arg, "--no-redeclare-builtin-globals=on")) {
+            options.no_redeclare_builtin_globals = .yes;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-await=off")) {
@@ -1654,6 +1656,7 @@ fn printHelp() void {
         \\  --no-process-exit=off     Disable no-process-exit
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-redeclare=off        Disable no-redeclare
+        \\  --no-redeclare-builtin-globals=on Report redeclarations of built-in globals
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign

--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -12,6 +12,7 @@ pub const Options = struct {
     rule_id: []const u8 = id,
     severity: core.Severity = .warning,
     mode: Mode = .javascript,
+    builtin_globals: bool = false,
 };
 
 pub const Mode = enum {
@@ -108,6 +109,7 @@ fn isBuiltinGlobalRedeclaration(
     options: Options,
 ) bool {
     return options.mode == .javascript and
+        options.builtin_globals and
         tree.source_type == .script and
         symbol.scope == .root and
         core.isKnownGlobal(name);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -722,7 +722,9 @@ pub fn runSemantic(
     const use_typescript_no_redeclare = options.typescript_eslint_no_redeclare and tree.isTs();
 
     if (options.no_redeclare and !use_typescript_no_redeclare) {
-        try no_redeclare.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_redeclare.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .builtin_globals = options.no_redeclare_builtin_globals == .yes,
+        });
     }
 
     if (use_typescript_no_redeclare) {

--- a/tests/rules/no_redeclare.zig
+++ b/tests/rules/no_redeclare.zig
@@ -24,7 +24,7 @@ test "reports no-redeclare for repeated declarations" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_redeclare.id));
 }
 
-test "reports no-redeclare for script built-in globals by default" {
+test "does not report no-redeclare for script built-in globals by default" {
     const source =
         \\var Object = 1;
         \\let undefinedValue = undefined;
@@ -32,6 +32,24 @@ test "reports no-redeclare for script built-in globals by default" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
+}
+
+test "reports no-redeclare for script built-in globals when configured" {
+    const source =
+        \\var Object = 1;
+        \\let undefinedValue = undefined;
+        \\let undefined = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", .{
+        .no_redeclare_builtin_globals = .yes,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary

- Align `no-redeclare` with ESLint by leaving built-in global redeclarations off by default.
- Add support for ESLint-style `builtinGlobals: true` configuration and a matching CLI switch.
- Update tests to cover the default behavior and the explicit opt-in path.

## Validation

- `zig build test -- tests/rules/no_redeclare.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/rules/no_redeclare.zig src/core.zig src/main.zig src/rules/root.zig tests/rules/no_redeclare.zig`
- `git diff --check`
