### PR TITLE
support no-shadow builtin globals option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -629,6 +629,7 @@ pub const Options = struct {
     no_setter_return: bool = true,
     no_shadow: bool = true,
     no_shadow_allow: NoShadowAllowNames = .{},
+    no_shadow_builtin_globals: bool = false,
     no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
     no_sequences_allow_in_parentheses: NoSequencesAllowInParentheses = .yes,
@@ -778,6 +779,7 @@ pub const Options = struct {
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
+    typescript_eslint_no_shadow_builtin_globals: bool = false,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
@@ -957,6 +959,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-shadow")) {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
+            self.no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
@@ -987,6 +990,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
+            self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -1620,6 +1624,23 @@ pub const Options = struct {
             allow.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noShadowBuiltinGlobalsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("builtinGlobals") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noPlusplusAllowForLoopAfterthoughtsFromConfig(value: std.json.Value) RuleConfigError!NoPlusplusAllowForLoopAfterthoughts {
@@ -2661,7 +2682,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"done\"]}]",
+        "[\"error\",{\"allow\":[\"done\"],\"builtinGlobals\":true}]",
         .{},
     );
     defer no_shadow_config.deinit();
@@ -2669,11 +2690,12 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_shadow);
     try std.testing.expect(options.no_shadow_allow.contains("done"));
     try std.testing.expect(!options.no_shadow_allow.contains("other"));
+    try std.testing.expect(options.no_shadow_builtin_globals);
 
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"value\"]}]",
+        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true}]",
         .{},
     );
     defer typescript_no_shadow_config.deinit();
@@ -2681,6 +2703,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_shadow);
     try std.testing.expect(options.typescript_eslint_no_shadow_allow.contains("value"));
     try std.testing.expect(!options.typescript_eslint_no_shadow_allow.contains("other"));
+    try std.testing.expect(options.typescript_eslint_no_shadow_builtin_globals);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -13,6 +13,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     mode: Mode = .javascript,
     allow: core.NoShadowAllowNames = .{},
+    builtin_globals: bool = false,
 };
 
 pub const Mode = enum {
@@ -48,10 +49,25 @@ pub fn runWithOptions(
         const name = tree.string(symbol.name);
         if (options.allow.contains(name)) continue;
 
-        const shadowed_id = findShadowedSymbol(scope_tree, symbol_table, symbol.scope, name, entry.id, symbol.flags, options) orelse continue;
         const decls = symbol_table.symbolDecls(entry.id);
+        if (decls.len == 0) continue;
+
+        if (options.builtin_globals and core.isKnownGlobal(name)) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                options.severity,
+                options.rule_id,
+                tree.span(decls[0]),
+                "'{s}' is already a global variable.",
+                .{name},
+            );
+            continue;
+        }
+
+        const shadowed_id = findShadowedSymbol(scope_tree, symbol_table, symbol.scope, name, entry.id, symbol.flags, options) orelse continue;
         const shadowed_decls = symbol_table.symbolDecls(shadowed_id);
-        if (decls.len == 0 or shadowed_decls.len == 0) continue;
+        if (shadowed_decls.len == 0) continue;
 
         const shadowed_position = offsetToLineColumn(tree.source, tree.span(shadowed_decls[0]).start);
         try core.addDiagnosticFmt(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -742,12 +742,14 @@ pub fn runSemantic(
     if (options.no_shadow and !use_typescript_no_shadow) {
         try no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .allow = options.no_shadow_allow,
+            .builtin_globals = options.no_shadow_builtin_globals,
         });
     }
 
     if (use_typescript_no_shadow) {
         try typescript_eslint_no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .allow = options.typescript_eslint_no_shadow_allow,
+            .builtin_globals = options.typescript_eslint_no_shadow_builtin_globals,
         });
     }
 

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -30,5 +30,6 @@ pub fn runWithOptions(
         .severity = .@"error",
         .mode = .typescript,
         .allow = options.allow,
+        .builtin_globals = options.builtin_globals,
     });
 }

--- a/tests/rules/no_shadow.zig
+++ b/tests/rules/no_shadow.zig
@@ -76,6 +76,35 @@ test "supports configured no-shadow allow names" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured no-shadow built-in globals" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"builtinGlobals\":true,\"allow\":[\"Object\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function allowed(Object) {
+        \\  return Object;
+        \\}
+        \\function reported(Array) {
+        \\  return Array;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable no-shadow" {
     const source =
         \\let a = 1;

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -92,6 +92,37 @@ test "supports configured @typescript-eslint/no-shadow allow names" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow built-in globals" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"builtinGlobals\":true,\"allow\":[\"Object\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function allowed(Object: unknown) {
+        \\  return Object;
+        \\}
+        \\function reported(Array: unknown) {
+        \\  return Array;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable @typescript-eslint/no-shadow and fall back to no-shadow" {
     const source =
         \\const value = 1;


### PR DESCRIPTION
## Summary

Add support for the ESLint `builtinGlobals` option on `no-shadow` and `@typescript-eslint/no-shadow`.

## Details

- Parse `builtinGlobals` from ESLint-style rule config arrays.
- Pass the option into both the core and TypeScript no-shadow rule paths.
- Report configured built-in global shadows while still honoring the `allow` list first.
- Add focused coverage for both rule ids.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_shadow.zig src/rules/typescript_eslint_no_shadow.zig tests/rules/no_shadow.zig tests/rules/typescript_eslint_no_shadow.zig`
- `git diff --check`
