### PR TITLE
support forbid prop types config

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -222,6 +222,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
+| [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1088,6 +1088,9 @@ pub const Options = struct {
     react_no_access_state_in_setstate: bool = true,
     react_no_deprecated: bool = true,
     react_forbid_prop_types: bool = true,
+    react_forbid_prop_types_forbid_any: bool = true,
+    react_forbid_prop_types_forbid_array: bool = true,
+    react_forbid_prop_types_forbid_object: bool = true,
     react_no_array_index_key: bool = true,
     react_no_children_prop: bool = true,
     react_no_find_dom_node: bool = true,
@@ -1478,6 +1481,12 @@ pub const Options = struct {
             self.react_button_has_type_button = try reactButtonHasTypeBoolOptionFromConfig(value, "button", true);
             self.react_button_has_type_submit = try reactButtonHasTypeBoolOptionFromConfig(value, "submit", true);
             self.react_button_has_type_reset = try reactButtonHasTypeBoolOptionFromConfig(value, "reset", true);
+        }
+        if (std.mem.eql(u8, cli_name, "react/forbid-prop-types")) {
+            const forbid = try reactForbidPropTypesForbidFromConfig(value);
+            self.react_forbid_prop_types_forbid_any = forbid.any;
+            self.react_forbid_prop_types_forbid_array = forbid.array;
+            self.react_forbid_prop_types_forbid_object = forbid.object;
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
@@ -3346,6 +3355,51 @@ pub const Options = struct {
         };
     }
 
+    const ReactForbidPropTypesForbid = struct {
+        any: bool = true,
+        array: bool = true,
+        object: bool = true,
+    };
+
+    fn reactForbidPropTypesForbidFromConfig(value: std.json.Value) RuleConfigError!ReactForbidPropTypesForbid {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const forbid_items = switch (config.get("forbid") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var forbid = ReactForbidPropTypesForbid{
+            .any = false,
+            .array = false,
+            .object = false,
+        };
+        for (forbid_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, name, "any")) {
+                forbid.any = true;
+            } else if (std.mem.eql(u8, name, "array")) {
+                forbid.array = true;
+            } else if (std.mem.eql(u8, name, "object")) {
+                forbid.object = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        return forbid;
+    }
+
     fn reactJsxBooleanValueStyleFromConfig(value: std.json.Value) RuleConfigError!ReactJsxBooleanValueStyle {
         const items = switch (value) {
             .array => |array| array.items,
@@ -3980,6 +4034,13 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_button_has_type_submit);
     try std.testing.expect(options.react_button_has_type_reset);
 
+    try std.testing.expect(!options.react_forbid_prop_types);
+    try std.testing.expect(options.setByCliName("react/forbid-prop-types", true));
+    try std.testing.expect(options.react_forbid_prop_types);
+    try std.testing.expect(options.react_forbid_prop_types_forbid_any);
+    try std.testing.expect(options.react_forbid_prop_types_forbid_array);
+    try std.testing.expect(options.react_forbid_prop_types_forbid_object);
+
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
@@ -4035,6 +4096,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_button_has_type_button);
     try std.testing.expect(!options.react_button_has_type_submit);
     try std.testing.expect(!options.react_button_has_type_reset);
+
+    var react_forbid_prop_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"forbid\":[\"array\"]}]",
+        .{},
+    );
+    defer react_forbid_prop_types_config.deinit();
+    try options.setByRuleConfigValue("react/forbid-prop-types", react_forbid_prop_types_config.value);
+    try std.testing.expect(options.react_forbid_prop_types);
+    try std.testing.expect(!options.react_forbid_prop_types_forbid_any);
+    try std.testing.expect(options.react_forbid_prop_types_forbid_array);
+    try std.testing.expect(!options.react_forbid_prop_types_forbid_object);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_forbid_prop_types.zig
+++ b/src/rules/react_forbid_prop_types.zig
@@ -7,11 +7,15 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/forbid-prop-types";
 
-const forbidden = [_][]const u8{ "any", "array", "object" };
-
 const ObjectBinding = struct {
     name: []const u8,
     value: ast.NodeIndex,
+};
+
+pub const Options = struct {
+    forbid_any: bool = true,
+    forbid_array: bool = true,
+    forbid_object: bool = true,
 };
 
 pub const State = struct {
@@ -68,9 +72,10 @@ pub fn checkPropertyDefinition(
     tree: *const ast.Tree,
     property: ast.PropertyDefinition,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     if (!isPropTypesKey(tree, property.key, property.computed)) return;
-    try checkNode(allocator, diagnostics, tree, property.value, state);
+    try checkNode(allocator, diagnostics, tree, property.value, state, options);
 }
 
 pub fn checkAssignmentExpression(
@@ -79,13 +84,14 @@ pub fn checkAssignmentExpression(
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     const member = switch (tree.data(unwrapTransparent(tree, expression.left))) {
         .member_expression => |member| member,
         else => return,
     };
     if (!isPropTypesKey(tree, member.property, member.computed)) return;
-    try checkNode(allocator, diagnostics, tree, expression.right, state);
+    try checkNode(allocator, diagnostics, tree, expression.right, state, options);
 }
 
 pub fn checkObjectExpression(
@@ -94,6 +100,7 @@ pub fn checkObjectExpression(
     tree: *const ast.Tree,
     object: ast.ObjectExpression,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.extra(object.properties)) |property_index| {
         const property = switch (tree.data(property_index)) {
@@ -101,7 +108,7 @@ pub fn checkObjectExpression(
             else => continue,
         };
         if (!isPropTypesKey(tree, property.key, property.computed)) continue;
-        try checkNode(allocator, diagnostics, tree, property.value, state);
+        try checkNode(allocator, diagnostics, tree, property.value, state, options);
     }
 }
 
@@ -111,10 +118,11 @@ pub fn checkMethodDefinition(
     tree: *const ast.Tree,
     method: ast.MethodDefinition,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     if (!isPropTypesKey(tree, method.key, method.computed)) return;
     const argument = returnArgument(tree, method.value) orelse return;
-    try checkNode(allocator, diagnostics, tree, argument, state);
+    try checkNode(allocator, diagnostics, tree, argument, state, options);
 }
 
 fn scanImportDeclaration(tree: *const ast.Tree, declaration: ast.ImportDeclaration, state: *State) void {
@@ -161,18 +169,19 @@ fn checkNode(
     tree: *const ast.Tree,
     node: ast.NodeIndex,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     if (node == .null) return;
     const current = unwrapTransparent(tree, node);
     switch (tree.data(current)) {
-        .object_expression => |object| try checkProperties(allocator, diagnostics, tree, object.properties, state),
+        .object_expression => |object| try checkProperties(allocator, diagnostics, tree, object.properties, state, options),
         .identifier_reference => |identifier| {
             const name = tree.string(identifier.name);
             if (objectBinding(state, name)) |value| {
-                try checkNode(allocator, diagnostics, tree, value, state);
+                try checkNode(allocator, diagnostics, tree, value, state, options);
             }
         },
-        .call_expression => |call| try checkCallExpressionValue(allocator, diagnostics, tree, call, state),
+        .call_expression => |call| try checkCallExpressionValue(allocator, diagnostics, tree, call, state, options),
         else => {},
     }
 }
@@ -183,13 +192,14 @@ fn checkProperties(
     tree: *const ast.Tree,
     properties: ast.IndexRange,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.extra(properties)) |property_index| {
         const property = switch (tree.data(property_index)) {
             .object_property => |property| property,
             else => continue,
         };
-        try checkPropValue(allocator, diagnostics, tree, property.value, property_index, state);
+        try checkPropValue(allocator, diagnostics, tree, property.value, property_index, state, options);
     }
 }
 
@@ -200,6 +210,7 @@ fn checkPropValue(
     value_index: ast.NodeIndex,
     diagnostic_node: ast.NodeIndex,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     var value = stripIsRequired(tree, value_index);
 
@@ -207,15 +218,15 @@ fn checkPropValue(
         if (!isPropTypesPackage(tree, call.callee, state)) return;
         for (tree.extra(call.arguments)) |argument| {
             const name = propTypeTargetName(tree, argument) orelse continue;
-            try reportIfForbidden(allocator, diagnostics, tree, diagnostic_node, name);
+            try reportIfForbidden(allocator, diagnostics, tree, diagnostic_node, name, options);
         }
-        try checkCallExpressionValue(allocator, diagnostics, tree, call, state);
+        try checkCallExpressionValue(allocator, diagnostics, tree, call, state, options);
         value = call.callee;
     }
 
     if (!isPropTypesPackage(tree, value, state)) return;
     const target = propTypeTargetName(tree, value) orelse return;
-    try reportIfForbidden(allocator, diagnostics, tree, diagnostic_node, target);
+    try reportIfForbidden(allocator, diagnostics, tree, diagnostic_node, target, options);
 }
 
 fn checkCallExpressionValue(
@@ -224,12 +235,13 @@ fn checkCallExpressionValue(
     tree: *const ast.Tree,
     call: ast.CallExpression,
     state: State,
+    options: Options,
 ) Allocator.Error!void {
     const callee_name = propTypeTargetName(tree, call.callee) orelse identifierReferenceName(tree, call.callee) orelse return;
     const arguments = tree.extra(call.arguments);
 
     if (std.mem.eql(u8, callee_name, "shape")) {
-        if (arguments.len > 0) try checkNode(allocator, diagnostics, tree, arguments[0], state);
+        if (arguments.len > 0) try checkNode(allocator, diagnostics, tree, arguments[0], state, options);
     }
 }
 
@@ -292,9 +304,9 @@ fn reportIfForbidden(
     tree: *const ast.Tree,
     node: ast.NodeIndex,
     target: []const u8,
+    options: Options,
 ) Allocator.Error!void {
-    for (forbidden) |name| {
-        if (!std.mem.eql(u8, name, target)) continue;
+    if (isForbidden(target, options)) {
         return core.addDiagnosticFmt(
             allocator,
             diagnostics,
@@ -305,6 +317,12 @@ fn reportIfForbidden(
             .{target},
         );
     }
+}
+
+fn isForbidden(target: []const u8, options: Options) bool {
+    return (options.forbid_any and std.mem.eql(u8, target, "any")) or
+        (options.forbid_array and std.mem.eql(u8, target, "array")) or
+        (options.forbid_object and std.mem.eql(u8, target, "object"));
 }
 
 fn objectBinding(state: State, name: []const u8) ?ast.NodeIndex {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2345,7 +2345,11 @@ const BasicVisitor = struct {
             try react_no_unused_state.checkAssignmentExpression(self.allocator, ctx.tree, expression, ctx, &self.react_no_unused_state_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state);
+            try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, .{
+                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
+                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
+                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
+            });
         }
         return .proceed;
     }
@@ -2969,7 +2973,11 @@ const BasicVisitor = struct {
             try react_no_unused_state.enterObjectExpression(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state);
+            try react_forbid_prop_types.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, .{
+                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
+                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
+                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
+            });
         }
         return .proceed;
     }
@@ -3113,7 +3121,11 @@ const BasicVisitor = struct {
             try react_no_typos.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index, ctx);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, self.react_forbid_prop_types_state);
+            try react_forbid_prop_types.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, self.react_forbid_prop_types_state, .{
+                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
+                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
+                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
+            });
         }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterMethodDefinition(self.allocator, ctx.tree, method, &self.react_no_unused_state_state);
@@ -3184,7 +3196,11 @@ const BasicVisitor = struct {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, self.react_forbid_prop_types_state);
+            try react_forbid_prop_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, self.react_forbid_prop_types_state, .{
+                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
+                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
+                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
+            });
         }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterPropertyDefinition(self.allocator, ctx.tree, property, &self.react_no_unused_state_state);

