### PR TITLE
support jsx key spread option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -225,6 +225,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |
+| [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` configuration |
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1162,6 +1162,7 @@ pub const Options = struct {
     react_jsx_no_bind_ignore_refs: bool = false,
     react_jsx_no_bind_ignore_dom_components: bool = false,
     react_jsx_key: bool = true,
+    react_jsx_key_check_key_must_before_spread: bool = false,
     react_button_has_type: bool = true,
     react_button_has_type_button: bool = true,
     react_button_has_type_submit: bool = true,
@@ -1601,6 +1602,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-duplicate-props")) {
             self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/jsx-key")) {
+            self.react_jsx_key_check_key_must_before_spread = try reactJsxKeyCheckKeyMustBeforeSpreadFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
@@ -3596,6 +3600,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactJsxKeyCheckKeyMustBeforeSpreadFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("checkKeyMustBeforeSpread") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactNoStringRefsNoTemplateLiteralsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4296,6 +4317,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_jsx_no_bind_ignore_refs);
     try std.testing.expect(!options.react_jsx_no_bind_ignore_dom_components);
 
+    try std.testing.expect(!options.react_jsx_key);
+    try std.testing.expect(options.setByCliName("react/jsx-key", true));
+    try std.testing.expect(options.react_jsx_key);
+    try std.testing.expect(!options.react_jsx_key_check_key_must_before_spread);
+
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
     try std.testing.expect(options.react_prop_types);
@@ -4408,6 +4434,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_no_bind_allow_bind);
     try std.testing.expect(options.react_jsx_no_bind_ignore_refs);
     try std.testing.expect(options.react_jsx_no_bind_ignore_dom_components);
+
+    var react_jsx_key_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkKeyMustBeforeSpread\":true}]",
+        .{},
+    );
+    defer react_jsx_key_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-key", react_jsx_key_config.value);
+    try std.testing.expect(options.react_jsx_key);
+    try std.testing.expect(options.react_jsx_key_check_key_must_before_spread);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_key.zig
+++ b/src/rules/react_jsx_key.zig
@@ -15,6 +15,10 @@ pub const State = struct {
     children_to_array_depth: usize = 0,
 };
 
+pub const Options = struct {
+    check_key_must_before_spread: bool = false,
+};
+
 pub fn collectProgram(tree: *const ast.Tree, state: *State) void {
     state.pragma = pragmaFromComments(tree) orelse "React";
 }
@@ -25,6 +29,7 @@ pub fn enterCallExpression(
     tree: *const ast.Tree,
     call: ast.CallExpression,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     if (isChildrenToArrayCall(tree, call, state.*)) {
         state.children_to_array_depth += 1;
@@ -33,7 +38,7 @@ pub fn enterCallExpression(
     if (state.children_to_array_depth > 0) return;
 
     const callback = iteratorCallback(tree, call) orelse return;
-    try checkIteratorCallback(allocator, diagnostics, tree, callback);
+    try checkIteratorCallback(allocator, diagnostics, tree, callback, options);
 }
 
 pub fn exitCallExpression(tree: *const ast.Tree, call: ast.CallExpression, state: *State) void {
@@ -48,6 +53,7 @@ pub fn checkArrayExpression(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.ArrayExpression,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.extra(expression.elements)) |element_index| {
         if (element_index == .null) continue;
@@ -55,7 +61,7 @@ pub fn checkArrayExpression(
             .jsx_element => |element| element,
             else => continue,
         };
-        if (hasKeyProp(tree, element)) continue;
+        if (hasKeyProp(tree, element, options)) continue;
         try report(allocator, diagnostics, tree, element_index, missing_array_key_message);
     }
 }
@@ -65,19 +71,20 @@ fn checkIteratorCallback(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     callback_index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const current = unwrapTransparent(tree, callback_index);
     switch (tree.data(current)) {
         .arrow_function_expression => |function| {
             if (function.expression) {
-                try checkIteratorExpression(allocator, diagnostics, tree, function.body);
+                try checkIteratorExpression(allocator, diagnostics, tree, function.body, options);
             } else {
-                try checkFunctionBody(allocator, diagnostics, tree, function.body);
+                try checkFunctionBody(allocator, diagnostics, tree, function.body, options);
             }
         },
         .function => |function| {
             if (function.type != .function_expression or function.body == .null) return;
-            try checkFunctionBody(allocator, diagnostics, tree, function.body);
+            try checkFunctionBody(allocator, diagnostics, tree, function.body, options);
         },
         else => {},
     }
@@ -88,15 +95,16 @@ fn checkIteratorExpression(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const current = unwrapTransparent(tree, index);
     switch (tree.data(current)) {
-        .jsx_element => |element| try checkIteratorElement(allocator, diagnostics, tree, element, current),
+        .jsx_element => |element| try checkIteratorElement(allocator, diagnostics, tree, element, current, options),
         .conditional_expression => |conditional| {
-            try checkIteratorExpression(allocator, diagnostics, tree, conditional.consequent);
-            try checkIteratorExpression(allocator, diagnostics, tree, conditional.alternate);
+            try checkIteratorExpression(allocator, diagnostics, tree, conditional.consequent, options);
+            try checkIteratorExpression(allocator, diagnostics, tree, conditional.alternate, options);
         },
-        .logical_expression => |logical| try checkIteratorExpression(allocator, diagnostics, tree, logical.right),
+        .logical_expression => |logical| try checkIteratorExpression(allocator, diagnostics, tree, logical.right, options),
         else => {},
     }
 }
@@ -106,13 +114,14 @@ fn checkFunctionBody(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const body = switch (tree.data(index)) {
         .function_body => |body| body.body,
         .block_statement => |block| block.body,
         else => return,
     };
-    try checkReturnStatements(allocator, diagnostics, tree, body);
+    try checkReturnStatements(allocator, diagnostics, tree, body, options);
 }
 
 fn checkReturnStatements(
@@ -120,9 +129,10 @@ fn checkReturnStatements(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     range: ast.IndexRange,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.extra(range)) |statement_index| {
-        try checkReturnStatement(allocator, diagnostics, tree, statement_index);
+        try checkReturnStatement(allocator, diagnostics, tree, statement_index, options);
     }
 }
 
@@ -131,20 +141,21 @@ fn checkReturnStatement(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     switch (tree.data(index)) {
         .return_statement => |statement| {
             if (statement.argument != .null) {
-                try checkIteratorExpression(allocator, diagnostics, tree, statement.argument);
+                try checkIteratorExpression(allocator, diagnostics, tree, statement.argument, options);
             }
         },
         .if_statement => |statement| {
-            try checkReturnStatement(allocator, diagnostics, tree, statement.consequent);
+            try checkReturnStatement(allocator, diagnostics, tree, statement.consequent, options);
             if (statement.alternate != .null) {
-                try checkReturnStatement(allocator, diagnostics, tree, statement.alternate);
+                try checkReturnStatement(allocator, diagnostics, tree, statement.alternate, options);
             }
         },
-        .block_statement => |block| try checkReturnStatements(allocator, diagnostics, tree, block.body),
+        .block_statement => |block| try checkReturnStatements(allocator, diagnostics, tree, block.body, options),
         else => {},
     }
 }
@@ -155,8 +166,9 @@ fn checkIteratorElement(
     tree: *const ast.Tree,
     element: ast.JSXElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
-    if (hasKeyProp(tree, element)) return;
+    if (hasKeyProp(tree, element, options)) return;
     try report(allocator, diagnostics, tree, index, missing_iter_key_message);
 }
 
@@ -179,18 +191,25 @@ fn iteratorCallback(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIn
     return arguments[1];
 }
 
-fn hasKeyProp(tree: *const ast.Tree, element: ast.JSXElement) bool {
+fn hasKeyProp(tree: *const ast.Tree, element: ast.JSXElement, options: Options) bool {
     const opening = switch (tree.data(element.opening_element)) {
         .jsx_opening_element => |opening| opening,
         else => return false,
     };
+    var seen_spread = false;
     for (tree.extra(opening.attributes)) |attribute_index| {
         const attribute = switch (tree.data(attribute_index)) {
             .jsx_attribute => |attribute| attribute,
+            .jsx_spread_attribute => {
+                seen_spread = true;
+                continue;
+            },
             else => continue,
         };
         const name = jsxIdentifierName(tree, attribute.name) orelse continue;
-        if (std.mem.eql(u8, name, "key")) return true;
+        if (std.mem.eql(u8, name, "key")) {
+            return !options.check_key_must_before_spread or !seen_spread;
+        }
     }
     return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2599,7 +2599,9 @@ const BasicVisitor = struct {
             try react_no_array_index_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, &self.react_no_array_index_key_state);
         }
         if (self.options.react_jsx_key) {
-            try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state);
+            try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state, .{
+                .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
+            });
         }
         if (self.options.new_cap) {
             try new_cap.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, index, .{
@@ -2757,7 +2759,9 @@ const BasicVisitor = struct {
             try no_sparse_arrays.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.react_jsx_key and self.react_jsx_key_state.children_to_array_depth == 0) {
-            try react_jsx_key.checkArrayExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try react_jsx_key.checkArrayExpression(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_jsx_key.zig
+++ b/tests/rules/react_jsx_key.zig
@@ -38,6 +38,32 @@ test "reports JSX elements without keys in map callbacks" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_jsx_key.id));
 }
 
+test "supports configured react jsx key must appear before spread" {
+    const source =
+        \\const nodes = [
+        \\  <Item key="stable" {...props} />,
+        \\  <Item {...props} key="late" />,
+        \\];
+        \\items.map((item) => <Item {...item} key={item.id} />);
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkKeyMustBeforeSpread\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-key", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
 test "reports JSX elements without keys in block callback returns" {
     const source =
         \\items.map(function (item) {


### PR DESCRIPTION
## Summary
- add `react/jsx-key` parsing for `checkKeyMustBeforeSpread` from ESLint-style rule config
- enforce `key` before JSX spread attributes when the option is enabled
- document the supported option in the rule status table

Official rule reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_key.zig tests/rules/react_jsx_key.zig`
- `git diff --check`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`