### PR TITLE
support no namespace options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -268,7 +268,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Implemented |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
-| [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for fishlint's `allowDeclarations: true, allowDefinitionFiles: true` configuration |
+| [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -939,6 +939,8 @@ pub const Options = struct {
     typescript_eslint_no_misused_new: bool = true,
     typescript_eslint_no_non_null_asserted_optional_chain: bool = true,
     typescript_eslint_no_namespace: bool = true,
+    typescript_eslint_no_namespace_allow_declarations: bool = true,
+    typescript_eslint_no_namespace_allow_definition_files: bool = true,
     typescript_eslint_no_redeclare: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
@@ -1254,6 +1256,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/method-signature-style")) {
             self.typescript_eslint_method_signature_style_style = try typescriptEslintMethodSignatureStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-namespace")) {
+            self.typescript_eslint_no_namespace_allow_declarations = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDeclarations", true);
+            self.typescript_eslint_no_namespace_allow_definition_files = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDefinitionFiles", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
@@ -2875,6 +2881,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "fields")) return .fields;
         if (std.mem.eql(u8, style, "getters")) return .getters;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintNoNamespaceBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {

--- a/src/root.zig
+++ b/src/root.zig
@@ -32,7 +32,7 @@ pub fn lintSourceWithIo(
     errdefer core.freeDiagnostics(allocator, &diagnostics);
 
     var effective_options = options;
-    if (isDefinitionFile(path)) {
+    if (isDefinitionFile(path) and effective_options.typescript_eslint_no_namespace_allow_definition_files) {
         effective_options.typescript_eslint_no_namespace = false;
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1754,7 +1754,14 @@ const BasicVisitor = struct {
             try typescript_eslint_prefer_namespace_keyword.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         if (self.options.typescript_eslint_no_namespace) {
-            try typescript_eslint_no_namespace.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+            try typescript_eslint_no_namespace.check(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                declaration,
+                index,
+                self.options.typescript_eslint_no_namespace_allow_declarations,
+            );
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_namespace.zig
+++ b/src/rules/typescript_eslint_no_namespace.zig
@@ -12,8 +12,9 @@ pub fn check(
     tree: *const ast.Tree,
     declaration: ast.TSModuleDeclaration,
     index: ast.NodeIndex,
+    allow_declarations: bool,
 ) Allocator.Error!void {
-    if (declaration.declare) return;
+    if (allow_declarations and declaration.declare) return;
 
     try core.addDiagnostic(
         allocator,

--- a/tests/rules/typescript_eslint_no_namespace.zig
+++ b/tests/rules/typescript_eslint_no_namespace.zig
@@ -47,6 +47,27 @@ test "allows declare namespaces and modules" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_namespace.id));
 }
 
+test "reports declare namespaces when allowDeclarations is false" {
+    const source =
+        \\declare namespace Internal {
+        \\  export const value: number;
+        \\}
+        \\declare module "external" {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .typescript_eslint_no_namespace_allow_declarations = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}
+
 test "allows namespaces in definition files" {
     const source =
         \\namespace Internal {
@@ -62,6 +83,42 @@ test "allows namespaces in definition files" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}
+
+test "reports namespaces in definition files when allowDefinitionFiles is false" {
+    const source =
+        \\namespace Internal {
+        \\  export const value: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.d.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_prefer_namespace_keyword = false,
+        .typescript_eslint_no_namespace_allow_definition_files = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_namespace.id));
+}
+
+test "supports configured @typescript-eslint/no-namespace options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"allowDeclarations": false, "allowDefinitionFiles": false}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-namespace", config.value);
+
+    try std.testing.expect(options.typescript_eslint_no_namespace);
+    try std.testing.expect(!options.typescript_eslint_no_namespace_allow_declarations);
+    try std.testing.expect(!options.typescript_eslint_no_namespace_allow_definition_files);
 }
 
 test "can disable @typescript-eslint/no-namespace" {


### PR DESCRIPTION
## Summary
- Support `allowDeclarations` for `@typescript-eslint/no-namespace`.
- Support `allowDefinitionFiles` so `.d.ts`, `.d.mts`, and `.d.cts` files can still be checked when configured.
- Preserve the existing defaults that allow declarations and definition files.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/root.zig src/rules/root.zig src/rules/typescript_eslint_no_namespace.zig tests/rules/typescript_eslint_no_namespace.zig`
- `git diff --check`
