### PR TITLE
support no this alias allowed names

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -273,7 +273,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Implemented |
-| [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for fishlint's `allowedNames: ['self']` configuration |
+| [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -387,6 +387,45 @@ pub const NoShadowAllowNames = struct {
     }
 };
 
+pub const max_no_this_alias_allowed_names = 32;
+pub const max_no_this_alias_allowed_name_len = 128;
+
+pub const NoThisAliasAllowedNamesError = error{
+    EmptyNoThisAliasAllowedName,
+    TooManyNoThisAliasAllowedNames,
+    NoThisAliasAllowedNameTooLong,
+};
+
+pub const NoThisAliasAllowedNames = struct {
+    custom: bool = false,
+    count: usize = 0,
+    lengths: [max_no_this_alias_allowed_names]usize = undefined,
+    storage: [max_no_this_alias_allowed_names][max_no_this_alias_allowed_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoThisAliasAllowedNames, name: []const u8) bool {
+        if (!self.custom) return std.mem.eql(u8, name, "self");
+
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoThisAliasAllowedNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoThisAliasAllowedNames, name: []const u8) NoThisAliasAllowedNamesError!void {
+        if (name.len == 0) return error.EmptyNoThisAliasAllowedName;
+        if (self.count >= max_no_this_alias_allowed_names) return error.TooManyNoThisAliasAllowedNames;
+        if (name.len > max_no_this_alias_allowed_name_len) return error.NoThisAliasAllowedNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_new_cap_exception_names = 32;
 pub const max_new_cap_exception_name_len = 128;
 
@@ -949,6 +988,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
     typescript_eslint_no_this_alias: bool = true,
+    typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_typedef: bool = true,
@@ -1266,6 +1306,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-namespace")) {
             self.typescript_eslint_no_namespace_allow_declarations = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDeclarations", true);
             self.typescript_eslint_no_namespace_allow_definition_files = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDefinitionFiles", true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
+            self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
@@ -2940,6 +2983,34 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn typescriptEslintNoThisAliasAllowedNamesFromConfig(value: std.json.Value) RuleConfigError!NoThisAliasAllowedNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allowed_names_value = config.get("allowedNames") orelse return .{};
+        const allowed_names = switch (allowed_names_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var names = NoThisAliasAllowedNames{ .custom = true };
+        for (allowed_names) |name_value| {
+            const name = switch (name_value) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            names.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return names;
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1482,7 +1482,13 @@ const BasicVisitor = struct {
             try typescript_eslint_prefer_as_const.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         if (self.options.typescript_eslint_no_this_alias) {
-            try typescript_eslint_no_this_alias.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+            try typescript_eslint_no_this_alias.checkVariableDeclarator(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                declarator,
+                &self.options.typescript_eslint_no_this_alias_allowed_names,
+            );
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
@@ -2254,7 +2260,13 @@ const BasicVisitor = struct {
             try typescript_eslint_no_confusing_non_null_assertion.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.typescript_eslint_no_this_alias) {
-            try typescript_eslint_no_this_alias.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try typescript_eslint_no_this_alias.checkAssignmentExpression(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                expression,
+                &self.options.typescript_eslint_no_this_alias_allowed_names,
+            );
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_no_typos_state);

--- a/src/rules/typescript_eslint_no_this_alias.zig
+++ b/src/rules/typescript_eslint_no_this_alias.zig
@@ -12,6 +12,7 @@ pub fn checkVariableDeclarator(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     declarator: ast.VariableDeclarator,
+    allowed_names: *const core.NoThisAliasAllowedNames,
 ) Allocator.Error!void {
     switch (tree.data(declarator.id)) {
         .binding_identifier => {},
@@ -20,7 +21,7 @@ pub fn checkVariableDeclarator(
 
     if (!isThisExpression(tree, declarator.init)) return;
 
-    try reportIfDisallowed(allocator, diagnostics, tree, declarator.id);
+    try reportIfDisallowed(allocator, diagnostics, tree, declarator.id, allowed_names);
 }
 
 pub fn checkAssignmentExpression(
@@ -28,6 +29,7 @@ pub fn checkAssignmentExpression(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
+    allowed_names: *const core.NoThisAliasAllowedNames,
 ) Allocator.Error!void {
     if (expression.operator != .assign) return;
 
@@ -38,7 +40,7 @@ pub fn checkAssignmentExpression(
 
     if (!isThisExpression(tree, expression.right)) return;
 
-    try reportIfDisallowed(allocator, diagnostics, tree, expression.left);
+    try reportIfDisallowed(allocator, diagnostics, tree, expression.left, allowed_names);
 }
 
 fn reportIfDisallowed(
@@ -46,8 +48,9 @@ fn reportIfDisallowed(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     target: ast.NodeIndex,
+    allowed_names: *const core.NoThisAliasAllowedNames,
 ) Allocator.Error!void {
-    if (isAllowedSelfAlias(tree, target)) return;
+    if (isAllowedAlias(tree, target, allowed_names)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -59,10 +62,10 @@ fn reportIfDisallowed(
     );
 }
 
-fn isAllowedSelfAlias(tree: *const ast.Tree, target: ast.NodeIndex) bool {
+fn isAllowedAlias(tree: *const ast.Tree, target: ast.NodeIndex, allowed_names: *const core.NoThisAliasAllowedNames) bool {
     const span = tree.span(target);
     if (span.end > tree.source.len or span.start > span.end) return false;
-    return std.mem.eql(u8, tree.source[span.start..span.end], "self");
+    return allowed_names.contains(tree.source[span.start..span.end]);
 }
 
 fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/typescript_eslint_no_this_alias.zig
+++ b/tests/rules/typescript_eslint_no_this_alias.zig
@@ -37,6 +37,46 @@ test "does not report @typescript-eslint/no-this-alias for fishlint allowed self
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_this_alias.id));
 }
 
+test "uses configured @typescript-eslint/no-this-alias allowedNames" {
+    const source =
+        \\const that = this;
+        \\let context;
+        \\context = this;
+        \\const self = this;
+    ;
+
+    var allowed_names: @TypeOf((lint.Options{}).typescript_eslint_no_this_alias_allowed_names) = .{ .custom = true };
+    try allowed_names.append("that");
+    try allowed_names.append("context");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_this_alias_allowed_names = allowed_names,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_this_alias.id));
+}
+
+test "supports configured @typescript-eslint/no-this-alias allowedNames option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"allowedNames": ["that"]}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-this-alias", config.value);
+
+    try std.testing.expect(options.typescript_eslint_no_this_alias);
+    try std.testing.expect(options.typescript_eslint_no_this_alias_allowed_names.contains("that"));
+    try std.testing.expect(!options.typescript_eslint_no_this_alias_allowed_names.contains("self"));
+}
+
 test "can disable @typescript-eslint/no-this-alias" {
     const source =
         \\const that = this;


### PR DESCRIPTION
## Summary
- Support configurable `allowedNames` for `@typescript-eslint/no-this-alias`.
- Preserve the existing default that allows `self` aliases.
- Replace the default allowed alias list when an explicit `allowedNames` array is provided.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_this_alias.zig tests/rules/typescript_eslint_no_this_alias.zig`
- `git diff --check`
