### PR TITLE
support no-unused-vars args option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -258,6 +258,12 @@ pub const NoUseBeforeDefineCheck = enum {
     no,
 };
 
+pub const NoUnusedVarsArgs = enum {
+    none,
+    after_used,
+    all,
+};
+
 pub const NoParamReassignProps = enum {
     yes,
     no,
@@ -696,6 +702,7 @@ pub const Options = struct {
     eqeqeq_style: EqeqeqStyle = .strict,
     use_isnan: bool = true,
     no_unused_vars: bool = true,
+    no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -803,6 +810,7 @@ pub const Options = struct {
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_useless_empty_export: bool = true,
     typescript_eslint_no_unused_vars: bool = true,
+    typescript_eslint_no_unused_vars_args: NoUnusedVarsArgs = .after_used,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -1016,6 +1024,9 @@ pub const Options = struct {
             self.no_unused_expressions_allow_ternary = try noUnusedExpressionsAllowTernaryFromConfig(value);
             self.no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-unused-vars")) {
+            self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
+        }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
@@ -1023,6 +1034,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
+            self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -1900,6 +1914,27 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn noUnusedVarsArgsFromConfig(value: std.json.Value, default: NoUnusedVarsArgs) RuleConfigError!NoUnusedVarsArgs {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const args = switch (config.get("args") orelse return default) {
+            .string => |args| args,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, args, "none")) return .none;
+        if (std.mem.eql(u8, args, "after-used")) return .after_used;
+        if (std.mem.eql(u8, args, "all")) return .all;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noUseBeforeDefineCheckFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!NoUseBeforeDefineCheck {
@@ -2930,6 +2965,28 @@ test "Options can apply ESLint-style rule config values" {
     defer no_unused_expressions_default_config.deinit();
     try options.setByRuleConfigValue("no-unused-expressions", no_unused_expressions_default_config.value);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
+
+    var no_unused_vars_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"all\"}]",
+        .{},
+    );
+    defer no_unused_vars_config.deinit();
+    try options.setByRuleConfigValue("no-unused-vars", no_unused_vars_config.value);
+    try std.testing.expect(options.no_unused_vars);
+    try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
+
+    var typescript_no_unused_vars_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"none\"}]",
+        .{},
+    );
+    defer typescript_no_unused_vars_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", typescript_no_unused_vars_config.value);
+    try std.testing.expect(options.typescript_eslint_no_unused_vars);
+    try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -892,6 +892,8 @@ pub fn runSemantic(
 
     if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {
         try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .check_parameters = options.no_unused_vars_args != .none,
+            .args_after_used = options.no_unused_vars_args == .after_used,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
         });
@@ -905,6 +907,7 @@ pub fn runSemantic(
             semantic_result.symbol_table,
             options.react_jsx_uses_react,
             options.react_jsx_uses_vars,
+            options.typescript_eslint_no_unused_vars_args,
         );
     }
 

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -14,12 +14,13 @@ pub fn run(
     symbol_table: traverser.semantic.SymbolTable,
     react_jsx_uses_react: bool,
     react_jsx_uses_vars: bool,
+    args: core.NoUnusedVarsArgs,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
-        .check_parameters = true,
-        .args_after_used = true,
+        .check_parameters = args != .none,
+        .args_after_used = args == .after_used,
         .ignore_rest_siblings = true,
         .check_type_parameters = true,
         .react_jsx_uses_react = react_jsx_uses_react,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -43,3 +43,31 @@ test "reports no-unused-vars for unused catch parameters" {
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars args all" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"all\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function demo(before, used, after) {
+        \\  console.log(used);
+        \\}
+        \\demo(1, 2, 3);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -52,6 +52,33 @@ test "ignores rest siblings for object destructuring" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars args none" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"none\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function demo(before: string, used: string, after: string) {
+        \\  console.log(used);
+        \\}
+        \\demo("before", "used", "after");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "can disable @typescript-eslint/no-unused-vars and fall back to core rule" {
     const source =
         \\const unused = 1;


### PR DESCRIPTION
## Summary

Add ESLint-style `args` option support for `no-unused-vars` and `@typescript-eslint/no-unused-vars`.

## Details

- Parse `args: "none" | "after-used" | "all"` into rule options.
- Keep the current core default unchanged, while preserving the TypeScript rule default as `after-used`.
- Map the option onto the existing parameter checking behavior.
- Add focused coverage for core `args: "all"` and TypeScript `args: "none"`.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `git diff --check`
