### PR TITLE
support typedef member variable option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -276,7 +276,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
-| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for fishlint's `propertyDeclaration: true` configuration |
+| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for `propertyDeclaration` and `memberVariableDeclaration` configurations |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -992,6 +992,8 @@ pub const Options = struct {
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_typedef: bool = true,
+    typescript_eslint_typedef_property_declaration: bool = true,
+    typescript_eslint_typedef_member_variable_declaration: bool = false,
     typescript_eslint_unified_signatures: bool = true,
     typescript_eslint_no_unnecessary_parameter_property_assignment: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
@@ -1314,6 +1316,10 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
             self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/typedef")) {
+            self.typescript_eslint_typedef_property_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "propertyDeclaration", true);
+            self.typescript_eslint_typedef_member_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "memberVariableDeclaration", false);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -3011,6 +3017,23 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    fn typescriptEslintTypedefBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1669,7 +1669,7 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.options.typescript_eslint_typedef) {
+        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_property_declaration) {
             try typescript_eslint_typedef.checkPropertySignature(self.allocator, self.diagnostics, ctx.tree, signature, index);
         }
         if (self.options.typescript_eslint_method_signature_style) {
@@ -3060,6 +3060,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
             try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+        }
+        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_member_variable_declaration) {
+            try typescript_eslint_typedef.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
         }
         if (self.options.typescript_eslint_class_literal_property_style) {
             try typescript_eslint_class_literal_property_style.checkPropertyDefinition(

--- a/src/rules/typescript_eslint_typedef.zig
+++ b/src/rules/typescript_eslint_typedef.zig
@@ -39,12 +39,45 @@ pub fn checkPropertySignature(
     );
 }
 
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (property.type_annotation != .null) return;
+
+    if (propertyName(tree, property.key)) |name| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            "Expected {s} to have a type annotation.",
+            .{name},
+        );
+        return;
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Expected a type annotation.",
+        tree.span(index),
+    );
+}
+
 fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     if (index == .null) return null;
 
     return switch (tree.data(index)) {
         .identifier_name => |identifier| tree.string(identifier.name),
         .identifier_reference => |identifier| tree.string(identifier.name),
+        .private_identifier => |identifier| tree.string(identifier.name),
         else => null,
     };
 }

--- a/tests/rules/typescript_eslint_typedef.zig
+++ b/tests/rules/typescript_eslint_typedef.zig
@@ -57,6 +57,49 @@ test "allows @typescript-eslint/typedef annotated properties and non-property de
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_typedef.id));
 }
 
+test "reports @typescript-eslint/typedef for unannotated class properties when configured" {
+    const source =
+        \\class Example {
+        \\  value = 1;
+        \\  readonly readonlyValue;
+        \\  static staticValue;
+        \\  accessor accessorValue;
+        \\  #privateValue;
+        \\  annotated: number = 1;
+        \\  method() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_inferrable_types = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_typedef_member_variable_declaration = true,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
+}
+
+test "supports configured @typescript-eslint/typedef declaration options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/typedef", config.value);
+
+    try std.testing.expect(options.typescript_eslint_typedef);
+    try std.testing.expect(!options.typescript_eslint_typedef_property_declaration);
+    try std.testing.expect(options.typescript_eslint_typedef_member_variable_declaration);
+}
+
 test "can disable @typescript-eslint/typedef" {
     const source =
         \\interface InterfaceShape {


### PR DESCRIPTION
## Summary
- Support `propertyDeclaration` for `@typescript-eslint/typedef` as an explicit configuration option.
- Support `memberVariableDeclaration` for class fields when configured.
- Keep existing defaults: type/interface properties are checked, class fields are not checked unless enabled.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_typedef.zig tests/rules/typescript_eslint_typedef.zig`
- `git diff --check`
