### PR TITLE
support no string refs template option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -233,6 +233,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
+| [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1160,6 +1160,7 @@ pub const Options = struct {
     react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
+    react_no_string_refs_no_template_literals: bool = false,
     react_no_unescaped_entities: bool = true,
     react_no_unescaped_entities_forbid_gt: bool = true,
     react_no_unescaped_entities_forbid_double_quote: bool = true,
@@ -1562,6 +1563,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-string-refs")) {
+            self.react_no_string_refs_no_template_literals = try reactNoStringRefsNoTemplateLiteralsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unescaped-entities")) {
             const forbid = try reactNoUnescapedEntitiesForbidFromConfig(value);
@@ -3515,6 +3519,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactNoStringRefsNoTemplateLiteralsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("noTemplateLiterals") orelse return false) {
+            .bool => |no_template_literals| no_template_literals,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxPascalCaseAllowAllCapsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4139,6 +4160,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_no_unused_prop_types_skip_shape_props);
     try std.testing.expectEqual(@as(usize, 0), options.react_jsx_pascal_case_ignore.count);
 
+    try std.testing.expect(!options.react_no_string_refs);
+    try std.testing.expect(options.setByCliName("react/no-string-refs", true));
+    try std.testing.expect(options.react_no_string_refs);
+    try std.testing.expect(!options.react_no_string_refs_no_template_literals);
+
     try std.testing.expect(!options.react_no_unescaped_entities);
     try std.testing.expect(options.setByCliName("react/no-unescaped-entities", true));
     try std.testing.expect(options.react_no_unescaped_entities);
@@ -4245,6 +4271,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/prop-types", react_prop_types_config.value);
     try std.testing.expect(options.react_prop_types);
     try std.testing.expect(options.react_prop_types_skip_undeclared);
+
+    var react_no_string_refs_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"noTemplateLiterals\":true}]",
+        .{},
+    );
+    defer react_no_string_refs_config.deinit();
+    try options.setByRuleConfigValue("react/no-string-refs", react_no_string_refs_config.value);
+    try std.testing.expect(options.react_no_string_refs);
+    try std.testing.expect(options.react_no_string_refs_no_template_literals);
 
     var react_no_unescaped_entities_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_string_refs.zig
+++ b/src/rules/react_no_string_refs.zig
@@ -7,16 +7,21 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/no-string-refs";
 
+pub const Options = struct {
+    no_template_literals: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     attribute: ast.JSXAttribute,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const name = jsxIdentifierName(tree, attribute.name) orelse return;
     if (!std.mem.eql(u8, name, "ref")) return;
-    if (!containsStringLiteral(tree, attribute.value)) return;
+    if (!containsStringLiteral(tree, attribute.value, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -28,13 +33,14 @@ pub fn check(
     );
 }
 
-fn containsStringLiteral(tree: *const ast.Tree, value_index: ast.NodeIndex) bool {
+fn containsStringLiteral(tree: *const ast.Tree, value_index: ast.NodeIndex, options: Options) bool {
     if (value_index == .null) return false;
 
     return switch (tree.data(value_index)) {
         .string_literal => true,
         .jsx_expression_container => |container| switch (tree.data(container.expression)) {
             .string_literal => true,
+            .template_literal => options.no_template_literals,
             else => false,
         },
         else => false,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2797,7 +2797,9 @@ const BasicVisitor = struct {
             try react_no_children_prop.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index);
         }
         if (self.options.react_no_string_refs) {
-            try react_no_string_refs.check(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+            try react_no_string_refs.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, .{
+                .no_template_literals = self.options.react_no_string_refs_no_template_literals,
+            });
         }
         if (self.options.react_no_array_index_key) {
             try react_no_array_index_key.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, self.react_no_array_index_key_state);

--- a/tests/rules/react_no_string_refs.zig
+++ b/tests/rules/react_no_string_refs.zig
@@ -42,6 +42,34 @@ test "allows non-string refs and default template literals" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_string_refs.id));
 }
 
+test "supports configured react/no-string-refs noTemplateLiterals" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"noTemplateLiterals\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/no-string-refs", config.value);
+
+    const source =
+        \\const template = <div ref={`root`} />;
+        \\const dynamic = <div ref={`root-${id}`} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_string_refs.id));
+}
+
 test "can disable react/no-string-refs" {
     const source =
         \\const direct = <div ref="root" />;


### PR DESCRIPTION
## Summary
- add react/no-string-refs noTemplateLiterals config parsing
- report template literal refs only when that option is enabled
- cover default and configured behavior in core and rule tests

## Reference
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_string_refs.zig tests/rules/react_no_string_refs.zig
- git diff --check