### PR TITLE
support curly multi-line style

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -21,6 +21,11 @@ pub const EqeqeqStyle = enum {
     allow_null,
 };
 
+pub const CurlyStyle = enum {
+    all,
+    multi_line,
+};
+
 pub const NoConfusingArrowAllowParens = enum {
     yes,
     no,
@@ -433,6 +438,7 @@ pub const Options = struct {
     consistent_return: bool = true,
     constructor_super: bool = true,
     curly: bool = true,
+    curly_style: CurlyStyle = .all,
     dot_notation: bool = true,
     dot_notation_allow_keywords: DotNotationAllowKeywords = .yes,
     typescript_eslint_dot_notation: bool = true,
@@ -901,6 +907,9 @@ pub const Options = struct {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "curly")) {
+            self.curly_style = try curlyStyleFromConfig(value);
+        }
         if (enabled and (std.mem.eql(u8, cli_name, "dot-notation") or std.mem.eql(u8, cli_name, "@typescript-eslint/dot-notation"))) {
             self.dot_notation_allow_keywords = try dotNotationAllowKeywordsFromConfig(value);
         }
@@ -1072,6 +1081,22 @@ pub const Options = struct {
             return true;
         }
         return null;
+    }
+
+    fn curlyStyleFromConfig(value: std.json.Value) RuleConfigError!CurlyStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .all,
+        };
+        if (items.len < 2) return .all;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "all")) return .all;
+        if (std.mem.eql(u8, style, "multi-line")) return .multi_line;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn eqeqeqStyleFromConfig(value: std.json.Value) RuleConfigError!EqeqeqStyle {
@@ -2442,6 +2467,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("@typescript-eslint/dot-notation", typescript_dot_notation_config.value);
     try std.testing.expect(options.typescript_eslint_dot_notation);
     try std.testing.expectEqual(DotNotationAllowKeywords.yes, options.dot_notation_allow_keywords);
+
+    var curly_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-line\"]",
+        .{},
+    );
+    defer curly_config.deinit();
+    try options.setByRuleConfigValue("curly", curly_config.value);
+    try std.testing.expect(options.curly);
+    try std.testing.expectEqual(CurlyStyle.multi_line, options.curly_style);
 
     var eqeqeq_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/curly.zig
+++ b/src/rules/curly.zig
@@ -7,18 +7,32 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "curly";
 
+pub const Options = struct {
+    style: core.CurlyStyle = .all,
+};
+
 pub fn checkIfStatement(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     statement: ast.IfStatement,
 ) Allocator.Error!void {
-    try checkBody(allocator, diagnostics, tree, statement.consequent);
+    try checkIfStatementWithOptions(allocator, diagnostics, tree, statement, .{});
+}
+
+pub fn checkIfStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    options: Options,
+) Allocator.Error!void {
+    try checkBodyWithOptions(allocator, diagnostics, tree, statement.consequent, options);
 
     if (statement.alternate == .null) return;
     if (tree.data(statement.alternate) == .if_statement) return;
 
-    try checkBody(allocator, diagnostics, tree, statement.alternate);
+    try checkBodyWithOptions(allocator, diagnostics, tree, statement.alternate, options);
 }
 
 pub fn checkBody(
@@ -27,8 +41,19 @@ pub fn checkBody(
     tree: *const ast.Tree,
     body: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkBodyWithOptions(allocator, diagnostics, tree, body, .{});
+}
+
+pub fn checkBodyWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (body == .null) return;
     if (tree.data(body) == .block_statement) return;
+    if (options.style == .multi_line and !isMultiLineBody(tree, body)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -38,4 +63,30 @@ pub fn checkBody(
         "Expected a block statement.",
         tree.span(body),
     );
+}
+
+fn isMultiLineBody(tree: *const ast.Tree, body: ast.NodeIndex) bool {
+    const span = tree.span(body);
+    if (containsLineTerminator(tree.source[span.start..span.end])) return true;
+    return hasLineTerminatorBeforeBody(tree.source, span.start);
+}
+
+fn hasLineTerminatorBeforeBody(source: []const u8, body_start: usize) bool {
+    var index = body_start;
+    while (index > 0) {
+        index -= 1;
+        switch (source[index]) {
+            ' ', '\t' => continue,
+            '\n', '\r' => return true,
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn containsLineTerminator(source: []const u8) bool {
+    for (source) |char| {
+        if (char == '\n' or char == '\r') return true;
+    }
+    return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -965,6 +965,12 @@ const BasicVisitor = struct {
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
 
+    fn curlyOptions(self: *const BasicVisitor) curly.Options {
+        return .{
+            .style = self.options.curly_style,
+        };
+    }
+
     pub fn enter_node(
         self: *BasicVisitor,
         data: ast.NodeData,
@@ -1190,7 +1196,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement);
+            try curly.checkIfStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1247,7 +1253,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+            try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1265,7 +1271,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+            try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1283,7 +1289,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+            try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign and statement.@"test" != .null) {
             try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1825,7 +1831,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+            try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.guard_for_in) {
             try guard_for_in.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
@@ -1843,7 +1849,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
-            try curly.checkBody(self.allocator, self.diagnostics, ctx.tree, statement.body);
+            try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         return .proceed;
     }

--- a/tests/rules/curly.zig
+++ b/tests/rules/curly.zig
@@ -49,6 +49,47 @@ test "does not report curly for block bodies or else-if chains" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.curly.id));
 }
 
+test "supports configured curly multi-line style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-line\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_for_in = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (ready) run();
+        \\if (ready)
+        \\  run();
+        \\while (ready) run();
+        \\while (ready)
+        \\  run();
+        \\for (let i = 0; i < 3; i++) run();
+        \\for (let i = 0; i < 3; i++)
+        \\  run();
+        \\for (const key in object) run();
+        \\for (const key in object)
+        \\  run();
+        \\for (const item of items) run();
+        \\for (const item of items)
+        \\  run();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.curly.id));
+}
+
 test "can disable curly" {
     const source =
         \\if (ready) run();


### PR DESCRIPTION
## Summary

Add support for ESLint-style `curly` `multi-line` configuration.

## Details

- Parse `["error", "multi-line"]` into a dedicated `curly` style option.
- Keep the default `all` behavior unchanged.
- In `multi-line` mode, report non-block control bodies only when the body crosses lines or starts on a new line after the control header.
- Cover configured `if`, loop, `for-in`, and `for-of` behavior.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/curly.zig tests/rules/curly.zig`
- `git diff --check`
