### PR TITLE
support typescript no-empty-function allow

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -776,6 +776,7 @@ pub const Options = struct {
     typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,
+    typescript_eslint_no_empty_function_allow: NoEmptyFunctionAllow = .{},
     typescript_eslint_no_empty_interface: bool = true,
     typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
@@ -943,6 +944,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-empty-function")) {
             self.no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
+            self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-extra-boolean-cast")) {
             self.no_extra_boolean_cast_enforce_for_inner_expressions = try noExtraBooleanCastEnforceForInnerExpressionsFromConfig(value);
@@ -2653,6 +2657,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_empty_function_allow.generatorMethods);
     try std.testing.expect(options.no_empty_function_allow.getters);
     try std.testing.expect(options.no_empty_function_allow.setters);
+
+    var typescript_no_empty_function_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"arrowFunctions\",\"methods\"]}]",
+        .{},
+    );
+    defer typescript_no_empty_function_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-empty-function", typescript_no_empty_function_config.value);
+    try std.testing.expect(options.typescript_eslint_no_empty_function);
+    try std.testing.expect(options.typescript_eslint_no_empty_function_allow.arrowFunctions);
+    try std.testing.expect(options.typescript_eslint_no_empty_function_allow.methods);
+    try std.testing.expect(!options.typescript_eslint_no_empty_function_allow.functions);
 
     var no_extra_boolean_cast_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_empty_function.zig
+++ b/src/rules/no_empty_function.zig
@@ -57,7 +57,7 @@ pub fn checkWithOptions(
     );
 }
 
-fn allowsKind(allow: core.NoEmptyFunctionAllow, kind: Kind) bool {
+pub fn allowsKind(allow: core.NoEmptyFunctionAllow, kind: Kind) bool {
     return switch (kind) {
         .functions => allow.functions,
         .arrowFunctions => allow.arrowFunctions,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1911,7 +1911,10 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.typescript_eslint_no_empty_function) {
-            try typescript_eslint_no_empty_function.checkFunctionBody(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);
+            try typescript_eslint_no_empty_function.checkFunctionBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, body, index, ctx, .{
+                .allow = self.options.typescript_eslint_no_empty_function_allow,
+                .kind = emptyFunctionKind(ctx.tree, ctx),
+            });
         }
         if (self.options.getter_return) {
             try getter_return.check(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);

--- a/src/rules/typescript_eslint_no_empty_function.zig
+++ b/src/rules/typescript_eslint_no_empty_function.zig
@@ -9,6 +9,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-empty-function";
 
+pub const Options = struct {
+    allow: core.NoEmptyFunctionAllow = .{},
+    kind: no_empty_function.Kind = .functions,
+};
+
 pub fn checkFunctionBody(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -17,7 +22,20 @@ pub fn checkFunctionBody(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    return checkFunctionBodyWithOptions(allocator, diagnostics, tree, body, index, ctx, .{});
+}
+
+pub fn checkFunctionBodyWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
     if (body.body.len != 0) return;
+    if (no_empty_function.allowsKind(options.allow, options.kind)) return;
     if (no_empty_function.hasCommentInsideBraces(tree, index)) return;
     if (hasParameterPropertyConstructor(tree, ctx)) return;
 

--- a/tests/rules/typescript_eslint_no_empty_function.zig
+++ b/tests/rules/typescript_eslint_no_empty_function.zig
@@ -49,6 +49,37 @@ test "does not report @typescript-eslint/no-empty-function for comments or param
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_function.id));
 }
 
+test "supports configured @typescript-eslint/no-empty-function allow kinds" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"arrowFunctions\",\"methods\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-empty-function", config.value);
+    options.no_empty_block_statements = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function empty() {}
+        \\const arrow = () => {};
+        \\class Example {
+        \\  method() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_function.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_function.id));
+}
+
 test "can disable @typescript-eslint/no-empty-function and fall back to core rule" {
     const source =
         \\function empty() {}


### PR DESCRIPTION
## Summary

Add `allow` option support for `@typescript-eslint/no-empty-function`.

## Details

- Parse `allow` from ESLint-style `@typescript-eslint/no-empty-function` configs.
- Reuse the existing no-empty-function kind classification for TypeScript rule execution.
- Keep the TypeScript-specific parameter-property constructor exemption intact.
- Add focused coverage for allowing arrow functions and methods while still reporting plain functions.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_empty_function.zig src/rules/typescript_eslint_no_empty_function.zig tests/rules/typescript_eslint_no_empty_function.zig`
- `git diff --check`
