### PR TITLE
support no-bitwise allow options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -495,6 +495,14 @@ pub const Options = struct {
     no_await_in_loop: bool = true,
     no_alert: bool = true,
     no_bitwise: bool = true,
+    no_bitwise_allow_bitwise_and: bool = false,
+    no_bitwise_allow_bitwise_or: bool = false,
+    no_bitwise_allow_bitwise_xor: bool = false,
+    no_bitwise_allow_bitwise_not: bool = false,
+    no_bitwise_allow_left_shift: bool = false,
+    no_bitwise_allow_right_shift: bool = false,
+    no_bitwise_allow_unsigned_right_shift: bool = false,
+    no_bitwise_int32_hint: bool = false,
     no_buffer_constructor: bool = true,
     no_caller: bool = true,
     no_case_declarations: bool = true,
@@ -981,6 +989,16 @@ pub const Options = struct {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "no-bitwise")) {
+            self.no_bitwise_allow_bitwise_and = try noBitwiseAllowFromConfig(value, "&");
+            self.no_bitwise_allow_bitwise_or = try noBitwiseAllowFromConfig(value, "|");
+            self.no_bitwise_allow_bitwise_xor = try noBitwiseAllowFromConfig(value, "^");
+            self.no_bitwise_allow_bitwise_not = try noBitwiseAllowFromConfig(value, "~");
+            self.no_bitwise_allow_left_shift = try noBitwiseAllowFromConfig(value, "<<");
+            self.no_bitwise_allow_right_shift = try noBitwiseAllowFromConfig(value, ">>");
+            self.no_bitwise_allow_unsigned_right_shift = try noBitwiseAllowFromConfig(value, ">>>");
+            self.no_bitwise_int32_hint = try noBitwiseInt32HintFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
         }
@@ -1461,6 +1479,59 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enforce) .yes else .no;
+    }
+
+    fn noBitwiseAllowFromConfig(value: std.json.Value, expected: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return false;
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        for (allow_items) |item| {
+            const operator = switch (item) {
+                .string => |operator| operator,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!isNoBitwiseOperatorToken(operator)) return error.UnsupportedRuleConfigValue;
+            if (std.mem.eql(u8, operator, expected)) return true;
+        }
+
+        return false;
+    }
+
+    fn noBitwiseInt32HintFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("int32Hint") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn isNoBitwiseOperatorToken(operator: []const u8) bool {
+        inline for (.{ "&", "|", "^", "~", "<<", ">>", ">>>" }) |allowed| {
+            if (std.mem.eql(u8, operator, allowed)) return true;
+        }
+        return false;
     }
 
     fn noConsoleAllowFromConfig(value: std.json.Value) RuleConfigError!NoConsoleAllow {
@@ -2885,6 +2956,24 @@ test "Options can apply ESLint-style rule config values" {
         LogicalAssignmentOperatorsEnforceForIfStatements.yes,
         options.logical_assignment_operators_enforce_for_if_statements,
     );
+
+    var no_bitwise_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"|\",\"~\",\">>\"],\"int32Hint\":true}]",
+        .{},
+    );
+    defer no_bitwise_config.deinit();
+    try options.setByRuleConfigValue("no-bitwise", no_bitwise_config.value);
+    try std.testing.expect(options.no_bitwise);
+    try std.testing.expect(!options.no_bitwise_allow_bitwise_and);
+    try std.testing.expect(options.no_bitwise_allow_bitwise_or);
+    try std.testing.expect(!options.no_bitwise_allow_bitwise_xor);
+    try std.testing.expect(options.no_bitwise_allow_bitwise_not);
+    try std.testing.expect(!options.no_bitwise_allow_left_shift);
+    try std.testing.expect(options.no_bitwise_allow_right_shift);
+    try std.testing.expect(!options.no_bitwise_allow_unsigned_right_shift);
+    try std.testing.expect(options.no_bitwise_int32_hint);
 
     var no_console_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_bitwise.zig
+++ b/src/rules/no_bitwise.zig
@@ -6,6 +6,17 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-bitwise";
 
+pub const Options = struct {
+    allow_bitwise_and: bool = false,
+    allow_bitwise_or: bool = false,
+    allow_bitwise_xor: bool = false,
+    allow_bitwise_not: bool = false,
+    allow_left_shift: bool = false,
+    allow_right_shift: bool = false,
+    allow_unsigned_right_shift: bool = false,
+    int32_hint: bool = false,
+};
+
 pub fn checkBinaryExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -13,7 +24,20 @@ pub fn checkBinaryExpression(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkBinaryExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkBinaryExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (!isBitwiseBinaryOperator(expression.operator)) return;
+    if (allowsBinaryOperator(options, expression.operator)) return;
+    if (options.int32_hint and isInt32Hint(tree, expression)) return;
     try addDiagnostic(allocator, diagnostics, tree, index);
 }
 
