### PR TITLE
support operator-assignment never style

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -33,6 +33,11 @@ pub const ObjectShorthandStyle = enum {
     never,
 };
 
+pub const OperatorAssignmentStyle = enum {
+    always,
+    never,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -740,6 +745,7 @@ pub const Options = struct {
     object_shorthand_avoid_quotes: bool = false,
     one_var: bool = true,
     operator_assignment: bool = true,
+    operator_assignment_style: OperatorAssignmentStyle = .always,
     eqeqeq: bool = true,
     eqeqeq_style: EqeqeqStyle = .strict,
     use_isnan: bool = true,
@@ -1119,6 +1125,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "object-shorthand")) {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
             self.object_shorthand_avoid_quotes = try objectShorthandAvoidQuotesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "operator-assignment")) {
+            self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -2319,6 +2328,22 @@ pub const Options = struct {
         };
     }
 
+    fn operatorAssignmentStyleFromConfig(value: std.json.Value) RuleConfigError!OperatorAssignmentStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
     fn noUndefTypeofFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3335,6 +3360,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.object_shorthand);
     try std.testing.expectEqual(ObjectShorthandStyle.methods, options.object_shorthand_style);
     try std.testing.expect(options.object_shorthand_avoid_quotes);
+
+    var operator_assignment_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer operator_assignment_config.deinit();
+    try options.setByRuleConfigValue("operator-assignment", operator_assignment_config.value);
+    try std.testing.expect(options.operator_assignment);
+    try std.testing.expectEqual(OperatorAssignmentStyle.never, options.operator_assignment_style);
 
     var prefer_const_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/operator_assignment.zig
+++ b/src/rules/operator_assignment.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "operator-assignment";
 
+pub const Options = struct {
+    style: core.OperatorAssignmentStyle = .always,
+};
+
 const Reference = union(enum) {
     this,
     identifier: []const u8,
@@ -23,6 +27,29 @@ pub fn check(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.style == .never) {
+        if (!isCompoundAssignmentOperator(expression.operator)) return;
+        return core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Assignment operator shorthand is not allowed.",
+            tree.span(index),
+        );
+    }
+
     if (expression.operator != .assign) return;
 
     const binary = switch (tree.data(unwrapTransparent(tree, expression.right))) {
@@ -51,6 +78,25 @@ pub fn check(
         "Assignment can be replaced with operator assignment.",
         tree.span(index),
     );
+}
+
+fn isCompoundAssignmentOperator(operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .add_assign,
+        .subtract_assign,
+        .multiply_assign,
+        .divide_assign,
+        .modulo_assign,
+        .exponent_assign,
+        .left_shift_assign,
+        .right_shift_assign,
+        .unsigned_right_shift_assign,
+        .bitwise_or_assign,
+        .bitwise_xor_assign,
+        .bitwise_and_assign,
+        => true,
+        else => false,
+    };
 }
 
 fn hasAssignmentOperator(operator: ast.BinaryOperator) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2158,7 +2158,9 @@ const BasicVisitor = struct {
             try no_multi_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.operator_assignment) {
-            try operator_assignment.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try operator_assignment.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .style = self.options.operator_assignment_style,
+            });
         }
         if (self.options.logical_assignment_operators) {
             try logical_assignment_operators.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{

--- a/tests/rules/operator_assignment.zig
+++ b/tests/rules/operator_assignment.zig
@@ -59,6 +59,46 @@ test "does not report operator-assignment when shorthand would change the expres
     try std.testing.expect(!helpers.hasRule(result, lint.rules.operator_assignment.id));
 }
 
+test "reports operator-assignment for shorthand when configured never" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_bitwise = false,
+        .no_multi_assign = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("operator-assignment", config.value);
+
+    const source =
+        \\value += amount;
+        \\value -= amount;
+        \\value *= amount;
+        \\value /= amount;
+        \\value %= amount;
+        \\value **= amount;
+        \\value <<= amount;
+        \\value >>= amount;
+        \\value >>>= amount;
+        \\value |= amount;
+        \\value ^= amount;
+        \\value &= amount;
+        \\value = value + amount;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.operator_assignment.id));
+}
+
 test "can disable operator-assignment" {
     const source =
         \\let value = 1;


### PR DESCRIPTION
## Summary

- Parse ESLint's `operator-assignment` style value.
- Preserve the existing default `always` behavior.
- Add `never` behavior that reports compound assignment shorthand operators.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/operator_assignment.zig tests/rules/operator_assignment.zig`
- `git diff --check`
