### PR TITLE
support jsx no target blank dynamic link option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -224,7 +224,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
-| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` configuration |
+| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` and `enforceDynamicLinks` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps` and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1073,6 +1073,7 @@ pub const Options = struct {
     react_require_render_return: bool = true,
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_target_blank_allow_referrer: bool = false,
+    react_jsx_no_target_blank_enforce_dynamic_links: bool = true,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
@@ -1478,6 +1479,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
+            self.react_jsx_no_target_blank_enforce_dynamic_links = try reactJsxNoTargetBlankEnforceDynamicLinksFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
@@ -1929,6 +1931,26 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn reactJsxNoTargetBlankEnforceDynamicLinksFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const mode = switch (config.get("enforceDynamicLinks") orelse return true) {
+            .string => |mode| mode,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, mode, "always")) return true;
+        if (std.mem.eql(u8, mode, "never")) return false;
+        return error.UnsupportedRuleConfigValue;
     }
 
     const ReactNoUnescapedEntitiesForbid = struct {
@@ -3852,6 +3874,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("react/jsx-no-target-blank", true));
     try std.testing.expect(options.react_jsx_no_target_blank);
     try std.testing.expect(!options.react_jsx_no_target_blank_allow_referrer);
+    try std.testing.expect(options.react_jsx_no_target_blank_enforce_dynamic_links);
 
     try std.testing.expect(!options.import_no_duplicates);
     try std.testing.expect(options.setByCliName("import/no-duplicates", true));
@@ -3971,13 +3994,14 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowReferrer\":true}]",
+        "[\"error\",{\"allowReferrer\":true,\"enforceDynamicLinks\":\"never\"}]",
         .{},
     );
     defer react_jsx_no_target_blank_config.deinit();
     try options.setByRuleConfigValue("react/jsx-no-target-blank", react_jsx_no_target_blank_config.value);
     try std.testing.expect(options.react_jsx_no_target_blank);
     try std.testing.expect(options.react_jsx_no_target_blank_allow_referrer);
+    try std.testing.expect(!options.react_jsx_no_target_blank_enforce_dynamic_links);
 
     var react_jsx_pascal_case_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_no_target_blank.zig
+++ b/src/rules/react_jsx_no_target_blank.zig
@@ -9,6 +9,7 @@ pub const id = "react/jsx-no-target-blank";
 
 pub const Options = struct {
     allow_referrer: bool = false,
+    enforce_dynamic_links: bool = true,
 };
 
 pub fn check(
@@ -23,7 +24,7 @@ pub fn check(
 
     const target = lastAttributeNamed(tree, opening, "target") orelse return;
     if (!attributeValuePossiblyBlank(tree, target.attribute)) return;
-    if (!hasDangerousHref(tree, opening)) return;
+    if (!hasDangerousHref(tree, opening, options.enforce_dynamic_links)) return;
     if (hasSecureRel(tree, opening, target.attribute.value, options.allow_referrer)) return;
 
     try core.addDiagnostic(
@@ -86,11 +87,11 @@ fn attributeValuePossiblyBlank(tree: *const ast.Tree, attribute: ast.JSXAttribut
         isStringLiteralIgnoreCase(tree, conditional.alternate, "_blank");
 }
 
-fn hasDangerousHref(tree: *const ast.Tree, opening: ast.JSXOpeningElement) bool {
+fn hasDangerousHref(tree: *const ast.Tree, opening: ast.JSXOpeningElement, enforce_dynamic_links: bool) bool {
     const href = lastAttributeNamed(tree, opening, "href") orelse return false;
     if (href.attribute.value == .null) return false;
     if (stringValue(tree, href.attribute.value)) |value| return isExternalHref(value);
-    return tree.data(href.attribute.value) == .jsx_expression_container;
+    return enforce_dynamic_links and tree.data(href.attribute.value) == .jsx_expression_container;
 }
 
 fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_value: ast.NodeIndex, allow_referrer: bool) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2892,6 +2892,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_no_target_blank) {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
                 .allow_referrer = self.options.react_jsx_no_target_blank_allow_referrer,
+                .enforce_dynamic_links = self.options.react_jsx_no_target_blank_enforce_dynamic_links,
             });
         }
         if (self.options.react_jsx_pascal_case) {

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -72,6 +72,34 @@ test "supports configured react/jsx-no-target-blank allowReferrer" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
 }
 
+test "supports configured react/jsx-no-target-blank enforceDynamicLinks never" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceDynamicLinks\":\"never\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/jsx-no-target-blank", config.value);
+    options.eol_last = false;
+    options.jsx_a11y_anchor_has_content = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const dynamic = <a href={url} target="_blank" />;
+        \\const external = <a href="https://example.com" target="_blank" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
+}
+
 test "can disable react/jsx-no-target-blank" {
     const source =
         \\const link = <a href="https://example.com" target="_blank" />;


### PR DESCRIPTION
## Summary
- add ESLint-style `enforceDynamicLinks` config parsing for `react/jsx-no-target-blank`
- skip dynamic href checks when configured as `never` while preserving static external link checks
- add coverage for configured dynamic-link behavior and update rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_no_target_blank.zig tests/rules/react_jsx_no_target_blank.zig`
- `git diff --check`