### PR TITLE
support consistent-return undefined option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -447,6 +447,7 @@ pub const Options = struct {
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
     consistent_return: bool = true,
+    consistent_return_treat_undefined_as_unspecified: bool = false,
     constructor_super: bool = true,
     curly: bool = true,
     curly_style: CurlyStyle = .all,
@@ -929,6 +930,9 @@ pub const Options = struct {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "consistent-return")) {
+            self.consistent_return_treat_undefined_as_unspecified = try consistentReturnTreatUndefinedAsUnspecifiedFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "curly")) {
             self.curly_style = try curlyStyleFromConfig(value);
         }
@@ -1148,6 +1152,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "always")) return .strict;
         if (std.mem.eql(u8, style, "allow-null")) return .allow_null;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn consistentReturnTreatUndefinedAsUnspecifiedFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("treatUndefinedAsUnspecified") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn accessorPairsGetWithoutSetFromConfig(value: std.json.Value) RuleConfigError!AccessorPairsGetWithoutSet {
@@ -2561,6 +2582,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.capitalized_comments);
     try std.testing.expectEqual(CapitalizedCommentsMode.never, options.capitalized_comments_mode);
     try std.testing.expectEqual(CapitalizedCommentsIgnoreInlineComments.yes, options.capitalized_comments_ignore_inline_comments);
+
+    var consistent_return_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"treatUndefinedAsUnspecified\":true}]",
+        .{},
+    );
+    defer consistent_return_config.deinit();
+    try options.setByRuleConfigValue("consistent-return", consistent_return_config.value);
+    try std.testing.expect(options.consistent_return);
+    try std.testing.expect(options.consistent_return_treat_undefined_as_unspecified);
 
     var dot_notation_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/consistent_return.zig
+++ b/src/rules/consistent_return.zig
@@ -1,8 +1,9 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "consistent-return";
 
@@ -11,9 +12,14 @@ const ReturnKind = enum {
     bare,
 };
 
+pub const Options = struct {
+    treat_undefined_as_unspecified: bool = false,
+};
+
 const ScanState = struct {
     expected: ?ReturnKind = null,
     reported: bool = false,
+    options: Options = .{},
 };
 
 pub fn checkFunction(
@@ -22,9 +28,19 @@ pub fn checkFunction(
     tree: *const ast.Tree,
     function: ast.Function,
 ) Allocator.Error!void {
+    try checkFunctionWithOptions(allocator, diagnostics, tree, function, .{});
+}
+
+pub fn checkFunctionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
+) Allocator.Error!void {
     if (function.body == .null) return;
 
-    var state = ScanState{};
+    var state = ScanState{ .options = options };
     try scanNode(allocator, diagnostics, tree, function.body, &state);
     try checkFallthrough(allocator, diagnostics, tree, function.body, &state);
 }
@@ -35,9 +51,19 @@ pub fn checkArrowFunction(
     tree: *const ast.Tree,
     expression: ast.ArrowFunctionExpression,
 ) Allocator.Error!void {
+    try checkArrowFunctionWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkArrowFunctionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
     if (expression.expression) return;
 
-    var state = ScanState{};
+    var state = ScanState{ .options = options };
     try scanNode(allocator, diagnostics, tree, expression.body, &state);
     try checkFallthrough(allocator, diagnostics, tree, expression.body, &state);
 }
@@ -110,7 +136,7 @@ fn checkReturn(
     index: ast.NodeIndex,
     state: *ScanState,
 ) Allocator.Error!void {
-    const kind: ReturnKind = if (statement.argument == .null) .bare else .value;
+    const kind: ReturnKind = if (returnArgumentIsUnspecified(tree, statement.argument, state.options)) .bare else .value;
     if (state.expected) |expected| {
         if (expected == kind) return;
         state.reported = true;
@@ -125,6 +151,17 @@ fn checkReturn(
         return;
     }
     state.expected = kind;
+}
+
+fn returnArgumentIsUnspecified(tree: *const ast.Tree, argument: ast.NodeIndex, options: Options) bool {
+    if (argument == .null) return true;
+    if (!options.treat_undefined_as_unspecified) return false;
+
+    return switch (tree.data(argument)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => |expression| expression.operator == .void,
+        else => false,
+    };
 }
 
 fn checkFallthrough(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1095,7 +1095,9 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.consistent_return) {
-            try consistent_return.checkFunction(self.allocator, self.diagnostics, ctx.tree, function);
+            try consistent_return.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
+                .treat_undefined_as_unspecified = self.options.consistent_return_treat_undefined_as_unspecified,
+            });
         }
         if (self.options.func_names) {
             try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, switch (self.options.func_names_style) {
@@ -2076,7 +2078,9 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.consistent_return) {
-            try consistent_return.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression);
+            try consistent_return.checkArrowFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .treat_undefined_as_unspecified = self.options.consistent_return_treat_undefined_as_unspecified,
+            });
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);

--- a/tests/rules/consistent_return.zig
+++ b/tests/rules/consistent_return.zig
@@ -26,6 +26,39 @@ test "reports consistent-return for mixed return values" {
     try std.testing.expectEqualStrings("Expected no return value.", result.diagnostics[1].message);
 }
 
+test "supports configured consistent-return treatUndefinedAsUnspecified" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"treatUndefinedAsUnspecified\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("consistent-return", config.value);
+    options.curly = false;
+    options.no_undefined = false;
+    options.no_unused_vars = false;
+    options.no_useless_return = false;
+    options.no_void = false;
+
+    const source =
+        "function undefinedThenBare(flag) {\n" ++
+        "  if (flag) return undefined;\n" ++
+        "  return;\n" ++
+        "}\n" ++
+        "const voidThenBare = (flag) => {\n" ++
+        "  if (flag) return void 0;\n" ++
+        "  return;\n" ++
+        "};\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.consistent_return.id));
+}
+
 test "reports consistent-return when value-returning functions can fall through" {
     const source =
         "function maybeValue(flag) {\n" ++


### PR DESCRIPTION
## Summary

- add `treatUndefinedAsUnspecified` support for ESLint-style `consistent-return` config
- treat `return undefined` and `return void ...` as bare returns when the option is enabled
- add config parsing and lint behavior coverage

## Validation

- `zig fmt --check src/core.zig src/rules/root.zig src/rules/consistent_return.zig tests/rules/consistent_return.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
