### PR TITLE
support new-cap properties option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -503,6 +503,7 @@ pub const Options = struct {
     new_cap: bool = true,
     new_cap_new_is_cap: bool = true,
     new_cap_cap_is_new: bool = true,
+    new_cap_properties: bool = true,
     new_parens: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
@@ -1010,6 +1011,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "new-cap")) {
             self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
             self.new_cap_cap_is_new = try newCapBoolOptionFromConfig(value, "capIsNew", true);
+            self.new_cap_properties = try newCapBoolOptionFromConfig(value, "properties", true);
         }
         if (std.mem.eql(u8, cli_name, "no-bitwise")) {
             self.no_bitwise_allow_bitwise_and = try noBitwiseAllowFromConfig(value, "&");
@@ -3270,7 +3272,7 @@ test "Options can apply ESLint-style rule config values" {
     var new_cap_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false}]",
+        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false,\"properties\":false}]",
         .{},
     );
     defer new_cap_config.deinit();
@@ -3278,6 +3280,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.new_cap);
     try std.testing.expect(!options.new_cap_new_is_cap);
     try std.testing.expect(!options.new_cap_cap_is_new);
+    try std.testing.expect(!options.new_cap_properties);
 
     var no_multi_spaces_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -10,6 +10,7 @@ pub const id = "new-cap";
 pub const Options = struct {
     new_is_cap: bool = true,
     cap_is_new: bool = true,
+    properties: bool = true,
 };
 
 pub fn checkNewExpression(
@@ -32,7 +33,7 @@ pub fn checkNewExpressionWithOptions(
 ) Allocator.Error!void {
     if (!options.new_is_cap) return;
 
-    const name = constructorName(tree, expression.callee) orelse return;
+    const name = constructorName(tree, expression.callee, options) orelse return;
     if (nameCase(name) != .lower) return;
 
     try core.addDiagnostic(
@@ -66,7 +67,7 @@ pub fn checkCallExpressionWithOptions(
     if (!options.cap_is_new) return;
 
     const callee = unwrapTransparent(tree, expression.callee);
-    const name = constructorName(tree, callee) orelse return;
+    const name = constructorName(tree, callee, options) orelse return;
     if (nameCase(name) != .upper) return;
     if (isAllowedCallableBuiltin(tree, callee, name)) return;
 
@@ -80,12 +81,12 @@ pub fn checkCallExpressionWithOptions(
     );
 }
 
-fn constructorName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+fn constructorName(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) ?[]const u8 {
     if (index == .null) return null;
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .identifier_reference => |identifier| tree.string(identifier.name),
-        .member_expression => |member| propertyName(tree, member),
+        .member_expression => |member| if (options.properties) propertyName(tree, member) else null,
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2457,6 +2457,7 @@ const BasicVisitor = struct {
             try new_cap.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, index, .{
                 .new_is_cap = self.options.new_cap_new_is_cap,
                 .cap_is_new = self.options.new_cap_cap_is_new,
+                .properties = self.options.new_cap_properties,
             });
         }
         if (self.options.no_extra_bind) {
@@ -2504,6 +2505,7 @@ const BasicVisitor = struct {
             try new_cap.checkNewExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
                 .new_is_cap = self.options.new_cap_new_is_cap,
                 .cap_is_new = self.options.new_cap_cap_is_new,
+                .properties = self.options.new_cap_properties,
             });
         }
         if (self.options.new_parens) {

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -105,3 +105,34 @@ test "supports configured new-cap newIsCap and capIsNew options" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.new_cap.id));
 }
+
+test "supports configured new-cap properties option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"properties\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("new-cap", config.value);
+    options.no_new = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\new foo();
+        \\Foo();
+        \\new namespace.foo();
+        \\namespace.Foo();
+        \\namespace["Foo"]();
+        \\new namespace[`foo`]();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.new_cap.id));
+}


### PR DESCRIPTION
## Summary

- add ESLint-style `new-cap` parsing for `properties`
- skip member-expression constructor/function-name checks when `properties:false`
- cover config parsing and lint behavior with tests

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/new_cap.zig tests/rules/new_cap.zig`
- `git diff --check`
