### PR TITLE
support no-unneeded-ternary defaultAssignment option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -764,6 +764,7 @@ pub const Options = struct {
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
+    no_unneeded_ternary_default_assignment: bool = true,
     no_unused_labels: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
@@ -1199,6 +1200,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-unneeded-ternary")) {
+            self.no_unneeded_ternary_default_assignment = try noUnneededTernaryDefaultAssignmentFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-use-before-define")) {
             self.typescript_eslint_no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", false);
@@ -2490,6 +2494,23 @@ pub const Options = struct {
         };
     }
 
+    fn noUnneededTernaryDefaultAssignmentFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("defaultAssignment") orelse return true) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noVoidAllowAsStatementFromConfig(value: std.json.Value) RuleConfigError!NoVoidAllowAsStatement {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3729,6 +3750,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-undef", no_undef_config.value);
     try std.testing.expect(options.no_undef);
     try std.testing.expect(options.no_undef_typeof);
+
+    var no_unneeded_ternary_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"defaultAssignment\":false}]",
+        .{},
+    );
+    defer no_unneeded_ternary_config.deinit();
+    try options.setByRuleConfigValue("no-unneeded-ternary", no_unneeded_ternary_config.value);
+    try std.testing.expect(options.no_unneeded_ternary);
+    try std.testing.expect(!options.no_unneeded_ternary_default_assignment);
 
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_unneeded_ternary.zig
+++ b/src/rules/no_unneeded_ternary.zig
@@ -1,10 +1,15 @@
 const parser = @import("parser");
 const core = @import("../core.zig");
+const std = @import("std");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-unneeded-ternary";
+
+pub const Options = struct {
+    default_assignment: bool = true,
+};
 
 pub fn check(
     allocator: Allocator,
@@ -13,17 +18,51 @@ pub fn check(
     expression: ast.ConditionalExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    _ = booleanLiteralValue(tree, expression.consequent) orelse return;
-    _ = booleanLiteralValue(tree, expression.alternate) orelse return;
+    return checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (isUnneededBooleanTernary(tree, expression)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary use of boolean literals in conditional expression.",
+            tree.span(index),
+        );
+        return;
+    }
+
+    if (options.default_assignment or !isDefaultAssignment(tree, expression)) return;
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Unnecessary use of boolean literals in conditional expression.",
+        "Unnecessary use of conditional expression for default assignment.",
         tree.span(index),
     );
+}
+
+fn isUnneededBooleanTernary(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {
+    _ = booleanLiteralValue(tree, expression.consequent) orelse return false;
+    _ = booleanLiteralValue(tree, expression.alternate) orelse return false;
+    return true;
+}
+
+fn isDefaultAssignment(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {
+    const test_name = identifierReferenceName(tree, expression.@"test") orelse return false;
+    const consequent_name = identifierReferenceName(tree, expression.consequent) orelse return false;
+    return std.mem.eql(u8, test_name, consequent_name);
 }
 
 fn booleanLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?bool {
@@ -31,6 +70,15 @@ fn booleanLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?bool {
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .boolean_literal => |literal| literal.value,
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1362,7 +1362,9 @@ const BasicVisitor = struct {
             try no_nested_ternary.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_unneeded_ternary) {
-            try no_unneeded_ternary.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_unneeded_ternary.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .default_assignment = self.options.no_unneeded_ternary_default_assignment,
+            });
         }
         if (self.options.no_ternary) {
             try no_ternary.check(self.allocator, self.diagnostics, ctx.tree, index);

--- a/tests/rules/no_unneeded_ternary.zig
+++ b/tests/rules/no_unneeded_ternary.zig
@@ -40,6 +40,35 @@ test "does not report no-unneeded-ternary for non-boolean branches or default as
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unneeded_ternary.id));
 }
 
+test "supports configured no-unneeded-ternary defaultAssignment false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"defaultAssignment\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unneeded-ternary", config.value);
+    options.no_ternary = false;
+    options.no_constant_condition = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const first = enabled ? enabled : fallback;
+        \\const second = (ready) ? (ready) : fallback;
+        \\const third = enabled ? value : enabled;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unneeded_ternary.id));
+}
+
 test "can disable no-unneeded-ternary" {
     const source =
         \\const value = enabled ? true : false;


### PR DESCRIPTION
## Summary

- add ESLint-style `no-unneeded-ternary` parsing for `defaultAssignment`
- report `condition ? condition : fallback` when `defaultAssignment:false`
- cover option parsing and lint behavior with tests

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_unneeded_ternary.zig tests/rules/no_unneeded_ternary.zig`
- `git diff --check`
