### PR TITLE
support array type styles

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -245,7 +245,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
-| [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) | Implemented for fishlint's `array-simple` configuration |
+| [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) | Implemented for `default: array`, `array-simple`, and `generic` configurations |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -531,6 +531,12 @@ pub const TypescriptEslintMethodSignatureStyle = enum {
     method,
 };
 
+pub const TypescriptEslintArrayTypeStyle = enum {
+    array,
+    array_simple,
+    generic,
+};
+
 pub const TypescriptEslintConsistentTypeDefinitionsStyle = enum {
     interface,
     type,
@@ -958,6 +964,7 @@ pub const Options = struct {
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
+    typescript_eslint_array_type_style: TypescriptEslintArrayTypeStyle = .array_simple,
     typescript_eslint_class_literal_property_style: bool = true,
     typescript_eslint_class_literal_property_style_style: TypescriptEslintClassLiteralPropertyStyle = .fields,
     typescript_eslint_consistent_type_assertions: bool = true,
@@ -1299,6 +1306,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
+            self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
@@ -2952,6 +2962,31 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "property")) return .property;
         if (std.mem.eql(u8, style, "method")) return .method;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintArrayTypeStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintArrayTypeStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .array_simple,
+        };
+        if (items.len < 2) return .array_simple;
+
+        const config_value = switch (items[1]) {
+            .object => items[1],
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const config = switch (config_value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const style = switch (config.get("default") orelse return .array_simple) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "array")) return .array;
+        if (std.mem.eql(u8, style, "array-simple")) return .array_simple;
+        if (std.mem.eql(u8, style, "generic")) return .generic;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1471,7 +1471,14 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_array_type) {
-            try typescript_eslint_array_type.checkArrayType(self.allocator, self.diagnostics, ctx.tree, array_type, index);
+            try typescript_eslint_array_type.checkArrayType(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                array_type,
+                index,
+                self.options.typescript_eslint_array_type_style,
+            );
         }
         return .proceed;
     }
@@ -1696,7 +1703,14 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_array_type) {
-            try typescript_eslint_array_type.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference, index);
+            try typescript_eslint_array_type.checkTypeReference(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                reference,
+                index,
+                self.options.typescript_eslint_array_type_style,
+            );
         }
         const wrapper_object_type_reported =
             self.options.typescript_eslint_no_wrapper_object_types and

--- a/src/rules/typescript_eslint_array_type.zig
+++ b/src/rules/typescript_eslint_array_type.zig
@@ -13,13 +13,15 @@ pub fn checkTypeReference(
     tree: *const ast.Tree,
     reference: ast.TSTypeReference,
     index: ast.NodeIndex,
+    style: core.TypescriptEslintArrayTypeStyle,
 ) Allocator.Error!void {
     const name = typeName(tree, reference.type_name) orelse return;
     const readonly = std.mem.eql(u8, name, "ReadonlyArray");
     if (!readonly and !std.mem.eql(u8, name, "Array")) return;
+    if (style == .generic) return;
 
     const element_type = singleTypeArgument(tree, reference.type_arguments) orelse return;
-    if (!isSimpleType(tree, element_type)) return;
+    if (style == .array_simple and !isSimpleType(tree, element_type)) return;
 
     const type_text = sourceText(tree, index);
     const element_text = sourceText(tree, unwrapParenthesized(tree, element_type));
@@ -53,8 +55,13 @@ pub fn checkArrayType(
     tree: *const ast.Tree,
     array_type: ast.TSArrayType,
     index: ast.NodeIndex,
+    style: core.TypescriptEslintArrayTypeStyle,
 ) Allocator.Error!void {
-    if (isSimpleType(tree, array_type.element_type)) return;
+    switch (style) {
+        .array => return,
+        .array_simple => if (isSimpleType(tree, array_type.element_type)) return,
+        .generic => {},
+    }
 
     try core.addDiagnostic(
         allocator,

--- a/tests/rules/typescript_eslint_array_type.zig
+++ b/tests/rules/typescript_eslint_array_type.zig
@@ -65,6 +65,64 @@ test "allows @typescript-eslint/array-type compliant array-simple forms" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_array_type.id));
 }
 
+test "reports @typescript-eslint/array-type generic arrays when configured array" {
+    const source =
+        \\type Names = Array<string>;
+        \\type Union = Array<string | number>;
+        \\type Readonly = ReadonlyArray<number>;
+        \\type Values = string[];
+        \\type Nested = (string | number)[];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_array_type_style = .array,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_array_type.id));
+}
+
+test "reports @typescript-eslint/array-type shorthand arrays when configured generic" {
+    const source =
+        \\type Names = string[];
+        \\type Union = (string | number)[];
+        \\type Readonly = readonly string[];
+        \\type Values = Array<string>;
+        \\type Complex = Array<string | number>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_array_type_style = .generic,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_array_type.id));
+}
+
+test "supports configured @typescript-eslint/array-type style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"default": "generic"}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/array-type", config.value);
+
+    try std.testing.expect(options.typescript_eslint_array_type);
+    const Style = @TypeOf((lint.Options{}).typescript_eslint_array_type_style);
+    try std.testing.expectEqual(Style.generic, options.typescript_eslint_array_type_style);
+}
+
 test "can disable @typescript-eslint/array-type" {
     const source =
         \\type Names = Array<string>;


### PR DESCRIPTION
## Summary
- Support configurable `default` styles for `@typescript-eslint/array-type`.
- Add `array`, `array-simple`, and `generic` behavior while preserving the existing `array-simple` default.
- Keep diagnostics aligned with the existing generic-to-shorthand and shorthand-to-generic checks.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_array_type.zig tests/rules/typescript_eslint_array_type.zig`
- `git diff --check`
