### PR TITLE
support method signature style option

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -468,6 +468,11 @@ pub const YodaStyle = enum {
     always,
 };
 
+pub const TypescriptEslintMethodSignatureStyle = enum {
+    property,
+    method,
+};
+
 pub const PreferConstDestructuring = enum {
     any,
     all,
@@ -884,6 +889,7 @@ pub const Options = struct {
     typescript_eslint_explicit_member_accessibility: bool = true,
     typescript_eslint_member_ordering: bool = true,
     typescript_eslint_method_signature_style: bool = true,
+    typescript_eslint_method_signature_style_style: TypescriptEslintMethodSignatureStyle = .property,
     typescript_eslint_no_confusing_non_null_assertion: bool = true,
     typescript_eslint_no_empty_function: bool = true,
     typescript_eslint_no_empty_function_allow: NoEmptyFunctionAllow = .{},
@@ -1192,6 +1198,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/method-signature-style")) {
+            self.typescript_eslint_method_signature_style_style = try typescriptEslintMethodSignatureStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
@@ -2687,6 +2696,22 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn typescriptEslintMethodSignatureStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintMethodSignatureStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .property,
+        };
+        if (items.len < 2) return .property;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "property")) return .property;
+        if (std.mem.eql(u8, style, "method")) return .method;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1602,7 +1602,14 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_method_signature_style) {
-            try typescript_eslint_method_signature_style.check(self.allocator, self.diagnostics, ctx.tree, signature, index);
+            try typescript_eslint_method_signature_style.checkMethodSignature(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                signature,
+                index,
+                self.options.typescript_eslint_method_signature_style_style,
+            );
         }
         return .proceed;
     }
@@ -1633,6 +1640,16 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_typedef) {
             try typescript_eslint_typedef.checkPropertySignature(self.allocator, self.diagnostics, ctx.tree, signature, index);
+        }
+        if (self.options.typescript_eslint_method_signature_style) {
+            try typescript_eslint_method_signature_style.checkPropertySignature(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                signature,
+                index,
+                self.options.typescript_eslint_method_signature_style_style,
+            );
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_method_signature_style.zig
+++ b/src/rules/typescript_eslint_method_signature_style.zig
@@ -6,13 +6,15 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/method-signature-style";
 
-pub fn check(
+pub fn checkMethodSignature(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     signature: ast.TSMethodSignature,
     index: ast.NodeIndex,
+    style: core.TypescriptEslintMethodSignatureStyle,
 ) Allocator.Error!void {
+    if (style != .property) return;
     if (signature.kind != .method) return;
 
     try core.addDiagnostic(
@@ -23,4 +25,39 @@ pub fn check(
         "Shorthand method signature is forbidden. Use a function property instead.",
         tree.span(index),
     );
+}
+
+pub fn checkPropertySignature(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    signature: ast.TSPropertySignature,
+    index: ast.NodeIndex,
+    style: core.TypescriptEslintMethodSignatureStyle,
+) Allocator.Error!void {
+    if (style != .method) return;
+    if (!isFunctionPropertySignature(tree, signature)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Function property signature is forbidden. Use a method signature instead.",
+        tree.span(index),
+    );
+}
+
+fn isFunctionPropertySignature(tree: *const ast.Tree, signature: ast.TSPropertySignature) bool {
+    if (signature.type_annotation == .null) return false;
+
+    const type_index = switch (tree.data(signature.type_annotation)) {
+        .ts_type_annotation => |annotation| annotation.type_annotation,
+        else => return false,
+    };
+
+    return switch (tree.data(type_index)) {
+        .ts_function_type => true,
+        else => false,
+    };
 }

--- a/tests/rules/typescript_eslint_method_signature_style.zig
+++ b/tests/rules/typescript_eslint_method_signature_style.zig
@@ -51,6 +51,59 @@ test "allows @typescript-eslint/method-signature-style property and non-method s
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_method_signature_style.id));
 }
 
+test "reports @typescript-eslint/method-signature-style function properties when configured method" {
+    const source =
+        \\interface Service {
+        \\  start: () => void;
+        \\  optional?: <T>(value: T) => T;
+        \\  value: string;
+        \\  run(input: string): void;
+        \\}
+        \\type Handler = {
+        \\  readonly handle: (input: string) => void;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_method_signature_style_style = .method,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_method_signature_style.id));
+}
+
+test "supports configured @typescript-eslint/method-signature-style method style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", "method"]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+    try options.setByRuleConfigValue("@typescript-eslint/method-signature-style", config.value);
+
+    const source =
+        \\interface Service {
+        \\  start: () => void;
+        \\  run(): void;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_method_signature_style.id));
+}
+
 test "can disable @typescript-eslint/method-signature-style" {
     const source =
         \\interface Service {


### PR DESCRIPTION
## Summary
- add the `@typescript-eslint/method-signature-style` `method` option
- report function property signatures when method style is configured
- keep the existing default `property` behavior and add regression coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_method_signature_style.zig tests/rules/typescript_eslint_method_signature_style.zig`
- `git diff --check`
