### PR TITLE
support jsx duplicate props ignore case option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -223,7 +223,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
-| [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented for fishlint's `ignoreCase: true` configuration |
+| [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Implemented for eslint-plugin-react's default link configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -859,6 +859,7 @@ pub const Options = struct {
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
     react_jsx_no_duplicate_props: bool = true,
+    react_jsx_no_duplicate_props_ignore_case: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
     react_jsx_no_bind: bool = true,
     react_jsx_key: bool = true,
@@ -1227,6 +1228,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-no-duplicate-props")) {
+            self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
@@ -2720,6 +2724,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "never")) return .never;
         if (std.mem.eql(u8, style, "always")) return .always;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("ignoreCase") orelse return true) {
+            .bool => |ignore_case| ignore_case,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn wrapIifeStyleFromConfig(value: std.json.Value) RuleConfigError!WrapIifeStyle {

--- a/src/rules/react_jsx_no_duplicate_props.zig
+++ b/src/rules/react_jsx_no_duplicate_props.zig
@@ -7,11 +7,25 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-no-duplicate-props";
 
+pub const Options = struct {
+    ignore_case: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
+) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, opening, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    options: Options,
 ) Allocator.Error!void {
     var seen: std.ArrayList([]const u8) = .empty;
     defer seen.deinit(allocator);
@@ -23,7 +37,7 @@ pub fn check(
         };
         const name = attributeName(tree, attribute.name) orelse continue;
 
-        if (containsIgnoreCase(seen.items, name)) {
+        if (containsName(seen.items, name, options.ignore_case)) {
             try core.addDiagnostic(
                 allocator,
                 diagnostics,
@@ -46,9 +60,9 @@ fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
     };
 }
 
-fn containsIgnoreCase(items: []const []const u8, name: []const u8) bool {
+fn containsName(items: []const []const u8, name: []const u8, ignore_case: bool) bool {
     for (items) |item| {
-        if (std.ascii.eqlIgnoreCase(item, name)) return true;
+        if (if (ignore_case) std.ascii.eqlIgnoreCase(item, name) else std.mem.eql(u8, item, name)) return true;
     }
     return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2740,7 +2740,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_duplicate_props) {
-            try react_jsx_no_duplicate_props.check(self.allocator, self.diagnostics, ctx.tree, opening);
+            try react_jsx_no_duplicate_props.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, .{
+                .ignore_case = self.options.react_jsx_no_duplicate_props_ignore_case,
+            });
         }
         if (self.options.jsx_a11y_alt_text) {
             try jsx_a11y_alt_text.checkOpeningElement(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/rules/react_jsx_no_duplicate_props.zig
+++ b/tests/rules/react_jsx_no_duplicate_props.zig
@@ -36,6 +36,34 @@ test "ignores spread attributes and distinct JSX props" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_duplicate_props.id));
 }
 
+test "supports configured react/jsx-no-duplicate-props ignoreCase false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreCase\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .react_jsx_boolean_value = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-no-duplicate-props", config.value);
+
+    const source =
+        \\const node = <Widget name="a" Name="b" enabled enabled={true} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_duplicate_props.id));
+}
+
 test "can disable react/jsx-no-duplicate-props" {
     const source =
         \\const node = <Widget name="a" name="b" />;


### PR DESCRIPTION
## Summary
- add `react/jsx-no-duplicate-props` support for the `ignoreCase` option
- keep the fishlint-compatible default `ignoreCase: true`
- update rule status documentation and add regression coverage for `ignoreCase: false`

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_no_duplicate_props.zig tests/rules/react_jsx_no_duplicate_props.zig`
- `git diff --check`
