### PR TITLE
support no-unused-vars caughtErrors option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -264,6 +264,11 @@ pub const NoUnusedVarsArgs = enum {
     all,
 };
 
+pub const NoUnusedVarsCaughtErrors = enum {
+    none,
+    all,
+};
+
 pub const NoParamReassignProps = enum {
     yes,
     no,
@@ -703,6 +708,7 @@ pub const Options = struct {
     use_isnan: bool = true,
     no_unused_vars: bool = true,
     no_unused_vars_args: NoUnusedVarsArgs = .none,
+    no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -811,6 +817,7 @@ pub const Options = struct {
     typescript_eslint_no_useless_empty_export: bool = true,
     typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_unused_vars_args: NoUnusedVarsArgs = .after_used,
+    typescript_eslint_no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -1026,6 +1033,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-unused-vars")) {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
+            self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
         }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
@@ -1037,6 +1045,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
+            self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -1934,6 +1943,26 @@ pub const Options = struct {
         if (std.mem.eql(u8, args, "none")) return .none;
         if (std.mem.eql(u8, args, "after-used")) return .after_used;
         if (std.mem.eql(u8, args, "all")) return .all;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noUnusedVarsCaughtErrorsFromConfig(value: std.json.Value, default: NoUnusedVarsCaughtErrors) RuleConfigError!NoUnusedVarsCaughtErrors {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const caught_errors = switch (config.get("caughtErrors") orelse return default) {
+            .string => |caught_errors| caught_errors,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, caught_errors, "none")) return .none;
+        if (std.mem.eql(u8, caught_errors, "all")) return .all;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -2969,24 +2998,26 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\"}]",
+        "[\"error\",{\"args\":\"all\",\"caughtErrors\":\"none\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
     try options.setByRuleConfigValue("no-unused-vars", no_unused_vars_config.value);
     try std.testing.expect(options.no_unused_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
+    try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
 
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"none\"}]",
+        "[\"error\",{\"args\":\"none\",\"caughtErrors\":\"none\"}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
     try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", typescript_no_unused_vars_config.value);
     try std.testing.expect(options.typescript_eslint_no_unused_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
+    try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -16,6 +16,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     check_parameters: bool = false,
     args_after_used: bool = false,
+    check_caught_errors: bool = true,
     ignore_rest_siblings: bool = false,
     check_type_parameters: bool = false,
     react_jsx_uses_react: bool = false,
@@ -107,6 +108,7 @@ pub fn runWithOptions(
 
         if (!isLintableSymbol(flags, options)) continue;
         if (flags.exported or flags.ambient) continue;
+        if (flags.catch_var and !options.check_caught_errors) continue;
         if (flags.parameter) {
             if (!options.check_parameters) continue;
             if (options.args_after_used and !shouldCheckParameter(entry.id, symbol.scope, parameters.items)) continue;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -894,6 +894,7 @@ pub fn runSemantic(
         try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .check_parameters = options.no_unused_vars_args != .none,
             .args_after_used = options.no_unused_vars_args == .after_used,
+            .check_caught_errors = options.no_unused_vars_caught_errors == .all,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
         });
@@ -908,6 +909,7 @@ pub fn runSemantic(
             options.react_jsx_uses_react,
             options.react_jsx_uses_vars,
             options.typescript_eslint_no_unused_vars_args,
+            options.typescript_eslint_no_unused_vars_caught_errors,
         );
     }
 

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -15,12 +15,14 @@ pub fn run(
     react_jsx_uses_react: bool,
     react_jsx_uses_vars: bool,
     args: core.NoUnusedVarsArgs,
+    caught_errors: core.NoUnusedVarsCaughtErrors,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
         .check_parameters = args != .none,
         .args_after_used = args == .after_used,
+        .check_caught_errors = caught_errors == .all,
         .ignore_rest_siblings = true,
         .check_type_parameters = true,
         .react_jsx_uses_react = react_jsx_uses_react,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -71,3 +71,31 @@ test "supports configured no-unused-vars args all" {
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars caughtErrors none" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"caughtErrors\":\"none\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\try {
+        \\  run();
+        \\} catch (unusedError) {
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -79,6 +79,33 @@ test "supports configured @typescript-eslint/no-unused-vars args none" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars caughtErrors none" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"caughtErrors\":\"none\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\try {
+        \\  run();
+        \\} catch (unusedError) {
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "can disable @typescript-eslint/no-unused-vars and fall back to core rule" {
     const source =
         \\const unused = 1;


### PR DESCRIPTION
## Summary

Add `caughtErrors` option support for `no-unused-vars` and `@typescript-eslint/no-unused-vars`.

## Details

- Parse `caughtErrors: "none" | "all"` from ESLint-style configs.
- Keep the current default behavior as `all`.
- Skip catch bindings when configured with `caughtErrors: "none"`.
- Add focused coverage for both core and TypeScript rule ids.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_unused_vars.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `git diff --check`
