### PR TITLE
support eqeqeq allow-null style

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -16,6 +16,11 @@ pub const Severity = enum {
     }
 };
 
+pub const EqeqeqStyle = enum {
+    strict,
+    allow_null,
+};
+
 pub const NoConfusingArrowAllowParens = enum {
     yes,
     no,
@@ -682,6 +687,7 @@ pub const Options = struct {
     one_var: bool = true,
     operator_assignment: bool = true,
     eqeqeq: bool = true,
+    eqeqeq_style: EqeqeqStyle = .strict,
     use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_use_before_define: bool = true,
@@ -910,6 +916,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "grouped-accessor-pairs")) {
             self.grouped_accessor_pairs_style = try groupedAccessorPairsStyleFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "eqeqeq")) {
+            self.eqeqeq_style = try eqeqeqStyleFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
@@ -1053,6 +1062,22 @@ pub const Options = struct {
             return true;
         }
         return null;
+    }
+
+    fn eqeqeqStyleFromConfig(value: std.json.Value) RuleConfigError!EqeqeqStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .strict,
+        };
+        if (items.len < 2) return .strict;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .strict;
+        if (std.mem.eql(u8, style, "allow-null")) return .allow_null;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn arrayCallbackReturnAllowImplicitFromConfig(value: std.json.Value) RuleConfigError!ArrayCallbackReturnAllowImplicit {
@@ -2390,6 +2415,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("@typescript-eslint/dot-notation", typescript_dot_notation_config.value);
     try std.testing.expect(options.typescript_eslint_dot_notation);
     try std.testing.expectEqual(DotNotationAllowKeywords.yes, options.dot_notation_allow_keywords);
+
+    var eqeqeq_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"allow-null\"]",
+        .{},
+    );
+    defer eqeqeq_config.deinit();
+    try options.setByRuleConfigValue("eqeqeq", eqeqeq_config.value);
+    try std.testing.expect(options.eqeqeq);
+    try std.testing.expectEqual(EqeqeqStyle.allow_null, options.eqeqeq_style);
 
     var profile_a_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/eqeqeq.zig
+++ b/src/rules/eqeqeq.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "eqeqeq";
 
+pub const Options = struct {
+    style: core.EqeqeqStyle = .strict,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +18,23 @@ pub fn check(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (expression.operator != .equal and expression.operator != .not_equal) return;
+    if (options.style == .allow_null and
+        (isNullLiteral(tree, expression.left) or isNullLiteral(tree, expression.right)))
+    {
+        return;
+    }
 
     try core.addDiagnostic(
         allocator,
@@ -24,4 +44,25 @@ pub fn check(
         "Use strict equality operators.",
         tree.span(index),
     );
+}
+
+fn isNullLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2176,7 +2176,9 @@ const BasicVisitor = struct {
             try no_compare_neg_zero.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.eqeqeq) {
-            try eqeqeq.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try eqeqeq.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .style = self.options.eqeqeq_style,
+            });
         }
         if (self.options.no_eq_null) {
             try no_eq_null.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/rules/eqeqeq.zig
+++ b/tests/rules/eqeqeq.zig
@@ -6,6 +6,7 @@ test "reports eqeqeq for loose equality operators" {
     const source =
         \\if (value == 1) { use(value); }
         \\if (value != 2) { use(value); }
+        \\if (value == null) { use(value); }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -13,6 +14,35 @@ test "reports eqeqeq for loose equality operators" {
         .no_undef = false,
         .parser_semantic_errors = false,
     });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.eqeqeq.id));
+}
+
+test "supports configured eqeqeq allow-null style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"allow-null\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("eqeqeq", config.value);
+    options.no_eq_null = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (value == null) { use(value); }
+        \\if (null != value) { use(value); }
+        \\if (value == undefined) { use(value); }
+        \\if (value == 1) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.eqeqeq.id));


### PR DESCRIPTION
## Summary

Add support for the ESLint `eqeqeq` `allow-null` style.

## Details

- Parse `["error", "allow-null"]` into a dedicated `eqeqeq` style option.
- Pass the configured style from root traversal into the `eqeqeq` rule.
- Keep the default strict behavior unchanged.
- Skip only loose comparisons where either side is the `null` literal when `allow-null` is configured.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/eqeqeq.zig tests/rules/eqeqeq.zig`
- `git diff --check`
