### PR TITLE
support type assertion style options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -250,7 +250,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
 | [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |
-| [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Implemented for fishlint's `assertionStyle: as, objectLiteralTypeAssertions: never` configuration |
+| [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Supports `assertionStyle` plus object/array literal assertion modes |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for `interface` and `type` configurations |
 | [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Supports `accessibility: "no-public"`, `"explicit"`, and `"off"` |

--- a/src/core.zig
+++ b/src/core.zig
@@ -553,6 +553,18 @@ pub const TypescriptEslintClassLiteralPropertyStyle = enum {
     getters,
 };
 
+pub const TypescriptEslintConsistentTypeAssertionsStyle = enum {
+    as,
+    angle_bracket,
+    never,
+};
+
+pub const TypescriptEslintLiteralTypeAssertions = enum {
+    allow,
+    allow_as_parameter,
+    never,
+};
+
 pub const TypescriptEslintExplicitMemberAccessibility = enum {
     explicit,
     no_public,
@@ -993,6 +1005,9 @@ pub const Options = struct {
     typescript_eslint_ban_tslint_comment: bool = true,
     typescript_eslint_explicit_member_accessibility: bool = true,
     typescript_eslint_explicit_member_accessibility_accessibility: TypescriptEslintExplicitMemberAccessibility = .no_public,
+    typescript_eslint_consistent_type_assertions_assertion_style: TypescriptEslintConsistentTypeAssertionsStyle = .as,
+    typescript_eslint_consistent_type_assertions_object_literal_type_assertions: TypescriptEslintLiteralTypeAssertions = .never,
+    typescript_eslint_consistent_type_assertions_array_literal_type_assertions: TypescriptEslintLiteralTypeAssertions = .allow,
     typescript_eslint_member_ordering: bool = true,
     typescript_eslint_method_signature_style: bool = true,
     typescript_eslint_method_signature_style_style: TypescriptEslintMethodSignatureStyle = .property,
@@ -1340,6 +1355,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/consistent-type-definitions")) {
             self.typescript_eslint_consistent_type_definitions_style = try typescriptEslintConsistentTypeDefinitionsStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/consistent-type-assertions")) {
+            self.typescript_eslint_consistent_type_assertions_assertion_style = try typescriptEslintConsistentTypeAssertionsStyleFromConfig(value);
+            self.typescript_eslint_consistent_type_assertions_object_literal_type_assertions = try typescriptEslintLiteralTypeAssertionsFromConfig(value, "objectLiteralTypeAssertions", .never);
+            self.typescript_eslint_consistent_type_assertions_array_literal_type_assertions = try typescriptEslintLiteralTypeAssertionsFromConfig(value, "arrayLiteralTypeAssertions", .allow);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/explicit-member-accessibility")) {
             self.typescript_eslint_explicit_member_accessibility_accessibility = try typescriptEslintExplicitMemberAccessibilityFromConfig(value);
@@ -1698,6 +1718,52 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "anyOrder")) return .any_order;
         if (std.mem.eql(u8, style, "getBeforeSet")) return .get_before_set;
         if (std.mem.eql(u8, style, "setBeforeGet")) return .set_before_get;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintConsistentTypeAssertionsStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintConsistentTypeAssertionsStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .as,
+        };
+        if (items.len < 2) return .as;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const style = switch (config.get("assertionStyle") orelse return .as) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "as")) return .as;
+        if (std.mem.eql(u8, style, "angle-bracket")) return .angle_bracket;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintLiteralTypeAssertionsFromConfig(
+        value: std.json.Value,
+        key: []const u8,
+        default: TypescriptEslintLiteralTypeAssertions,
+    ) RuleConfigError!TypescriptEslintLiteralTypeAssertions {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const style = switch (config.get(key) orelse return default) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "allow")) return .allow;
+        if (std.mem.eql(u8, style, "allow-as-parameter")) return .allow_as_parameter;
+        if (std.mem.eql(u8, style, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -4220,6 +4286,28 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
+
+    var typescript_consistent_type_assertions_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"assertionStyle\":\"angle-bracket\",\"objectLiteralTypeAssertions\":\"allow-as-parameter\",\"arrayLiteralTypeAssertions\":\"never\"}]",
+        .{},
+    );
+    defer typescript_consistent_type_assertions_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/consistent-type-assertions", typescript_consistent_type_assertions_config.value);
+    try std.testing.expect(options.typescript_eslint_consistent_type_assertions);
+    try std.testing.expectEqual(
+        TypescriptEslintConsistentTypeAssertionsStyle.angle_bracket,
+        options.typescript_eslint_consistent_type_assertions_assertion_style,
+    );
+    try std.testing.expectEqual(
+        TypescriptEslintLiteralTypeAssertions.allow_as_parameter,
+        options.typescript_eslint_consistent_type_assertions_object_literal_type_assertions,
+    );
+    try std.testing.expectEqual(
+        TypescriptEslintLiteralTypeAssertions.never,
+        options.typescript_eslint_consistent_type_assertions_array_literal_type_assertions,
+    );
 
     var typescript_explicit_member_accessibility_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1447,7 +1447,11 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_consistent_type_assertions) {
-            try typescript_eslint_consistent_type_assertions.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try typescript_eslint_consistent_type_assertions.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx, .{
+                .assertion_style = self.options.typescript_eslint_consistent_type_assertions_assertion_style,
+                .object_literal_type_assertions = self.options.typescript_eslint_consistent_type_assertions_object_literal_type_assertions,
+                .array_literal_type_assertions = self.options.typescript_eslint_consistent_type_assertions_array_literal_type_assertions,
+            });
         }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkAsExpression(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -1462,7 +1466,11 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_consistent_type_assertions) {
-            try typescript_eslint_consistent_type_assertions.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion, index);
+            try typescript_eslint_consistent_type_assertions.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion, index, ctx, .{
+                .assertion_style = self.options.typescript_eslint_consistent_type_assertions_assertion_style,
+                .object_literal_type_assertions = self.options.typescript_eslint_consistent_type_assertions_object_literal_type_assertions,
+                .array_literal_type_assertions = self.options.typescript_eslint_consistent_type_assertions_array_literal_type_assertions,
+            });
         }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkTypeAssertion(self.allocator, self.diagnostics, ctx.tree, assertion);

