### PR TITLE
support radix as-needed mode

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -113,6 +113,11 @@ pub const NoReturnAssignStyle = enum {
     always,
 };
 
+pub const RadixStyle = enum {
+    always,
+    as_needed,
+};
+
 pub const NoSequencesAllowInParentheses = enum {
     yes,
     no,
@@ -693,6 +698,7 @@ pub const Options = struct {
     react_void_dom_elements_no_children: bool = true,
     react_hooks_rules_of_hooks: bool = true,
     radix: bool = true,
+    radix_style: RadixStyle = .always,
     require_await: bool = true,
     require_atomic_updates: bool = true,
     require_yield: bool = true,
@@ -901,6 +907,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "prefer-const")) {
             self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "radix")) {
+            self.radix_style = try radixStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
@@ -1538,6 +1547,22 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "except-parens")) return .except_parens;
         if (std.mem.eql(u8, style, "always")) return .always;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn radixStyleFromConfig(value: std.json.Value) RuleConfigError!RadixStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "as-needed")) return .as_needed;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -2468,6 +2493,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("prefer-const", prefer_const_config.value);
     try std.testing.expect(options.prefer_const);
     try std.testing.expectEqual(PreferConstDestructuring.all, options.prefer_const_destructuring);
+
+    var radix_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"as-needed\"]",
+        .{},
+    );
+    defer radix_config.deinit();
+    try options.setByRuleConfigValue("radix", radix_config.value);
+    try std.testing.expect(options.radix);
+    try std.testing.expectEqual(RadixStyle.as_needed, options.radix_style);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/radix.zig
+++ b/src/rules/radix.zig
@@ -8,16 +8,36 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "radix";
 
+pub const Style = enum {
+    always,
+    as_needed,
+};
+
+pub const Options = struct {
+    style: Style = .always,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +47,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -54,12 +75,19 @@ const Visitor = struct {
         }
 
         if (arguments.len == 1) {
-            try self.addDiagnostic(tree, index, "Missing radix parameter.");
+            if (self.options.style == .always) {
+                try self.addDiagnostic(tree, index, "Missing radix parameter.");
+            }
             return;
         }
 
         if (!isValidRadix(tree, arguments[1])) {
             try self.addDiagnostic(tree, index, "Invalid radix parameter, must be an integer between 2 and 36.");
+            return;
+        }
+
+        if (self.options.style == .as_needed and isDecimalRadix(tree, arguments[1])) {
+            try self.addDiagnostic(tree, index, "Redundant radix parameter.");
         }
     }
 
@@ -108,6 +136,24 @@ fn isGlobalParseIntCall(
     return std.mem.eql(u8, object_name, "Number") and isUnresolvedReference(symbol_table, object);
 }
 
+fn isDecimalRadix(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+
+    switch (tree.data(unwrapped)) {
+        .numeric_literal => |literal| return isNumericRadix(tree, literal, 1, 10),
+        .unary_expression => |expression| {
+            if (expression.operator != .positive and expression.operator != .negate) return false;
+
+            const literal = switch (tree.data(unwrapTransparent(tree, expression.argument))) {
+                .numeric_literal => |literal| literal,
+                else => return false,
+            };
+            return isNumericRadix(tree, literal, if (expression.operator == .negate) -1 else 1, 10);
+        },
+        else => return false,
+    }
+}
+
 fn isValidRadix(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     const unwrapped = unwrapTransparent(tree, index);
 
@@ -132,6 +178,12 @@ fn isValidNumericRadix(tree: *const ast.Tree, literal: ast.NumericLiteral, sign:
     const value = literal.value(tree);
     const signed_value = value * @as(f64, @floatFromInt(sign));
     return signed_value >= 2 and signed_value <= 36 and signed_value == @floor(signed_value);
+}
+
+fn isNumericRadix(tree: *const ast.Tree, literal: ast.NumericLiteral, sign: i64, expected: i64) bool {
+    const value = literal.value(tree);
+    const signed_value = value * @as(f64, @floatFromInt(sign));
+    return signed_value == @as(f64, @floatFromInt(expected));
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -870,7 +870,12 @@ pub fn runSemantic(
     }
 
     if (options.radix) {
-        try radix.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try radix.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .style = switch (options.radix_style) {
+                .always => .always,
+                .as_needed => .as_needed,
+            },
+        });
     }
 
     if (options.require_atomic_updates) {

--- a/tests/rules/radix.zig
+++ b/tests/rules/radix.zig
@@ -62,6 +62,36 @@ test "does not report radix for valid radix arguments or shadowed globals" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.radix.id));
 }
 
+test "supports radix as-needed mode" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"as-needed\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("radix", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\parseInt(value);
+        \\parseInt(value, 10);
+        \\parseInt(value, 16);
+        \\parseInt(value, undefined);
+        \\Number.parseInt(value);
+        \\Number.parseInt(value, 10);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.radix.id));
+}
+
 test "can disable radix" {
     const source =
         \\parseInt(value);


### PR DESCRIPTION
## Summary

Add ESLint-compatible `radix` support for the `"as-needed"` mode.

## Details

- parse `["error", "as-needed"]` into lint options
- pass the configured radix mode into the rule runner
- keep the default `"always"` behavior unchanged
- in `"as-needed"` mode, allow single-argument `parseInt` calls, keep invalid radix diagnostics, and report redundant decimal radix arguments

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/radix.zig tests/rules/radix.zig`
- `git diff --check`
