### PR TITLE
support no-use-before-define nofunc config

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -2262,6 +2262,12 @@ pub const Options = struct {
         if (items.len < 2) return if (default) .yes else .no;
 
         const config = switch (items[1]) {
+            .string => |style| {
+                if (std.mem.eql(u8, style, "nofunc")) {
+                    return if (std.mem.eql(u8, key, "functions")) .no else if (default) .yes else .no;
+                }
+                return error.UnsupportedRuleConfigValue;
+            },
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -3475,6 +3481,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_use_before_define);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_classes);
+
+    var no_use_before_define_nofunc_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"nofunc\"]",
+        .{},
+    );
+    defer no_use_before_define_nofunc_config.deinit();
+    try options.setByRuleConfigValue("no-use-before-define", no_use_before_define_nofunc_config.value);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.no_use_before_define_check_classes);
 
     var no_undef_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -108,6 +108,45 @@ test "uses configured no-use-before-define function and class checks" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "supports configured no-use-before-define nofunc style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"nofunc\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-use-before-define", config.value);
+    options.eol_last = false;
+    options.no_empty_block_statements = false;
+    options.no_empty_function = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.no_new = false;
+    options.no_var = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.vars_on_top = false;
+    options.typescript_eslint_no_use_before_define = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\f();
+        \\function f() {}
+        \\new C();
+        \\class C {}
+        \\a;
+        \\var a = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "can disable no-use-before-define" {
     const source =
         \\a;


### PR DESCRIPTION
## Summary

- Parse ESLint's legacy `no-use-before-define` `"nofunc"` style.
- Keep class and variable checks enabled while disabling function declaration checks.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig tests/rules/no_use_before_define.zig`
- `git diff --check`
