### PR TITLE
support no-shadow allow option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -289,6 +289,42 @@ pub const NoParamReassignIgnoredNames = struct {
     }
 };
 
+pub const max_no_shadow_allow_names = 32;
+pub const max_no_shadow_allow_name_len = 128;
+
+pub const NoShadowAllowNamesError = error{
+    EmptyNoShadowAllowName,
+    TooManyNoShadowAllowNames,
+    NoShadowAllowNameTooLong,
+};
+
+pub const NoShadowAllowNames = struct {
+    count: usize = 0,
+    lengths: [max_no_shadow_allow_names]usize = undefined,
+    storage: [max_no_shadow_allow_names][max_no_shadow_allow_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoShadowAllowNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoShadowAllowNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoShadowAllowNames, name: []const u8) NoShadowAllowNamesError!void {
+        if (name.len == 0) return error.EmptyNoShadowAllowName;
+        if (self.count >= max_no_shadow_allow_names) return error.TooManyNoShadowAllowNames;
+        if (name.len > max_no_shadow_allow_name_len) return error.NoShadowAllowNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const NoUselessComputedKeyEnforceForClassMembers = enum {
     yes,
     no,
@@ -592,6 +628,7 @@ pub const Options = struct {
     no_self_compare: bool = true,
     no_setter_return: bool = true,
     no_shadow: bool = true,
+    no_shadow_allow: NoShadowAllowNames = .{},
     no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
     no_sequences_allow_in_parentheses: NoSequencesAllowInParentheses = .yes,
@@ -740,6 +777,7 @@ pub const Options = struct {
     typescript_eslint_no_redeclare: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
+    typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
@@ -917,6 +955,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-shadow")) {
+            self.no_shadow_allow = try noShadowAllowFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
         }
@@ -943,6 +984,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
+            self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -1548,6 +1592,34 @@ pub const Options = struct {
             ignored.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return ignored;
+    }
+
+    fn noShadowAllowFromConfig(value: std.json.Value) RuleConfigError!NoShadowAllowNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow = NoShadowAllowNames{};
+        for (allow_items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            allow.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn noPlusplusAllowForLoopAfterthoughtsFromConfig(value: std.json.Value) RuleConfigError!NoPlusplusAllowForLoopAfterthoughts {
@@ -2585,6 +2657,30 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-redeclare", no_redeclare_config.value);
     try std.testing.expect(options.no_redeclare);
     try std.testing.expectEqual(NoRedeclareBuiltinGlobals.yes, options.no_redeclare_builtin_globals);
+
+    var no_shadow_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"done\"]}]",
+        .{},
+    );
+    defer no_shadow_config.deinit();
+    try options.setByRuleConfigValue("no-shadow", no_shadow_config.value);
+    try std.testing.expect(options.no_shadow);
+    try std.testing.expect(options.no_shadow_allow.contains("done"));
+    try std.testing.expect(!options.no_shadow_allow.contains("other"));
+
+    var typescript_no_shadow_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"value\"]}]",
+        .{},
+    );
+    defer typescript_no_shadow_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", typescript_no_shadow_config.value);
+    try std.testing.expect(options.typescript_eslint_no_shadow);
+    try std.testing.expect(options.typescript_eslint_no_shadow_allow.contains("value"));
+    try std.testing.expect(!options.typescript_eslint_no_shadow_allow.contains("other"));
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -12,6 +12,7 @@ pub const Options = struct {
     rule_id: []const u8 = id,
     severity: core.Severity = .warning,
     mode: Mode = .javascript,
+    allow: core.NoShadowAllowNames = .{},
 };
 
 pub const Mode = enum {
@@ -45,6 +46,8 @@ pub fn runWithOptions(
         if (symbol.scope == .root or symbol.scope == .module) continue;
 
         const name = tree.string(symbol.name);
+        if (options.allow.contains(name)) continue;
+
         const shadowed_id = findShadowedSymbol(scope_tree, symbol_table, symbol.scope, name, entry.id, symbol.flags, options) orelse continue;
         const decls = symbol_table.symbolDecls(entry.id);
         const shadowed_decls = symbol_table.symbolDecls(shadowed_id);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -740,11 +740,15 @@ pub fn runSemantic(
     const use_typescript_no_shadow = options.typescript_eslint_no_shadow and tree.isTs();
 
     if (options.no_shadow and !use_typescript_no_shadow) {
-        try no_shadow.run(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table);
+        try no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
+            .allow = options.no_shadow_allow,
+        });
     }
 
     if (use_typescript_no_shadow) {
-        try typescript_eslint_no_shadow.run(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table);
+        try typescript_eslint_no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
+            .allow = options.typescript_eslint_no_shadow_allow,
+        });
     }
 
     if (reassignment_rules.shouldRun(options)) {

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -14,9 +14,21 @@ pub fn run(
     scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const parser.ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: no_shadow.Options,
+) Allocator.Error!void {
     try no_shadow.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
         .mode = .typescript,
+        .allow = options.allow,
     });
 }

--- a/tests/rules/no_shadow.zig
+++ b/tests/rules/no_shadow.zig
@@ -45,6 +45,37 @@ test "does not report no-shadow for distinct sibling scopes or type declarations
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured no-shadow allow names" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"done\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const done = 1;
+        \\function f(done) {
+        \\  return done;
+        \\}
+        \\const other = 1;
+        \\function g(other) {
+        \\  return other;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable no-shadow" {
     const source =
         \\let a = 1;

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -59,6 +59,39 @@ test "allows @typescript-eslint/no-shadow TypeScript class interface merging" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow allow names" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"value\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const value = 1;
+        \\const other = 2;
+        \\function f(value: number) {
+        \\  return value;
+        \\}
+        \\function g(other: number) {
+        \\  return other;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable @typescript-eslint/no-shadow and fall back to no-shadow" {
     const source =
         \\const value = 1;


### PR DESCRIPTION
## Summary

Add ESLint-compatible `allow` support for `no-shadow` and `@typescript-eslint/no-shadow`.

## Details

- parse `allow` name arrays from both rule configs
- pass allow names into the shared shadow checker
- skip shadow diagnostics for declarations whose name is explicitly allowed
- keep TypeScript-specific shadow behavior and severity unchanged

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_shadow.zig src/rules/typescript_eslint_no_shadow.zig tests/rules/no_shadow.zig tests/rules/typescript_eslint_no_shadow.zig`
- `git diff --check`
