### PR TITLE
support no-underscore-dangle config options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -970,6 +970,16 @@ pub const Options = struct {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
             self.no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-underscore-dangle")) {
+            self.no_underscore_dangle_allow_after_this = try noUnderscoreDangleBoolOptionFromConfig(value, "allowAfterThis", false);
+            self.no_underscore_dangle_allow_after_super = try noUnderscoreDangleBoolOptionFromConfig(value, "allowAfterSuper", false);
+            self.no_underscore_dangle_allow_after_this_constructor = try noUnderscoreDangleBoolOptionFromConfig(value, "allowAfterThisConstructor", false);
+            self.no_underscore_dangle_allow_function_params = if (try noUnderscoreDangleBoolOptionFromConfig(value, "allowFunctionParams", true)) .yes else .no;
+            self.no_underscore_dangle_allow_in_array_destructuring = if (try noUnderscoreDangleBoolOptionFromConfig(value, "allowInArrayDestructuring", true)) .yes else .no;
+            self.no_underscore_dangle_allow_in_object_destructuring = if (try noUnderscoreDangleBoolOptionFromConfig(value, "allowInObjectDestructuring", true)) .yes else .no;
+            self.no_underscore_dangle_enforce_in_method_names = try noUnderscoreDangleBoolOptionFromConfig(value, "enforceInMethodNames", false);
+            self.no_underscore_dangle_enforce_in_class_fields = try noUnderscoreDangleBoolOptionFromConfig(value, "enforceInClassFields", false);
+        }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
         }
@@ -1663,6 +1673,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("builtinGlobals") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noUnderscoreDangleBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -2727,6 +2754,24 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_shadow_allow.contains("done"));
     try std.testing.expect(!options.no_shadow_allow.contains("other"));
     try std.testing.expect(options.no_shadow_builtin_globals);
+
+    var no_underscore_dangle_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAfterThis\":true,\"allowAfterSuper\":true,\"allowAfterThisConstructor\":true,\"allowFunctionParams\":false,\"allowInArrayDestructuring\":false,\"allowInObjectDestructuring\":false,\"enforceInMethodNames\":true,\"enforceInClassFields\":true}]",
+        .{},
+    );
+    defer no_underscore_dangle_config.deinit();
+    try options.setByRuleConfigValue("no-underscore-dangle", no_underscore_dangle_config.value);
+    try std.testing.expect(options.no_underscore_dangle);
+    try std.testing.expect(options.no_underscore_dangle_allow_after_this);
+    try std.testing.expect(options.no_underscore_dangle_allow_after_super);
+    try std.testing.expect(options.no_underscore_dangle_allow_after_this_constructor);
+    try std.testing.expectEqual(NoUnderscoreDangleAllowFunctionParams.no, options.no_underscore_dangle_allow_function_params);
+    try std.testing.expectEqual(NoUnderscoreDangleAllowDestructuring.no, options.no_underscore_dangle_allow_in_array_destructuring);
+    try std.testing.expectEqual(NoUnderscoreDangleAllowDestructuring.no, options.no_underscore_dangle_allow_in_object_destructuring);
+    try std.testing.expect(options.no_underscore_dangle_enforce_in_method_names);
+    try std.testing.expect(options.no_underscore_dangle_enforce_in_class_fields);
 
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -85,6 +85,47 @@ test "allows no-underscore-dangle configured member contexts" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "supports configured no-underscore-dangle options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAfterThis\":true,\"allowAfterSuper\":true,\"allowAfterThisConstructor\":true,\"allowFunctionParams\":false,\"allowInArrayDestructuring\":false,\"allowInObjectDestructuring\":false,\"enforceInMethodNames\":true,\"enforceInClassFields\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-underscore-dangle", config.value);
+    options.no_empty_function = false;
+    options.no_undef = false;
+    options.no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\class Child extends Parent {
+        \\  _run() {}
+        \\  _field = 1;
+        \\  method() {
+        \\    this._allowed;
+        \\    super._allowed;
+        \\    this.constructor._allowed;
+        \\    object._member;
+        \\  }
+        \\}
+        \\function run(_param) {
+        \\  return _param;
+        \\}
+        \\const [_array] = values;
+        \\const { _object } = record;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "allows default names and skipped forms" {
     const source =
         \\const _ = 1;


### PR DESCRIPTION
## Summary

Parse ESLint-style `no-underscore-dangle` option objects.

## Details

- Wire `allowAfterThis`, `allowAfterSuper`, and `allowAfterThisConstructor` into the existing member-access options.
- Wire `allowFunctionParams`, `allowInArrayDestructuring`, and `allowInObjectDestructuring` into the existing reporting switches.
- Wire `enforceInMethodNames` and `enforceInClassFields` into the existing method/class-field enforcement options.
- Add config parsing and rule-level coverage for the combined option set.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig tests/rules/no_underscore_dangle.zig`
- `git diff --check`