@@ -24,7 +48,19 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (!isBitwiseAssignmentOperator(expression.operator)) return;
+    if (allowsAssignmentOperator(options, expression.operator)) return;
     try addDiagnostic(allocator, diagnostics, tree, index);
 }
 
@@ -35,7 +71,19 @@ pub fn checkUnaryExpression(
     expression: ast.UnaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkUnaryExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkUnaryExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UnaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (expression.operator != .bitwise_not) return;
+    if (options.allow_bitwise_not) return;
     try addDiagnostic(allocator, diagnostics, tree, index);
 }
 
@@ -79,4 +127,54 @@ fn isBitwiseAssignmentOperator(operator: ast.AssignmentOperator) bool {
         => true,
         else => false,
     };
+}
+
+fn allowsBinaryOperator(options: Options, operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .bitwise_or => options.allow_bitwise_or,
+        .bitwise_xor => options.allow_bitwise_xor,
+        .bitwise_and => options.allow_bitwise_and,
+        .left_shift => options.allow_left_shift,
+        .right_shift => options.allow_right_shift,
+        .unsigned_right_shift => options.allow_unsigned_right_shift,
+        else => false,
+    };
+}
+
+fn allowsAssignmentOperator(options: Options, operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .bitwise_or_assign => options.allow_bitwise_or,
+        .bitwise_xor_assign => options.allow_bitwise_xor,
+        .bitwise_and_assign => options.allow_bitwise_and,
+        .left_shift_assign => options.allow_left_shift,
+        .right_shift_assign => options.allow_right_shift,
+        .unsigned_right_shift_assign => options.allow_unsigned_right_shift,
+        else => false,
+    };
+}
+
+fn isInt32Hint(tree: *const ast.Tree, expression: ast.BinaryExpression) bool {
+    if (expression.operator != .bitwise_or) return false;
+    return isNumericZero(tree, expression.right);
+}
+
+fn isNumericZero(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .numeric_literal => |literal| literal.value(tree) == 0,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -985,6 +985,19 @@ const BasicVisitor = struct {
         };
     }
 
+    fn noBitwiseOptions(self: *const BasicVisitor) no_bitwise.Options {
+        return .{
+            .allow_bitwise_and = self.options.no_bitwise_allow_bitwise_and,
+            .allow_bitwise_or = self.options.no_bitwise_allow_bitwise_or,
+            .allow_bitwise_xor = self.options.no_bitwise_allow_bitwise_xor,
+            .allow_bitwise_not = self.options.no_bitwise_allow_bitwise_not,
+            .allow_left_shift = self.options.no_bitwise_allow_left_shift,
+            .allow_right_shift = self.options.no_bitwise_allow_right_shift,
+            .allow_unsigned_right_shift = self.options.no_bitwise_allow_unsigned_right_shift,
+            .int32_hint = self.options.no_bitwise_int32_hint,
+        };
+    }
+
     pub fn enter_node(
         self: *BasicVisitor,
         data: ast.NodeData,
@@ -2139,7 +2152,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_bitwise) {
-            try no_bitwise.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_bitwise.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.no_multi_assign) {
             try no_multi_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
@@ -2214,7 +2227,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_bitwise) {
-            try no_bitwise.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_bitwise.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.typescript_eslint_restrict_plus_operands) {
             try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
@@ -2273,7 +2286,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_bitwise) {
-            try no_bitwise.checkUnaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_bitwise.checkUnaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.no_delete_var) {
             try no_delete_var.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/rules/no_bitwise.zig
+++ b/tests/rules/no_bitwise.zig
@@ -62,6 +62,64 @@ test "does not report no-bitwise for logical or arithmetic operators" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_bitwise.id));
 }
 
+test "supports configured no-bitwise allow operators" {
+    const source =
+        \\const a = left | right;
+        \\value |= mask;
+        \\const b = ~value;
+        \\const c = left >> right;
+        \\value >>= bits;
+        \\const d = left & right;
+        \\value &= mask;
+    ;
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"|\",\"~\",\">>\"]}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("no-bitwise", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_bitwise.id));
+}
+
+test "supports configured no-bitwise int32Hint" {
+    const source =
+        \\const a = value | 0;
+        \\const b = value | 1;
+        \\const c = value | zero;
+    ;
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"int32Hint\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("no-bitwise", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_bitwise.id));
+}
+
 test "can disable no-bitwise" {
     const source =
         \\const value = left | right;


### PR DESCRIPTION
## Summary

- Parse ESLint-style `no-bitwise` `allow` operator lists.
- Parse `int32Hint` and skip `value | 0` when enabled.
- Thread the new options into binary, assignment, and unary bitwise checks.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_bitwise.zig tests/rules/no_bitwise.zig`
- `git diff --check`
