### PR TITLE
support button has type options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -221,6 +221,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1070,6 +1070,9 @@ pub const Options = struct {
     react_jsx_no_bind: bool = true,
     react_jsx_key: bool = true,
     react_button_has_type: bool = true,
+    react_button_has_type_button: bool = true,
+    react_button_has_type_submit: bool = true,
+    react_button_has_type_reset: bool = true,
     react_require_render_return: bool = true,
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_target_blank_allow_referrer: bool = false,
@@ -1470,6 +1473,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "operator-assignment")) {
             self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/button-has-type")) {
+            self.react_button_has_type_button = try reactButtonHasTypeBoolOptionFromConfig(value, "button", true);
+            self.react_button_has_type_submit = try reactButtonHasTypeBoolOptionFromConfig(value, "submit", true);
+            self.react_button_has_type_reset = try reactButtonHasTypeBoolOptionFromConfig(value, "reset", true);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
@@ -3321,6 +3329,23 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
+    fn reactButtonHasTypeBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxBooleanValueStyleFromConfig(value: std.json.Value) RuleConfigError!ReactJsxBooleanValueStyle {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3948,6 +3973,13 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));
     try std.testing.expect(options.react_default_props_match_prop_types);
 
+    try std.testing.expect(!options.react_button_has_type);
+    try std.testing.expect(options.setByCliName("react/button-has-type", true));
+    try std.testing.expect(options.react_button_has_type);
+    try std.testing.expect(options.react_button_has_type_button);
+    try std.testing.expect(options.react_button_has_type_submit);
+    try std.testing.expect(options.react_button_has_type_reset);
+
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
@@ -3990,6 +4022,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.jsx_a11y_aria_props);
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
+
+    var react_button_has_type_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"button\":true,\"submit\":false,\"reset\":false}]",
+        .{},
+    );
+    defer react_button_has_type_config.deinit();
+    try options.setByRuleConfigValue("react/button-has-type", react_button_has_type_config.value);
+    try std.testing.expect(options.react_button_has_type);
+    try std.testing.expect(options.react_button_has_type_button);
+    try std.testing.expect(!options.react_button_has_type_submit);
+    try std.testing.expect(!options.react_button_has_type_reset);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_button_has_type.zig
+++ b/src/rules/react_button_has_type.zig
@@ -15,6 +15,12 @@ pub const State = struct {
     has_bare_create_element: bool = false,
 };
 
