### PR TITLE
support no inferrable types ignore options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -273,7 +273,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
-| [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Implemented |
+| [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
 | [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Implemented |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1260,6 +1260,8 @@ pub const Options = struct {
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_duplicate_enum_values: bool = true,
     typescript_eslint_no_inferrable_types: bool = true,
+    typescript_eslint_no_inferrable_types_ignore_parameters: bool = false,
+    typescript_eslint_no_inferrable_types_ignore_properties: bool = false,
     typescript_eslint_no_invalid_void_type: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_loop_func: bool = true,
@@ -1668,6 +1670,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/explicit-member-accessibility")) {
             self.typescript_eslint_explicit_member_accessibility_accessibility = try typescriptEslintExplicitMemberAccessibilityFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-inferrable-types")) {
+            self.typescript_eslint_no_inferrable_types_ignore_parameters = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreParameters", false);
+            self.typescript_eslint_no_inferrable_types_ignore_properties = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreProperties", false);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -3994,6 +4000,23 @@ pub const Options = struct {
         return names;
     }
 
+    fn typescriptEslintNoInferrableTypesBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintTypedefBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4207,6 +4230,12 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unused-vars", true));
     try std.testing.expect(options.typescript_eslint_no_unused_vars);
     try std.testing.expect(!options.no_unused_vars);
+
+    try std.testing.expect(!options.typescript_eslint_no_inferrable_types);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-inferrable-types", true));
+    try std.testing.expect(options.typescript_eslint_no_inferrable_types);
+    try std.testing.expect(!options.typescript_eslint_no_inferrable_types_ignore_parameters);
+    try std.testing.expect(!options.typescript_eslint_no_inferrable_types_ignore_properties);
 
     try std.testing.expect(!options.typescript_eslint_no_duplicate_enum_values);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-duplicate-enum-values", true));
@@ -5362,6 +5391,18 @@ test "Options can apply ESLint-style rule config values" {
         TypescriptEslintExplicitMemberAccessibility.off,
         options.typescript_eslint_explicit_member_accessibility_accessibility,
     );
+
+    var typescript_no_inferrable_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreParameters\":true,\"ignoreProperties\":true}]",
+        .{},
+    );
+    defer typescript_no_inferrable_types_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-inferrable-types", typescript_no_inferrable_types_config.value);
+    try std.testing.expect(options.typescript_eslint_no_inferrable_types);
+    try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_parameters);
+    try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_properties);
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1590,7 +1590,10 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_inferrable_types) {
-            try typescript_eslint_no_inferrable_types.checkAssignmentPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+            try typescript_eslint_no_inferrable_types.checkAssignmentPattern(self.allocator, self.diagnostics, ctx.tree, pattern, .{
+                .ignore_parameters = self.options.typescript_eslint_no_inferrable_types_ignore_parameters,
+                .ignore_properties = self.options.typescript_eslint_no_inferrable_types_ignore_properties,
+            });
         }
         return .proceed;
     }
@@ -3204,7 +3207,10 @@ const BasicVisitor = struct {
             try typescript_eslint_prefer_as_const.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
-            try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+            try typescript_eslint_no_inferrable_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .ignore_parameters = self.options.typescript_eslint_no_inferrable_types_ignore_parameters,
+                .ignore_properties = self.options.typescript_eslint_no_inferrable_types_ignore_properties,
+            });
         }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_member_variable_declaration) {
             try typescript_eslint_typedef.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, index);

--- a/src/rules/typescript_eslint_no_inferrable_types.zig
+++ b/src/rules/typescript_eslint_no_inferrable_types.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-inferrable-types";
 
+pub const Options = struct {
+    ignore_parameters: bool = false,
+    ignore_properties: bool = false,
+};
+
 pub fn checkVariableDeclarator(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -23,7 +28,10 @@ pub fn checkAssignmentPattern(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     pattern: ast.AssignmentPattern,
+    options: Options,
 ) Allocator.Error!void {
+    if (options.ignore_parameters) return;
+
     const type_annotation = if (pattern.type_annotation != .null)
         pattern.type_annotation
     else
@@ -37,7 +45,9 @@ pub fn checkPropertyDefinition(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     property: ast.PropertyDefinition,
+    options: Options,
 ) Allocator.Error!void {
+    if (options.ignore_properties) return;
     if (property.readonly or property.optional) return;
     if (property.value == .null) return;
     try reportInferrableType(allocator, diagnostics, tree, property.type_annotation, property.value);

--- a/tests/rules/typescript_eslint_no_inferrable_types.zig
+++ b/tests/rules/typescript_eslint_no_inferrable_types.zig
@@ -45,6 +45,37 @@ test "reports @typescript-eslint/no-inferrable-types for defaulted parameters" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
 }
 
+test "supports configured @typescript-eslint/no-inferrable-types ignored parameters and properties" {
+    const source =
+        \\const name: string = "Ada";
+        \\function visit(count: number = 1) {
+        \\  return count;
+        \\}
+        \\class Example {
+        \\  value: number = 1;
+        \\}
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreParameters\":true,\"ignoreProperties\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-inferrable-types", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_inferrable_types.id));
+}
+
 test "does not report @typescript-eslint/no-inferrable-types for non-inferrable annotations" {
     const source =
         \\const value: string | number = "Ada";


### PR DESCRIPTION
## Summary
- add `@typescript-eslint/no-inferrable-types` parsing for `ignoreParameters` and `ignoreProperties`
- skip defaulted parameter diagnostics when `ignoreParameters` is enabled
- skip class property diagnostics when `ignoreProperties` is enabled while preserving variable diagnostics
- document the supported options in the rule status table

Official rule reference: https://typescript-eslint.io/rules/no-inferrable-types/

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_inferrable_types.zig tests/rules/typescript_eslint_no_inferrable_types.zig`
- `git diff --check`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`