### PR TITLE
support jsx no bind options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -225,6 +225,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |
+| [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` and `enforceDynamicLinks` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1120,6 +1120,11 @@ pub const Options = struct {
     react_jsx_no_duplicate_props_ignore_case: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
     react_jsx_no_bind: bool = true,
+    react_jsx_no_bind_allow_arrow_functions: bool = false,
+    react_jsx_no_bind_allow_functions: bool = false,
+    react_jsx_no_bind_allow_bind: bool = false,
+    react_jsx_no_bind_ignore_refs: bool = false,
+    react_jsx_no_bind_ignore_dom_components: bool = false,
     react_jsx_key: bool = true,
     react_button_has_type: bool = true,
     react_button_has_type_button: bool = true,
@@ -1546,6 +1551,13 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-no-bind")) {
+            self.react_jsx_no_bind_allow_arrow_functions = try reactJsxNoBindBoolOptionFromConfig(value, "allowArrowFunctions", false);
+            self.react_jsx_no_bind_allow_functions = try reactJsxNoBindBoolOptionFromConfig(value, "allowFunctions", false);
+            self.react_jsx_no_bind_allow_bind = try reactJsxNoBindBoolOptionFromConfig(value, "allowBind", false);
+            self.react_jsx_no_bind_ignore_refs = try reactJsxNoBindBoolOptionFromConfig(value, "ignoreRefs", false);
+            self.react_jsx_no_bind_ignore_dom_components = try reactJsxNoBindBoolOptionFromConfig(value, "ignoreDOMComponents", false);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-duplicate-props")) {
             self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
@@ -3502,6 +3514,23 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
+    fn reactJsxNoBindBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4149,6 +4178,15 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_jsx_filename_extension);
     try std.testing.expectEqual(react_jsx_filename_extension_default_extensions.len, options.react_jsx_filename_extension_extensions.len());
 
+    try std.testing.expect(!options.react_jsx_no_bind);
+    try std.testing.expect(options.setByCliName("react/jsx-no-bind", true));
+    try std.testing.expect(options.react_jsx_no_bind);
+    try std.testing.expect(!options.react_jsx_no_bind_allow_arrow_functions);
+    try std.testing.expect(!options.react_jsx_no_bind_allow_functions);
+    try std.testing.expect(!options.react_jsx_no_bind_allow_bind);
+    try std.testing.expect(!options.react_jsx_no_bind_ignore_refs);
+    try std.testing.expect(!options.react_jsx_no_bind_ignore_dom_components);
+
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
@@ -4234,6 +4272,21 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_filename_extension);
     try std.testing.expectEqual(@as(usize, 1), options.react_jsx_filename_extension_extensions.len());
     try std.testing.expectEqualStrings(".tsx", options.react_jsx_filename_extension_extensions.at(0));
+
+    var react_jsx_no_bind_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowArrowFunctions\":true,\"allowFunctions\":true,\"allowBind\":true,\"ignoreRefs\":true,\"ignoreDOMComponents\":true}]",
+        .{},
+    );
+    defer react_jsx_no_bind_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-no-bind", react_jsx_no_bind_config.value);
+    try std.testing.expect(options.react_jsx_no_bind);
+    try std.testing.expect(options.react_jsx_no_bind_allow_arrow_functions);
+    try std.testing.expect(options.react_jsx_no_bind_allow_functions);
+    try std.testing.expect(options.react_jsx_no_bind_allow_bind);
+    try std.testing.expect(options.react_jsx_no_bind_ignore_refs);
+    try std.testing.expect(options.react_jsx_no_bind_ignore_dom_components);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_no_bind.zig
+++ b/src/rules/react_jsx_no_bind.zig
@@ -8,6 +8,14 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-no-bind";
 
+pub const Options = struct {
+    allow_arrow_functions: bool = false,
+    allow_functions: bool = false,
+    allow_bind: bool = false,
+    ignore_refs: bool = false,
+    ignore_dom_components: bool = false,
+};
+
 const Violation = enum {
     bind_call,
     arrow_func,
@@ -98,7 +106,10 @@ pub fn checkJSXAttribute(
     attribute: ast.JSXAttribute,
     index: ast.NodeIndex,
     state: State,
+    parent_index: ?ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
+    if (shouldIgnoreAttribute(tree, attribute, parent_index, options)) return;
     if (attribute.value == .null) return;
     const container = switch (tree.data(attribute.value)) {
         .jsx_expression_container => |container| container,
@@ -109,12 +120,14 @@ pub fn checkJSXAttribute(
     const expression = unwrapTransparent(tree, container.expression);
     if (identifierReferenceName(tree, expression)) |name| {
         if (findBinding(state, name)) |violation| {
+            if (!shouldReportViolation(violation, options)) return;
             try report(allocator, diagnostics, tree, index, violation);
         }
         return;
     }
 
     const violation = nodeViolationType(tree, expression) orelse return;
+    if (!shouldReportViolation(violation, options)) return;
     try report(allocator, diagnostics, tree, index, violation);
 }
 
@@ -143,6 +156,29 @@ fn findBinding(state: State, name: []const u8) ?Violation {
     return null;
 }
 
+fn shouldReportViolation(violation: Violation, options: Options) bool {
+    return switch (violation) {
+        .bind_call => !options.allow_bind,
+        .arrow_func => !options.allow_arrow_functions,
+        .func => !options.allow_functions,
+    };
+}
+
+fn shouldIgnoreAttribute(tree: *const ast.Tree, attribute: ast.JSXAttribute, parent_index: ?ast.NodeIndex, options: Options) bool {
+    if (options.ignore_refs) {
+        if (jsxIdentifierName(tree, attribute.name)) |name| {
+            if (std.mem.eql(u8, name, "ref")) return true;
+        }
+    }
+
+    if (options.ignore_dom_components) {
+        const opening = jsxOpeningElement(tree, parent_index) orelse return false;
+        if (isDomComponent(tree, opening.name)) return true;
+    }
+
+    return false;
+}
+
 fn nodeViolationType(tree: *const ast.Tree, index: ast.NodeIndex) ?Violation {
     const current = unwrapTransparent(tree, index);
     return switch (tree.data(current)) {
@@ -157,6 +193,26 @@ fn nodeViolationType(tree: *const ast.Tree, index: ast.NodeIndex) ?Violation {
             => .func,
             else => null,
         },
+        else => null,
+    };
+}
+
+fn jsxOpeningElement(tree: *const ast.Tree, parent_index: ?ast.NodeIndex) ?ast.JSXOpeningElement {
+    const parent = parent_index orelse return null;
+    return switch (tree.data(parent)) {
+        .jsx_opening_element => |opening| opening,
+        else => null,
+    };
+}
+
+fn isDomComponent(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
+    const name = jsxIdentifierName(tree, name_index) orelse return false;
+    return name.len > 0 and std.ascii.isLower(name[0]);
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2805,7 +2805,13 @@ const BasicVisitor = struct {
             try react_no_array_index_key.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, self.react_no_array_index_key_state);
         }
         if (self.options.react_jsx_no_bind) {
-            try react_jsx_no_bind.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, self.react_jsx_no_bind_state);
+            try react_jsx_no_bind.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, self.react_jsx_no_bind_state, ctx.path.ancestor(1), .{
+                .allow_arrow_functions = self.options.react_jsx_no_bind_allow_arrow_functions,
+                .allow_functions = self.options.react_jsx_no_bind_allow_functions,
+                .allow_bind = self.options.react_jsx_no_bind_allow_bind,
+                .ignore_refs = self.options.react_jsx_no_bind_ignore_refs,
+                .ignore_dom_components = self.options.react_jsx_no_bind_ignore_dom_components,
+            });
         }
         if (self.options.react_no_unknown_property) {
             try react_no_unknown_property.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));

--- a/tests/rules/react_jsx_no_bind.zig
+++ b/tests/rules/react_jsx_no_bind.zig
@@ -54,6 +54,64 @@ test "does not report safe prop references" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_bind.id));
 }
 
+test "supports configured react/jsx-no-bind allow options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowArrowFunctions\":true,\"allowFunctions\":true,\"allowBind\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-no-bind", config.value);
+
+    const source =
+        \\function Demo() {
+        \\  const alias = () => action();
+        \\  function handler() {}
+        \\  return (
+        \\    <Button
+        \\      onClick={() => action()}
+        \\      onFocus={function () { action(); }}
+        \\      onMouseDown={this.handle.bind(this)}
+        \\      onKeyDown={alias}
+        \\      onBlur={handler}
+        \\    />
+        \\  );
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_bind.id));
+}
+
+test "supports configured react/jsx-no-bind ignore options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreRefs\":true,\"ignoreDOMComponents\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-no-bind", config.value);
+
+    const source =
+        \\const ignoredRef = <Button ref={() => action()} />;
+        \\const ignoredDom = <button onClick={() => action()} />;
+        \\const reported = <Button onClick={() => action()} />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_bind.id));
+}
+
 test "can disable react jsx no bind" {
     const source = "const node = <Button onClick={() => action()} />;";
 


### PR DESCRIPTION
## Summary
- add react/jsx-no-bind config parsing for allowArrowFunctions, allowFunctions, allowBind, ignoreRefs, and ignoreDOMComponents
- apply those options when reporting direct and aliased JSX prop function bindings
- cover configured allow and ignore behavior in rule tests

## Reference
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_no_bind.zig tests/rules/react_jsx_no_bind.zig
- git diff --check