### PR TITLE
support ban ts comment options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -246,7 +246,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`@typescript-eslint/adjacent-overload-signatures`](https://typescript-eslint.io/rules/adjacent-overload-signatures/) | Implemented |
 | [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) | Implemented for `default: array`, `array-simple`, and `generic` configurations |
-| [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for fishlint's `allow-with-description` configuration |
+| [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for directive modes and `minimumDescriptionLength` |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -537,6 +537,12 @@ pub const TypescriptEslintArrayTypeStyle = enum {
     generic,
 };
 
+pub const TypescriptEslintBanTsCommentMode = enum {
+    allow,
+    ban,
+    allow_with_description,
+};
+
 pub const TypescriptEslintConsistentTypeDefinitionsStyle = enum {
     interface,
     type,
@@ -973,6 +979,11 @@ pub const Options = struct {
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,
     typescript_eslint_ban_ts_comment: bool = true,
+    typescript_eslint_ban_ts_comment_ts_expect_error: TypescriptEslintBanTsCommentMode = .allow_with_description,
+    typescript_eslint_ban_ts_comment_ts_ignore: TypescriptEslintBanTsCommentMode = .allow_with_description,
+    typescript_eslint_ban_ts_comment_ts_nocheck: TypescriptEslintBanTsCommentMode = .allow_with_description,
+    typescript_eslint_ban_ts_comment_ts_check: TypescriptEslintBanTsCommentMode = .allow_with_description,
+    typescript_eslint_ban_ts_comment_minimum_description_length: usize = 3,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_explicit_member_accessibility: bool = true,
     typescript_eslint_member_ordering: bool = true,
@@ -1309,6 +1320,13 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/ban-ts-comment")) {
+            self.typescript_eslint_ban_ts_comment_ts_expect_error = try typescriptEslintBanTsCommentModeFromConfig(value, "ts-expect-error", .allow_with_description);
+            self.typescript_eslint_ban_ts_comment_ts_ignore = try typescriptEslintBanTsCommentModeFromConfig(value, "ts-ignore", .allow_with_description);
+            self.typescript_eslint_ban_ts_comment_ts_nocheck = try typescriptEslintBanTsCommentModeFromConfig(value, "ts-nocheck", .allow_with_description);
+            self.typescript_eslint_ban_ts_comment_ts_check = try typescriptEslintBanTsCommentModeFromConfig(value, "ts-check", .allow_with_description);
+            self.typescript_eslint_ban_ts_comment_minimum_description_length = try typescriptEslintBanTsCommentMinimumDescriptionLengthFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/class-literal-property-style")) {
             self.typescript_eslint_class_literal_property_style_style = try typescriptEslintClassLiteralPropertyStyleFromConfig(value);
@@ -2988,6 +3006,46 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "array-simple")) return .array_simple;
         if (std.mem.eql(u8, style, "generic")) return .generic;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintBanTsCommentModeFromConfig(value: std.json.Value, key: []const u8, default: TypescriptEslintBanTsCommentMode) RuleConfigError!TypescriptEslintBanTsCommentMode {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| if (enabled) .ban else .allow,
+            .string => |mode| if (std.mem.eql(u8, mode, "allow-with-description"))
+                .allow_with_description
+            else
+                error.UnsupportedRuleConfigValue,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn typescriptEslintBanTsCommentMinimumDescriptionLengthFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 3,
+        };
+        if (items.len < 2) return 3;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const length = switch (config.get("minimumDescriptionLength") orelse return 3) {
+            .integer => |length| length,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (length < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(length);
     }
 
     fn typescriptEslintConsistentTypeDefinitionsStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintConsistentTypeDefinitionsStyle {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -494,7 +494,13 @@ pub fn runBasic(
         });
     }
     if (options.typescript_eslint_ban_ts_comment) {
-        try typescript_eslint_ban_ts_comment.run(allocator, diagnostics, tree);
+        try typescript_eslint_ban_ts_comment.runWithOptions(allocator, diagnostics, tree, .{
+            .ts_expect_error = options.typescript_eslint_ban_ts_comment_ts_expect_error,
+            .ts_ignore = options.typescript_eslint_ban_ts_comment_ts_ignore,
+            .ts_nocheck = options.typescript_eslint_ban_ts_comment_ts_nocheck,
+            .ts_check = options.typescript_eslint_ban_ts_comment_ts_check,
+            .minimum_description_length = options.typescript_eslint_ban_ts_comment_minimum_description_length,
+        });
     }
     if (options.typescript_eslint_ban_tslint_comment) {
         try typescript_eslint_ban_tslint_comment.run(allocator, diagnostics, tree);

--- a/src/rules/typescript_eslint_ban_ts_comment.zig
+++ b/src/rules/typescript_eslint_ban_ts_comment.zig
@@ -7,16 +7,47 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/ban-ts-comment";
 
-const minimum_description_length = 3;
+pub const Options = struct {
+    ts_expect_error: core.TypescriptEslintBanTsCommentMode = .allow_with_description,
+    ts_ignore: core.TypescriptEslintBanTsCommentMode = .allow_with_description,
+    ts_nocheck: core.TypescriptEslintBanTsCommentMode = .allow_with_description,
+    ts_check: core.TypescriptEslintBanTsCommentMode = .allow_with_description,
+    minimum_description_length: usize = 3,
+};
 
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     for (tree.comments) |comment| {
         const directive = directiveFromComment(tree, comment) orelse continue;
-        if (descriptionLength(directive.description) >= minimum_description_length) continue;
+        switch (modeForDirective(options, directive.kind)) {
+            .allow => continue,
+            .ban => {},
+            .allow_with_description => {
+                if (descriptionLength(directive.description) >= options.minimum_description_length) continue;
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    .{ .start = comment.start, .end = comment.end },
+                    "Include a description after the \"@ts-{s}\" directive to explain why the @ts-{s} is necessary. The description must be {d} characters or longer.",
+                    .{ directive.name, directive.name, options.minimum_description_length },
+                );
+                continue;
+            },
+        }
 
         try core.addDiagnosticFmt(
             allocator,
@@ -24,13 +55,21 @@ pub fn run(
             .warning,
             id,
             .{ .start = comment.start, .end = comment.end },
-            "Include a description after the \"@ts-{s}\" directive to explain why the @ts-{s} is necessary. The description must be {d} characters or longer.",
-            .{ directive.name, directive.name, minimum_description_length },
+            "Do not use \"@ts-{s}\" directives.",
+            .{directive.name},
         );
     }
 }
 
+const DirectiveKind = enum {
+    ts_expect_error,
+    ts_ignore,
+    ts_nocheck,
+    ts_check,
+};
+
 const Directive = struct {
+    kind: DirectiveKind,
     name: []const u8,
     description: []const u8,
 };
@@ -45,16 +84,31 @@ fn directiveFromComment(tree: *const ast.Tree, comment: ast.Comment) ?Directive 
     if (!std.mem.startsWith(u8, text, "@ts-")) return null;
     const after_prefix = text["@ts-".len..];
 
-    inline for (.{ "expect-error", "ignore", "nocheck", "check" }) |name| {
-        if (std.mem.startsWith(u8, after_prefix, name)) {
+    inline for (.{
+        .{ .kind = DirectiveKind.ts_expect_error, .name = "expect-error" },
+        .{ .kind = DirectiveKind.ts_ignore, .name = "ignore" },
+        .{ .kind = DirectiveKind.ts_nocheck, .name = "nocheck" },
+        .{ .kind = DirectiveKind.ts_check, .name = "check" },
+    }) |directive| {
+        if (std.mem.startsWith(u8, after_prefix, directive.name)) {
             return .{
-                .name = name,
-                .description = after_prefix[name.len..],
+                .kind = directive.kind,
+                .name = directive.name,
+                .description = after_prefix[directive.name.len..],
             };
         }
     }
 
     return null;
+}
+
+fn modeForDirective(options: Options, kind: DirectiveKind) core.TypescriptEslintBanTsCommentMode {
+    return switch (kind) {
+        .ts_expect_error => options.ts_expect_error,
+        .ts_ignore => options.ts_ignore,
+        .ts_nocheck => options.ts_nocheck,
+        .ts_check => options.ts_check,
+    };
 }
 
 fn trimLeftSlashesAndWhitespace(value: []const u8) []const u8 {

--- a/tests/rules/typescript_eslint_ban_ts_comment.zig
+++ b/tests/rules/typescript_eslint_ban_ts_comment.zig
@@ -42,6 +42,71 @@ test "allows @typescript-eslint/ban-ts-comment directives with descriptions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_ts_comment.id));
 }
 
+test "uses configured @typescript-eslint/ban-ts-comment directive modes" {
+    const source =
+        \\// @ts-expect-error
+        \\// @ts-ignore: described ignore
+        \\/* @ts-nocheck */
+        \\/* @ts-check */
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .typescript_eslint_ban_ts_comment_ts_expect_error = .allow,
+        .typescript_eslint_ban_ts_comment_ts_ignore = .ban,
+        .typescript_eslint_ban_ts_comment_ts_nocheck = .allow_with_description,
+        .typescript_eslint_ban_ts_comment_ts_check = .allow,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_ban_ts_comment.id));
+}
+
+test "uses configured @typescript-eslint/ban-ts-comment minimumDescriptionLength" {
+    const source =
+        \\// @ts-expect-error: abc
+        \\// @ts-ignore: abcdef
+        \\const value = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .typescript_eslint_ban_ts_comment_minimum_description_length = 6,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_ban_ts_comment.id));
+}
+
+test "supports configured @typescript-eslint/ban-ts-comment options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"ts-expect-error": false, "ts-ignore": true, "ts-nocheck": "allow-with-description", "ts-check": false, "minimumDescriptionLength": 6}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/ban-ts-comment", config.value);
+
+    const Mode = @TypeOf((lint.Options{}).typescript_eslint_ban_ts_comment_ts_expect_error);
+    try std.testing.expect(options.typescript_eslint_ban_ts_comment);
+    try std.testing.expectEqual(Mode.allow, options.typescript_eslint_ban_ts_comment_ts_expect_error);
+    try std.testing.expectEqual(Mode.ban, options.typescript_eslint_ban_ts_comment_ts_ignore);
+    try std.testing.expectEqual(Mode.allow_with_description, options.typescript_eslint_ban_ts_comment_ts_nocheck);
+    try std.testing.expectEqual(Mode.allow, options.typescript_eslint_ban_ts_comment_ts_check);
+    try std.testing.expectEqual(@as(usize, 6), options.typescript_eslint_ban_ts_comment_minimum_description_length);
+}
+
 test "can disable @typescript-eslint/ban-ts-comment" {
     const source =
         \\// @ts-ignore


### PR DESCRIPTION
## Summary
- Support per-directive modes for `@typescript-eslint/ban-ts-comment`.
- Add support for `false`, `true`, and `allow-with-description` values.
- Support configurable `minimumDescriptionLength` while preserving the existing default behavior.

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_ban_ts_comment.zig tests/rules/typescript_eslint_ban_ts_comment.zig`
- `git diff --check`
