### PR TITLE
support prop types skip undeclared option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -232,7 +232,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
-| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Implemented for fishlint's `ignore: [], customValidators: [], skipUndeclared: false` configuration |
+| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
 
 ## React Hooks rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -1058,6 +1058,7 @@ pub const Options = struct {
     react_no_typos: bool = true,
     react_no_unknown_property: bool = true,
     react_prop_types: bool = true,
+    react_prop_types_skip_undeclared: bool = false,
     react_no_unused_prop_types: bool = true,
     react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_state: bool = true,
@@ -1435,6 +1436,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/prop-types")) {
+            self.react_prop_types_skip_undeclared = try reactPropTypesSkipUndeclaredFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
@@ -1835,6 +1839,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("skipShapeProps") orelse return true) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn reactPropTypesSkipUndeclaredFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("skipUndeclared") orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -3756,6 +3777,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
+    try std.testing.expect(!options.react_prop_types_skip_undeclared);
 
     try std.testing.expect(!options.react_no_unused_prop_types);
     try std.testing.expect(options.setByCliName("react/no-unused-prop-types", true));
@@ -3785,6 +3807,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.jsx_a11y_aria_props);
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
+
+    var react_prop_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipUndeclared\":true}]",
+        .{},
+    );
+    defer react_prop_types_config.deinit();
+    try options.setByRuleConfigValue("react/prop-types", react_prop_types_config.value);
+    try std.testing.expect(options.react_prop_types);
+    try std.testing.expect(options.react_prop_types_skip_undeclared);
 
     var react_no_unused_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -119,11 +119,12 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    skip_undeclared: bool,
 ) Allocator.Error!void {
     var state = try collect(allocator, tree);
     defer state.deinit(allocator);
 
-    try finish(allocator, diagnostics, tree, &state);
+    try finish(allocator, diagnostics, tree, &state, skip_undeclared);
 }
 
 pub fn collect(
@@ -605,7 +606,10 @@ fn finish(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     state: *State,
+    skip_undeclared: bool,
 ) Allocator.Error!void {
+    if (skip_undeclared) return;
+
     for (state.components.items) |component| {
         if (!component.detected) continue;
         for (component.used_props.items) |used| {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -525,7 +525,7 @@ pub fn runBasic(
         try require_await.run(allocator, diagnostics, tree);
     }
     if (options.react_prop_types) {
-        try react_prop_types.run(allocator, diagnostics, tree);
+        try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared);
     }
     if (options.react_no_unused_prop_types) {
         try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props);

--- a/tests/rules/react_prop_types.zig
+++ b/tests/rules/react_prop_types.zig
@@ -29,6 +29,31 @@ test "reports react/prop-types for missing function component props" {
     try std.testing.expect(std.mem.eql(u8, result.diagnostics[1].message, "'user.name' is missing in props validation"));
 }
 
+test "supports configured react/prop-types skipUndeclared" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipUndeclared\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/prop-types", config.value);
+
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prop_types.id));
+}
+
 test "allows react/prop-types declared object children" {
     const source =
         \\import React from 'react';


### PR DESCRIPTION
## Summary
- add ESLint-style `skipUndeclared` config parsing for `react/prop-types`
- thread the option into the rule while preserving the existing default behavior
- add coverage for suppressing missing prop validation diagnostics when configured

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_prop_types.zig tests/rules/react_prop_types.zig`
- `git diff --check`