### PR TITLE
support no-cond-assign always option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,11 @@ pub const CurlyStyle = enum {
     multi_line,
 };
 
+pub const NoCondAssignStyle = enum {
+    except_parens,
+    always,
+};
+
 pub const NoConfusingArrowAllowParens = enum {
     yes,
     no,
@@ -487,6 +492,7 @@ pub const Options = struct {
     no_confusing_arrow: bool = true,
     no_confusing_arrow_allow_parens: NoConfusingArrowAllowParens = .yes,
     no_cond_assign: bool = true,
+    no_cond_assign_style: NoCondAssignStyle = .except_parens,
     no_compare_neg_zero: bool = true,
     no_constant_condition: bool = true,
     no_const_assign: bool = true,
@@ -960,6 +966,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-cond-assign")) {
+            self.no_cond_assign_style = try noCondAssignStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-confusing-arrow")) {
             self.no_confusing_arrow_allow_parens = try noConfusingArrowAllowParensFromConfig(value);
@@ -1450,6 +1459,22 @@ pub const Options = struct {
             if (!allow.enable(method)) return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noCondAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoCondAssignStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .except_parens,
+        };
+        if (items.len < 2) return .except_parens;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "except-parens")) return .except_parens;
+        if (std.mem.eql(u8, style, "always")) return .always;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noConfusingArrowAllowParensFromConfig(value: std.json.Value) RuleConfigError!NoConfusingArrowAllowParens {
@@ -2767,6 +2792,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_console_allow.contains("warn"));
     try std.testing.expect(options.no_console_allow.contains("error"));
     try std.testing.expect(!options.no_console_allow.contains("log"));
+
+    var no_cond_assign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer no_cond_assign_config.deinit();
+    try options.setByRuleConfigValue("no-cond-assign", no_cond_assign_config.value);
+    try std.testing.expect(options.no_cond_assign);
+    try std.testing.expectEqual(NoCondAssignStyle.always, options.no_cond_assign_style);
 
     var no_confusing_arrow_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_cond_assign.zig
+++ b/src/rules/no_cond_assign.zig
@@ -6,13 +6,27 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-cond-assign";
 
+pub const Options = struct {
+    style: core.NoCondAssignStyle = .except_parens,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (findAmbiguousAssignment(tree, expression)) |assignment| {
+    try checkWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (findAssignment(tree, expression, options.style == .always)) |assignment| {
         try core.addDiagnostic(
             allocator,
             diagnostics,
@@ -22,6 +36,62 @@ pub fn check(
             tree.span(assignment),
         );
     }
+}
+
+fn findAssignment(tree: *const ast.Tree, index: ast.NodeIndex, allow_parenthesized: bool) ?ast.NodeIndex {
+    if (!allow_parenthesized) return findAmbiguousAssignment(tree, index);
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .parenthesized_expression => |expression| {
+            return findAssignment(tree, expression.expression, allow_parenthesized);
+        },
+        .assignment_expression => index,
+        .chain_expression => |chain| return findAssignment(tree, chain.expression, allow_parenthesized),
+        .binary_expression => |expression| {
+            if (findAssignment(tree, expression.left, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.right, allow_parenthesized);
+        },
+        .logical_expression => |expression| {
+            if (findAssignment(tree, expression.left, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.right, allow_parenthesized);
+        },
+        .unary_expression => |expression| return findAssignment(tree, expression.argument, allow_parenthesized),
+        .conditional_expression => |expression| {
+            if (findAssignment(tree, expression.@"test", allow_parenthesized)) |assignment| return assignment;
+            if (findAssignment(tree, expression.consequent, allow_parenthesized)) |assignment| return assignment;
+            return findAssignment(tree, expression.alternate, allow_parenthesized);
+        },
+        .sequence_expression => |expression| {
+            for (tree.extra(expression.expressions)) |item| {
+                if (findAssignment(tree, item, allow_parenthesized)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .call_expression => |call| {
+            if (!allow_parenthesized) return null;
+            if (findAssignment(tree, call.callee, allow_parenthesized)) |assignment| return assignment;
+            for (tree.extra(call.arguments)) |argument| {
+                if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .new_expression => |new| {
+            if (!allow_parenthesized) return null;
+            if (findAssignment(tree, new.callee, allow_parenthesized)) |assignment| return assignment;
+            for (tree.extra(new.arguments)) |argument| {
+                if (findAssignment(tree, argument, allow_parenthesized)) |assignment| return assignment;
+            }
+            return null;
+        },
+        .member_expression => |member| {
+            if (!allow_parenthesized) return null;
+            if (findAssignment(tree, member.object, allow_parenthesized)) |assignment| return assignment;
+            if (member.computed) return findAssignment(tree, member.property, allow_parenthesized);
+            return null;
+        },
+        else => null,
+    };
 }
 
 fn findAmbiguousAssignment(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1208,7 +1208,9 @@ const BasicVisitor = struct {
             try curly.checkIfStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
-            try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+            try no_cond_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.@"test", .{
+                .style = self.options.no_cond_assign_style,
+            });
         }
         if (self.options.no_constant_condition) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1265,7 +1267,9 @@ const BasicVisitor = struct {
             try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
-            try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+            try no_cond_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.@"test", .{
+                .style = self.options.no_cond_assign_style,
+            });
         }
         if (self.options.no_constant_condition) {
             try no_constant_condition.checkWhile(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1283,7 +1287,9 @@ const BasicVisitor = struct {
             try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign) {
-            try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+            try no_cond_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.@"test", .{
+                .style = self.options.no_cond_assign_style,
+            });
         }
         if (self.options.no_constant_condition) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
@@ -1301,7 +1307,9 @@ const BasicVisitor = struct {
             try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
         }
         if (self.options.no_cond_assign and statement.@"test" != .null) {
-            try no_cond_assign.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+            try no_cond_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.@"test", .{
+                .style = self.options.no_cond_assign_style,
+            });
         }
         if (self.options.no_constant_condition and statement.@"test" != .null) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");

--- a/tests/rules/no_cond_assign.zig
+++ b/tests/rules/no_cond_assign.zig
@@ -45,6 +45,34 @@ test "does not report no-cond-assign for parenthesized assignments or comparison
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_cond_assign.id));
 }
 
+test "supports configured no-cond-assign always" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-cond-assign", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if ((value = next)) { use(value); }
+        \\while (use(node = node.parentNode)) { use(node); }
+        \\do { use(value); } while (!(value += 1));
+        \\for (; other || (value = next); ) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_cond_assign.id));
+}
+
 test "can disable no-cond-assign" {
     const source =
         \\if (value = next) { use(value); }


### PR DESCRIPTION
## Summary

- parse ESLint-style `no-cond-assign` style values
- preserve the default `except-parens` behavior
- add `always` support that reports parenthesized and nested assignments in conditions

## Validation

- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_cond_assign.zig tests/rules/no_cond_assign.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
