### PR TITLE
support no-invalid-regexp allowed flags

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -83,7 +83,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |
 | [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Implemented |
-| [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) | Implemented |
+| [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) | Implemented with optional `allowConstructorFlags` behavior |
 | [`no-irregular-whitespace`](https://eslint.org/docs/latest/rules/no-irregular-whitespace) | Implemented |
 | [`no-iterator`](https://eslint.org/docs/latest/rules/no-iterator) | Implemented |
 | [`no-label-var`](https://eslint.org/docs/latest/rules/no-label-var) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -140,6 +140,20 @@ pub const NoFallthroughAllowEmptyCase = enum {
     no,
 };
 
+pub const NoInvalidRegexpAllowConstructorFlags = struct {
+    flags: [256]bool = [_]bool{false} ** 256,
+
+    pub fn contains(self: NoInvalidRegexpAllowConstructorFlags, flag: u8) bool {
+        return self.flags[flag];
+    }
+
+    pub fn enable(self: *NoInvalidRegexpAllowConstructorFlags, flag: []const u8) bool {
+        if (flag.len != 1) return false;
+        self.flags[flag[0]] = true;
+        return true;
+    }
+};
+
 pub const NoMultiSpacesIgnoreEOLComments = enum {
     yes,
     no,
@@ -689,6 +703,7 @@ pub const Options = struct {
     jsx_a11y_role_supports_aria_props: bool = true,
     jsx_a11y_scope: bool = true,
     no_invalid_regexp: bool = true,
+    no_invalid_regexp_allow_constructor_flags: NoInvalidRegexpAllowConstructorFlags = .{},
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,
     no_inner_declarations: bool = true,
@@ -1122,6 +1137,9 @@ pub const Options = struct {
             self.no_implicit_coercion_allow_unary_plus = try noImplicitCoercionAllowFromConfig(value, "+");
             self.no_implicit_coercion_allow_multiply = try noImplicitCoercionAllowFromConfig(value, "*");
             self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
+        }
+        if (std.mem.eql(u8, cli_name, "no-invalid-regexp")) {
+            self.no_invalid_regexp_allow_constructor_flags = try noInvalidRegexpAllowConstructorFlagsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-labels")) {
             self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
@@ -1674,6 +1692,34 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noInvalidRegexpAllowConstructorFlagsFromConfig(value: std.json.Value) RuleConfigError!NoInvalidRegexpAllowConstructorFlags {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allowConstructorFlags") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow: NoInvalidRegexpAllowConstructorFlags = .{};
+        for (allow_items) |item| {
+            const flag = switch (item) {
+                .string => |flag| flag,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!allow.enable(flag)) return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn isNoBitwiseOperatorToken(operator: []const u8) bool {

--- a/src/rules/no_invalid_regexp.zig
+++ b/src/rules/no_invalid_regexp.zig
@@ -8,15 +8,29 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-invalid-regexp";
 
+pub const Options = struct {
+    allow_constructor_flags: core.NoInvalidRegexpAllowConstructorFlags = .{},
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -25,6 +39,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -59,7 +74,7 @@ const Visitor = struct {
 
         const flags = if (arguments.len >= 2) stringLiteralValue(tree, arguments[1]) else null;
         if (flags) |value| {
-            if (validateFlags(value)) |message| {
+            if (validateFlags(value, self.options.allow_constructor_flags)) |message| {
                 try self.addDiagnostic(tree, index, message);
                 return;
             }
@@ -88,10 +103,12 @@ const Visitor = struct {
     }
 };
 
-fn validateFlags(flags: []const u8) ?[]const u8 {
+fn validateFlags(flags: []const u8, allow_constructor_flags: core.NoInvalidRegexpAllowConstructorFlags) ?[]const u8 {
     var seen: u32 = 0;
 
     for (flags) |flag| {
+        if (allow_constructor_flags.contains(flag)) continue;
+
         const valid = switch (flag) {
             'd', 'g', 'i', 'm', 's', 'u', 'v', 'y' => true,
             else => false,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -777,7 +777,9 @@ pub fn runSemantic(
     }
 
     if (options.no_invalid_regexp) {
-        try no_invalid_regexp.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_invalid_regexp.runWithOptions(allocator, diagnostics, tree, .{
+            .allow_constructor_flags = options.no_invalid_regexp_allow_constructor_flags,
+        });
     }
 
     if (options.no_regex_spaces) {

--- a/tests/rules/no_invalid_regexp.zig
+++ b/tests/rules/no_invalid_regexp.zig
@@ -62,6 +62,37 @@ test "does not report no-invalid-regexp for valid or non-static RegExp calls" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_regexp.id));
 }
 
+test "supports configured no-invalid-regexp allowConstructorFlags" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowConstructorFlags\":[\"z\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .prefer_regex_literals = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-invalid-regexp", config.value);
+
+    const source =
+        \\RegExp("abc", "z");
+        \\RegExp("abc", "zz");
+        \\RegExp("abc", "gz");
+        \\RegExp("abc", "q");
+        \\RegExp("abc", "Z");
+        \\RegExp("abc", "uv");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_invalid_regexp.id));
+}
+
 test "can disable no-invalid-regexp" {
     const source =
         \\RegExp("(", "g");


### PR DESCRIPTION
## Summary
- add `no-invalid-regexp` support for `allowConstructorFlags`
- skip explicitly allowed constructor flags while preserving standard duplicate and incompatible flag checks
- update rule status documentation and add regression coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_invalid_regexp.zig tests/rules/no_invalid_regexp.zig`
- `git diff --check`
