### PR TITLE
support jsx no target blank allow referrer

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -224,7 +224,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
-| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Implemented for eslint-plugin-react's default link configuration |
+| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented with configurable `allowAllCaps` behavior |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1036,6 +1036,7 @@ pub const Options = struct {
     react_button_has_type: bool = true,
     react_require_render_return: bool = true,
     react_jsx_no_target_blank: bool = true,
+    react_jsx_no_target_blank_allow_referrer: bool = false,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
@@ -1437,6 +1438,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-duplicate-props")) {
             self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
+            self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
@@ -1867,6 +1871,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("skipUndeclared") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn reactJsxNoTargetBlankAllowReferrerFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowReferrer") orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -3765,6 +3786,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_jsx_no_target_blank);
     try std.testing.expect(options.setByCliName("react/jsx-no-target-blank", true));
     try std.testing.expect(options.react_jsx_no_target_blank);
+    try std.testing.expect(!options.react_jsx_no_target_blank_allow_referrer);
 
     try std.testing.expect(!options.import_no_duplicates);
     try std.testing.expect(options.setByCliName("import/no-duplicates", true));
@@ -3879,6 +3901,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.jsx_a11y_aria_props);
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
+
+    var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowReferrer\":true}]",
+        .{},
+    );
+    defer react_jsx_no_target_blank_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-no-target-blank", react_jsx_no_target_blank_config.value);
+    try std.testing.expect(options.react_jsx_no_target_blank);
+    try std.testing.expect(options.react_jsx_no_target_blank_allow_referrer);
 
     var react_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_no_target_blank.zig
+++ b/src/rules/react_jsx_no_target_blank.zig
@@ -7,19 +7,24 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-no-target-blank";
 
+pub const Options = struct {
+    allow_referrer: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (!isAnchorElement(tree, opening.name)) return;
 
     const target = lastAttributeNamed(tree, opening, "target") orelse return;
     if (!attributeValuePossiblyBlank(tree, target.attribute)) return;
     if (!hasDangerousHref(tree, opening)) return;
-    if (hasSecureRel(tree, opening, target.attribute.value)) return;
+    if (hasSecureRel(tree, opening, target.attribute.value, options.allow_referrer)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -88,7 +93,7 @@ fn hasDangerousHref(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool 
     return tree.data(href.attribute.value) == .jsx_expression_container;
 }
 
-fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_value: ast.NodeIndex) bool {
+fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_value: ast.NodeIndex, allow_referrer: bool) bool {
     const rel = lastAttributeNamed(tree, opening, "rel") orelse return false;
     if (rel.attribute.value == .null) return false;
 
@@ -97,7 +102,7 @@ fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_va
     if (count == 0) return false;
 
     for (values[0..count]) |value| {
-        if (!valueHasNoreferrer(value orelse return false)) return false;
+        if (!valueIsSecureRel(value orelse return false, allow_referrer)) return false;
     }
     return true;
 }
@@ -183,6 +188,17 @@ fn valueHasNoreferrer(value: []const u8) bool {
     var iter = std.mem.tokenizeScalar(u8, value, ' ');
     while (iter.next()) |token| {
         if (std.ascii.eqlIgnoreCase(token, "noreferrer")) return true;
+    }
+    return false;
+}
+
+fn valueIsSecureRel(value: []const u8, allow_referrer: bool) bool {
+    if (valueHasNoreferrer(value)) return true;
+    if (!allow_referrer) return false;
+
+    var iter = std.mem.tokenizeScalar(u8, value, ' ');
+    while (iter.next()) |token| {
+        if (std.ascii.eqlIgnoreCase(token, "noopener")) return true;
     }
     return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2890,7 +2890,9 @@ const BasicVisitor = struct {
             try jsx_a11y_scope.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.react_jsx_no_target_blank) {
-            try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+            try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
+                .allow_referrer = self.options.react_jsx_no_target_blank_allow_referrer,
+            });
         }
         if (self.options.react_jsx_pascal_case) {
             try react_jsx_pascal_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, index, .{

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -44,6 +44,34 @@ test "allows secure rel non-external links and non-anchor elements" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_target_blank.id));
 }
 
+test "supports configured react/jsx-no-target-blank allowReferrer" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowReferrer\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/jsx-no-target-blank", config.value);
+    options.eol_last = false;
+    options.jsx_a11y_anchor_has_content = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const noopener = <a href="https://example.com" target="_blank" rel="noopener" />;
+        \\const missing = <a href="https://example.com" target="_blank" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
+}
+
 test "can disable react/jsx-no-target-blank" {
     const source =
         \\const link = <a href="https://example.com" target="_blank" />;


### PR DESCRIPTION
## Summary
- add ESLint-style `allowReferrer` config parsing for `react/jsx-no-target-blank`
- allow `rel="noopener"` when `allowReferrer` is enabled while keeping the default `noreferrer` requirement
- add coverage for the configured behavior and update rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_no_target_blank.zig tests/rules/react_jsx_no_target_blank.zig`
- `git diff --check`