### PR TITLE
support consistent type definitions type style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -251,7 +251,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |
 | [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Implemented for fishlint's `assertionStyle: as, objectLiteralTypeAssertions: never` configuration |
-| [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for fishlint's `interface` configuration |
+| [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for `interface` and `type` configurations |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |
 | [`@typescript-eslint/member-ordering`](https://typescript-eslint.io/rules/member-ordering/) | Implemented for fishlint's default class member ordering |

--- a/src/core.zig
+++ b/src/core.zig
@@ -492,6 +492,11 @@ pub const TypescriptEslintMethodSignatureStyle = enum {
     method,
 };
 
+pub const TypescriptEslintConsistentTypeDefinitionsStyle = enum {
+    interface,
+    type,
+};
+
 pub const TypescriptEslintClassLiteralPropertyStyle = enum {
     fields,
     getters,
@@ -911,6 +916,7 @@ pub const Options = struct {
     typescript_eslint_class_literal_property_style_style: TypescriptEslintClassLiteralPropertyStyle = .fields,
     typescript_eslint_consistent_type_assertions: bool = true,
     typescript_eslint_consistent_type_definitions: bool = true,
+    typescript_eslint_consistent_type_definitions_style: TypescriptEslintConsistentTypeDefinitionsStyle = .interface,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
@@ -1238,6 +1244,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/consistent-type-definitions")) {
+            self.typescript_eslint_consistent_type_definitions_style = try typescriptEslintConsistentTypeDefinitionsStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -2833,6 +2842,22 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "property")) return .property;
         if (std.mem.eql(u8, style, "method")) return .method;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintConsistentTypeDefinitionsStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintConsistentTypeDefinitionsStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .interface,
+        };
+        if (items.len < 2) return .interface;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "interface")) return .interface;
+        if (std.mem.eql(u8, style, "type")) return .type;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1555,6 +1555,15 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkInterfaceDeclaration(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
         }
+        if (self.options.typescript_eslint_consistent_type_definitions) {
+            try typescript_eslint_consistent_type_definitions.checkInterfaceDeclaration(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                interface_declaration,
+                self.options.typescript_eslint_consistent_type_definitions_style,
+            );
+        }
         return .proceed;
     }
 
@@ -1565,8 +1574,15 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_consistent_type_definitions) {
-            try typescript_eslint_consistent_type_definitions.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+            try typescript_eslint_consistent_type_definitions.checkTypeAliasDeclaration(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                declaration,
+                self.options.typescript_eslint_consistent_type_definitions_style,
+            );
         }
+        _ = index;
         return .proceed;
     }
 

--- a/src/rules/typescript_eslint_consistent_type_definitions.zig
+++ b/src/rules/typescript_eslint_consistent_type_definitions.zig
@@ -6,15 +6,14 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/consistent-type-definitions";
 
-pub fn check(
+pub fn checkTypeAliasDeclaration(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     declaration: ast.TSTypeAliasDeclaration,
-    index: ast.NodeIndex,
+    style: core.TypescriptEslintConsistentTypeDefinitionsStyle,
 ) Allocator.Error!void {
-    _ = index;
-
+    if (style != .interface) return;
     if (tree.data(declaration.type_annotation) != .ts_type_literal) return;
 
     try core.addDiagnostic(
@@ -23,6 +22,25 @@ pub fn check(
         .warning,
         id,
         "Use an interface instead of a type.",
+        tree.span(declaration.id),
+    );
+}
+
+pub fn checkInterfaceDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.TSInterfaceDeclaration,
+    style: core.TypescriptEslintConsistentTypeDefinitionsStyle,
+) Allocator.Error!void {
+    if (style != .type) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Use a type instead of an interface.",
         tree.span(declaration.id),
     );
 }

--- a/tests/rules/typescript_eslint_consistent_type_definitions.zig
+++ b/tests/rules/typescript_eslint_consistent_type_definitions.zig
@@ -46,6 +46,62 @@ test "does not report @typescript-eslint/consistent-type-definitions for non-obj
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
 }
 
+test "reports @typescript-eslint/consistent-type-definitions for interfaces when configured type" {
+    const source =
+        \\interface User {
+        \\  name: string;
+        \\}
+        \\interface Service<T> extends User {
+        \\  get(value: T): string;
+        \\}
+        \\type ObjectAlias = {
+        \\  value: string;
+        \\};
+        \\type Id = string | number;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_definitions_style = .type,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
+}
+
+test "supports configured @typescript-eslint/consistent-type-definitions type style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", "type"]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+    try options.setByRuleConfigValue("@typescript-eslint/consistent-type-definitions", config.value);
+
+    const source =
+        \\interface User {
+        \\  name: string;
+        \\}
+        \\type ObjectAlias = {
+        \\  value: string;
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_definitions.id));
+}
+
 test "can disable @typescript-eslint/consistent-type-definitions" {
     const source =
         \\type User = {


### PR DESCRIPTION
## Summary
- Support the `"type"` option for `@typescript-eslint/consistent-type-definitions`.
- Report interface declarations when the rule is configured for type aliases.
- Keep the existing default `interface` behavior for object type aliases.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_consistent_type_definitions.zig tests/rules/typescript_eslint_consistent_type_definitions.zig`
- `git diff --check`
