### PR TITLE
support ts unused expression options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -282,7 +282,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
-| [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Implemented for fishlint's `allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true` configuration |
+| [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -978,6 +978,9 @@ pub const Options = struct {
     no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .no,
     no_unused_expressions_allow_tagged_templates: NoUnusedExpressionsAllowTaggedTemplates = .no,
     typescript_eslint_no_unused_expressions: bool = true,
+    typescript_eslint_no_unused_expressions_allow_short_circuit: NoUnusedExpressionsAllowShortCircuit = .yes,
+    typescript_eslint_no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .yes,
+    typescript_eslint_no_unused_expressions_allow_tagged_templates: NoUnusedExpressionsAllowTaggedTemplates = .yes,
     no_warning_comments: bool = true,
     no_warning_comments_location: NoWarningCommentsLocation = .start,
     no_warning_comments_decoration: NoWarningCommentsDecoration = .none,
@@ -1401,6 +1404,11 @@ pub const Options = struct {
             self.no_unused_expressions_allow_short_circuit = try noUnusedExpressionsAllowShortCircuitFromConfig(value);
             self.no_unused_expressions_allow_ternary = try noUnusedExpressionsAllowTernaryFromConfig(value);
             self.no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-expressions")) {
+            self.typescript_eslint_no_unused_expressions_allow_short_circuit = try noUnusedExpressionsAllowShortCircuitFromConfig(value);
+            self.typescript_eslint_no_unused_expressions_allow_ternary = try noUnusedExpressionsAllowTernaryFromConfig(value);
+            self.typescript_eslint_no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-unused-vars")) {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
@@ -4428,6 +4436,19 @@ test "Options can apply ESLint-style rule config values" {
     defer no_unused_expressions_default_config.deinit();
     try options.setByRuleConfigValue("no-unused-expressions", no_unused_expressions_default_config.value);
     try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.no_unused_expressions_allow_tagged_templates);
+
+    var typescript_no_unused_expressions_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowShortCircuit\":false,\"allowTernary\":false,\"allowTaggedTemplates\":false}]",
+        .{},
+    );
+    defer typescript_no_unused_expressions_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-expressions", typescript_no_unused_expressions_config.value);
+    try std.testing.expect(options.typescript_eslint_no_unused_expressions);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowShortCircuit.no, options.typescript_eslint_no_unused_expressions_allow_short_circuit);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowTernary.no, options.typescript_eslint_no_unused_expressions_allow_ternary);
+    try std.testing.expectEqual(NoUnusedExpressionsAllowTaggedTemplates.no, options.typescript_eslint_no_unused_expressions_allow_tagged_templates);
 
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1435,7 +1435,11 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.typescript_eslint_no_unused_expressions) {
-            try typescript_eslint_no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try typescript_eslint_no_unused_expressions.check(self.allocator, self.diagnostics, ctx.tree, statement, index, .{
+                .allow_short_circuit = self.options.typescript_eslint_no_unused_expressions_allow_short_circuit == .yes,
+                .allow_ternary = self.options.typescript_eslint_no_unused_expressions_allow_ternary == .yes,
+                .allow_tagged_templates = self.options.typescript_eslint_no_unused_expressions_allow_tagged_templates == .yes,
+            });
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_unused_expressions.zig
+++ b/src/rules/typescript_eslint_no_unused_expressions.zig
@@ -12,12 +12,13 @@ pub fn check(
     tree: *const parser.ast.Tree,
     statement: parser.ast.ExpressionStatement,
     index: parser.ast.NodeIndex,
+    options: no_unused_expressions.Options,
 ) Allocator.Error!void {
     try no_unused_expressions.checkWithOptions(allocator, diagnostics, tree, statement, index, .{
         .rule_id = id,
         .severity = .@"error",
-        .allow_short_circuit = true,
-        .allow_ternary = true,
-        .allow_tagged_templates = true,
+        .allow_short_circuit = options.allow_short_circuit,
+        .allow_ternary = options.allow_ternary,
+        .allow_tagged_templates = options.allow_tagged_templates,
     });
 }

--- a/tests/rules/typescript_eslint_no_unused_expressions.zig
+++ b/tests/rules/typescript_eslint_no_unused_expressions.zig
@@ -47,6 +47,26 @@ test "allows fishlint short circuit ternary and tagged template expressions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_expressions.id));
 }
 
+test "honors @typescript-eslint/no-unused-expressions allow options" {
+    const source =
+        \\foo && bar();
+        \\foo ? bar() : baz();
+        \\tag`template`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions_allow_short_circuit = .no,
+        .typescript_eslint_no_unused_expressions_allow_ternary = .no,
+        .typescript_eslint_no_unused_expressions_allow_tagged_templates = .no,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_expressions.id));
+}
+
 test "can disable @typescript-eslint/no-unused-expressions and fall back to core rule" {
     const source =
         \\foo && bar();


### PR DESCRIPTION
## Summary

- add configurable allow options for `@typescript-eslint/no-unused-expressions`
- preserve fishlint-compatible defaults for short-circuit, ternary, and tagged-template expressions
- wire ESLint-style config parsing for the TypeScript rule variant
- update rule-status documentation

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_unused_expressions.zig tests/rules/typescript_eslint_no_unused_expressions.zig`
- `git diff --check`
