### PR TITLE
support no unused prop types skip shape option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -231,7 +231,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
-| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Implemented for fishlint's `customValidators: [], skipShapeProps: true` configuration |
+| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Implemented for fishlint's `ignore: [], customValidators: [], skipUndeclared: false` configuration |
 
 ## React Hooks rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -1059,6 +1059,7 @@ pub const Options = struct {
     react_no_unknown_property: bool = true,
     react_prop_types: bool = true,
     react_no_unused_prop_types: bool = true,
+    react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
@@ -1434,6 +1435,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
+            self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
@@ -1817,6 +1821,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "getBeforeSet")) return .get_before_set;
         if (std.mem.eql(u8, style, "setBeforeGet")) return .set_before_get;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn reactNoUnusedPropTypesSkipShapePropsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("skipShapeProps") orelse return true) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn typescriptEslintBanTypesConfigFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintBanTypesConfig {
@@ -3739,6 +3760,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_no_unused_prop_types);
     try std.testing.expect(options.setByCliName("react/no-unused-prop-types", true));
     try std.testing.expect(options.react_no_unused_prop_types);
+    try std.testing.expect(options.react_no_unused_prop_types_skip_shape_props);
 
     try std.testing.expect(!options.react_hooks_rules_of_hooks);
     try std.testing.expect(options.setByCliName("react-hooks/rules-of-hooks", true));
@@ -3763,6 +3785,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.jsx_a11y_aria_props);
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
+
+    var react_no_unused_prop_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipShapeProps\":false}]",
+        .{},
+    );
+    defer react_no_unused_prop_types_config.deinit();
+    try options.setByRuleConfigValue("react/no-unused-prop-types", react_no_unused_prop_types_config.value);
+    try std.testing.expect(options.react_no_unused_prop_types);
+    try std.testing.expect(!options.react_no_unused_prop_types_skip_shape_props);
 
     var array_callback_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_unused_prop_types.zig
+++ b/src/rules/react_no_unused_prop_types.zig
@@ -12,13 +12,14 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    skip_shape_props: bool,
 ) Allocator.Error!void {
     var state = try react_prop_types.collect(allocator, tree);
     defer state.deinit(allocator);
 
     for (state.components.items) |component| {
         if (!component.detected) continue;
-        try reportUnusedProps(allocator, diagnostics, tree, component, component.declared_props.items, "");
+        try reportUnusedProps(allocator, diagnostics, tree, component, component.declared_props.items, "", skip_shape_props);
     }
 }
 
@@ -29,6 +30,7 @@ fn reportUnusedProps(
     component: react_prop_types.ComponentInfo,
     props: []const react_prop_types.DeclaredProp,
     prefix: []const u8,
+    skip_shape_props: bool,
 ) Allocator.Error!void {
     for (props) |prop| {
         const full_name = if (prefix.len == 0)
@@ -37,7 +39,7 @@ fn reportUnusedProps(
             try std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, prop.name });
         defer allocator.free(full_name);
 
-        if (prop.kind == .shape or prop.kind == .exact) {
+        if (skip_shape_props and (prop.kind == .shape or prop.kind == .exact)) {
             continue;
         }
 
@@ -53,7 +55,7 @@ fn reportUnusedProps(
             );
         }
 
-        try reportUnusedProps(allocator, diagnostics, tree, component, prop.children.items, full_name);
+        try reportUnusedProps(allocator, diagnostics, tree, component, prop.children.items, full_name, skip_shape_props);
     }
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -528,7 +528,7 @@ pub fn runBasic(
         try react_prop_types.run(allocator, diagnostics, tree);
     }
     if (options.react_no_unused_prop_types) {
-        try react_no_unused_prop_types.run(allocator, diagnostics, tree);
+        try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props);
     }
 
     var visitor = BasicVisitor{

--- a/tests/rules/react_no_unused_prop_types.zig
+++ b/tests/rules/react_no_unused_prop_types.zig
@@ -5,6 +5,7 @@ const helpers = @import("../helpers.zig");
 fn noUnusedPropTypesOnly() lint.Options {
     var options = lint.Options.allDisabled();
     options.react_no_unused_prop_types = true;
+    options.react_no_unused_prop_types_skip_shape_props = true;
     return options;
 }
 
@@ -45,6 +46,31 @@ test "skips react/no-unused-prop-types shape props for fishlint configuration" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_prop_types.id));
+}
+
+test "reports react/no-unused-prop-types shape props when configured" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  user: PropTypes.shape({
+        \\    age: PropTypes.number,
+        \\  }),
+        \\};
+    ;
+
+    var options = noUnusedPropTypesOnly();
+    options.react_no_unused_prop_types_skip_shape_props = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(hasMessage(result, "'user' PropType is defined but prop is never used"));
+    try std.testing.expect(hasMessage(result, "'user.age' PropType is defined but prop is never used"));
 }
 
 test "reports react/no-unused-prop-types object props" {
@@ -105,4 +131,11 @@ test "can disable react/no-unused-prop-types" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unused_prop_types.id));
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.message, expected)) return true;
+    }
+    return false;
 }


### PR DESCRIPTION
## Summary
- add ESLint-style `skipShapeProps` config parsing for `react/no-unused-prop-types`
- thread the option into the rule while preserving the fishlint default of skipping shape/exact props
- add coverage for reporting shape props when the option is disabled

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_unused_prop_types.zig tests/rules/react_no_unused_prop_types.zig`
- `git diff --check`