### PR TITLE
support import newline count options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -195,7 +195,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/first`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md) | Implemented |
 | [`import/named`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
-| [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for fishlint's default `count: 1` behavior |
+| [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count` and `exactCount` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -692,6 +692,8 @@ pub const Options = struct {
     import_named: bool = true,
     import_namespace: bool = true,
     import_newline_after_import: bool = true,
+    import_newline_after_import_count: usize = 1,
+    import_newline_after_import_exact_count: bool = false,
     import_no_amd: bool = true,
     import_no_cycle: bool = true,
     import_no_duplicates: bool = true,
@@ -1096,6 +1098,10 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "import/newline-after-import")) {
+            self.import_newline_after_import_count = try importNewlineAfterImportCountFromConfig(value);
+            self.import_newline_after_import_exact_count = try importNewlineAfterImportExactCountFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "new-cap")) {
             self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
@@ -1943,6 +1949,42 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (allow) .yes else .no;
+    }
+
+    fn importNewlineAfterImportCountFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 1,
+        };
+        if (items.len < 2) return 1;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const count = switch (config.get("count") orelse return 1) {
+            .integer => |count| count,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (count < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(count);
+    }
+
+    fn importNewlineAfterImportExactCountFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("exactCount") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noImplicitCoercionBooleanFromConfig(value: std.json.Value) RuleConfigError!NoImplicitCoercionBoolean {

--- a/src/rules/import_newline_after_import.zig
+++ b/src/rules/import_newline_after_import.zig
@@ -11,6 +11,8 @@ pub fn check(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     program: ast.Program,
+    count: usize,
+    exact_count: bool,
 ) Allocator.Error!void {
     const body = tree.extra(program.body);
     for (body, 0..) |statement_index, i| {
@@ -22,15 +24,19 @@ pub fn check(
 
         const import_end = offsetToLine(tree.source, tree.span(statement_index).end);
         const next_start = offsetToLine(tree.source, tree.span(next_index).start);
-        if (next_start > import_end + 1) continue;
+        const blank_lines = if (next_start > import_end) next_start - import_end - 1 else 0;
+        if (exact_count) {
+            if (blank_lines == count) continue;
+        } else if (blank_lines >= count) continue;
 
-        try core.addDiagnostic(
+        try core.addDiagnosticFmt(
             allocator,
             diagnostics,
             .warning,
             id,
-            "Expected 1 empty line after import statement not followed by another import.",
             tree.span(statement_index),
+            "Expected {d} empty line{s} after import statement not followed by another import.",
+            .{ count, if (count == 1) "" else "s" },
         );
     }
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1029,7 +1029,14 @@ const BasicVisitor = struct {
             try import_first.check(self.allocator, self.diagnostics, ctx.tree, program);
         }
         if (self.options.import_newline_after_import) {
-            try import_newline_after_import.check(self.allocator, self.diagnostics, ctx.tree, program);
+            try import_newline_after_import.check(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                program,
+                self.options.import_newline_after_import_count,
+                self.options.import_newline_after_import_exact_count,
+            );
         }
         if (self.options.import_no_duplicates) {
             try import_no_duplicates.check(self.allocator, self.diagnostics, ctx.tree, program);

--- a/tests/rules/import_newline_after_import.zig
+++ b/tests/rules/import_newline_after_import.zig
@@ -39,6 +39,84 @@ test "allows grouped imports and a blank line before code" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.import_newline_after_import.id));
 }
 
+test "reports import/newline-after-import when configured count is not met" {
+    const source =
+        \\import thing from "./thing";
+        \\
+        \\const value = thing;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .import_newline_after_import_count = 2,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_newline_after_import.id));
+}
+
+test "allows import/newline-after-import when configured count is met" {
+    const source =
+        \\import thing from "./thing";
+        \\
+        \\
+        \\const value = thing;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .import_newline_after_import_count = 2,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_newline_after_import.id));
+}
+
+test "reports import/newline-after-import when exactCount rejects extra blank lines" {
+    const source =
+        \\import thing from "./thing";
+        \\
+        \\
+        \\const value = thing;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .import_newline_after_import_count = 1,
+        .import_newline_after_import_exact_count = true,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_newline_after_import.id));
+}
+
+test "supports configured import/newline-after-import count options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"count": 2, "exactCount": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("import/newline-after-import", config.value);
+
+    try std.testing.expect(options.import_newline_after_import);
+    try std.testing.expectEqual(@as(usize, 2), options.import_newline_after_import_count);
+    try std.testing.expect(options.import_newline_after_import_exact_count);
+}
+
 test "can disable import/newline-after-import" {
     const source =
         \\import thing from "./thing";


### PR DESCRIPTION
## Summary
- Support the `count` option for `import/newline-after-import`.
- Support `exactCount` so extra blank lines can be rejected when configured.
- Keep the existing default behavior equivalent to `count: 1` and `exactCount: false`.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/import_newline_after_import.zig tests/rules/import_newline_after_import.zig`
- `git diff --check`
