### PR TITLE
support no-undef typeof option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -644,6 +644,7 @@ pub const Options = struct {
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     no_undef: bool = true,
+    no_undef_typeof: bool = false,
     prefer_const: bool = true,
     prefer_const_destructuring: PreferConstDestructuring = .any,
     prefer_exponentiation_operator: bool = true,
@@ -928,6 +929,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+        }
+        if (std.mem.eql(u8, cli_name, "no-undef")) {
+            self.no_undef_typeof = try noUndefTypeofFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-use-before-define")) {
             self.typescript_eslint_no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", false);
@@ -1672,6 +1676,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enabled) .yes else .no;
+    }
+
+    fn noUndefTypeofFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("typeof") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noVoidAllowAsStatementFromConfig(value: std.json.Value) RuleConfigError!NoVoidAllowAsStatement {
@@ -2575,6 +2596,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_use_before_define);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_classes);
+
+    var no_undef_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"typeof\":true}]",
+        .{},
+    );
+    defer no_undef_config.deinit();
+    try options.setByRuleConfigValue("no-undef", no_undef_config.value);
+    try std.testing.expect(options.no_undef);
+    try std.testing.expect(options.no_undef_typeof);
 
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_undef.zig
+++ b/src/rules/no_undef.zig
@@ -8,17 +8,33 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-undef";
 
+pub const Options = struct {
+    check_typeof: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var allowed_typeof_refs = std.AutoHashMap(ast.NodeIndex, void).init(allocator);
     defer allowed_typeof_refs.deinit();
 
-    var visitor = TypeofVisitor{ .allowed_refs = &allowed_typeof_refs };
-    try traverser.basic.traverse(TypeofVisitor, tree, &visitor);
+    if (!options.check_typeof) {
+        var visitor = TypeofVisitor{ .allowed_refs = &allowed_typeof_refs };
+        try traverser.basic.traverse(TypeofVisitor, tree, &visitor);
+    }
 
     var iter = symbol_table.iterUnresolved();
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -915,7 +915,9 @@ pub fn runSemantic(
     }
 
     if (options.no_undef) {
-        try no_undef.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_undef.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .check_typeof = options.no_undef_typeof,
+        });
     }
 
     if (options.react_jsx_no_undef) {

--- a/tests/rules/no_undef.zig
+++ b/tests/rules/no_undef.zig
@@ -30,6 +30,32 @@ test "does not report no-undef for direct typeof identifier operands by default"
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_undef.id));
 }
 
+test "reports no-undef for direct typeof identifier operands when configured" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"typeof\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-undef", config.value);
+    options.no_unused_expressions = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\typeof missing;
+        \\typeof (alsoMissing);
+        \\typeof missing.member;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_undef.id));
+}
+
 test "reports no-undef for unresolved member objects inside typeof" {
     const source =
         \\typeof missing.prop;


### PR DESCRIPTION
## Summary

Add ESLint-compatible `no-undef` support for the `{ "typeof": true }` option.

## Details

- parse `no-undef` rule config objects with the `typeof` option
- pass the configured value into the semantic no-undef runner
- preserve the default behavior that allows direct `typeof missing` checks
- report direct `typeof` unresolved identifiers when `typeof: true` is configured

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_undef.zig tests/rules/no_undef.zig`
- `git diff --check`
