### PR TITLE
support explicit member accessibility modes

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -253,7 +253,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Implemented for fishlint's `assertionStyle: as, objectLiteralTypeAssertions: never` configuration |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for `interface` and `type` configurations |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
-| [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Implemented for fishlint's `no-public` configuration |
+| [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Supports `accessibility: "no-public"`, `"explicit"`, and `"off"` |
 | [`@typescript-eslint/member-ordering`](https://typescript-eslint.io/rules/member-ordering/) | Implemented for fishlint's default class member ordering |
 | [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -553,6 +553,12 @@ pub const TypescriptEslintClassLiteralPropertyStyle = enum {
     getters,
 };
 
+pub const TypescriptEslintExplicitMemberAccessibility = enum {
+    explicit,
+    no_public,
+    off,
+};
+
 pub const TypescriptEslintTripleSlashReferenceMode = enum {
     always,
     never,
@@ -986,6 +992,7 @@ pub const Options = struct {
     typescript_eslint_ban_ts_comment_minimum_description_length: usize = 3,
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_explicit_member_accessibility: bool = true,
+    typescript_eslint_explicit_member_accessibility_accessibility: TypescriptEslintExplicitMemberAccessibility = .no_public,
     typescript_eslint_member_ordering: bool = true,
     typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_method_signature_style_style: TypescriptEslintMethodSignatureStyle = .property,
@@ -1333,6 +1340,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/consistent-type-definitions")) {
             self.typescript_eslint_consistent_type_definitions_style = try typescriptEslintConsistentTypeDefinitionsStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/explicit-member-accessibility")) {
+            self.typescript_eslint_explicit_member_accessibility_accessibility = try typescriptEslintExplicitMemberAccessibilityFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -1688,6 +1698,27 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "anyOrder")) return .any_order;
         if (std.mem.eql(u8, style, "getBeforeSet")) return .get_before_set;
         if (std.mem.eql(u8, style, "setBeforeGet")) return .set_before_get;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintExplicitMemberAccessibilityFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintExplicitMemberAccessibility {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .no_public,
+        };
+        if (items.len < 2) return .no_public;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const accessibility = switch (config.get("accessibility") orelse return .no_public) {
+            .string => |accessibility| accessibility,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, accessibility, "explicit")) return .explicit;
+        if (std.mem.eql(u8, accessibility, "no-public")) return .no_public;
+        if (std.mem.eql(u8, accessibility, "off")) return .off;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -4189,6 +4220,33 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
+
+    var typescript_explicit_member_accessibility_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"accessibility\":\"explicit\"}]",
+        .{},
+    );
+    defer typescript_explicit_member_accessibility_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/explicit-member-accessibility", typescript_explicit_member_accessibility_config.value);
+    try std.testing.expect(options.typescript_eslint_explicit_member_accessibility);
+    try std.testing.expectEqual(
+        TypescriptEslintExplicitMemberAccessibility.explicit,
+        options.typescript_eslint_explicit_member_accessibility_accessibility,
+    );
+
+    var typescript_explicit_member_accessibility_off_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"accessibility\":\"off\"}]",
+        .{},
+    );
+    defer typescript_explicit_member_accessibility_off_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/explicit-member-accessibility", typescript_explicit_member_accessibility_off_config.value);
+    try std.testing.expectEqual(
+        TypescriptEslintExplicitMemberAccessibility.off,
+        options.typescript_eslint_explicit_member_accessibility_accessibility,
+    );
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3027,7 +3027,14 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
-            try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index);
+            try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                method,
+                index,
+                self.options.typescript_eslint_explicit_member_accessibility_accessibility,
+            );
         }
         if (self.options.typescript_eslint_class_literal_property_style) {
             try typescript_eslint_class_literal_property_style.checkMethodDefinition(
@@ -3077,7 +3084,14 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
-            try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);
+            try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                property,
+                index,
+                self.options.typescript_eslint_explicit_member_accessibility_accessibility,
+            );
         }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);

