### PR TITLE
support jsx pascal case ignore option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -225,7 +225,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` configuration |
-| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Implemented with configurable `allowAllCaps` behavior |
+| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps` and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -426,6 +426,42 @@ pub const NoThisAliasAllowedNames = struct {
     }
 };
 
+pub const max_react_jsx_pascal_case_ignore_names = 32;
+pub const max_react_jsx_pascal_case_ignore_name_len = 128;
+
+pub const ReactJsxPascalCaseIgnoreNamesError = error{
+    EmptyReactJsxPascalCaseIgnoreName,
+    TooManyReactJsxPascalCaseIgnoreNames,
+    ReactJsxPascalCaseIgnoreNameTooLong,
+};
+
+pub const ReactJsxPascalCaseIgnoreNames = struct {
+    count: usize = 0,
+    lengths: [max_react_jsx_pascal_case_ignore_names]usize = undefined,
+    storage: [max_react_jsx_pascal_case_ignore_names][max_react_jsx_pascal_case_ignore_name_len]u8 = undefined,
+
+    pub fn contains(self: *const ReactJsxPascalCaseIgnoreNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const ReactJsxPascalCaseIgnoreNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ReactJsxPascalCaseIgnoreNames, name: []const u8) ReactJsxPascalCaseIgnoreNamesError!void {
+        if (name.len == 0) return error.EmptyReactJsxPascalCaseIgnoreName;
+        if (self.count >= max_react_jsx_pascal_case_ignore_names) return error.TooManyReactJsxPascalCaseIgnoreNames;
+        if (name.len > max_react_jsx_pascal_case_ignore_name_len) return error.ReactJsxPascalCaseIgnoreNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_typescript_eslint_ban_type_entries = 32;
 pub const max_typescript_eslint_ban_type_name_len = 128;
 pub const max_typescript_eslint_ban_type_message_len = 512;
@@ -1040,6 +1076,7 @@ pub const Options = struct {
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
+    react_jsx_pascal_case_ignore: ReactJsxPascalCaseIgnoreNames = .{},
     react_jsx_uses_react: bool = true,
     react_jsx_uses_vars: bool = true,
     react_no_danger: bool = true,
@@ -1444,6 +1481,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
+            self.react_jsx_pascal_case_ignore = try reactJsxPascalCaseIgnoreFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/prop-types")) {
             self.react_prop_types_skip_undeclared = try reactPropTypesSkipUndeclaredFromConfig(value);
@@ -3311,6 +3349,33 @@ pub const Options = struct {
         };
     }
 
+    fn reactJsxPascalCaseIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactJsxPascalCaseIgnoreNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore_items = switch (config.get("ignore") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignore = ReactJsxPascalCaseIgnoreNames{};
+        for (ignore_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            ignore.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return ignore;
+    }
+
     fn wrapIifeStyleFromConfig(value: std.json.Value) RuleConfigError!WrapIifeStyle {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3869,6 +3934,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("react/no-unused-prop-types", true));
     try std.testing.expect(options.react_no_unused_prop_types);
     try std.testing.expect(options.react_no_unused_prop_types_skip_shape_props);
+    try std.testing.expectEqual(@as(usize, 0), options.react_jsx_pascal_case_ignore.count);
 
     try std.testing.expect(!options.react_no_unescaped_entities);
     try std.testing.expect(options.setByCliName("react/no-unescaped-entities", true));
@@ -3912,6 +3978,20 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/jsx-no-target-blank", react_jsx_no_target_blank_config.value);
     try std.testing.expect(options.react_jsx_no_target_blank);
     try std.testing.expect(options.react_jsx_no_target_blank_allow_referrer);
+
+    var react_jsx_pascal_case_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAllCaps\":false,\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
+        .{},
+    );
+    defer react_jsx_pascal_case_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-pascal-case", react_jsx_pascal_case_config.value);
+    try std.testing.expect(options.react_jsx_pascal_case);
+    try std.testing.expect(!options.react_jsx_pascal_case_allow_all_caps);
+    try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("bar"));
+    try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("Legacy_widget"));
+    try std.testing.expect(!options.react_jsx_pascal_case_ignore.contains("other"));
 
     var react_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_pascal_case.zig
+++ b/src/rules/react_jsx_pascal_case.zig
@@ -9,6 +9,7 @@ pub const id = "react/jsx-pascal-case";
 
 pub const Options = struct {
     allow_all_caps: bool = true,
+    ignore: core.ReactJsxPascalCaseIgnoreNames = .{},
 };
 
 pub fn check(
@@ -62,6 +63,7 @@ fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Op
         .jsx_identifier => |identifier| {
             const name = tree.string(identifier.name);
             if (name.len == 1) return null;
+            if (options.ignore.contains(name)) return null;
             return if (isPascalCase(name) or (options.allow_all_caps and isAllCaps(name))) null else name;
         },
         .jsx_namespaced_name => |name| {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2897,6 +2897,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_pascal_case) {
             try react_jsx_pascal_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
                 .allow_all_caps = self.options.react_jsx_pascal_case_allow_all_caps,
+                .ignore = self.options.react_jsx_pascal_case_ignore,
             });
         }
         if (self.options.react_self_closing_comp) {

--- a/tests/rules/react_jsx_pascal_case.zig
+++ b/tests/rules/react_jsx_pascal_case.zig
@@ -66,6 +66,36 @@ test "supports configured react/jsx-pascal-case allowAllCaps false" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
 }
 
+test "supports configured react/jsx-pascal-case ignore list" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-pascal-case", config.value);
+
+    const source =
+        \\const ignoredMember = <Foo.bar />;
+        \\const ignoredRoot = <Legacy_widget />;
+        \\const reported = <Foo.baz />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
+    try std.testing.expectEqualStrings("Imported JSX component baz must be in PascalCase or SCREAMING_SNAKE_CASE", result.diagnostics[0].message);
+}
+
 test "can disable react/jsx-pascal-case" {
     const source =
         \\const node = <Foo.bar />;


### PR DESCRIPTION
## Summary
- add ESLint-style `ignore` config parsing for `react/jsx-pascal-case`
- pass ignored JSX name parts into the rule alongside existing `allowAllCaps` support
- add coverage for ignored member/root names and update rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_pascal_case.zig tests/rules/react_jsx_pascal_case.zig`
- `git diff --check`