### PR TITLE
support yoda onlyEquality option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -882,6 +882,7 @@ pub const Options = struct {
     wrap_iife_style: WrapIifeStyle = .outside,
     yoda: bool = true,
     yoda_style: YodaStyle = .never,
+    yoda_only_equality: bool = false,
 
     pub fn allDisabled() Options {
         var options = Options{};
@@ -1161,6 +1162,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "yoda")) {
             self.yoda_style = try yodaStyleFromConfig(value);
+            self.yoda_only_equality = try yodaOnlyEqualityFromConfig(value);
         }
     }
 
@@ -2509,11 +2511,34 @@ pub const Options = struct {
 
         const style = switch (items[1]) {
             .string => |style| style,
+            .object => return .never,
             else => return error.UnsupportedRuleConfigValue,
         };
         if (std.mem.eql(u8, style, "never")) return .never;
         if (std.mem.eql(u8, style, "always")) return .always;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn yodaOnlyEqualityFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config_value = switch (items[1]) {
+            .object => items[1],
+            .string => if (items.len >= 3) items[2] else return false,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const config = switch (config_value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("onlyEquality") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
@@ -3610,6 +3635,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("yoda", yoda_config.value);
     try std.testing.expect(options.yoda);
     try std.testing.expectEqual(YodaStyle.always, options.yoda_style);
+
+    var yoda_only_equality_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\",{\"onlyEquality\":true}]",
+        .{},
+    );
+    defer yoda_only_equality_config.deinit();
+    try options.setByRuleConfigValue("yoda", yoda_only_equality_config.value);
+    try std.testing.expectEqual(YodaStyle.never, options.yoda_style);
+    try std.testing.expect(options.yoda_only_equality);
 
     try std.testing.expectError(
         Options.RuleConfigError.UnsupportedRuleConfigValue,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2270,9 +2270,12 @@ const BasicVisitor = struct {
             try no_path_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.yoda) {
-            try yoda.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, expression, index, switch (self.options.yoda_style) {
-                .never => .never,
-                .always => .always,
+            try yoda.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .style = switch (self.options.yoda_style) {
+                    .never => .never,
+                    .always => .always,
+                },
+                .only_equality = self.options.yoda_only_equality,
             });
         }
         if (self.options.typescript_eslint_no_confusing_non_null_assertion) {

--- a/src/rules/yoda.zig
+++ b/src/rules/yoda.zig
@@ -11,6 +11,11 @@ pub const Style = enum {
     always,
 };
 
+pub const Options = struct {
+    style: Style = .never,
+    only_equality: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -29,18 +34,30 @@ pub fn checkWithStyle(
     index: ast.NodeIndex,
     style: Style,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, expression, index, .{ .style = style });
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (!isComparisonOperator(expression.operator)) return;
+    if (options.only_equality and !isEqualityOperator(expression.operator)) return;
 
     const left_literal = isLiteralLike(tree, expression.left);
     const right_literal = isLiteralLike(tree, expression.right);
-    if (hasExpectedYodaStyle(style, left_literal, right_literal)) return;
+    if (hasExpectedYodaStyle(options.style, left_literal, right_literal)) return;
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        message(style),
+        message(options.style),
         tree.span(index),
     );
 }
@@ -71,6 +88,17 @@ fn isComparisonOperator(operator: ast.BinaryOperator) bool {
         .less_than_or_equal,
         .greater_than,
         .greater_than_or_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isEqualityOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .equal,
+        .not_equal,
+        .strict_equal,
+        .strict_not_equal,
         => true,
         else => false,
     };

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -95,6 +95,37 @@ test "allows yoda always when literals are on the left side or both sides" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.yoda.id));
 }
 
+test "supports configured yoda onlyEquality option" {
+    const source =
+        \\if ("red" === color) {}
+        \\if (0 < count) {}
+        \\if (value >= -1) {}
+    ;
+
+    var options = lint.Options{
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\",{\"onlyEquality\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("yoda", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.yoda.id));
+}
+
 test "can disable yoda" {
     const source =
         \\if ("red" === color) {}


### PR DESCRIPTION
## Summary

- Parse ESLint's `yoda` `onlyEquality` option.
- Preserve the existing `always` / `never` style behavior.
- Skip relational comparisons when `onlyEquality` is enabled.
- Add config parsing and rule behavior coverage.

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/yoda.zig tests/rules/yoda.zig`
- `git diff --check`