--- a/src/rules/typescript_eslint_consistent_type_assertions.zig
+++ b/src/rules/typescript_eslint_consistent_type_assertions.zig
@@ -3,9 +3,16 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/consistent-type-assertions";
+
+pub const Options = struct {
+    assertion_style: core.TypescriptEslintConsistentTypeAssertionsStyle,
+    object_literal_type_assertions: core.TypescriptEslintLiteralTypeAssertions,
+    array_literal_type_assertions: core.TypescriptEslintLiteralTypeAssertions,
+};
 
 pub fn checkAsExpression(
     allocator: Allocator,
@@ -13,18 +20,34 @@ pub fn checkAsExpression(
     tree: *const ast.Tree,
     expression: ast.TSAsExpression,
     index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
 ) Allocator.Error!void {
     if (isConstType(tree, expression.type_annotation)) return;
-    if (!isObjectExpression(tree, expression.expression)) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .@"error",
-        id,
-        "Always prefer const x: T = { ... }.",
-        tree.span(index),
-    );
+    if (try checkLiteralAssertion(allocator, diagnostics, tree, expression.expression, index, ctx, options)) return;
+
+    const type_text = sourceText(tree, expression.type_annotation);
+    switch (options.assertion_style) {
+        .as => {},
+        .angle_bracket => try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            "Use '<{s}>' instead of 'as {s}'.",
+            .{ type_text, type_text },
+        ),
+        .never => try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Do not use type assertions.",
+            tree.span(index),
+        ),
+    }
 }
 
 pub fn checkTypeAssertion(
@@ -33,26 +56,86 @@ pub fn checkTypeAssertion(
     tree: *const ast.Tree,
     assertion: ast.TSTypeAssertion,
     index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
 ) Allocator.Error!void {
+    if (isConstType(tree, assertion.type_annotation)) return;
+    if (try checkLiteralAssertion(allocator, diagnostics, tree, assertion.expression, index, ctx, options)) return;
+
     const type_text = sourceText(tree, assertion.type_annotation);
 
+    switch (options.assertion_style) {
+        .as => try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(index),
+            "Use 'as {s}' instead of '<{s}>'.",
+            .{ type_text, type_text },
+        ),
+        .angle_bracket => {},
+        .never => try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Do not use type assertions.",
+            tree.span(index),
+        ),
+    }
+}
+
+fn checkLiteralAssertion(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.NodeIndex,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!bool {
+    const literal = literalAssertionKind(tree, expression) orelse return false;
+    const mode = switch (literal) {
+        .object => options.object_literal_type_assertions,
+        .array => options.array_literal_type_assertions,
+    };
+
+    const allowed = switch (mode) {
+        .allow => true,
+        .allow_as_parameter => isParameterAssertion(tree, index, ctx),
+        .never => false,
+    };
+    if (allowed) return false;
+
+    const placeholder = switch (literal) {
+        .object => "{ ... }",
+        .array => "[ ... ]",
+    };
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
         .@"error",
         id,
         tree.span(index),
-        "Use 'as {s}' instead of '<{s}>'.",
-        .{ type_text, type_text },
+        "Always prefer const x: T = {s}.",
+        .{placeholder},
     );
+    return true;
 }
 
