### PR TITLE
support no empty interface single extends option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -269,7 +269,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Implemented |
-| [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Implemented |
+| [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Supports `allowSingleExtends` configuration |
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1256,6 +1256,7 @@ pub const Options = struct {
     typescript_eslint_no_empty_function: bool = true,
     typescript_eslint_no_empty_function_allow: NoEmptyFunctionAllow = .{},
     typescript_eslint_no_empty_interface: bool = true,
+    typescript_eslint_no_empty_interface_allow_single_extends: bool = false,
     typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_duplicate_enum_values: bool = true,
@@ -1670,6 +1671,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/explicit-member-accessibility")) {
             self.typescript_eslint_explicit_member_accessibility_accessibility = try typescriptEslintExplicitMemberAccessibilityFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-interface")) {
+            self.typescript_eslint_no_empty_interface_allow_single_extends = try typescriptEslintNoEmptyInterfaceAllowSingleExtendsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-inferrable-types")) {
             self.typescript_eslint_no_inferrable_types_ignore_parameters = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreParameters", false);
@@ -4017,6 +4021,23 @@ pub const Options = struct {
         };
     }
 
+    fn typescriptEslintNoEmptyInterfaceAllowSingleExtendsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowSingleExtends") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintTypedefBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4236,6 +4257,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.typescript_eslint_no_inferrable_types);
     try std.testing.expect(!options.typescript_eslint_no_inferrable_types_ignore_parameters);
     try std.testing.expect(!options.typescript_eslint_no_inferrable_types_ignore_properties);
+
+    try std.testing.expect(!options.typescript_eslint_no_empty_interface);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-empty-interface", true));
+    try std.testing.expect(options.typescript_eslint_no_empty_interface);
+    try std.testing.expect(!options.typescript_eslint_no_empty_interface_allow_single_extends);
 
     try std.testing.expect(!options.typescript_eslint_no_duplicate_enum_values);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-duplicate-enum-values", true));
@@ -4933,6 +4959,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.arrowFunctions);
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.methods);
     try std.testing.expect(!options.typescript_eslint_no_empty_function_allow.functions);
+
+    var typescript_no_empty_interface_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowSingleExtends\":true}]",
+        .{},
+    );
+    defer typescript_no_empty_interface_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-empty-interface", typescript_no_empty_interface_config.value);
+    try std.testing.expect(options.typescript_eslint_no_empty_interface);
+    try std.testing.expect(options.typescript_eslint_no_empty_interface_allow_single_extends);
 
     var no_else_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1605,7 +1605,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_empty_interface) {
-            try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration);
+            try typescript_eslint_no_empty_interface.check(self.allocator, self.diagnostics, ctx.tree, interface_declaration, .{
+                .allow_single_extends = self.options.typescript_eslint_no_empty_interface_allow_single_extends,
+            });
         }
         if (self.options.typescript_eslint_no_misused_new) {
             try typescript_eslint_no_misused_new.checkInterfaceDeclaration(self.allocator, self.diagnostics, ctx.tree, interface_declaration);

--- a/src/rules/typescript_eslint_no_empty_interface.zig
+++ b/src/rules/typescript_eslint_no_empty_interface.zig
@@ -6,11 +6,16 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-empty-interface";
 
+pub const Options = struct {
+    allow_single_extends: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     interface_declaration: ast.TSInterfaceDeclaration,
+    options: Options,
 ) Allocator.Error!void {
     const body = switch (tree.data(interface_declaration.body)) {
         .ts_interface_body => |interface_body| interface_body,
@@ -22,7 +27,7 @@ pub fn check(
     const message =
         if (interface_declaration.extends.len == 0)
             "An empty interface is equivalent to `{}`."
-        else if (interface_declaration.extends.len == 1)
+        else if (interface_declaration.extends.len == 1 and !options.allow_single_extends)
             "An interface declaring no members is equivalent to its supertype."
         else
             return;

--- a/tests/rules/typescript_eslint_no_empty_interface.zig
+++ b/tests/rules/typescript_eslint_no_empty_interface.zig
@@ -36,6 +36,33 @@ test "does not report @typescript-eslint/no-empty-interface for non-empty or mul
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_empty_interface.id));
 }
 
+test "supports configured @typescript-eslint/no-empty-interface allowSingleExtends" {
+    const source =
+        \\interface Empty {}
+        \\interface SingleExtends extends Base {}
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowSingleExtends\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-empty-interface", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_interface.id));
+}
+
 test "can disable @typescript-eslint/no-empty-interface" {
     const source =
         \\interface Empty {}


### PR DESCRIPTION
## Summary
- add `@typescript-eslint/no-empty-interface` parsing for `allowSingleExtends`
- keep the default behavior of reporting empty interfaces with zero or one extends
- allow single-extends empty interfaces when `allowSingleExtends` is enabled
- document the supported option in the rule status table

Official rule reference: https://typescript-eslint.io/rules/no-empty-interface/

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_empty_interface.zig tests/rules/typescript_eslint_no_empty_interface.zig`
- `git diff --check`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`