### PR TITLE
support no unescaped entities forbid option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -230,7 +230,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
-| [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Implemented for eslint-plugin-react's default entity set |
+| [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -1064,6 +1064,10 @@ pub const Options = struct {
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_unescaped_entities: bool = true,
+    react_no_unescaped_entities_forbid_gt: bool = true,
+    react_no_unescaped_entities_forbid_double_quote: bool = true,
+    react_no_unescaped_entities_forbid_single_quote: bool = true,
+    react_no_unescaped_entities_forbid_closing_brace: bool = true,
     react_prefer_es6_class: bool = true,
     react_self_closing_comp: bool = true,
     react_style_prop_object: bool = true,
@@ -1442,6 +1446,13 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-unescaped-entities")) {
+            const forbid = try reactNoUnescapedEntitiesForbidFromConfig(value);
+            self.react_no_unescaped_entities_forbid_gt = forbid.gt;
+            self.react_no_unescaped_entities_forbid_double_quote = forbid.double_quote;
+            self.react_no_unescaped_entities_forbid_single_quote = forbid.single_quote;
+            self.react_no_unescaped_entities_forbid_closing_brace = forbid.closing_brace;
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
@@ -1859,6 +1870,59 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    const ReactNoUnescapedEntitiesForbid = struct {
+        gt: bool = true,
+        double_quote: bool = true,
+        single_quote: bool = true,
+        closing_brace: bool = true,
+    };
+
+    fn reactNoUnescapedEntitiesForbidFromConfig(value: std.json.Value) RuleConfigError!ReactNoUnescapedEntitiesForbid {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const forbid = switch (config.get("forbid") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = ReactNoUnescapedEntitiesForbid{
+            .gt = false,
+            .double_quote = false,
+            .single_quote = false,
+            .closing_brace = false,
+        };
+        for (forbid) |entry| {
+            const char = switch (entry) {
+                .string => |string| string,
+                .object => |object| switch (object.get("char") orelse return error.UnsupportedRuleConfigValue) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                },
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, char, ">")) {
+                result.gt = true;
+            } else if (std.mem.eql(u8, char, "\"")) {
+                result.double_quote = true;
+            } else if (std.mem.eql(u8, char, "'")) {
+                result.single_quote = true;
+            } else if (std.mem.eql(u8, char, "}")) {
+                result.closing_brace = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        return result;
     }
 
     fn typescriptEslintBanTypesConfigFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintBanTypesConfig {
@@ -3784,6 +3848,14 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_no_unused_prop_types);
     try std.testing.expect(options.react_no_unused_prop_types_skip_shape_props);
 
+    try std.testing.expect(!options.react_no_unescaped_entities);
+    try std.testing.expect(options.setByCliName("react/no-unescaped-entities", true));
+    try std.testing.expect(options.react_no_unescaped_entities);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_gt);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_double_quote);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_single_quote);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_closing_brace);
+
     try std.testing.expect(!options.react_hooks_rules_of_hooks);
     try std.testing.expect(options.setByCliName("react-hooks/rules-of-hooks", true));
     try std.testing.expect(options.react_hooks_rules_of_hooks);
@@ -3818,6 +3890,20 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/prop-types", react_prop_types_config.value);
     try std.testing.expect(options.react_prop_types);
     try std.testing.expect(options.react_prop_types_skip_undeclared);
+
+    var react_no_unescaped_entities_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"forbid\":[\">\",{\"char\":\"}\"}]}]",
+        .{},
+    );
+    defer react_no_unescaped_entities_config.deinit();
+    try options.setByRuleConfigValue("react/no-unescaped-entities", react_no_unescaped_entities_config.value);
+    try std.testing.expect(options.react_no_unescaped_entities);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_gt);
+    try std.testing.expect(!options.react_no_unescaped_entities_forbid_double_quote);
+    try std.testing.expect(!options.react_no_unescaped_entities_forbid_single_quote);
+    try std.testing.expect(options.react_no_unescaped_entities_forbid_closing_brace);
 
     var react_no_unused_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_unescaped_entities.zig
+++ b/src/rules/react_no_unescaped_entities.zig
@@ -7,16 +7,25 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/no-unescaped-entities";
 
+pub const Options = struct {
+    forbid_gt: bool = true,
+    forbid_double_quote: bool = true,
+    forbid_single_quote: bool = true,
+    forbid_closing_brace: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const span = tree.span(index);
     const source = sourceSlice(tree, span) orelse return;
 
     for (source, 0..) |byte, offset| {
+        if (!isForbidden(byte, options)) continue;
         const alternatives = alternativesFor(byte) orelse continue;
         const start: u32 = span.start + @as(u32, @intCast(offset));
         try core.addDiagnosticFmt(
@@ -29,6 +38,16 @@ pub fn check(
             .{ byte, alternatives },
         );
     }
+}
+
+fn isForbidden(byte: u8, options: Options) bool {
+    return switch (byte) {
+        '>' => options.forbid_gt,
+        '"' => options.forbid_double_quote,
+        '\'' => options.forbid_single_quote,
+        '}' => options.forbid_closing_brace,
+        else => false,
+    };
 }
 
 fn alternativesFor(byte: u8) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2913,7 +2913,12 @@ const BasicVisitor = struct {
             try react_jsx_no_comment_textnodes.check(self.allocator, self.diagnostics, ctx.tree, text, index);
         }
         if (self.options.react_no_unescaped_entities) {
-            try react_no_unescaped_entities.check(self.allocator, self.diagnostics, ctx.tree, index);
+            try react_no_unescaped_entities.check(self.allocator, self.diagnostics, ctx.tree, index, .{
+                .forbid_gt = self.options.react_no_unescaped_entities_forbid_gt,
+                .forbid_double_quote = self.options.react_no_unescaped_entities_forbid_double_quote,
+                .forbid_single_quote = self.options.react_no_unescaped_entities_forbid_single_quote,
+                .forbid_closing_brace = self.options.react_no_unescaped_entities_forbid_closing_brace,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_no_unescaped_entities.zig
+++ b/tests/rules/react_no_unescaped_entities.zig
@@ -39,6 +39,34 @@ test "allows escaped entities and JavaScript expression strings" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unescaped_entities.id));
 }
 
+test "supports configured react/no-unescaped-entities forbid list" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"forbid\":[\">\",{\"char\":\"}\"}]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/no-unescaped-entities", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const node = <div>Tom's "quote" > brace }</div>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_unescaped_entities.id));
+    try std.testing.expectEqualStrings("`>` can be escaped with `&gt;`.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("`}` can be escaped with `&#125;`.", result.diagnostics[1].message);
+}
+
 test "can disable react/no-unescaped-entities" {
     const source =
         \\const node = <div>Tom's ></div>;


### PR DESCRIPTION
## Summary
- add ESLint-style `forbid` config parsing for `react/no-unescaped-entities`
- pass the configured forbidden entity set into the JSX text rule
- add coverage for string and object forbid entries while preserving the default entity set

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_unescaped_entities.zig tests/rules/react_no_unescaped_entities.zig`
- `git diff --check`