### PR TITLE
support jsx filename extension config

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -224,6 +224,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
+| [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` and `enforceDynamicLinks` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -429,6 +429,57 @@ pub const NoThisAliasAllowedNames = struct {
 pub const max_react_jsx_pascal_case_ignore_names = 32;
 pub const max_react_jsx_pascal_case_ignore_name_len = 128;
 
+pub const react_jsx_filename_extension_default_extensions = [_][]const u8{
+    ".jsx",
+    ".js",
+    ".tsx",
+    ".ts",
+    ".vue",
+};
+
+pub const max_react_jsx_filename_extensions = 16;
+pub const max_react_jsx_filename_extension_len = 32;
+
+pub const ReactJsxFilenameExtensionsError = error{
+    EmptyReactJsxFilenameExtension,
+    TooManyReactJsxFilenameExtensions,
+    ReactJsxFilenameExtensionTooLong,
+};
+
+pub const ReactJsxFilenameExtensions = struct {
+    custom: bool = false,
+    count: usize = 0,
+    lengths: [max_react_jsx_filename_extensions]usize = undefined,
+    storage: [max_react_jsx_filename_extensions][max_react_jsx_filename_extension_len]u8 = undefined,
+
+    pub fn len(self: *const ReactJsxFilenameExtensions) usize {
+        return if (self.custom) self.count else react_jsx_filename_extension_default_extensions.len;
+    }
+
+    pub fn at(self: *const ReactJsxFilenameExtensions, index: usize) []const u8 {
+        if (!self.custom) return react_jsx_filename_extension_default_extensions[index];
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn containsFilePath(self: *const ReactJsxFilenameExtensions, file_path: []const u8) bool {
+        for (0..self.len()) |index| {
+            if (std.mem.endsWith(u8, file_path, self.at(index))) return true;
+        }
+        return false;
+    }
+
+    pub fn append(self: *ReactJsxFilenameExtensions, extension_name: []const u8) ReactJsxFilenameExtensionsError!void {
+        if (extension_name.len == 0) return error.EmptyReactJsxFilenameExtension;
+        if (self.count >= max_react_jsx_filename_extensions) return error.TooManyReactJsxFilenameExtensions;
+        if (extension_name.len > max_react_jsx_filename_extension_len) return error.ReactJsxFilenameExtensionTooLong;
+
+        self.custom = true;
+        @memcpy(self.storage[self.count][0..extension_name.len], extension_name);
+        self.lengths[self.count] = extension_name.len;
+        self.count += 1;
+    }
+};
+
 pub const ReactJsxPascalCaseIgnoreNamesError = error{
     EmptyReactJsxPascalCaseIgnoreName,
     TooManyReactJsxPascalCaseIgnoreNames,
@@ -1064,6 +1115,7 @@ pub const Options = struct {
     react_jsx_boolean_value: bool = true,
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
+    react_jsx_filename_extension_extensions: ReactJsxFilenameExtensions = .{},
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_duplicate_props_ignore_case: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
@@ -1487,6 +1539,9 @@ pub const Options = struct {
             self.react_forbid_prop_types_forbid_any = forbid.any;
             self.react_forbid_prop_types_forbid_array = forbid.array;
             self.react_forbid_prop_types_forbid_object = forbid.object;
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-filename-extension")) {
+            self.react_jsx_filename_extension_extensions = try reactJsxFilenameExtensionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
@@ -3400,6 +3455,33 @@ pub const Options = struct {
         return forbid;
     }
 
+    fn reactJsxFilenameExtensionsFromConfig(value: std.json.Value) RuleConfigError!ReactJsxFilenameExtensions {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const extension_items = switch (config.get("extensions") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var extensions = ReactJsxFilenameExtensions{};
+        for (extension_items) |item| {
+            const extension_name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            extensions.append(extension_name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return extensions;
+    }
+
     fn reactJsxBooleanValueStyleFromConfig(value: std.json.Value) RuleConfigError!ReactJsxBooleanValueStyle {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4041,6 +4123,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_forbid_prop_types_forbid_array);
     try std.testing.expect(options.react_forbid_prop_types_forbid_object);
 
+    try std.testing.expect(!options.react_jsx_filename_extension);
+    try std.testing.expect(options.setByCliName("react/jsx-filename-extension", true));
+    try std.testing.expect(options.react_jsx_filename_extension);
+    try std.testing.expectEqual(react_jsx_filename_extension_default_extensions.len, options.react_jsx_filename_extension_extensions.len());
+
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
@@ -4109,6 +4196,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.react_forbid_prop_types_forbid_any);
     try std.testing.expect(options.react_forbid_prop_types_forbid_array);
     try std.testing.expect(!options.react_forbid_prop_types_forbid_object);
+
+    var react_jsx_filename_extension_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"extensions\":[\".tsx\"]}]",
+        .{},
+    );
+    defer react_jsx_filename_extension_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-filename-extension", react_jsx_filename_extension_config.value);
+    try std.testing.expect(options.react_jsx_filename_extension);
+    try std.testing.expectEqual(@as(usize, 1), options.react_jsx_filename_extension_extensions.len());
+    try std.testing.expectEqualStrings(".tsx", options.react_jsx_filename_extension_extensions.at(0));
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_filename_extension.zig
+++ b/src/rules/react_jsx_filename_extension.zig
@@ -7,12 +7,8 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-filename-extension";
 
-const allowed_extensions = [_][]const u8{
-    ".jsx",
-    ".js",
-    ".tsx",
-    ".ts",
-    ".vue",
+pub const Options = struct {
+    extensions: core.ReactJsxFilenameExtensions = .{},
 };
 
 pub const State = struct {
@@ -26,8 +22,9 @@ pub fn check(
     file_path: []const u8,
     index: ast.NodeIndex,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
-    if (state.reported or isAllowedExtension(file_path)) return;
+    if (state.reported or options.extensions.containsFilePath(file_path)) return;
 
     state.reported = true;
     try core.addDiagnosticFmt(
@@ -39,13 +36,6 @@ pub fn check(
         "JSX not allowed in files with extension '{s}'",
         .{extension(file_path)},
     );
-}
-
-fn isAllowedExtension(file_path: []const u8) bool {
-    for (&allowed_extensions) |allowed| {
-        if (std.mem.endsWith(u8, file_path, allowed)) return true;
-    }
-    return false;
 }
 
 fn extension(file_path: []const u8) []const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2821,7 +2821,9 @@ const BasicVisitor = struct {
             try react_no_children_prop.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
         if (self.options.react_jsx_filename_extension) {
-            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state);
+            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
+                .extensions = self.options.react_jsx_filename_extension_extensions,
+            });
         }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, .{
@@ -2852,7 +2854,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_filename_extension) {
-            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state);
+            try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
+                .extensions = self.options.react_jsx_filename_extension_extensions,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_jsx_filename_extension.zig
+++ b/tests/rules/react_jsx_filename_extension.zig
@@ -67,6 +67,34 @@ test "allows react/jsx-filename-extension for fishlint allowed extensions" {
     try std.testing.expect(!helpers.hasRule(tsx_result, "parse"));
 }
 
+test "supports configured react/jsx-filename-extension extensions" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"extensions\":[\".tsx\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/jsx-filename-extension", config.value);
+
+    const source =
+        \\const view = <div />;
+    ;
+
+    var js_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer js_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(js_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(hasMessage(js_result, "JSX not allowed in files with extension '.js'"));
+    try std.testing.expect(!helpers.hasRule(js_result, "parse"));
+
+    var tsx_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer tsx_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(tsx_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(tsx_result, "parse"));
+}
+
 test "preserves parser diagnostics when JSX fallback still fails" {
     const source =
         \\const view = <div;


### PR DESCRIPTION
## Summary
- add bounded extension list support for react/jsx-filename-extension
- parse ESLint-style extensions config while preserving current fishlint defaults
- cover configured .tsx-only behavior in core and rule tests

## Reference
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_filename_extension.zig tests/rules/react_jsx_filename_extension.zig
- git diff --check