### PR TITLE
support prefer-destructuring config options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -741,6 +741,10 @@ pub const Options = struct {
     prefer_object_has_own: bool = true,
     prefer_promise_reject_errors: bool = true,
     prefer_destructuring: bool = true,
+    prefer_destructuring_variable_declarator_array: bool = true,
+    prefer_destructuring_variable_declarator_object: bool = true,
+    prefer_destructuring_assignment_expression_array: bool = true,
+    prefer_destructuring_assignment_expression_object: bool = true,
     prefer_regex_literals: bool = true,
     prefer_rest_params: bool = true,
     prefer_object_spread: bool = true,
@@ -1048,6 +1052,12 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "prefer-const")) {
             self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "prefer-destructuring")) {
+            self.prefer_destructuring_variable_declarator_array = try preferDestructuringOptionFromConfig(value, "VariableDeclarator", "array", true);
+            self.prefer_destructuring_variable_declarator_object = try preferDestructuringOptionFromConfig(value, "VariableDeclarator", "object", true);
+            self.prefer_destructuring_assignment_expression_array = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "array", true);
+            self.prefer_destructuring_assignment_expression_object = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "object", true);
         }
         if (std.mem.eql(u8, cli_name, "radix")) {
             self.radix_style = try radixStyleFromConfig(value);
@@ -1925,6 +1935,38 @@ pub const Options = struct {
         if (std.mem.eql(u8, destructuring, "any")) return .any;
         if (std.mem.eql(u8, destructuring, "all")) return .all;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn preferDestructuringOptionFromConfig(
+        value: std.json.Value,
+        node_key: []const u8,
+        kind_key: []const u8,
+        default: bool,
+    ) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (config.get(node_key)) |node_config_value| {
+            const node_config = switch (node_config_value) {
+                .object => |object| object,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            return switch (node_config.get(kind_key) orelse return default) {
+                .bool => |enabled| enabled,
+                else => error.UnsupportedRuleConfigValue,
+            };
+        }
+        return switch (config.get(kind_key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noReturnAssignStyleFromConfig(value: std.json.Value) RuleConfigError!NoReturnAssignStyle {
@@ -3111,6 +3153,33 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("prefer-const", prefer_const_config.value);
     try std.testing.expect(options.prefer_const);
     try std.testing.expectEqual(PreferConstDestructuring.all, options.prefer_const_destructuring);
+
+    var prefer_destructuring_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"VariableDeclarator\":{\"array\":false,\"object\":true},\"AssignmentExpression\":{\"array\":true,\"object\":false}}]",
+        .{},
+    );
+    defer prefer_destructuring_config.deinit();
+    try options.setByRuleConfigValue("prefer-destructuring", prefer_destructuring_config.value);
+    try std.testing.expect(options.prefer_destructuring);
+    try std.testing.expect(!options.prefer_destructuring_variable_declarator_array);
+    try std.testing.expect(options.prefer_destructuring_variable_declarator_object);
+    try std.testing.expect(options.prefer_destructuring_assignment_expression_array);
+    try std.testing.expect(!options.prefer_destructuring_assignment_expression_object);
+
+    var prefer_destructuring_top_level_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"array\":false,\"object\":true}]",
+        .{},
+    );
+    defer prefer_destructuring_top_level_config.deinit();
+    try options.setByRuleConfigValue("prefer-destructuring", prefer_destructuring_top_level_config.value);
+    try std.testing.expect(!options.prefer_destructuring_variable_declarator_array);
+    try std.testing.expect(options.prefer_destructuring_variable_declarator_object);
+    try std.testing.expect(!options.prefer_destructuring_assignment_expression_array);
+    try std.testing.expect(options.prefer_destructuring_assignment_expression_object);
 
     var radix_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -12,11 +12,28 @@ const DestructuringKind = enum {
     array,
 };
 
+pub const Options = struct {
+    variable_declarator_array: bool = true,
+    variable_declarator_object: bool = true,
+    assignment_expression_array: bool = true,
+    assignment_expression_object: bool = true,
+};
+
 pub fn checkVariableDeclaration(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     declaration: ast.VariableDeclaration,
+) Allocator.Error!void {
+    return checkVariableDeclarationWithOptions(allocator, diagnostics, tree, declaration, .{});
+}
+
+pub fn checkVariableDeclarationWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.extra(declaration.declarators)) |declarator_index| {
         const declarator = switch (tree.data(declarator_index)) {
@@ -24,6 +41,7 @@ pub fn checkVariableDeclaration(
             else => continue,
         };
         const kind = preferredDestructuringKind(tree, declarator) orelse continue;
+        if (!allowsVariableDeclarator(options, kind)) continue;
 
         try core.addDiagnostic(
             allocator,
@@ -42,9 +60,20 @@ pub fn checkAssignmentExpression(
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
 ) Allocator.Error!void {
+    return checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    options: Options,
+) Allocator.Error!void {
     if (expression.operator != .assign) return;
 
     const kind = preferredAssignmentDestructuringKind(tree, expression) orelse return;
+    if (!allowsAssignmentExpression(options, kind)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -92,6 +121,20 @@ fn diagnosticMessage(kind: DestructuringKind) []const u8 {
     return switch (kind) {
         .object => "Use object destructuring.",
         .array => "Use array destructuring.",
+    };
+}
+
+fn allowsVariableDeclarator(options: Options, kind: DestructuringKind) bool {
+    return switch (kind) {
+        .object => options.variable_declarator_object,
+        .array => options.variable_declarator_array,
+    };
+}
+
+fn allowsAssignmentExpression(options: Options, kind: DestructuringKind) bool {
+    return switch (kind) {
+        .object => options.assignment_expression_object,
+        .array => options.assignment_expression_array,
     };
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2004,7 +2004,12 @@ const BasicVisitor = struct {
             try one_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
         }
         if (self.options.prefer_destructuring) {
-            try prefer_destructuring.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
+            try prefer_destructuring.checkVariableDeclarationWithOptions(self.allocator, self.diagnostics, ctx.tree, declaration, .{
+                .variable_declarator_array = self.options.prefer_destructuring_variable_declarator_array,
+                .variable_declarator_object = self.options.prefer_destructuring_variable_declarator_object,
+                .assignment_expression_array = self.options.prefer_destructuring_assignment_expression_array,
+                .assignment_expression_object = self.options.prefer_destructuring_assignment_expression_object,
+            });
         }
         return .proceed;
     }
@@ -2154,7 +2159,12 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.prefer_destructuring) {
-            try prefer_destructuring.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try prefer_destructuring.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .variable_declarator_array = self.options.prefer_destructuring_variable_declarator_array,
+                .variable_declarator_object = self.options.prefer_destructuring_variable_declarator_object,
+                .assignment_expression_array = self.options.prefer_destructuring_assignment_expression_array,
+                .assignment_expression_object = self.options.prefer_destructuring_assignment_expression_object,
+            });
         }
         if (self.options.no_useless_rename) {
             try no_useless_rename.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -84,6 +84,72 @@ test "does not report prefer-destructuring for renamed dynamic or optional cases
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_destructuring.id));
 }
 
+test "supports configured prefer-destructuring node type options" {
+    const source =
+        \\let first = object.first;
+        \\let item = array[0];
+        \\first = object.first;
+        \\item = array[0];
+    ;
+
+    var options = lint.Options{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_dot_notation = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"VariableDeclarator\":{\"array\":false,\"object\":true},\"AssignmentExpression\":{\"array\":true,\"object\":false}}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("prefer-destructuring", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Use array destructuring.", result.diagnostics[1].message);
+}
+
+test "supports top-level prefer-destructuring kind options" {
+    const source =
+        \\let first = object.first;
+        \\let item = array[0];
+        \\first = object.first;
+        \\item = array[0];
+    ;
+
+    var options = lint.Options{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_dot_notation = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"array\":false,\"object\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("prefer-destructuring", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[1].message);
+}
+
 test "can disable prefer-destructuring" {
     const source =
         \\const first = object.first;


### PR DESCRIPTION
## Summary

- Parse ESLint-style `prefer-destructuring` kind options for both top-level `{ array, object }` config and per-node `VariableDeclarator` / `AssignmentExpression` config.
- Thread those options into the rule so array/object diagnostics can be enabled independently for declarations and assignments.
- Add parser and rule tests for both supported option shapes.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/prefer_destructuring.zig tests/rules/prefer_destructuring.zig`
- `git diff --check`
