### PR TITLE
support no-unused-vars ignoreRestSiblings option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -709,6 +709,7 @@ pub const Options = struct {
     no_unused_vars: bool = true,
     no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
+    no_unused_vars_ignore_rest_siblings: bool = false,
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -818,6 +819,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_vars: bool = true,
     typescript_eslint_no_unused_vars_args: NoUnusedVarsArgs = .after_used,
     typescript_eslint_no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
+    typescript_eslint_no_unused_vars_ignore_rest_siblings: bool = true,
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -1034,6 +1036,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-unused-vars")) {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
             self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
+            self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
         }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
@@ -1046,6 +1049,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
             self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
+            self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -1964,6 +1968,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, caught_errors, "none")) return .none;
         if (std.mem.eql(u8, caught_errors, "all")) return .all;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noUnusedVarsIgnoreRestSiblingsFromConfig(value: std.json.Value, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("ignoreRestSiblings") orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noUseBeforeDefineCheckFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!NoUseBeforeDefineCheck {
@@ -2998,7 +3019,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"caughtErrors\":\"none\"}]",
+        "[\"error\",{\"args\":\"all\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":true}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -3006,11 +3027,12 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_unused_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
+    try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
 
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"none\",\"caughtErrors\":\"none\"}]",
+        "[\"error\",{\"args\":\"none\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":false}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
@@ -3018,6 +3040,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_unused_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
+    try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -895,6 +895,7 @@ pub fn runSemantic(
             .check_parameters = options.no_unused_vars_args != .none,
             .args_after_used = options.no_unused_vars_args == .after_used,
             .check_caught_errors = options.no_unused_vars_caught_errors == .all,
+            .ignore_rest_siblings = options.no_unused_vars_ignore_rest_siblings,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
         });
@@ -910,6 +911,7 @@ pub fn runSemantic(
             options.react_jsx_uses_vars,
             options.typescript_eslint_no_unused_vars_args,
             options.typescript_eslint_no_unused_vars_caught_errors,
+            options.typescript_eslint_no_unused_vars_ignore_rest_siblings,
         );
     }
 

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -16,6 +16,7 @@ pub fn run(
     react_jsx_uses_vars: bool,
     args: core.NoUnusedVarsArgs,
     caught_errors: core.NoUnusedVarsCaughtErrors,
+    ignore_rest_siblings: bool,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
@@ -23,7 +24,7 @@ pub fn run(
         .check_parameters = args != .none,
         .args_after_used = args == .after_used,
         .check_caught_errors = caught_errors == .all,
-        .ignore_rest_siblings = true,
+        .ignore_rest_siblings = ignore_rest_siblings,
         .check_type_parameters = true,
         .react_jsx_uses_react = react_jsx_uses_react,
         .react_jsx_uses_vars = react_jsx_uses_vars,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -99,3 +99,30 @@ test "supports configured no-unused-vars caughtErrors none" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars ignoreRestSiblings" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreRestSiblings\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const data = { a: 1, b: 2 };
+        \\const { a, ...rest } = data;
+        \\console.log(rest);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -52,6 +52,32 @@ test "ignores rest siblings for object destructuring" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars ignoreRestSiblings false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreRestSiblings\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const data = { a: 1, b: 2 };
+        \\const { a, ...rest } = data;
+        \\console.log(rest);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "supports configured @typescript-eslint/no-unused-vars args none" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary

- parse `ignoreRestSiblings` for `no-unused-vars` and `@typescript-eslint/no-unused-vars`
- thread the configured value into both core and TypeScript unused-var checks
- add rule tests for enabling the core option and disabling the TypeScript default

## Validation

- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
