### PR TITLE
support object-shorthand style options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,13 @@ pub const CurlyStyle = enum {
     multi_line,
 };
 
+pub const ObjectShorthandStyle = enum {
+    always,
+    methods,
+    properties,
+    never,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -729,6 +736,8 @@ pub const Options = struct {
     no_with: bool = true,
     no_var: bool = true,
     object_shorthand: bool = true,
+    object_shorthand_style: ObjectShorthandStyle = .always,
+    object_shorthand_avoid_quotes: bool = false,
     one_var: bool = true,
     operator_assignment: bool = true,
     eqeqeq: bool = true,
@@ -1106,6 +1115,10 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+        }
+        if (std.mem.eql(u8, cli_name, "object-shorthand")) {
+            self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
+            self.object_shorthand_avoid_quotes = try objectShorthandAvoidQuotesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -2259,6 +2272,47 @@ pub const Options = struct {
         return if (enabled) .yes else .no;
     }
 
+    fn objectShorthandStyleFromConfig(value: std.json.Value) RuleConfigError!ObjectShorthandStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            .object => return .always,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "methods")) return .methods;
+        if (std.mem.eql(u8, style, "properties")) return .properties;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn objectShorthandAvoidQuotesFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config_value = switch (items[1]) {
+            .object => items[1],
+            .string => if (items.len >= 3) items[2] else return false,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const config = switch (config_value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("avoidQuotes") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noUndefTypeofFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3263,6 +3317,18 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-plusplus", no_plusplus_config.value);
     try std.testing.expect(options.no_plusplus);
     try std.testing.expectEqual(NoPlusplusAllowForLoopAfterthoughts.yes, options.no_plusplus_allow_for_loop_afterthoughts);
+
+    var object_shorthand_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"methods\",{\"avoidQuotes\":true}]",
+        .{},
+    );
+    defer object_shorthand_config.deinit();
+    try options.setByRuleConfigValue("object-shorthand", object_shorthand_config.value);
+    try std.testing.expect(options.object_shorthand);
+    try std.testing.expectEqual(ObjectShorthandStyle.methods, options.object_shorthand_style);
+    try std.testing.expect(options.object_shorthand_avoid_quotes);
 
     var prefer_const_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "object-shorthand";
 
+pub const Options = struct {
+    style: core.ObjectShorthandStyle = .always,
+    avoid_quotes: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,16 +19,56 @@ pub fn check(
     property: ast.ObjectProperty,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (property.shorthand or property.kind != .init or property.method) return;
+    return checkWithOptions(allocator, diagnostics, tree, property, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (property.kind != .init) return;
+
+    if (options.style == .never) {
+        const shorthand_kind: ?ShorthandKind = if (property.shorthand)
+            .property
+        else if (property.method)
+            .method
+        else
+            null;
+        if (shorthand_kind == null) return;
+        return addDiagnostic(allocator, diagnostics, tree, index, shorthand_kind.?, options.style);
+    }
+
+    if (property.shorthand or property.method) return;
+    if (options.avoid_quotes and isStringLiteralKey(tree, property.key)) return;
 
     const shorthand_kind = shorthandKind(tree, property) orelse return;
+    if (!styleAllowsKind(options.style, shorthand_kind)) return;
 
+    try addDiagnostic(allocator, diagnostics, tree, index, shorthand_kind, options.style);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    shorthand_kind: ShorthandKind,
+    style: core.ObjectShorthandStyle,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        switch (shorthand_kind) {
+        if (style == .never) switch (shorthand_kind) {
+            .property => "Expected property longform.",
+            .method => "Expected method longform.",
+        } else switch (shorthand_kind) {
             .property => "Expected property shorthand.",
             .method => "Expected method shorthand.",
         },
@@ -44,6 +89,22 @@ fn shorthandKind(tree: *const ast.Tree, property: ast.ObjectProperty) ?Shorthand
 
     if (isAnonymousFunctionExpression(tree, property.value)) return .method;
     return null;
+}
+
+fn styleAllowsKind(style: core.ObjectShorthandStyle, shorthand_kind: ShorthandKind) bool {
+    return switch (style) {
+        .always => true,
+        .methods => shorthand_kind == .method,
+        .properties => shorthand_kind == .property,
+        .never => false,
+    };
+}
+
+fn isStringLiteralKey(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .string_literal => true,
+        else => false,
+    };
 }
 
 fn propertyKeyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2807,7 +2807,10 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.object_shorthand) {
-            try object_shorthand.check(self.allocator, self.diagnostics, ctx.tree, property, index);
+            try object_shorthand.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, property, index, .{
+                .style = self.options.object_shorthand_style,
+                .avoid_quotes = self.options.object_shorthand_avoid_quotes,
+            });
         }
         if (self.options.func_name_matching) {
             try func_name_matching.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -66,6 +66,128 @@ test "does not report object-shorthand for non-shorthandable properties" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.object_shorthand.id));
 }
 
+test "supports configured object-shorthand methods style" {
+    const source =
+        \\const obj = {
+        \\  foo: foo,
+        \\  bar: function () {
+        \\    return 1;
+        \\  },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"methods\"]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
+test "supports configured object-shorthand properties style" {
+    const source =
+        \\const obj = {
+        \\  foo: foo,
+        \\  bar: function () {
+        \\    return 1;
+        \\  },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"properties\"]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
+test "supports configured object-shorthand never style" {
+    const source =
+        \\const obj = {
+        \\  foo,
+        \\  bar() {
+        \\    return 1;
+        \\  },
+        \\  baz: baz,
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
+test "supports configured object-shorthand avoidQuotes option" {
+    const source =
+        \\const obj = {
+        \\  foo: foo,
+        \\  "quoted": quoted,
+        \\  "quoted-method": function () {
+        \\    return 1;
+        \\  },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"avoidQuotes\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
 test "can disable object-shorthand" {
     const source =
         \\const obj = {


### PR DESCRIPTION
## Summary

- Parse ESLint-style `object-shorthand` style values for `always`, `methods`, `properties`, and `never`.
- Parse `avoidQuotes` and skip shorthand enforcement for quoted keys when enabled.
- Thread the new options into the object property rule.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/object_shorthand.zig tests/rules/object_shorthand.zig`
- `git diff --check`
