### PR TITLE
support self closing comp options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -238,6 +238,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
+| [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |
 
 ## React Hooks rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -1173,6 +1173,8 @@ pub const Options = struct {
     react_no_unescaped_entities_forbid_closing_brace: bool = true,
     react_prefer_es6_class: bool = true,
     react_self_closing_comp: bool = true,
+    react_self_closing_comp_component: bool = true,
+    react_self_closing_comp_html: bool = true,
     react_style_prop_object: bool = true,
     react_void_dom_elements_no_children: bool = true,
     react_hooks_rules_of_hooks: bool = true,
@@ -1585,6 +1587,10 @@ pub const Options = struct {
             self.react_no_unescaped_entities_forbid_double_quote = forbid.double_quote;
             self.react_no_unescaped_entities_forbid_single_quote = forbid.single_quote;
             self.react_no_unescaped_entities_forbid_closing_brace = forbid.closing_brace;
+        }
+        if (std.mem.eql(u8, cli_name, "react/self-closing-comp")) {
+            self.react_self_closing_comp_component = try reactSelfClosingCompBoolOptionFromConfig(value, "component", true);
+            self.react_self_closing_comp_html = try reactSelfClosingCompBoolOptionFromConfig(value, "html", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
@@ -3565,6 +3571,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactSelfClosingCompBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxPascalCaseAllowAllCapsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4203,6 +4226,12 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(!options.react_no_string_refs_no_template_literals);
 
+    try std.testing.expect(!options.react_self_closing_comp);
+    try std.testing.expect(options.setByCliName("react/self-closing-comp", true));
+    try std.testing.expect(options.react_self_closing_comp);
+    try std.testing.expect(options.react_self_closing_comp_component);
+    try std.testing.expect(options.react_self_closing_comp_html);
+
     try std.testing.expect(!options.react_no_unescaped_entities);
     try std.testing.expect(options.setByCliName("react/no-unescaped-entities", true));
     try std.testing.expect(options.react_no_unescaped_entities);
@@ -4335,6 +4364,18 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/no-string-refs", react_no_string_refs_config.value);
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(options.react_no_string_refs_no_template_literals);
+
+    var react_self_closing_comp_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"component\":false,\"html\":true}]",
+        .{},
+    );
+    defer react_self_closing_comp_config.deinit();
+    try options.setByRuleConfigValue("react/self-closing-comp", react_self_closing_comp_config.value);
+    try std.testing.expect(options.react_self_closing_comp);
+    try std.testing.expect(!options.react_self_closing_comp_component);
+    try std.testing.expect(options.react_self_closing_comp_html);
 
     var react_no_unescaped_entities_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_self_closing_comp.zig
+++ b/src/rules/react_self_closing_comp.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/self-closing-comp";
 
+pub const Options = struct {
+    component: bool = true,
+    html: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,9 +19,10 @@ pub fn check(
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
     parent: ?ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (opening.self_closing) return;
-    if (!isConfiguredElementName(tree, opening.name)) return;
+    if (!isConfiguredElementName(tree, opening.name, options)) return;
 
     const element = switch (tree.data(parent orelse return)) {
         .jsx_element => |element| element,
@@ -34,10 +40,13 @@ pub fn check(
     );
 }
 
-fn isConfiguredElementName(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn isConfiguredElementName(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) bool {
     return switch (tree.data(index)) {
-        .jsx_identifier => true,
-        .jsx_member_expression => true,
+        .jsx_identifier => |identifier| {
+            const name = tree.string(identifier.name);
+            return if (name.len > 0 and std.ascii.isLower(name[0])) options.html else options.component;
+        },
+        .jsx_member_expression => options.component,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2926,7 +2926,10 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.react_self_closing_comp) {
-            try react_self_closing_comp.check(self.allocator, self.diagnostics, ctx.tree, opening, index, ctx.path.ancestor(1));
+            try react_self_closing_comp.check(self.allocator, self.diagnostics, ctx.tree, opening, index, ctx.path.ancestor(1), .{
+                .component = self.options.react_self_closing_comp_component,
+                .html = self.options.react_self_closing_comp_html,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_self_closing_comp.zig
+++ b/tests/rules/react_self_closing_comp.zig
@@ -65,6 +65,54 @@ test "allows react/self-closing-comp when elements have children or are already 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_self_closing_comp.id));
 }
 
+test "supports configured react/self-closing-comp component option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"component\":false,\"html\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/self-closing-comp", config.value);
+
+    const source =
+        \\const html = <div></div>;
+        \\const component = <Widget></Widget>;
+        \\const member = <UI.Widget></UI.Widget>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_self_closing_comp.id));
+}
+
+test "supports configured react/self-closing-comp html option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"component\":true,\"html\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/self-closing-comp", config.value);
+
+    const source =
+        \\const html = <div></div>;
+        \\const component = <Widget></Widget>;
+        \\const member = <UI.Widget></UI.Widget>;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_self_closing_comp.id));
+}
+
 test "can disable react/self-closing-comp" {
     const source =
         \\const html = <div></div>;
@@ -81,4 +129,14 @@ test "can disable react/self-closing-comp" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_self_closing_comp.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .eol_last = false,
+        .react_void_dom_elements_no_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
 }


### PR DESCRIPTION
## Summary
- add react/self-closing-comp component and html config parsing
- apply those options when deciding whether empty JSX tags should be self-closing
- cover component-only and html-only configuration behavior

## Reference
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig fmt --check src/core.zig src/rules/root.zig src/rules/react_self_closing_comp.zig tests/rules/react_self_closing_comp.zig
- git diff --check