### PR TITLE
support no-implicit-coercion allow option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -477,6 +477,11 @@ pub const Options = struct {
     no_implicit_coercion_boolean: NoImplicitCoercionBoolean = .yes,
     no_implicit_coercion_number: NoImplicitCoercionNumber = .yes,
     no_implicit_coercion_string: NoImplicitCoercionString = .yes,
+    no_implicit_coercion_allow_double_negation: bool = false,
+    no_implicit_coercion_allow_bitwise_not: bool = false,
+    no_implicit_coercion_allow_unary_plus: bool = false,
+    no_implicit_coercion_allow_multiply: bool = false,
+    no_implicit_coercion_allow_subtract: bool = false,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
@@ -891,6 +896,11 @@ pub const Options = struct {
             self.no_implicit_coercion_boolean = try noImplicitCoercionBooleanFromConfig(value);
             self.no_implicit_coercion_number = try noImplicitCoercionNumberFromConfig(value);
             self.no_implicit_coercion_string = try noImplicitCoercionStringFromConfig(value);
+            self.no_implicit_coercion_allow_double_negation = try noImplicitCoercionAllowFromConfig(value, "!!");
+            self.no_implicit_coercion_allow_bitwise_not = try noImplicitCoercionAllowFromConfig(value, "~");
+            self.no_implicit_coercion_allow_unary_plus = try noImplicitCoercionAllowFromConfig(value, "+");
+            self.no_implicit_coercion_allow_multiply = try noImplicitCoercionAllowFromConfig(value, "*");
+            self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
         }
         if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
             self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
@@ -1380,6 +1390,43 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noImplicitCoercionAllowFromConfig(value: std.json.Value, expected: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return false;
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var found = false;
+        for (allow_items) |item| {
+            const allow = switch (item) {
+                .string => |allow| allow,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!isNoImplicitCoercionAllowToken(allow)) return error.UnsupportedRuleConfigValue;
+            if (std.mem.eql(u8, allow, expected)) found = true;
+        }
+        return found;
+    }
+
+    fn isNoImplicitCoercionAllowToken(value: []const u8) bool {
+        return std.mem.eql(u8, value, "!!") or
+            std.mem.eql(u8, value, "~") or
+            std.mem.eql(u8, value, "+") or
+            std.mem.eql(u8, value, "*") or
+            std.mem.eql(u8, value, "-");
     }
 
     fn noMultiSpacesIgnoreEOLCommentsFromConfig(value: std.json.Value) RuleConfigError!NoMultiSpacesIgnoreEOLComments {
@@ -2449,6 +2496,20 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoImplicitCoercionBoolean.no, options.no_implicit_coercion_boolean);
     try std.testing.expectEqual(NoImplicitCoercionNumber.no, options.no_implicit_coercion_number);
     try std.testing.expectEqual(NoImplicitCoercionString.yes, options.no_implicit_coercion_string);
+
+    var no_implicit_coercion_allow_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\"]}]",
+        .{},
+    );
+    defer no_implicit_coercion_allow_config.deinit();
+    try options.setByRuleConfigValue("no-implicit-coercion", no_implicit_coercion_allow_config.value);
+    try std.testing.expect(options.no_implicit_coercion_allow_double_negation);
+    try std.testing.expect(options.no_implicit_coercion_allow_bitwise_not);
+    try std.testing.expect(options.no_implicit_coercion_allow_unary_plus);
+    try std.testing.expect(options.no_implicit_coercion_allow_multiply);
+    try std.testing.expect(options.no_implicit_coercion_allow_subtract);
 
     var no_multi_spaces_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -11,6 +11,11 @@ pub const Options = struct {
     boolean: bool = true,
     number: bool = true,
     string: bool = true,
+    allow_double_negation: bool = false,
+    allow_bitwise_not: bool = false,
+    allow_unary_plus: bool = false,
+    allow_multiply: bool = false,
+    allow_subtract: bool = false,
 };
 
 pub fn checkUnaryExpression(
@@ -33,17 +38,17 @@ pub fn checkUnaryExpressionWithOptions(
 ) Allocator.Error!void {
     switch (expression.operator) {
         .logical_not => {
-            if (options.boolean and isDoubleNegation(tree, expression)) {
+            if (options.boolean and !options.allow_double_negation and isDoubleNegation(tree, expression)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Boolean()` instead of double negation.");
             }
         },
         .bitwise_not => {
-            if (options.boolean and isIndexOfCall(tree, expression.argument)) {
+            if (options.boolean and !options.allow_bitwise_not and isIndexOfCall(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use an explicit comparison instead of bitwise negation.");
             }
         },
         .positive => {
-            if (options.number and !isNumeric(tree, expression.argument)) {
+            if (options.number and !options.allow_unary_plus and !isNumeric(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of unary plus.");
             }
         },
@@ -81,12 +86,12 @@ pub fn checkBinaryExpressionWithOptions(
             }
         },
         .subtract => {
-            if (options.number and isZeroLiteral(tree, expression.right) and !isNumeric(tree, expression.left)) {
+            if (options.number and !options.allow_subtract and isZeroLiteral(tree, expression.right) and !isNumeric(tree, expression.left)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of subtracting zero.");
             }
         },
         .multiply => {
-            if (options.number and ((isOneLiteral(tree, expression.left) and !isNumeric(tree, expression.right)) or
+            if (options.number and !options.allow_multiply and ((isOneLiteral(tree, expression.left) and !isNumeric(tree, expression.right)) or
                 (isOneLiteral(tree, expression.right) and !isNumeric(tree, expression.left))))
             {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of multiplying by one.");

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2239,6 +2239,11 @@ const BasicVisitor = struct {
             .boolean = self.options.no_implicit_coercion_boolean == .yes,
             .number = self.options.no_implicit_coercion_number == .yes,
             .string = self.options.no_implicit_coercion_string == .yes,
+            .allow_double_negation = self.options.no_implicit_coercion_allow_double_negation,
+            .allow_bitwise_not = self.options.no_implicit_coercion_allow_bitwise_not,
+            .allow_unary_plus = self.options.no_implicit_coercion_allow_unary_plus,
+            .allow_multiply = self.options.no_implicit_coercion_allow_multiply,
+            .allow_subtract = self.options.no_implicit_coercion_allow_subtract,
         };
     }
 

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -154,6 +154,40 @@ test "supports no-implicit-coercion category options" {
     try std.testing.expect(!helpers.hasRule(all_result, lint.rules.no_implicit_coercion.id));
 }
 
+test "supports no-implicit-coercion allow option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-implicit-coercion", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const first = !!value;
+        \\const second = ~items.indexOf(value);
+        \\const third = +value;
+        \\const fourth = value - 0;
+        \\const fifth = value * 1;
+        \\const sixth = -(-value);
+        \\const seventh = value + "";
+        \\let eighth = value;
+        \\eighth += "";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+}
+
 test "can disable no-implicit-coercion" {
     const source =
         \\const first = !!value;


### PR DESCRIPTION
## Summary

Add ESLint-compatible `no-implicit-coercion` support for the `allow` option.

## Details

- parse `allow` entries for `!!`, `~`, `+`, `*`, and `-`
- pass those allow flags into the rule runner
- keep category options (`boolean`, `number`, `string`) unchanged
- keep string coercion reporting unchanged because ESLint does not accept string coercion in `allow`
- keep `-(-value)` reporting even when `"-"` is allowed, matching ESLint behavior

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_implicit_coercion.zig tests/rules/no_implicit_coercion.zig`
- `git diff --check`
