### PR TITLE
support class literal getters style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -249,7 +249,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
-| [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for fishlint's `fields` configuration |
+| [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |
 | [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Implemented for fishlint's `assertionStyle: as, objectLiteralTypeAssertions: never` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -473,6 +473,11 @@ pub const TypescriptEslintMethodSignatureStyle = enum {
     method,
 };
 
+pub const TypescriptEslintClassLiteralPropertyStyle = enum {
+    fields,
+    getters,
+};
+
 pub const PreferConstDestructuring = enum {
     any,
     all,
@@ -880,6 +885,7 @@ pub const Options = struct {
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
     typescript_eslint_class_literal_property_style: bool = true,
+    typescript_eslint_class_literal_property_style_style: TypescriptEslintClassLiteralPropertyStyle = .fields,
     typescript_eslint_consistent_type_assertions: bool = true,
     typescript_eslint_consistent_type_definitions: bool = true,
     typescript_eslint_no_array_constructor: bool = true,
@@ -1194,6 +1200,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "operator-assignment")) {
             self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
+            self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -2711,6 +2720,22 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "property")) return .property;
         if (std.mem.eql(u8, style, "method")) return .method;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintClassLiteralPropertyStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintClassLiteralPropertyStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .fields,
+        };
+        if (items.len < 2) return .fields;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "fields")) return .fields;
+        if (std.mem.eql(u8, style, "getters")) return .getters;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2951,7 +2951,14 @@ const BasicVisitor = struct {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
         }
         if (self.options.typescript_eslint_class_literal_property_style) {
-            try typescript_eslint_class_literal_property_style.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+            try typescript_eslint_class_literal_property_style.checkMethodDefinition(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                method,
+                index,
+                self.options.typescript_eslint_class_literal_property_style_style,
+            );
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index, ctx);
@@ -2998,6 +3005,16 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+        }
+        if (self.options.typescript_eslint_class_literal_property_style) {
+            try typescript_eslint_class_literal_property_style.checkPropertyDefinition(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                property,
+                index,
+                self.options.typescript_eslint_class_literal_property_style_style,
+            );
         }
         if (self.options.func_name_matching) {
             try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{

--- a/src/rules/typescript_eslint_class_literal_property_style.zig
+++ b/src/rules/typescript_eslint_class_literal_property_style.zig
@@ -12,7 +12,9 @@ pub fn checkMethodDefinition(
     tree: *const ast.Tree,
     method: ast.MethodDefinition,
     index: ast.NodeIndex,
+    style: core.TypescriptEslintClassLiteralPropertyStyle,
 ) Allocator.Error!void {
+    if (style != .fields) return;
     if (method.kind != .get) return;
     if (!getterReturnsSingleLiteral(tree, method)) return;
 
@@ -22,6 +24,28 @@ pub fn checkMethodDefinition(
         .warning,
         id,
         "Literals should be exposed using readonly fields.",
+        tree.span(index),
+    );
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    index: ast.NodeIndex,
+    style: core.TypescriptEslintClassLiteralPropertyStyle,
+) Allocator.Error!void {
+    if (style != .getters) return;
+    if (!property.readonly) return;
+    if (!isLiteral(tree, property.value)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Literals should be exposed using getters.",
         tree.span(index),
     );
 }

--- a/tests/rules/typescript_eslint_class_literal_property_style.zig
+++ b/tests/rules/typescript_eslint_class_literal_property_style.zig
@@ -65,6 +65,63 @@ test "allows @typescript-eslint/class-literal-property-style non-literal and non
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
 }
 
+test "reports @typescript-eslint/class-literal-property-style readonly literal fields when configured getters" {
+    const source =
+        \\class Example {
+        \\  readonly name = "fish";
+        \\  static readonly count = 1;
+        \\  readonly enabled = true;
+        \\  readonly pattern = /fish/;
+        \\  readonly dynamic = compute();
+        \\  mutable = "fish";
+        \\  get title() {
+        \\    return "fish";
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_class_literal_property_style_style = .getters,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
+}
+
+test "supports configured @typescript-eslint/class-literal-property-style getters style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", "getters"]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+    try options.setByRuleConfigValue("@typescript-eslint/class-literal-property-style", config.value);
+
+    const source =
+        \\class Example {
+        \\  readonly name = "fish";
+        \\  get title() {
+        \\    return "fish";
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_class_literal_property_style.id));
+}
+
 test "can disable @typescript-eslint/class-literal-property-style" {
     const source =
         \\class Example {


### PR DESCRIPTION
## Summary
- add the `@typescript-eslint/class-literal-property-style` `getters` option
- report readonly literal class fields when getter style is configured
- keep the existing default `fields` behavior and update rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_class_literal_property_style.zig tests/rules/typescript_eslint_class_literal_property_style.zig`
- `git diff --check`