-fn isObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
-    if (index == .null) return false;
+const LiteralAssertionKind = enum {
+    object,
+    array,
+};
+
+fn literalAssertionKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralAssertionKind {
+    if (index == .null) return null;
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
-        .object_expression => true,
-        else => false,
+        .object_expression => .object,
+        .array_expression => .array,
+        else => null,
     };
 }
 
@@ -88,6 +171,34 @@ fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex 
         }
     }
     return current;
+}
+
+fn isParameterAssertion(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var child = index;
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child) return false;
+                child = parent_index;
+            },
+            .chain_expression => |chain| {
+                if (chain.expression != child) return false;
+                child = parent_index;
+            },
+            .call_expression => |call| return rangeContains(tree, call.arguments, child),
+            .new_expression => |new_expression| return rangeContains(tree, new_expression.arguments, child),
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn rangeContains(tree: *const ast.Tree, range: ast.IndexRange, index: ast.NodeIndex) bool {
+    for (0..range.len) |i| {
+        if (tree.extra(range)[i] == index) return true;
+    }
+    return false;
 }
 
 fn sourceText(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {

--- a/tests/rules/typescript_eslint_consistent_type_assertions.zig
+++ b/tests/rules/typescript_eslint_consistent_type_assertions.zig
@@ -40,6 +40,87 @@ test "reports @typescript-eslint/consistent-type-assertions for object literal a
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
 }
 
+test "reports @typescript-eslint/consistent-type-assertions for as assertions in angle bracket mode" {
+    const source =
+        \\declare const input: unknown;
+        \\const value = input as string;
+        \\const objectValue = { x: 1 } as const;
+        \\const angleValue = <string>input;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_assertions_assertion_style = .angle_bracket,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+    try std.testing.expect(hasMessage(result, "Use '<string>' instead of 'as string'."));
+}
+
+test "reports @typescript-eslint/consistent-type-assertions for all assertions in never mode" {
+    const source =
+        \\declare const input: unknown;
+        \\const asValue = input as string;
+        \\const angleValue = <string>input;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_assertions_assertion_style = .never,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+    try std.testing.expect(hasMessage(result, "Do not use type assertions."));
+}
+
+test "allows @typescript-eslint/consistent-type-assertions object literal parameter assertions" {
+    const source =
+        \\declare function use(value: Foo): void;
+        \\declare class Box {
+        \\  constructor(value: Foo);
+        \\}
+        \\use({ x: 1 } as Foo);
+        \\new Box(({ x: 1 }) as Foo);
+        \\const value = { x: 1 } as Foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_assertions_object_literal_type_assertions = .allow_as_parameter,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+    try std.testing.expect(hasMessage(result, "Always prefer const x: T = { ... }."));
+}
+
+test "reports @typescript-eslint/consistent-type-assertions array literal assertions" {
+    const source =
+        \\const value = [1] as Foo;
+        \\const objectValue = { x: 1 } as Foo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .typescript_eslint_consistent_type_assertions_object_literal_type_assertions = .allow,
+        .typescript_eslint_consistent_type_assertions_array_literal_type_assertions = .never,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+    try std.testing.expect(hasMessage(result, "Always prefer const x: T = [ ... ]."));
+}
+
 test "allows @typescript-eslint/consistent-type-assertions compliant assertions" {
     const source =
         \\declare const input: unknown;
@@ -75,4 +156,11 @@ test "can disable @typescript-eslint/consistent-type-assertions" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_consistent_type_assertions.id));
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, expected)) return true;
+    }
+    return false;
 }


### PR DESCRIPTION
## Summary

- add configurable assertion style support for `@typescript-eslint/consistent-type-assertions`
- support object and array literal assertion modes, including `allow-as-parameter`
- preserve the existing fishlint-compatible defaults: `as`, object literals `never`, arrays `allow`
- update rule-status documentation

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_consistent_type_assertions.zig tests/rules/typescript_eslint_consistent_type_assertions.zig`
- `git diff --check`