--- a/tests/rules/react_forbid_prop_types.zig
+++ b/tests/rules/react_forbid_prop_types.zig
@@ -28,6 +28,40 @@ test "reports react/forbid-prop-types for forbidden direct prop types" {
     try std.testing.expect(hasMessage(result, "Prop type \"object\" is forbidden"));
 }
 
+test "supports configured react/forbid-prop-types forbid list" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"forbid\":[\"array\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/forbid-prop-types", config.value);
+
+    const source =
+        \\class View extends React.Component {
+        \\  static propTypes = {
+        \\    anyValue: PropTypes.any,
+        \\    arrayValue: PropTypes.array,
+        \\    objectValue: PropTypes.object,
+        \\  };
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_forbid_prop_types.id));
+    try std.testing.expect(hasMessage(result, "Prop type \"array\" is forbidden"));
+}
+
 test "reports react/forbid-prop-types in assignments and variable references" {
     const source =
         \\const declaredTypes = {


### PR DESCRIPTION
## Summary
- add ESLint-style `forbid` config parsing for `react/forbid-prop-types`
- pass configured forbidden prop type names through every rule check path
- add coverage for custom forbidden type lists and document the rule status

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_forbid_prop_types.zig tests/rules/react_forbid_prop_types.zig`
- `git diff --check`

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md