### PR TITLE
support no unknown property options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -236,6 +236,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
+| [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -513,6 +513,42 @@ pub const ReactJsxPascalCaseIgnoreNames = struct {
     }
 };
 
+pub const max_react_no_unknown_property_ignore_names = 32;
+pub const max_react_no_unknown_property_ignore_name_len = 128;
+
+pub const ReactNoUnknownPropertyIgnoreNamesError = error{
+    EmptyReactNoUnknownPropertyIgnoreName,
+    TooManyReactNoUnknownPropertyIgnoreNames,
+    ReactNoUnknownPropertyIgnoreNameTooLong,
+};
+
+pub const ReactNoUnknownPropertyIgnoreNames = struct {
+    count: usize = 0,
+    lengths: [max_react_no_unknown_property_ignore_names]usize = undefined,
+    storage: [max_react_no_unknown_property_ignore_names][max_react_no_unknown_property_ignore_name_len]u8 = undefined,
+
+    pub fn contains(self: *const ReactNoUnknownPropertyIgnoreNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const ReactNoUnknownPropertyIgnoreNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ReactNoUnknownPropertyIgnoreNames, name: []const u8) ReactNoUnknownPropertyIgnoreNamesError!void {
+        if (name.len == 0) return error.EmptyReactNoUnknownPropertyIgnoreName;
+        if (self.count >= max_react_no_unknown_property_ignore_names) return error.TooManyReactNoUnknownPropertyIgnoreNames;
+        if (name.len > max_react_no_unknown_property_ignore_name_len) return error.ReactNoUnknownPropertyIgnoreNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_typescript_eslint_ban_type_entries = 32;
 pub const max_typescript_eslint_ban_type_name_len = 128;
 pub const max_typescript_eslint_ban_type_message_len = 512;
@@ -1159,6 +1195,8 @@ pub const Options = struct {
     react_no_this_in_sfc: bool = true,
     react_no_typos: bool = true,
     react_no_unknown_property: bool = true,
+    react_no_unknown_property_ignore: ReactNoUnknownPropertyIgnoreNames = .{},
+    react_no_unknown_property_require_data_lowercase: bool = false,
     react_prop_types: bool = true,
     react_prop_types_skip_undeclared: bool = false,
     react_no_unused_prop_types: bool = true,
@@ -1580,6 +1618,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-string-refs")) {
             self.react_no_string_refs_no_template_literals = try reactNoStringRefsNoTemplateLiteralsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-unknown-property")) {
+            self.react_no_unknown_property_ignore = try reactNoUnknownPropertyIgnoreFromConfig(value);
+            self.react_no_unknown_property_require_data_lowercase = try reactNoUnknownPropertyRequireDataLowercaseFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unescaped-entities")) {
             const forbid = try reactNoUnescapedEntitiesForbidFromConfig(value);
@@ -3571,6 +3613,50 @@ pub const Options = struct {
         };
     }
 
+    fn reactNoUnknownPropertyIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactNoUnknownPropertyIgnoreNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore_items = switch (config.get("ignore") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignore = ReactNoUnknownPropertyIgnoreNames{};
+        for (ignore_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            ignore.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return ignore;
+    }
+
+    fn reactNoUnknownPropertyRequireDataLowercaseFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("requireDataLowercase") orelse return false) {
+            .bool => |require_data_lowercase| require_data_lowercase,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactSelfClosingCompBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4226,6 +4312,12 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(!options.react_no_string_refs_no_template_literals);
 
+    try std.testing.expect(!options.react_no_unknown_property);
+    try std.testing.expect(options.setByCliName("react/no-unknown-property", true));
+    try std.testing.expect(options.react_no_unknown_property);
+    try std.testing.expectEqual(@as(usize, 0), options.react_no_unknown_property_ignore.count);
+    try std.testing.expect(!options.react_no_unknown_property_require_data_lowercase);
+
     try std.testing.expect(!options.react_self_closing_comp);
     try std.testing.expect(options.setByCliName("react/self-closing-comp", true));
     try std.testing.expect(options.react_self_closing_comp);
@@ -4364,6 +4456,20 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/no-string-refs", react_no_string_refs_config.value);
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(options.react_no_string_refs_no_template_literals);
+
+    var react_no_unknown_property_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"class\",\"data-Foo\"],\"requireDataLowercase\":true}]",
+        .{},
+    );
+    defer react_no_unknown_property_config.deinit();
+    try options.setByRuleConfigValue("react/no-unknown-property", react_no_unknown_property_config.value);
+    try std.testing.expect(options.react_no_unknown_property);
+    try std.testing.expect(options.react_no_unknown_property_ignore.contains("class"));
+    try std.testing.expect(options.react_no_unknown_property_ignore.contains("data-Foo"));
+    try std.testing.expect(!options.react_no_unknown_property_ignore.contains("other"));
+    try std.testing.expect(options.react_no_unknown_property_require_data_lowercase);
 
     var react_self_closing_comp_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_unknown_property.zig
+++ b/src/rules/react_no_unknown_property.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/no-unknown-property";
 
+pub const Options = struct {
+    ignore: core.ReactNoUnknownPropertyIgnoreNames = .{},
+    require_data_lowercase: bool = false,
+};
+
 const NameMap = struct {
     from: []const u8,
     to: []const u8,
@@ -286,6 +291,7 @@ pub fn check(
     attribute: ast.JSXAttribute,
     index: ast.NodeIndex,
     parent_index: ?ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const actual_name_text = try jsxNameText(allocator, tree, attribute.name) orelse return;
     defer actual_name_text.deinit(allocator);
@@ -293,9 +299,13 @@ pub fn check(
     if (tagNameHasDot(tree, parent_index)) return;
 
     const actual_name = actual_name_text.value;
+    if (options.ignore.contains(actual_name)) return;
+
     const name = normalizeAttributeCase(actual_name);
 
-    if (isValidDataAttribute(name)) return;
+    if (isValidDataAttribute(name)) {
+        if (!options.require_data_lowercase or isLowercaseDataAttributeName(name)) return;
+    }
     if (isValidAriaAttribute(name)) return;
 
     const opening = jsxOpeningElement(tree, parent_index) orelse return;
@@ -394,6 +404,13 @@ fn normalizeAttributeCase(name: []const u8) []const u8 {
 fn isValidDataAttribute(name: []const u8) bool {
     if (startsWithIgnoreCase(name, "data-xml")) return false;
     return std.mem.startsWith(u8, name, "data-") and std.mem.indexOfScalar(u8, name, ':') == null;
+}
+
+fn isLowercaseDataAttributeName(name: []const u8) bool {
+    for (name["data-".len..]) |byte| {
+        if (std.ascii.isUpper(byte)) return false;
+    }
+    return true;
 }
 
 fn isValidAriaAttribute(name: []const u8) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2814,7 +2814,10 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.react_no_unknown_property) {
-            try react_no_unknown_property.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1));
+            try react_no_unknown_property.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1), .{
+                .ignore = self.options.react_no_unknown_property_ignore,
+                .require_data_lowercase = self.options.react_no_unknown_property_require_data_lowercase,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_no_unknown_property.zig
+++ b/tests/rules/react_no_unknown_property.zig
@@ -58,6 +58,53 @@ test "allows react/no-unknown-property for known DOM props and skipped JSX tags"
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_unknown_property.id));
 }
 
+test "supports configured react/no-unknown-property ignore list" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"class\",\"unknownProp\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/no-unknown-property", config.value);
+
+    const source =
+        \\const view = <div class="box" unknownProp="x" tabindex="0" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unknown_property.id));
+    try std.testing.expect(hasMessage(result, "Unknown property 'tabindex' found, use 'tabIndex' instead"));
+}
+
+test "supports configured react/no-unknown-property requireDataLowercase" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"requireDataLowercase\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/no-unknown-property", config.value);
+
+    const source =
+        \\const view = <div data-foo="a" data-Foo="b" data-fooBar="c" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_unknown_property.id));
+    try std.testing.expect(hasMessage(result, "Unknown property 'data-Foo' found"));
+    try std.testing.expect(hasMessage(result, "Unknown property 'data-fooBar' found"));
+}
+
 test "reports react/no-unknown-property for namespaced SVG attributes" {
     const source =
         \\const view = <svg xlink:href="#a" xml:lang="en" />;


### PR DESCRIPTION
## Summary
- add react/no-unknown-property ignore list and requireDataLowercase config parsing
- apply ignored attributes before standard DOM/data/aria validation
- report mixed-case data-* props only when requireDataLowercase is enabled

## Reference
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_unknown_property.zig tests/rules/react_no_unknown_property.zig
- git diff --check