### PR TITLE
support no-else-return allowElseIf option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -531,6 +531,7 @@ pub const Options = struct {
     no_empty_pattern: bool = true,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
+    no_else_return_allow_else_if: bool = true,
     no_eq_null: bool = true,
     no_eval: bool = true,
     no_ex_assign: bool = true,
@@ -997,6 +998,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
             self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-else-return")) {
+            self.no_else_return_allow_else_if = try noElseReturnAllowElseIfFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-extra-boolean-cast")) {
             self.no_extra_boolean_cast_enforce_for_inner_expressions = try noExtraBooleanCastEnforceForInnerExpressionsFromConfig(value);
@@ -1565,6 +1569,23 @@ pub const Options = struct {
             if (!allow.enable(kind)) return error.UnsupportedRuleConfigValue;
         }
         return allow;
+    }
+
+    fn noElseReturnAllowElseIfFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowElseIf") orelse return true) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noExtraBooleanCastEnforceForInnerExpressionsFromConfig(value: std.json.Value) RuleConfigError!bool {
@@ -2951,6 +2972,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.arrowFunctions);
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.methods);
     try std.testing.expect(!options.typescript_eslint_no_empty_function_allow.functions);
+
+    var no_else_return_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowElseIf\":false}]",
+        .{},
+    );
+    defer no_else_return_config.deinit();
+    try options.setByRuleConfigValue("no-else-return", no_else_return_config.value);
+    try std.testing.expect(options.no_else_return);
+    try std.testing.expect(!options.no_else_return_allow_else_if);
 
     var no_extra_boolean_cast_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_else_return.zig
+++ b/src/rules/no_else_return.zig
@@ -6,16 +6,32 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-else-return";
 
+pub const Options = struct {
+    allow_else_if: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     statement: ast.IfStatement,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, statement, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    options: Options,
+) Allocator.Error!void {
     if (statement.alternate == .null) return;
-    switch (tree.data(statement.alternate)) {
-        .if_statement => return,
-        else => {},
+    if (options.allow_else_if) {
+        switch (tree.data(statement.alternate)) {
+            .if_statement => return,
+            else => {},
+        }
     }
     if (!alwaysExits(tree, statement.consequent)) return;
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1223,7 +1223,9 @@ const BasicVisitor = struct {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
         }
         if (self.options.no_else_return) {
-            try no_else_return.check(self.allocator, self.diagnostics, ctx.tree, statement);
+            try no_else_return.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, .{
+                .allow_else_if = self.options.no_else_return_allow_else_if,
+            });
         }
         if (self.options.no_dupe_else_if) {
             try no_dupe_else_if.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);

--- a/tests/rules/no_else_return.zig
+++ b/tests/rules/no_else_return.zig
@@ -77,6 +77,41 @@ test "does not report no-else-return for else-if alternate" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_else_return.id));
 }
 
+test "reports no-else-return for else-if alternate when allowElseIf is false" {
+    const source =
+        \\function first(value) {
+        \\  if (value) {
+        \\    return 1;
+        \\  } else if (value > 1) {
+        \\    return 2;
+        \\  }
+        \\}
+        \\function second(value) {
+        \\  if (value) return 1;
+        \\  else if (value > 1) return 2;
+        \\}
+    ;
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowElseIf\":false}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("no-else-return", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_else_return.id));
+}
+
 test "can disable no-else-return" {
     const source =
         \\function first(value) {


### PR DESCRIPTION
## Summary

- Add parsing for ESLint's `no-else-return` `allowElseIf` option.
- Thread the option into the rule so `else if` remains ignored by default, but is reported when `allowElseIf` is `false`.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_else_return.zig tests/rules/no_else_return.zig`
- `git diff --check`
