### PR TITLE
support no-labels allow options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -31,6 +31,16 @@ pub const NoCondAssignStyle = enum {
     always,
 };
 
+pub const NoLabelsAllowLoop = enum {
+    yes,
+    no,
+};
+
+pub const NoLabelsAllowSwitch = enum {
+    yes,
+    no,
+};
+
 pub const NoConfusingArrowAllowParens = enum {
     yes,
     no,
@@ -606,6 +616,8 @@ pub const Options = struct {
     no_iterator: bool = true,
     no_label_var: bool = true,
     no_labels: bool = true,
+    no_labels_allow_loop: NoLabelsAllowLoop = .no,
+    no_labels_allow_switch: NoLabelsAllowSwitch = .no,
     no_lone_blocks: bool = true,
     no_lonely_if: bool = true,
     no_loop_func: bool = true,
@@ -997,6 +1009,10 @@ pub const Options = struct {
             self.no_implicit_coercion_allow_unary_plus = try noImplicitCoercionAllowFromConfig(value, "+");
             self.no_implicit_coercion_allow_multiply = try noImplicitCoercionAllowFromConfig(value, "*");
             self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
+        }
+        if (std.mem.eql(u8, cli_name, "no-labels")) {
+            self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
+            self.no_labels_allow_switch = try noLabelsAllowSwitchFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
             self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
@@ -1643,6 +1659,33 @@ pub const Options = struct {
             std.mem.eql(u8, value, "+") or
             std.mem.eql(u8, value, "*") or
             std.mem.eql(u8, value, "-");
+    }
+
+    fn noLabelsAllowLoopFromConfig(value: std.json.Value) RuleConfigError!NoLabelsAllowLoop {
+        const enabled = try noLabelsBoolOptionFromConfig(value, "allowLoop", false);
+        return if (enabled) .yes else .no;
+    }
+
+    fn noLabelsAllowSwitchFromConfig(value: std.json.Value) RuleConfigError!NoLabelsAllowSwitch {
+        const enabled = try noLabelsBoolOptionFromConfig(value, "allowSwitch", false);
+        return if (enabled) .yes else .no;
+    }
+
+    fn noLabelsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noMultiSpacesIgnoreEOLCommentsFromConfig(value: std.json.Value) RuleConfigError!NoMultiSpacesIgnoreEOLComments {
@@ -2915,6 +2958,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_implicit_coercion_allow_unary_plus);
     try std.testing.expect(options.no_implicit_coercion_allow_multiply);
     try std.testing.expect(options.no_implicit_coercion_allow_subtract);
+
+    var no_labels_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowLoop\":true,\"allowSwitch\":true}]",
+        .{},
+    );
+    defer no_labels_config.deinit();
+    try options.setByRuleConfigValue("no-labels", no_labels_config.value);
+    try std.testing.expect(options.no_labels);
+    try std.testing.expectEqual(NoLabelsAllowLoop.yes, options.no_labels_allow_loop);
+    try std.testing.expectEqual(NoLabelsAllowSwitch.yes, options.no_labels_allow_switch);
 
     var no_multi_spaces_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_labels.zig
+++ b/src/rules/no_labels.zig
@@ -1,17 +1,38 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-labels";
+
+pub const Options = struct {
+    allow_loop: bool = false,
+    allow_switch: bool = false,
+};
 
 pub fn checkLabeledStatement(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    statement: ast.LabeledStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkLabeledStatementWithOptions(allocator, diagnostics, tree, statement, index, .{});
+}
+
+pub fn checkLabeledStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.LabeledStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (labelBodyAllowed(tree, statement.body, options)) return;
+
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -29,7 +50,20 @@ pub fn checkBreakStatement(
     statement: ast.BreakStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkBreakStatementWithOptions(allocator, diagnostics, tree, statement, index, null, .{});
+}
+
+pub fn checkBreakStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.BreakStatement,
+    index: ast.NodeIndex,
+    path: ?*const traverser.NodePath,
+    options: Options,
+) Allocator.Error!void {
     if (statement.label == .null) return;
+    if (labelTargetAllowed(tree, statement.label, path, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -48,7 +82,23 @@ pub fn checkContinueStatement(
     statement: ast.ContinueStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkContinueStatementWithOptions(allocator, diagnostics, tree, statement, index, null, .{});
+}
+
+pub fn checkContinueStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ContinueStatement,
+    index: ast.NodeIndex,
+    path: ?*const traverser.NodePath,
+    options: Options,
+) Allocator.Error!void {
     if (statement.label == .null) return;
+    if (labelTargetAllowed(tree, statement.label, path, .{
+        .allow_loop = options.allow_loop,
+        .allow_switch = false,
+    })) return;
 
     try core.addDiagnostic(
         allocator,
@@ -58,4 +108,51 @@ pub fn checkContinueStatement(
         "Unexpected label in continue statement.",
         tree.span(index),
     );
+}
+
+fn labelTargetAllowed(
+    tree: *const ast.Tree,
+    label_index: ast.NodeIndex,
+    path: ?*const traverser.NodePath,
+    options: Options,
+) bool {
+    const node_path = path orelse return false;
+    const expected = labelName(tree, label_index) orelse return false;
+
+    var depth: usize = 1;
+    while (node_path.ancestor(depth)) |ancestor| : (depth += 1) {
+        const labeled = switch (tree.data(ancestor)) {
+            .labeled_statement => |statement| statement,
+            else => continue,
+        };
+        const name = labelName(tree, labeled.label) orelse continue;
+        if (!std.mem.eql(u8, name, expected)) continue;
+
+        return labelBodyAllowed(tree, labeled.body, options);
+    }
+    return false;
+}
+
+fn labelBodyAllowed(tree: *const ast.Tree, body_index: ast.NodeIndex, options: Options) bool {
+    if (body_index == .null) return false;
+
+    return switch (tree.data(body_index)) {
+        .labeled_statement => |statement| labelBodyAllowed(tree, statement.body, options),
+        .for_statement,
+        .for_in_statement,
+        .for_of_statement,
+        .while_statement,
+        .do_while_statement,
+        => options.allow_loop,
+        .switch_statement => options.allow_switch,
+        else => false,
+    };
+}
+
+fn labelName(tree: *const ast.Tree, label_index: ast.NodeIndex) ?[]const u8 {
+    if (label_index == .null) return null;
+    return switch (tree.data(label_index)) {
+        .label_identifier => |label| tree.string(label.name),
+        else => null,
+    };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -978,6 +978,13 @@ const BasicVisitor = struct {
         };
     }
 
+    fn noLabelsOptions(self: *const BasicVisitor) no_labels.Options {
+        return .{
+            .allow_loop = self.options.no_labels_allow_loop == .yes,
+            .allow_switch = self.options.no_labels_allow_switch == .yes,
+        };
+    }
+
     pub fn enter_node(
         self: *BasicVisitor,
         data: ast.NodeData,
@@ -1806,7 +1813,7 @@ const BasicVisitor = struct {
             try no_continue.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
         if (self.options.no_labels) {
-            try no_labels.checkContinueStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try no_labels.checkContinueStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, &ctx.path, self.noLabelsOptions());
         }
         return .proceed;
     }
@@ -1818,7 +1825,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_labels) {
-            try no_labels.checkBreakStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try no_labels.checkBreakStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, &ctx.path, self.noLabelsOptions());
         }
         return .proceed;
     }
@@ -1836,7 +1843,7 @@ const BasicVisitor = struct {
             try no_unused_labels.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.no_labels) {
-            try no_labels.checkLabeledStatement(self.allocator, self.diagnostics, ctx.tree, index);
+            try no_labels.checkLabeledStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noLabelsOptions());
         }
         return .proceed;
     }

