### PR TITLE
support no-extra-boolean-cast inner option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -464,6 +464,7 @@ pub const Options = struct {
     no_extra_label: bool = true,
     no_extra_semi: bool = true,
     no_extra_boolean_cast: bool = true,
+    no_extra_boolean_cast_enforce_for_inner_expressions: bool = false,
     no_floating_decimal: bool = true,
     no_fallthrough: bool = true,
     no_fallthrough_allow_empty_case: NoFallthroughAllowEmptyCase = .no,
@@ -879,6 +880,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-empty-function")) {
             self.no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-extra-boolean-cast")) {
+            self.no_extra_boolean_cast_enforce_for_inner_expressions = try noExtraBooleanCastEnforceForInnerExpressionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
@@ -1309,6 +1313,23 @@ pub const Options = struct {
             if (!allow.enable(kind)) return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noExtraBooleanCastEnforceForInnerExpressionsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("enforceForInnerExpressions") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noFallthroughAllowEmptyCaseFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughAllowEmptyCase {
@@ -2393,6 +2414,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_empty_function_allow.generatorMethods);
     try std.testing.expect(options.no_empty_function_allow.getters);
     try std.testing.expect(options.no_empty_function_allow.setters);
+
+    var no_extra_boolean_cast_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForInnerExpressions\":true}]",
+        .{},
+    );
+    defer no_extra_boolean_cast_config.deinit();
+    try options.setByRuleConfigValue("no-extra-boolean-cast", no_extra_boolean_cast_config.value);
+    try std.testing.expect(options.no_extra_boolean_cast);
+    try std.testing.expect(options.no_extra_boolean_cast_enforce_for_inner_expressions);
 
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -8,15 +8,29 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-extra-boolean-cast";
 
+pub const Options = struct {
+    enforce_for_inner_expressions: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -25,6 +39,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    options: Options,
 
     pub fn enter_if_statement(
         self: *Visitor,
@@ -103,13 +118,18 @@ const Visitor = struct {
             );
         }
 
-        const unary = switch (tree.data(unwrapped)) {
-            .unary_expression => |unary| unary,
+        switch (tree.data(unwrapped)) {
+            .unary_expression => |unary| {
+                if (unary.operator != .logical_not) return;
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, unary.argument));
+            },
+            .logical_expression => |logical| {
+                if (!self.options.enforce_for_inner_expressions) return;
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.left));
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.right));
+            },
             else => return,
-        };
-        if (unary.operator != .logical_not) return;
-
-        try self.checkBooleanExpression(tree, unwrapTransparent(tree, unary.argument));
+        }
     }
 };
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -700,7 +700,9 @@ pub fn runSemantic(
     }
 
     if (options.no_extra_boolean_cast) {
-        try no_extra_boolean_cast.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_extra_boolean_cast.runWithOptions(allocator, diagnostics, tree, .{
+            .enforce_for_inner_expressions = options.no_extra_boolean_cast_enforce_for_inner_expressions,
+        });
     }
 
     if (options.no_extend_native) {

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -44,6 +44,33 @@ test "does not report no-extra-boolean-cast outside boolean contexts or member c
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_boolean_cast.id));
 }
 
+test "reports no-extra-boolean-cast inner expressions when configured" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForInnerExpressions\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-extra-boolean-cast", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (foo && !!bar) { use(bar); }
+        \\if (foo || Boolean(bar)) { use(bar); }
+        \\const value = foo && !!bar;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
+}
+
 test "reports no-extra-boolean-cast inside negated boolean contexts" {
     const source =
         \\if (!Boolean(value)) { use(value); }


### PR DESCRIPTION
## Summary

Add ESLint-compatible `no-extra-boolean-cast` support for `enforceForInnerExpressions`.

## Details

- parse `no-extra-boolean-cast` rule config objects with `enforceForInnerExpressions`
- pass the configured value into the rule runner
- keep the default behavior unchanged
- when enabled, report redundant casts inside boolean-context logical expressions like `if (foo && !!bar)`

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_extra_boolean_cast.zig tests/rules/no_extra_boolean_cast.zig`
- `git diff --check`
