### PR TITLE
support new-cap boolean options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -501,6 +501,8 @@ pub const Options = struct {
     logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
     new_cap: bool = true,
+    new_cap_new_is_cap: bool = true,
+    new_cap_cap_is_new: bool = true,
     new_parens: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
@@ -1005,6 +1007,10 @@ pub const Options = struct {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "new-cap")) {
+            self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
+            self.new_cap_cap_is_new = try newCapBoolOptionFromConfig(value, "capIsNew", true);
+        }
         if (std.mem.eql(u8, cli_name, "no-bitwise")) {
             self.no_bitwise_allow_bitwise_and = try noBitwiseAllowFromConfig(value, "&");
             self.no_bitwise_allow_bitwise_or = try noBitwiseAllowFromConfig(value, "|");
@@ -1503,6 +1509,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enforce) .yes else .no;
+    }
+
+    fn newCapBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noBitwiseAllowFromConfig(value: std.json.Value, expected: []const u8) RuleConfigError!bool {
@@ -3243,6 +3266,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_labels);
     try std.testing.expectEqual(NoLabelsAllowLoop.yes, options.no_labels_allow_loop);
     try std.testing.expectEqual(NoLabelsAllowSwitch.yes, options.no_labels_allow_switch);
+
+    var new_cap_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false}]",
+        .{},
+    );
+    defer new_cap_config.deinit();
+    try options.setByRuleConfigValue("new-cap", new_cap_config.value);
+    try std.testing.expect(options.new_cap);
+    try std.testing.expect(!options.new_cap_new_is_cap);
+    try std.testing.expect(!options.new_cap_cap_is_new);
 
     var no_multi_spaces_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "new-cap";
 
+pub const Options = struct {
+    new_is_cap: bool = true,
+    cap_is_new: bool = true,
+};
+
 pub fn checkNewExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,6 +19,19 @@ pub fn checkNewExpression(
     expression: ast.NewExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkNewExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkNewExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NewExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.new_is_cap) return;
+
     const name = constructorName(tree, expression.callee) orelse return;
     if (nameCase(name) != .lower) return;
 
@@ -34,6 +52,19 @@ pub fn checkCallExpression(
     expression: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkCallExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkCallExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.CallExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.cap_is_new) return;
+
     const callee = unwrapTransparent(tree, expression.callee);
     const name = constructorName(tree, callee) orelse return;
     if (nameCase(name) != .upper) return;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2454,7 +2454,10 @@ const BasicVisitor = struct {
             try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state);
         }
         if (self.options.new_cap) {
-            try new_cap.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+            try new_cap.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, index, .{
+                .new_is_cap = self.options.new_cap_new_is_cap,
+                .cap_is_new = self.options.new_cap_cap_is_new,
+            });
         }
         if (self.options.no_extra_bind) {
             try no_extra_bind.check(self.allocator, self.diagnostics, ctx.tree, call, index);
@@ -2498,7 +2501,10 @@ const BasicVisitor = struct {
             try no_new_require.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.new_cap) {
-            try new_cap.checkNewExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try new_cap.checkNewExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .new_is_cap = self.options.new_cap_new_is_cap,
+                .cap_is_new = self.options.new_cap_cap_is_new,
+            });
         }
         if (self.options.new_parens) {
             try new_parens.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -78,3 +78,30 @@ test "can disable new-cap" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.new_cap.id));
 }
+
+test "supports configured new-cap newIsCap and capIsNew options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("new-cap", config.value);
+    options.no_new = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\new foo();
+        \\Foo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.new_cap.id));
+}


### PR DESCRIPTION
## Summary

- add ESLint-style `new-cap` parsing for `newIsCap` and `capIsNew`
- thread those options into the `new-cap` rule checks
- cover both option parsing and lint behavior with tests

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/new_cap.zig tests/rules/new_cap.zig`
- `git diff --check`