+pub const Options = struct {
+    allow_button: bool = true,
+    allow_submit: bool = true,
+    allow_reset: bool = true,
+};
+
 pub fn collectProgram(tree: *const ast.Tree, program: ast.Program, state: *State) void {
     state.pragma = pragmaFromComments(tree) orelse "React";
     for (tree.extra(program.body)) |statement_index| {
@@ -45,6 +51,7 @@ pub fn checkJSXElement(
     tree: *const ast.Tree,
     element: ast.JSXElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const opening = switch (tree.data(element.opening_element)) {
         .jsx_opening_element => |opening| opening,
@@ -57,7 +64,7 @@ pub fn checkJSXElement(
         try report(allocator, diagnostics, tree, index, missing_type_message);
         return;
     };
-    try checkJSXAttributeValue(allocator, diagnostics, tree, type_attribute);
+    try checkJSXAttributeValue(allocator, diagnostics, tree, type_attribute, options);
 }
 
 pub fn checkCallExpression(
@@ -67,6 +74,7 @@ pub fn checkCallExpression(
     call: ast.CallExpression,
     index: ast.NodeIndex,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     if (!isCreateElementCall(tree, call, state)) return;
 
@@ -94,7 +102,7 @@ pub fn checkCallExpression(
         };
         const key = objectPropertyKeyName(tree, property) orelse continue;
         if (!std.mem.eql(u8, key, "type")) continue;
-        try checkExpressionValue(allocator, diagnostics, tree, property.value);
+        try checkExpressionValue(allocator, diagnostics, tree, property.value, options);
         return;
     }
 
@@ -106,6 +114,7 @@ fn checkJSXAttributeValue(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     attribute: ast.JSXAttribute,
+    options: Options,
 ) Allocator.Error!void {
     if (attribute.value == .null) {
         try reportInvalidValue(allocator, diagnostics, tree, attribute.name, "true");
@@ -113,8 +122,8 @@ fn checkJSXAttributeValue(
     }
 
     switch (tree.data(attribute.value)) {
-        .string_literal => |literal| try checkValue(allocator, diagnostics, tree, attribute.value, tree.string(literal.value)),
-        .jsx_expression_container => |container| try checkExpressionValue(allocator, diagnostics, tree, container.expression),
+        .string_literal => |literal| try checkValue(allocator, diagnostics, tree, attribute.value, tree.string(literal.value), options),
+        .jsx_expression_container => |container| try checkExpressionValue(allocator, diagnostics, tree, container.expression, options),
         else => try report(allocator, diagnostics, tree, attribute.value, complex_type_message),
     }
 }
@@ -124,6 +133,7 @@ fn checkExpressionValue(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (index == .null) {
         try report(allocator, diagnostics, tree, index, complex_type_message);
@@ -132,7 +142,7 @@ fn checkExpressionValue(
 
     const current = unwrapTransparent(tree, index);
     switch (tree.data(current)) {
-        .string_literal => |literal| try checkValue(allocator, diagnostics, tree, current, tree.string(literal.value)),
+        .string_literal => |literal| try checkValue(allocator, diagnostics, tree, current, tree.string(literal.value), options),
         .template_literal => |literal| {
             if (literal.expressions.len != 0) {
                 try report(allocator, diagnostics, tree, current, complex_type_message);
@@ -147,11 +157,11 @@ fn checkExpressionValue(
                 .template_element => |element| element,
                 else => return,
             };
-            try checkValue(allocator, diagnostics, tree, current, tree.string(element.cooked));
+            try checkValue(allocator, diagnostics, tree, current, tree.string(element.cooked), options);
         },
         .conditional_expression => |conditional| {
-            try checkExpressionValue(allocator, diagnostics, tree, conditional.consequent);
-            try checkExpressionValue(allocator, diagnostics, tree, conditional.alternate);
+            try checkExpressionValue(allocator, diagnostics, tree, conditional.consequent, options);
+            try checkExpressionValue(allocator, diagnostics, tree, conditional.alternate, options);
         },
         else => try report(allocator, diagnostics, tree, current, complex_type_message),
     }
@@ -163,15 +173,16 @@ fn checkValue(
     tree: *const ast.Tree,
     index: ast.NodeIndex,
     value: []const u8,
+    options: Options,
 ) Allocator.Error!void {
-    if (isAllowedButtonType(value)) return;
+    if (isAllowedButtonType(value, options)) return;
     try reportInvalidValue(allocator, diagnostics, tree, index, value);
 }
 
-fn isAllowedButtonType(value: []const u8) bool {
-    return std.mem.eql(u8, value, "button") or
-        std.mem.eql(u8, value, "submit") or
-        std.mem.eql(u8, value, "reset");
+fn isAllowedButtonType(value: []const u8, options: Options) bool {
+    return (options.allow_button and std.mem.eql(u8, value, "button")) or
+        (options.allow_submit and std.mem.eql(u8, value, "submit")) or
+        (options.allow_reset and std.mem.eql(u8, value, "reset"));
 }
 
 fn findTypeAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement) ?ast.JSXAttribute {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2570,7 +2570,11 @@ const BasicVisitor = struct {
             try react_display_name.checkCallExpression(self.allocator, ctx.tree, call, index, ctx.path.parent(), &self.react_display_name_state);
         }
         if (self.options.react_button_has_type) {
-            try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state);
+            try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state, .{
+                .allow_button = self.options.react_button_has_type_button,
+                .allow_submit = self.options.react_button_has_type_submit,
+                .allow_reset = self.options.react_button_has_type_reset,
+            });
         }
         if (self.options.react_require_render_return) {
             try react_require_render_return.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_require_render_return_state);
@@ -2816,7 +2820,11 @@ const BasicVisitor = struct {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state);
         }
         if (self.options.react_button_has_type) {
-            try react_button_has_type.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+            try react_button_has_type.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, .{
+                .allow_button = self.options.react_button_has_type_button,
+                .allow_submit = self.options.react_button_has_type_submit,
+                .allow_reset = self.options.react_button_has_type_reset,
+            });
         }
         if (self.options.react_no_danger_with_children) {
             try react_no_danger_with_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, &self.react_no_danger_with_children_bindings);

--- a/tests/rules/react_button_has_type.zig
+++ b/tests/rules/react_button_has_type.zig
@@ -51,6 +51,31 @@ test "allows static valid button type values" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_button_has_type.id));
 }
 
+test "supports configured react/button-has-type allowed values" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"button\":true,\"submit\":false,\"reset\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/button-has-type", config.value);
+
+    const source =
+        \\const a = <button type="button" />;
+        \\const b = <button type="submit" />;
+        \\const c = <button type={`reset`} />;
+        \\const d = React.createElement("button", { type: "submit" });
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_button_has_type.id));
+}
+
 test "checks React createElement button calls" {
     const source =
         \\import { createElement } from "react";


### PR DESCRIPTION
## Summary
- add ESLint-style `button`, `submit`, and `reset` config parsing for `react/button-has-type`
- pass the configured allowed button type values through JSX and `createElement` checks
- add coverage for disallowing configured type values and document the rule status

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_button_has_type.zig tests/rules/react_button_has_type.zig`
- `git diff --check`

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md