--- a/tests/rules/no_labels.zig
+++ b/tests/rules/no_labels.zig
@@ -44,6 +44,79 @@ test "does not report no-labels for unlabeled break and continue" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_labels.id));
 }
 
+test "supports configured no-labels allowLoop" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowLoop\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-labels", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\loop:
+        \\for (const item of items) {
+        \\  if (item) break loop;
+        \\  continue loop;
+        \\}
+        \\switchLabel:
+        \\switch (value) {
+        \\  case 1:
+        \\    break switchLabel;
+        \\}
+        \\plain:
+        \\use(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_labels.id));
+}
+
+test "supports configured no-labels allowSwitch" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowSwitch\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-labels", config.value);
+    options.no_continue = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\loop:
+        \\for (const item of items) {
+        \\  if (item) break loop;
+        \\  continue loop;
+        \\}
+        \\switchLabel:
+        \\switch (value) {
+        \\  case 1:
+        \\    break switchLabel;
+        \\}
+        \\plain:
+        \\use(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_labels.id));
+}
+
 test "can disable no-labels" {
     const source =
         \\start:


### PR DESCRIPTION
## Summary

- parse ESLint-style `allowLoop` and `allowSwitch` options for `no-labels`
- allow labels and labeled break/continue only when they target the configured statement kind
- add config parsing and rule behavior coverage

## Validation

- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_labels.zig tests/rules/no_labels.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
