### PR TITLE
support no multi comp stateless option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -234,6 +234,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
+| [`react/no-multi-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md) | Supports `ignoreStateless` configuration |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1190,6 +1190,7 @@ pub const Options = struct {
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
     react_no_multi_comp: bool = true,
+    react_no_multi_comp_ignore_stateless: bool = true,
     react_no_redundant_should_component_update: bool = true,
     react_no_render_return_value: bool = true,
     react_no_will_update_set_state: bool = true,
@@ -1622,6 +1623,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-string-refs")) {
             self.react_no_string_refs_no_template_literals = try reactNoStringRefsNoTemplateLiteralsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-multi-comp")) {
+            self.react_no_multi_comp_ignore_stateless = try reactNoMultiCompIgnoreStatelessFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unknown-property")) {
             self.react_no_unknown_property_ignore = try reactNoUnknownPropertyIgnoreFromConfig(value);
@@ -3634,6 +3638,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactNoMultiCompIgnoreStatelessFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("ignoreStateless") orelse return true) {
+            .bool => |ignore_stateless| ignore_stateless,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactNoUnknownPropertyIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactNoUnknownPropertyIgnoreNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4338,6 +4359,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(!options.react_no_string_refs_no_template_literals);
 
+    try std.testing.expect(!options.react_no_multi_comp);
+    try std.testing.expect(options.setByCliName("react/no-multi-comp", true));
+    try std.testing.expect(options.react_no_multi_comp);
+    try std.testing.expect(options.react_no_multi_comp_ignore_stateless);
+
     try std.testing.expect(!options.react_no_unknown_property);
     try std.testing.expect(options.setByCliName("react/no-unknown-property", true));
     try std.testing.expect(options.react_no_unknown_property);
@@ -4493,6 +4519,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/no-string-refs", react_no_string_refs_config.value);
     try std.testing.expect(options.react_no_string_refs);
     try std.testing.expect(options.react_no_string_refs_no_template_literals);
+
+    var react_no_multi_comp_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreStateless\":false}]",
+        .{},
+    );
+    defer react_no_multi_comp_config.deinit();
+    try options.setByRuleConfigValue("react/no-multi-comp", react_no_multi_comp_config.value);
+    try std.testing.expect(options.react_no_multi_comp);
+    try std.testing.expect(!options.react_no_multi_comp_ignore_stateless);
 
     var react_no_unknown_property_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_multi_comp.zig
+++ b/src/rules/react_no_multi_comp.zig
@@ -11,6 +11,10 @@ pub const State = struct {
     component_count: usize = 0,
 };
 
+pub const Options = struct {
+    ignore_stateless: bool = true,
+};
+
 pub fn checkClass(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -20,7 +24,48 @@ pub fn checkClass(
     state: *State,
 ) Allocator.Error!void {
     if (!isReactComponentClass(tree, class)) return;
+    try reportComponent(allocator, diagnostics, tree, index, state);
+}
 
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_stateless) return;
+    if (function.type != .function_declaration) return;
+    if (!functionNameStartsUppercase(tree, function)) return;
+    if (!functionReturnsJSXOrNull(tree, index)) return;
+    try reportComponent(allocator, diagnostics, tree, index, state);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    index: ast.NodeIndex,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_stateless) return;
+    if (!bindingIdentifierStartsUppercase(tree, declarator.id)) return;
+    if (declarator.init == .null) return;
+    if (!functionReturnsJSXOrNull(tree, declarator.init)) return;
+    try reportComponent(allocator, diagnostics, tree, index, state);
+}
+
+fn reportComponent(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: *State,
+) Allocator.Error!void {
     state.component_count += 1;
     if (state.component_count <= 1) return;
 
@@ -52,15 +97,125 @@ fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
     return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
 }
 
+fn functionNameStartsUppercase(tree: *const ast.Tree, function: ast.Function) bool {
+    const name = bindingIdentifierName(tree, function.id) orelse return true;
+    return startsUppercase(name);
+}
+
+fn functionReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function => |function| function.body != .null and bodyReturnsJSXOrNull(tree, function.body),
+        .arrow_function_expression => |arrow| if (arrow.expression)
+            isJSXOrNullValue(tree, arrow.body)
+        else
+            bodyReturnsJSXOrNull(tree, arrow.body),
+        else => false,
+    };
+}
+
+fn bodyReturnsJSXOrNull(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    const range = switch (tree.data(body_index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return false,
+    };
+    return rangeReturnsJSXOrNull(tree, range);
+}
+
+fn rangeReturnsJSXOrNull(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |statement_index| {
+        if (statementReturnsJSXOrNull(tree, statement_index)) return true;
+    }
+    return false;
+}
+
+fn statementReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .return_statement => |statement| isJSXOrNullValue(tree, statement.argument),
+        .block_statement => |block| rangeReturnsJSXOrNull(tree, block.body),
+        .if_statement => |statement| statementReturnsJSXOrNull(tree, statement.consequent) or
+            statementReturnsJSXOrNull(tree, statement.alternate),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const case = switch (tree.data(case_index)) {
+                    .switch_case => |case| case,
+                    else => continue,
+                };
+                if (rangeReturnsJSXOrNull(tree, case.consequent)) return true;
+            }
+            return false;
+        },
+        .function,
+        .arrow_function_expression,
+        => false,
+        else => false,
+    };
+}
+
+fn isJSXOrNullValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .jsx_element,
+        .jsx_fragment,
+        .null_literal,
+        => true,
+        .call_expression => |call| isCreateElementCall(tree, call),
+        .conditional_expression => |conditional| isJSXOrNullValue(tree, conditional.consequent) or
+            isJSXOrNullValue(tree, conditional.alternate),
+        .logical_expression => |logical| isJSXOrNullValue(tree, logical.left) or isJSXOrNullValue(tree, logical.right),
+        .sequence_expression => |sequence| {
+            if (sequence.expressions.len == 0) return false;
+            const items = tree.extra(sequence.expressions);
+            return isJSXOrNullValue(tree, items[items.len - 1]);
+        },
+        else => false,
+    };
+}
+
+fn isCreateElementCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createElement");
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "createElement");
+}
+
+fn bindingIdentifierStartsUppercase(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = bindingIdentifierName(tree, index) orelse return false;
+    return startsUppercase(name);
+}
+
+fn startsUppercase(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}
+
 fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
     if (computed) return null;
     return switch (tree.data(index)) {
         .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
         else => null,
     };
 }
 
 fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1172,6 +1172,11 @@ const BasicVisitor = struct {
         if (self.options.react_display_name) {
             try react_display_name.checkFunction(self.allocator, ctx.tree, function, index, ctx.path.parent(), &self.react_display_name_state);
         }
+        if (self.options.react_no_multi_comp) {
+            try react_no_multi_comp.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, &self.react_no_multi_comp_state, .{
+                .ignore_stateless = self.options.react_no_multi_comp_ignore_stateless,
+            });
+        }
         return .proceed;
     }
 
@@ -1553,6 +1558,11 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
+        }
+        if (self.options.react_no_multi_comp) {
+            try react_no_multi_comp.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, index, &self.react_no_multi_comp_state, .{
+                .ignore_stateless = self.options.react_no_multi_comp_ignore_stateless,
+            });
         }
         if (self.options.react_no_access_state_in_setstate) {
             try react_no_access_state_in_setstate.checkVariableDeclarator(

--- a/tests/rules/react_no_multi_comp.zig
+++ b/tests/rules/react_no_multi_comp.zig
@@ -59,6 +59,42 @@ test "allows react/no-multi-comp ignored stateless and single class components" 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_multi_comp.id));
 }
 
+test "supports configured react/no-multi-comp ignoreStateless false" {
+    const source =
+        \\class One extends React.Component {
+        \\  render() {
+        \\    return null;
+        \\  }
+        \\}
+        \\function Two() {
+        \\  return <div />;
+        \\}
+        \\const Three = () => <span />;
+        \\const four = () => <span />;
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreStateless\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/no-multi-comp", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_multi_comp.id));
+}
+
 test "can disable react/no-multi-comp" {
     const source =
         \\class One extends React.Component {


### PR DESCRIPTION
## Summary
- add `react/no-multi-comp` parsing for `ignoreStateless` from ESLint-style rule config
- keep the existing default behavior of ignoring stateless function components
- when `ignoreStateless` is `false`, count uppercase function and variable JSX components alongside class components
- document the supported option in the rule status table

Official rule reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_multi_comp.zig tests/rules/react_no_multi_comp.zig`
- `git diff --check`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`