### PR TITLE
support jsx boolean always style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -221,7 +221,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
-| [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for fishlint's `never` configuration |
+| [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Implemented for eslint-plugin-react's default link configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -460,6 +460,11 @@ pub const LogicalAssignmentOperatorsStyle = enum {
     never,
 };
 
+pub const ReactJsxBooleanValueStyle = enum {
+    never,
+    always,
+};
+
 pub const FuncNamesStyle = enum {
     always,
     as_needed,
@@ -851,6 +856,7 @@ pub const Options = struct {
     react_default_props_match_prop_types: bool = true,
     react_display_name: bool = true,
     react_jsx_boolean_value: bool = true,
+    react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
@@ -1218,6 +1224,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "operator-assignment")) {
             self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
+            self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
@@ -2694,6 +2703,22 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "always")) return .always;
         if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn reactJsxBooleanValueStyleFromConfig(value: std.json.Value) RuleConfigError!ReactJsxBooleanValueStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .never,
+        };
+        if (items.len < 2) return .never;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "never")) return .never;
+        if (std.mem.eql(u8, style, "always")) return .always;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/react_jsx_boolean_value.zig
+++ b/src/rules/react_jsx_boolean_value.zig
@@ -14,8 +14,34 @@ pub fn check(
     attribute: ast.JSXAttribute,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithStyle(allocator, diagnostics, tree, attribute, index, .never);
+}
+
+pub fn checkWithStyle(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    attribute: ast.JSXAttribute,
+    index: ast.NodeIndex,
+    style: core.ReactJsxBooleanValueStyle,
+) Allocator.Error!void {
     const name = attributeName(tree, attribute.name) orelse return;
-    if (!isExplicitTrue(tree, attribute.value)) return;
+    if (style == .never) {
+        if (!isExplicitTrue(tree, attribute.value)) return;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            "Value must be omitted for boolean attribute `{s}`",
+            .{name},
+        );
+        return;
+    }
+
+    if (attribute.value != .null) return;
 
     try core.addDiagnosticFmt(
         allocator,
@@ -23,7 +49,7 @@ pub fn check(
         .@"error",
         id,
         tree.span(index),
-        "Value must be omitted for boolean attribute `{s}`",
+        "Value must be set for boolean attribute `{s}`",
         .{name},
     );
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2661,7 +2661,14 @@ const BasicVisitor = struct {
             try react_no_danger.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));
         }
         if (self.options.react_jsx_boolean_value) {
-            try react_jsx_boolean_value.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+            try react_jsx_boolean_value.checkWithStyle(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                attribute,
+                index,
+                self.options.react_jsx_boolean_value_style,
+            );
         }
         if (self.options.react_style_prop_object) {
             try react_style_prop_object.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1), &self.react_style_prop_object_bindings);

--- a/tests/rules/react_jsx_boolean_value.zig
+++ b/tests/rules/react_jsx_boolean_value.zig
@@ -35,6 +35,52 @@ test "allows omitted false and non-boolean JSX attribute values" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_boolean_value.id));
 }
 
+test "reports react/jsx-boolean-value for omitted values when configured always" {
+    const source =
+        \\const node = <Widget disabled checked={true} label="ok" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .react_jsx_boolean_value_style = .always,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_boolean_value.id));
+    try std.testing.expectEqualStrings("Value must be set for boolean attribute `disabled`", result.diagnostics[0].message);
+}
+
+test "supports configured react/jsx-boolean-value always style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", "always"]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-boolean-value", config.value);
+
+    const source =
+        \\const node = <Widget disabled checked={true} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_boolean_value.id));
+}
+
 test "can disable react/jsx-boolean-value" {
     const source =
         \\const node = <Widget disabled={true} />;


### PR DESCRIPTION
## Summary
- add `react/jsx-boolean-value` support for the `always` style
- keep the existing default `never` behavior for explicit `true` attributes
- update rule status documentation and add regression coverage for config parsing

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_boolean_value.zig tests/rules/react_jsx_boolean_value.zig`
- `git diff --check`
