### PR TITLE
support ban types config

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -248,7 +248,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) | Implemented for `default: array`, `array-simple`, and `generic` configurations |
 | [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) | Implemented for directive modes and `minimumDescriptionLength` |
 | [`@typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/) | Implemented |
-| [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Implemented for fishlint's `types: { '{}': false, object: false }, extendDefaults: true` configuration |
+| [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) | Supports `types` and `extendDefaults` configuration |
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |
 | [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Supports `assertionStyle` plus object/array literal assertion modes |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for `interface` and `type` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -426,6 +426,92 @@ pub const NoThisAliasAllowedNames = struct {
     }
 };
 
+pub const max_typescript_eslint_ban_type_entries = 32;
+pub const max_typescript_eslint_ban_type_name_len = 128;
+pub const max_typescript_eslint_ban_type_message_len = 512;
+
+pub const TypescriptEslintBanTypesConfigError = error{
+    EmptyBanTypeName,
+    BanTypeNameTooLong,
+    BanTypeMessageTooLong,
+    TooManyBanTypes,
+};
+
+pub const TypescriptEslintBanTypeNames = struct {
+    count: usize = 0,
+    lengths: [max_typescript_eslint_ban_type_entries]usize = undefined,
+    storage: [max_typescript_eslint_ban_type_entries][max_typescript_eslint_ban_type_name_len]u8 = undefined,
+
+    pub fn contains(self: *const TypescriptEslintBanTypeNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const TypescriptEslintBanTypeNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *TypescriptEslintBanTypeNames, name: []const u8) TypescriptEslintBanTypesConfigError!void {
+        if (name.len == 0) return error.EmptyBanTypeName;
+        if (name.len > max_typescript_eslint_ban_type_name_len) return error.BanTypeNameTooLong;
+        if (self.count >= max_typescript_eslint_ban_type_entries) return error.TooManyBanTypes;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
+pub const TypescriptEslintBanTypeEntries = struct {
+    count: usize = 0,
+    name_lengths: [max_typescript_eslint_ban_type_entries]usize = undefined,
+    message_lengths: [max_typescript_eslint_ban_type_entries]usize = undefined,
+    names: [max_typescript_eslint_ban_type_entries][max_typescript_eslint_ban_type_name_len]u8 = undefined,
+    messages: [max_typescript_eslint_ban_type_entries][max_typescript_eslint_ban_type_message_len]u8 = undefined,
+
+    pub fn messageFor(self: *const TypescriptEslintBanTypeEntries, name: []const u8) ?[]const u8 {
+        var index = self.count;
+        while (index > 0) {
+            index -= 1;
+            if (std.mem.eql(u8, self.nameAt(index), name)) return self.messageAt(index);
+        }
+        return null;
+    }
+
+    pub fn nameAt(self: *const TypescriptEslintBanTypeEntries, index: usize) []const u8 {
+        return self.names[index][0..self.name_lengths[index]];
+    }
+
+    pub fn messageAt(self: *const TypescriptEslintBanTypeEntries, index: usize) []const u8 {
+        return self.messages[index][0..self.message_lengths[index]];
+    }
+
+    pub fn append(
+        self: *TypescriptEslintBanTypeEntries,
+        name: []const u8,
+        message: []const u8,
+    ) TypescriptEslintBanTypesConfigError!void {
+        if (name.len == 0) return error.EmptyBanTypeName;
+        if (name.len > max_typescript_eslint_ban_type_name_len) return error.BanTypeNameTooLong;
+        if (message.len > max_typescript_eslint_ban_type_message_len) return error.BanTypeMessageTooLong;
+        if (self.count >= max_typescript_eslint_ban_type_entries) return error.TooManyBanTypes;
+
+        @memcpy(self.names[self.count][0..name.len], name);
+        @memcpy(self.messages[self.count][0..message.len], message);
+        self.name_lengths[self.count] = name.len;
+        self.message_lengths[self.count] = message.len;
+        self.count += 1;
+    }
+};
+
+pub const TypescriptEslintBanTypesConfig = struct {
+    extend_defaults: bool = true,
+    disabled: TypescriptEslintBanTypeNames = .{},
+    custom: TypescriptEslintBanTypeEntries = .{},
+};
+
 pub const max_new_cap_exception_names = 32;
 pub const max_new_cap_exception_name_len = 128;
 
@@ -996,6 +1082,7 @@ pub const Options = struct {
     typescript_eslint_consistent_type_definitions_style: TypescriptEslintConsistentTypeDefinitionsStyle = .interface,
     typescript_eslint_no_array_constructor: bool = true,
     typescript_eslint_ban_types: bool = true,
+    typescript_eslint_ban_types_config: TypescriptEslintBanTypesConfig = .{},
     typescript_eslint_ban_ts_comment: bool = true,
     typescript_eslint_ban_ts_comment_ts_expect_error: TypescriptEslintBanTsCommentMode = .allow_with_description,
     typescript_eslint_ban_ts_comment_ts_ignore: TypescriptEslintBanTsCommentMode = .allow_with_description,
@@ -1342,6 +1429,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/ban-types")) {
+            self.typescript_eslint_ban_types_config = try typescriptEslintBanTypesConfigFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/ban-ts-comment")) {
             self.typescript_eslint_ban_ts_comment_ts_expect_error = try typescriptEslintBanTsCommentModeFromConfig(value, "ts-expect-error", .allow_with_description);
@@ -1719,6 +1809,84 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "getBeforeSet")) return .get_before_set;
         if (std.mem.eql(u8, style, "setBeforeGet")) return .set_before_get;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn typescriptEslintBanTypesConfigFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintBanTypesConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config_object = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var config = TypescriptEslintBanTypesConfig{};
+        config.extend_defaults = if (config_object.get("extendDefaults")) |extend_defaults| switch (extend_defaults) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        } else true;
+
+        const types_value = config_object.get("types") orelse return config;
+        const types = switch (types_value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var iter = types.iterator();
+        while (iter.next()) |entry| {
+            const name = entry.key_ptr.*;
+            switch (entry.value_ptr.*) {
+                .bool => |enabled| {
+                    if (enabled) {
+                        try appendBanTypeConfig(&config.custom, name, defaultBanTypeMessage(name));
+                    } else {
+                        try appendDisabledBanType(&config.disabled, name);
+                    }
+                },
+                .string => |message| try appendBanTypeConfig(&config.custom, name, message),
+                .object => |object| {
+                    const message = if (object.get("message")) |message_value| switch (message_value) {
+                        .string => |message| message,
+                        else => return error.UnsupportedRuleConfigValue,
+                    } else defaultBanTypeMessage(name);
+                    try appendBanTypeConfig(&config.custom, name, message);
+                },
+                else => return error.UnsupportedRuleConfigValue,
+            }
+        }
+
+        return config;
+    }
+
+    fn appendDisabledBanType(
+        disabled: *TypescriptEslintBanTypeNames,
+        name: []const u8,
+    ) RuleConfigError!void {
+        disabled.append(name) catch return error.UnsupportedRuleConfigValue;
+    }
+
+    fn appendBanTypeConfig(
+        entries: *TypescriptEslintBanTypeEntries,
+        name: []const u8,
+        message: []const u8,
+    ) RuleConfigError!void {
+        entries.append(name, message) catch return error.UnsupportedRuleConfigValue;
+    }
+
+    fn defaultBanTypeMessage(name: []const u8) []const u8 {
+        if (std.mem.eql(u8, name, "String")) return "Use string instead";
+        if (std.mem.eql(u8, name, "Boolean")) return "Use boolean instead";
+        if (std.mem.eql(u8, name, "Number")) return "Use number instead";
+        if (std.mem.eql(u8, name, "Symbol")) return "Use symbol instead";
+        if (std.mem.eql(u8, name, "BigInt")) return "Use bigint instead";
+        if (std.mem.eql(u8, name, "Function")) return "The `Function` type accepts any function-like value.";
+        if (std.mem.eql(u8, name, "Object")) return "Use object instead";
+        if (std.mem.eql(u8, name, "object")) return "Use a more specific object type instead";
+        if (std.mem.eql(u8, name, "{}")) return "Use a more specific object type instead";
+        return "This type is banned.";
     }
 
     fn typescriptEslintConsistentTypeAssertionsStyleFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintConsistentTypeAssertionsStyle {
@@ -4286,6 +4454,26 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
+
+    var typescript_ban_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"extendDefaults\":false,\"types\":{\"String\":false,\"object\":\"Use a named object shape.\",\"CustomType\":{\"message\":\"Use BetterType instead.\"}}}]",
+        .{},
+    );
+    defer typescript_ban_types_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/ban-types", typescript_ban_types_config.value);
+    try std.testing.expect(options.typescript_eslint_ban_types);
+    try std.testing.expect(!options.typescript_eslint_ban_types_config.extend_defaults);
+    try std.testing.expect(options.typescript_eslint_ban_types_config.disabled.contains("String"));
+    try std.testing.expectEqualStrings(
+        "Use a named object shape.",
+        options.typescript_eslint_ban_types_config.custom.messageFor("object") orelse "",
+    );
+    try std.testing.expectEqualStrings(
+        "Use BetterType instead.",
+        options.typescript_eslint_ban_types_config.custom.messageFor("CustomType") orelse "",
+    );
 
     var typescript_consistent_type_assertions_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1673,7 +1673,7 @@ const BasicVisitor = struct {
     pub fn enter_ts_type_literal(
         self: *BasicVisitor,
         type_literal: ast.TSTypeLiteral,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
@@ -1684,6 +1684,16 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkTypeLiteral(self.allocator, self.diagnostics, ctx.tree, type_literal);
+        }
+        if (self.options.typescript_eslint_ban_types) {
+            try typescript_eslint_ban_types.checkTypeLiteral(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                type_literal,
+                index,
+                self.options.typescript_eslint_ban_types_config,
+            );
         }
         return .proceed;
     }
@@ -1730,7 +1740,13 @@ const BasicVisitor = struct {
             self.options.typescript_eslint_no_wrapper_object_types and
             typescript_eslint_no_wrapper_object_types.isWrapperObjectTypeReference(ctx.tree, reference);
         if (self.options.typescript_eslint_ban_types and !wrapper_object_type_reported) {
-            try typescript_eslint_ban_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
+            try typescript_eslint_ban_types.checkTypeReference(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                reference,
+                self.options.typescript_eslint_ban_types_config,
+            );
         }
         if (self.options.typescript_eslint_no_wrapper_object_types) {
             try typescript_eslint_no_wrapper_object_types.checkTypeReference(self.allocator, self.diagnostics, ctx.tree, reference);
@@ -1785,6 +1801,24 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_invalid_void_type) {
             try typescript_eslint_no_invalid_void_type.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_object_keyword(
+        self: *BasicVisitor,
+        _: ast.TSObjectKeyword,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_ban_types) {
+            try typescript_eslint_ban_types.checkObjectKeyword(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                index,
+                self.options.typescript_eslint_ban_types_config,
+            );
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_ban_types.zig
+++ b/src/rules/typescript_eslint_ban_types.zig
@@ -17,9 +17,10 @@ pub fn checkTypeReference(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     reference: ast.TSTypeReference,
+    config: core.TypescriptEslintBanTypesConfig,
 ) Allocator.Error!void {
     const name = typeName(tree, reference.type_name) orelse return;
-    const banned = bannedType(name) orelse return;
+    const banned = bannedType(name, &config) orelse return;
 
     try core.addDiagnosticFmt(
         allocator,
@@ -32,7 +33,59 @@ pub fn checkTypeReference(
     );
 }
 
-fn bannedType(name: []const u8) ?BannedType {
+pub fn checkTypeLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    type_literal: ast.TSTypeLiteral,
+    index: ast.NodeIndex,
+    config: core.TypescriptEslintBanTypesConfig,
+) Allocator.Error!void {
+    if (type_literal.members.len != 0) return;
+    const banned = bannedType("{}", &config) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Don't use `{s}` as a type. {s}",
+        .{ banned.name, banned.message },
+    );
+}
+
+pub fn checkObjectKeyword(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    config: core.TypescriptEslintBanTypesConfig,
+) Allocator.Error!void {
+    const banned = bannedType("object", &config) orelse return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Don't use `{s}` as a type. {s}",
+        .{ banned.name, banned.message },
+    );
+}
+
+fn bannedType(name: []const u8, config: *const core.TypescriptEslintBanTypesConfig) ?BannedType {
+    if (config.custom.messageFor(name)) |message| return .{
+        .name = name,
+        .message = message,
+    };
+    if (config.disabled.contains(name)) return null;
+    if (!config.extend_defaults) return null;
+    return defaultBannedType(name);
+}
+
+fn defaultBannedType(name: []const u8) ?BannedType {
     if (std.mem.eql(u8, name, "String")) return .{
         .name = "String",
         .message = "Use string instead",

--- a/tests/rules/typescript_eslint_ban_types.zig
+++ b/tests/rules/typescript_eslint_ban_types.zig
@@ -46,6 +46,57 @@ test "does not report @typescript-eslint/ban-types for fishlint allowed object f
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_types.id));
 }
 
+test "supports @typescript-eslint/ban-types custom type config" {
+    const source =
+        \\let text: String;
+        \\let value: object;
+        \\let empty: {};
+        \\let custom: CustomType;
+    ;
+
+    var config: @TypeOf((lint.Options{}).typescript_eslint_ban_types_config) = .{
+        .extend_defaults = false,
+    };
+    try config.custom.append("object", "Use a named object shape.");
+    try config.custom.append("{}", "Use Record<string, unknown>.");
+    try config.custom.append("CustomType", "Use BetterType instead.");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_ban_types_config = config,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_ban_types.id));
+    try std.testing.expect(hasMessage(result, "Don't use `object` as a type. Use a named object shape."));
+    try std.testing.expect(hasMessage(result, "Don't use `{}` as a type. Use Record<string, unknown>."));
+    try std.testing.expect(hasMessage(result, "Don't use `CustomType` as a type. Use BetterType instead."));
+}
+
+test "supports @typescript-eslint/ban-types disabled default types" {
+    const source =
+        \\let text: String;
+        \\let count: Number;
+    ;
+
+    var config: @TypeOf((lint.Options{}).typescript_eslint_ban_types_config) = .{};
+    try config.disabled.append("String");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_wrapper_object_types = false,
+        .typescript_eslint_ban_types_config = config,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_ban_types.id));
+    try std.testing.expect(hasMessage(result, "Don't use `Number` as a type. Use number instead"));
+}
+
 test "can disable @typescript-eslint/ban-types" {
     const source =
         \\let text: String;
@@ -59,4 +110,11 @@ test "can disable @typescript-eslint/ban-types" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_ban_types.id));
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, expected)) return true;
+    }
+    return false;
 }


### PR DESCRIPTION
## Summary

- add `types` and `extendDefaults` config support for `@typescript-eslint/ban-types`
- allow configured custom banned type messages and disabled default types
- support configured bans for `object` keyword and empty `{}` type literals while preserving existing fishlint-compatible defaults
- update rule-status documentation

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_ban_types.zig tests/rules/typescript_eslint_ban_types.zig`
- `git diff --check`
