### PR TITLE
support jsx pascal case allow all caps option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -225,7 +225,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Implemented for eslint-plugin-react's default link configuration |
-| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented for fishlint's `allowAllCaps: true, ignore: []` configuration |
+| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented with configurable `allowAllCaps` behavior |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -868,6 +868,7 @@ pub const Options = struct {
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
+    react_jsx_pascal_case_allow_all_caps: bool = true,
     react_jsx_uses_react: bool = true,
     react_jsx_uses_vars: bool = true,
     react_no_danger: bool = true,
@@ -1231,6 +1232,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-duplicate-props")) {
             self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
+            self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
@@ -2739,6 +2743,23 @@ pub const Options = struct {
         };
         return switch (config.get("ignoreCase") orelse return true) {
             .bool => |ignore_case| ignore_case,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn reactJsxPascalCaseAllowAllCapsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowAllCaps") orelse return true) {
+            .bool => |allow_all_caps| allow_all_caps,
             else => error.UnsupportedRuleConfigValue,
         };
     }

--- a/src/rules/react_jsx_pascal_case.zig
+++ b/src/rules/react_jsx_pascal_case.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-pascal-case";
 
+pub const Options = struct {
+    allow_all_caps: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,9 +18,20 @@ pub fn check(
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, opening, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (isDomComponent(tree, opening.name)) return;
 
-    const invalid_name = invalidNamePart(tree, opening.name) orelse return;
+    const invalid_name = invalidNamePart(tree, opening.name, options) orelse return;
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
@@ -42,20 +57,20 @@ fn firstNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
     };
 }
 
-fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Options) ?[]const u8 {
     switch (tree.data(name_index)) {
         .jsx_identifier => |identifier| {
             const name = tree.string(identifier.name);
             if (name.len == 1) return null;
-            return if (isPascalCase(name) or isAllCaps(name)) null else name;
+            return if (isPascalCase(name) or (options.allow_all_caps and isAllCaps(name))) null else name;
         },
         .jsx_namespaced_name => |name| {
-            if (invalidNamePart(tree, name.namespace)) |invalid| return invalid;
-            return invalidNamePart(tree, name.name);
+            if (invalidNamePart(tree, name.namespace, options)) |invalid| return invalid;
+            return invalidNamePart(tree, name.name, options);
         },
         .jsx_member_expression => |member| {
-            if (invalidNamePart(tree, member.object)) |invalid| return invalid;
-            return invalidNamePart(tree, member.property);
+            if (invalidNamePart(tree, member.object, options)) |invalid| return invalid;
+            return invalidNamePart(tree, member.property, options);
         },
         else => return null,
     }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2781,7 +2781,9 @@ const BasicVisitor = struct {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_pascal_case) {
-            try react_jsx_pascal_case.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+            try react_jsx_pascal_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
+                .allow_all_caps = self.options.react_jsx_pascal_case_allow_all_caps,
+            });
         }
         if (self.options.react_self_closing_comp) {
             try react_self_closing_comp.check(self.allocator, self.diagnostics, ctx.tree, opening, index, ctx.path.ancestor(1));

--- a/tests/rules/react_jsx_pascal_case.zig
+++ b/tests/rules/react_jsx_pascal_case.zig
@@ -38,6 +38,34 @@ test "allows DOM tags pascal case and screaming snake case components" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_pascal_case.id));
 }
 
+test "supports configured react/jsx-pascal-case allowAllCaps false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAllCaps\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-pascal-case", config.value);
+
+    const source =
+        \\const caps = <FOO_BAR><FOO.BAR /></FOO_BAR>;
+        \\const pascal = <FooBar><Foo.Bar /></FooBar>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
+}
+
 test "can disable react/jsx-pascal-case" {
     const source =
         \\const node = <Foo.bar />;


### PR DESCRIPTION
## Summary
- add `react/jsx-pascal-case` support for the `allowAllCaps` option
- keep the fishlint-compatible default `allowAllCaps: true`
- update rule status documentation and add regression coverage for `allowAllCaps: false`

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_pascal_case.zig tests/rules/react_jsx_pascal_case.zig`
- `git diff --check`
