### PR TITLE
support triple slash reference modes

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -275,7 +275,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Implemented |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
-| [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for fishlint's `path: never, types: always, lib: always` configuration |
+| [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for `propertyDeclaration` and `memberVariableDeclaration` configurations |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |

--- a/src/core.zig
+++ b/src/core.zig
@@ -541,6 +541,11 @@ pub const TypescriptEslintClassLiteralPropertyStyle = enum {
     getters,
 };
 
+pub const TypescriptEslintTripleSlashReferenceMode = enum {
+    always,
+    never,
+};
+
 pub const PreferConstDestructuring = enum {
     any,
     all,
@@ -991,6 +996,9 @@ pub const Options = struct {
     typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
+    typescript_eslint_triple_slash_reference_path: TypescriptEslintTripleSlashReferenceMode = .never,
+    typescript_eslint_triple_slash_reference_types: TypescriptEslintTripleSlashReferenceMode = .always,
+    typescript_eslint_triple_slash_reference_lib: TypescriptEslintTripleSlashReferenceMode = .always,
     typescript_eslint_typedef: bool = true,
     typescript_eslint_typedef_property_declaration: bool = true,
     typescript_eslint_typedef_member_variable_declaration: bool = false,
@@ -1316,6 +1324,11 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
             self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/triple-slash-reference")) {
+            self.typescript_eslint_triple_slash_reference_path = try typescriptEslintTripleSlashReferenceModeFromConfig(value, "path", .never);
+            self.typescript_eslint_triple_slash_reference_types = try typescriptEslintTripleSlashReferenceModeFromConfig(value, "types", .always);
+            self.typescript_eslint_triple_slash_reference_lib = try typescriptEslintTripleSlashReferenceModeFromConfig(value, "lib", .always);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/typedef")) {
             self.typescript_eslint_typedef_property_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "propertyDeclaration", true);
@@ -2971,6 +2984,26 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "fields")) return .fields;
         if (std.mem.eql(u8, style, "getters")) return .getters;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintTripleSlashReferenceModeFromConfig(value: std.json.Value, key: []const u8, default: TypescriptEslintTripleSlashReferenceMode) RuleConfigError!TypescriptEslintTripleSlashReferenceMode {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const mode = switch (config.get(key) orelse return default) {
+            .string => |mode| mode,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, mode, "always")) return .always;
+        if (std.mem.eql(u8, mode, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -500,7 +500,11 @@ pub fn runBasic(
         try typescript_eslint_ban_tslint_comment.run(allocator, diagnostics, tree);
     }
     if (options.typescript_eslint_triple_slash_reference) {
-        try typescript_eslint_triple_slash_reference.run(allocator, diagnostics, tree);
+        try typescript_eslint_triple_slash_reference.runWithOptions(allocator, diagnostics, tree, .{
+            .path = options.typescript_eslint_triple_slash_reference_path,
+            .types = options.typescript_eslint_triple_slash_reference_types,
+            .lib = options.typescript_eslint_triple_slash_reference_lib,
+        });
     }
     if (options.alipay_ant_no_too_large_file) {
         try alipay_ant_no_too_large_file.run(allocator, diagnostics, tree, file_path);

--- a/src/rules/typescript_eslint_triple_slash_reference.zig
+++ b/src/rules/typescript_eslint_triple_slash_reference.zig
@@ -7,15 +7,31 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/triple-slash-reference";
 
+pub const Options = struct {
+    path: core.TypescriptEslintTripleSlashReferenceMode = .never,
+    types: core.TypescriptEslintTripleSlashReferenceMode = .always,
+    lib: core.TypescriptEslintTripleSlashReferenceMode = .always,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     for (tree.comments) |comment| {
         if (comment.type != .line) continue;
 
-        const path = referencePath(tree.string(comment.value)) orelse continue;
+        const reference = referenceDirective(tree.string(comment.value)) orelse continue;
+        if (isAllowed(reference, options)) continue;
 
         try core.addDiagnosticFmt(
             allocator,
@@ -24,26 +40,66 @@ pub fn run(
             id,
             .{ .start = comment.start, .end = comment.end },
             "Do not use a triple slash reference for {s}, use `import` style instead.",
-            .{path},
+            .{reference.value},
         );
     }
 }
 
-fn referencePath(value: []const u8) ?[]const u8 {
+const ReferenceKind = enum {
+    path,
+    types,
+    lib,
+};
+
+const Reference = struct {
+    kind: ReferenceKind,
+    value: []const u8,
+};
+
+fn referenceDirective(value: []const u8) ?Reference {
     if (value.len == 0 or value[0] != '/') return null;
 
     const body = trimLeftWhitespace(value[1..]);
     if (!std.mem.startsWith(u8, body, "<reference")) return null;
 
-    const path_index = std.mem.indexOf(u8, body, "path=") orelse return null;
-    var rest = body[path_index + "path=".len ..];
+    const kind = referenceKind(body) orelse return null;
+    const attribute = switch (kind) {
+        .path => "path=",
+        .types => "types=",
+        .lib => "lib=",
+    };
+    const attribute_index = std.mem.indexOf(u8, body, attribute) orelse return null;
+    var rest = body[attribute_index + attribute.len ..];
     rest = trimLeftWhitespace(rest);
     if (rest.len < 2) return null;
 
     const quote = rest[0];
     if (quote != '"' and quote != '\'') return null;
     const end = std.mem.indexOfScalar(u8, rest[1..], quote) orelse return null;
-    return rest[1..][0..end];
+    return .{ .kind = kind, .value = rest[1..][0..end] };
+}
+
+fn referenceKind(body: []const u8) ?ReferenceKind {
+    const path_index = std.mem.indexOf(u8, body, "path=");
+    const types_index = std.mem.indexOf(u8, body, "types=");
+    const lib_index = std.mem.indexOf(u8, body, "lib=");
+    const path = path_index orelse body.len;
+    const types = types_index orelse body.len;
+    const lib = lib_index orelse body.len;
+
+    if (path == body.len and types == body.len and lib == body.len) return null;
+    if (path <= types and path <= lib) return .path;
+    if (types <= path and types <= lib) return .types;
+    return .lib;
+}
+
+fn isAllowed(reference: Reference, options: Options) bool {
+    const mode = switch (reference.kind) {
+        .path => options.path,
+        .types => options.types,
+        .lib => options.lib,
+    };
+    return mode == .always;
 }
 
 fn trimLeftWhitespace(value: []const u8) []const u8 {

--- a/tests/rules/typescript_eslint_triple_slash_reference.zig
+++ b/tests/rules/typescript_eslint_triple_slash_reference.zig
@@ -42,6 +42,62 @@ test "allows @typescript-eslint/triple-slash-reference types and lib references"
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
 }
 
+test "allows @typescript-eslint/triple-slash-reference path references when configured always" {
+    const source =
+        \\/// <reference path="./foo.d.ts" />
+        \\export const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_triple_slash_reference_path = .always,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
+}
+
+test "reports @typescript-eslint/triple-slash-reference types and lib references when configured never" {
+    const source =
+        \\/// <reference types="node" />
+        \\/// <reference lib="dom" />
+        \\export const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_triple_slash_reference_types = .never,
+        .typescript_eslint_triple_slash_reference_lib = .never,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_triple_slash_reference.id));
+}
+
+test "supports configured @typescript-eslint/triple-slash-reference modes" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"path": "always", "types": "never", "lib": "never"}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/triple-slash-reference", config.value);
+
+    try std.testing.expect(options.typescript_eslint_triple_slash_reference);
+    const Mode = @TypeOf((lint.Options{}).typescript_eslint_triple_slash_reference_path);
+    try std.testing.expectEqual(Mode.always, options.typescript_eslint_triple_slash_reference_path);
+    try std.testing.expectEqual(Mode.never, options.typescript_eslint_triple_slash_reference_types);
+    try std.testing.expectEqual(Mode.never, options.typescript_eslint_triple_slash_reference_lib);
+}
+
 test "can disable @typescript-eslint/triple-slash-reference" {
     const source =
         \\/// <reference path="./foo.d.ts" />


### PR DESCRIPTION
## Summary
- Support `path`, `types`, and `lib` mode options for `@typescript-eslint/triple-slash-reference`.
- Implement the `always` and `never` modes while preserving the existing defaults.
- Keep `prefer-import` out of scope for now because it requires import-aware matching.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_triple_slash_reference.zig tests/rules/typescript_eslint_triple_slash_reference.zig`
- `git diff --check`