--- a/src/rules/typescript_eslint_explicit_member_accessibility.zig
+++ b/src/rules/typescript_eslint_explicit_member_accessibility.zig
@@ -13,9 +13,8 @@ pub fn checkMethodDefinition(
     tree: *const ast.Tree,
     method: ast.MethodDefinition,
     index: ast.NodeIndex,
+    accessibility: core.TypescriptEslintExplicitMemberAccessibility,
 ) Allocator.Error!void {
-    if (method.accessibility != .public) return;
-
     const member_name = methodName(tree, method);
     const description = switch (method.kind) {
         .get => "get property accessor",
@@ -23,14 +22,17 @@ pub fn checkMethodDefinition(
         else => "method definition",
     };
 
+    if (!shouldReport(method.accessibility, accessibility)) return;
+    const message = messageForAccessibility(method.accessibility);
+
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
         .warning,
         id,
         tree.span(index),
-        "Public accessibility modifier on {s} {s}.",
-        .{ description, member_name },
+        "{s} {s} {s}.",
+        .{ message, description, member_name },
     );
 }
 
@@ -40,11 +42,13 @@ pub fn checkPropertyDefinition(
     tree: *const ast.Tree,
     property: ast.PropertyDefinition,
     index: ast.NodeIndex,
+    accessibility: core.TypescriptEslintExplicitMemberAccessibility,
 ) Allocator.Error!void {
-    if (property.accessibility != .public) return;
-
     const member_name = staticKeyName(tree, property.key, property.computed) orelse "member";
     const description = if (property.accessor) "accessor property" else "class property";
+
+    if (!shouldReport(property.accessibility, accessibility)) return;
+    const message = messageForAccessibility(property.accessibility);
 
     try core.addDiagnosticFmt(
         allocator,
@@ -52,9 +56,28 @@ pub fn checkPropertyDefinition(
         .warning,
         id,
         tree.span(index),
-        "Public accessibility modifier on {s} {s}.",
-        .{ description, member_name },
+        "{s} {s} {s}.",
+        .{ message, description, member_name },
     );
+}
+
+fn shouldReport(
+    member_accessibility: ast.Accessibility,
+    accessibility: core.TypescriptEslintExplicitMemberAccessibility,
+) bool {
+    return switch (accessibility) {
+        .explicit => member_accessibility == .none,
+        .no_public => member_accessibility == .public,
+        .off => false,
+    };
+}
+
+fn messageForAccessibility(member_accessibility: ast.Accessibility) []const u8 {
+    return switch (member_accessibility) {
+        .none => "Missing accessibility modifier on",
+        .public => "Public accessibility modifier on",
+        else => "Accessibility modifier on",
+    };
 }
 
 fn methodName(tree: *const ast.Tree, method: ast.MethodDefinition) []const u8 {

--- a/tests/rules/typescript_eslint_explicit_member_accessibility.zig
+++ b/tests/rules/typescript_eslint_explicit_member_accessibility.zig
@@ -50,6 +50,59 @@ test "allows @typescript-eslint/explicit-member-accessibility non-public and omi
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
 }
 
+test "reports @typescript-eslint/explicit-member-accessibility explicit mode for omitted accessibility" {
+    const source =
+        \\class Service {
+        \\  constructor() {}
+        \\  public start(): void {}
+        \\  private stop(): void {}
+        \\  get size(): number {
+        \\    return 1;
+        \\  }
+        \\  value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_explicit_member_accessibility_accessibility = .explicit,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
+    try std.testing.expect(hasMessage(result, "Missing accessibility modifier on method definition constructor."));
+    try std.testing.expect(hasMessage(result, "Missing accessibility modifier on get property accessor size."));
+    try std.testing.expect(hasMessage(result, "Missing accessibility modifier on class property value."));
+}
+
+test "allows @typescript-eslint/explicit-member-accessibility accessibility off mode" {
+    const source =
+        \\class Service {
+        \\  public start(): void {}
+        \\  value = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_explicit_member_accessibility_accessibility = .off,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_explicit_member_accessibility.id));
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, expected)) return true;
+    }
+    return false;
+}
+
 test "can disable @typescript-eslint/explicit-member-accessibility" {
     const source =
         \\class Service {


### PR DESCRIPTION
## Summary

- add an `accessibility` mode option for `@typescript-eslint/explicit-member-accessibility`
- preserve the current default `no-public` behavior
- support `explicit` and `off` modes in rule execution and ESLint-style config parsing
- update rule-status documentation

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/typescript_eslint_explicit_member_accessibility.zig src/rules/root.zig tests/rules/typescript_eslint_explicit_member_accessibility.zig`
- `git diff --check`
