### PR TITLE
support restrict plus operands number string option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -298,4 +298,4 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |
 | [`@typescript-eslint/prefer-namespace-keyword`](https://typescript-eslint.io/rules/prefer-namespace-keyword/) | Implemented |
-| [`@typescript-eslint/restrict-plus-operands`](https://typescript-eslint.io/rules/restrict-plus-operands/) | Implemented for primitive literals and explicit primitive annotations |
+| [`@typescript-eslint/restrict-plus-operands`](https://typescript-eslint.io/rules/restrict-plus-operands/) | Supports `allowNumberAndString` configuration for primitive literals and explicit primitive annotations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1303,6 +1303,7 @@ pub const Options = struct {
     typescript_eslint_prefer_as_const: bool = true,
     typescript_eslint_prefer_namespace_keyword: bool = true,
     typescript_eslint_restrict_plus_operands: bool = true,
+    typescript_eslint_restrict_plus_operands_allow_number_and_string: bool = false,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
     vars_on_top: bool = true,
@@ -1706,6 +1707,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/typedef")) {
             self.typescript_eslint_typedef_property_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "propertyDeclaration", true);
             self.typescript_eslint_typedef_member_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "memberVariableDeclaration", false);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/restrict-plus-operands")) {
+            self.typescript_eslint_restrict_plus_operands_allow_number_and_string = try typescriptEslintRestrictPlusOperandsBoolOptionFromConfig(value, "allowNumberAndString", false);
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
@@ -4055,6 +4059,23 @@ pub const Options = struct {
         };
     }
 
+    fn typescriptEslintRestrictPlusOperandsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn setByPrefixedRuleName(self: *Options, comptime field_prefix: []const u8, rule_name: []const u8, value: bool) bool {
         inline for (@typeInfo(Options).@"struct".fields) |field| {
             if (field.type == bool) {
@@ -4262,6 +4283,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-empty-interface", true));
     try std.testing.expect(options.typescript_eslint_no_empty_interface);
     try std.testing.expect(!options.typescript_eslint_no_empty_interface_allow_single_extends);
+
+    try std.testing.expect(!options.typescript_eslint_restrict_plus_operands);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/restrict-plus-operands", true));
+    try std.testing.expect(options.typescript_eslint_restrict_plus_operands);
+    try std.testing.expect(!options.typescript_eslint_restrict_plus_operands_allow_number_and_string);
 
     try std.testing.expect(!options.typescript_eslint_no_duplicate_enum_values);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-duplicate-enum-values", true));
@@ -5440,6 +5466,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_inferrable_types);
     try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_parameters);
     try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_properties);
+
+    var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowNumberAndString\":true}]",
+        .{},
+    );
+    defer typescript_restrict_plus_operands_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/restrict-plus-operands", typescript_restrict_plus_operands_config.value);
+    try std.testing.expect(options.typescript_eslint_restrict_plus_operands);
+    try std.testing.expect(options.typescript_eslint_restrict_plus_operands_allow_number_and_string);
 
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2391,7 +2391,9 @@ const BasicVisitor = struct {
             try no_bitwise.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.typescript_eslint_restrict_plus_operands) {
-            try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .allow_number_and_string = self.options.typescript_eslint_restrict_plus_operands_allow_number_and_string,
+            });
         }
         if (self.options.no_compare_neg_zero) {
             try no_compare_neg_zero.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/src/rules/typescript_eslint_restrict_plus_operands.zig
+++ b/src/rules/typescript_eslint_restrict_plus_operands.zig
@@ -8,6 +8,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/restrict-plus-operands";
 
+pub const Options = struct {
+    allow_number_and_string: bool = false,
+};
+
 const ValueType = enum {
     string,
     number,
@@ -38,6 +42,7 @@ pub fn checkBinaryExpression(
     tree: *const ast.Tree,
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (expression.operator != .add) return;
 
@@ -50,7 +55,7 @@ pub fn checkBinaryExpression(
     const left = inferExpressionType(tree, env, expression.left);
     const right = inferExpressionType(tree, env, expression.right);
     if (left == .unknown_expression or right == .unknown_expression) return;
-    if (isAllowedPair(left, right)) return;
+    if (isAllowedPair(left, right, options)) return;
 
     if (isAllowedOperand(left) and isAllowedOperand(right)) {
         try core.addDiagnosticFmt(
@@ -77,9 +82,17 @@ pub fn checkBinaryExpression(
     );
 }
 
-fn isAllowedPair(left: ValueType, right: ValueType) bool {
-    return (left == .number and right == .number) or
-        (left == .string and right == .string);
+fn isAllowedPair(left: ValueType, right: ValueType, options: Options) bool {
+    if ((left == .number and right == .number) or
+        (left == .string and right == .string))
+    {
+        return true;
+    }
+    if (options.allow_number_and_string) {
+        return (left == .number and right == .string) or
+            (left == .string and right == .number);
+    }
+    return false;
 }
 
 fn isAllowedOperand(value_type: ValueType) bool {

--- a/tests/rules/typescript_eslint_restrict_plus_operands.zig
+++ b/tests/rules/typescript_eslint_restrict_plus_operands.zig
@@ -54,6 +54,41 @@ test "allows @typescript-eslint/restrict-plus-operands compatible primitive oper
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_restrict_plus_operands.id));
 }
 
+test "supports configured @typescript-eslint/restrict-plus-operands allowNumberAndString" {
+    const source =
+        \\const count: number = 1;
+        \\const label: string = "items";
+        \\const enabled: boolean = true;
+        \\const mystery: unknown = 1;
+        \\count + label;
+        \\enabled + count;
+        \\mystery + count;
+        \\1 + "x";
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowNumberAndString\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/restrict-plus-operands", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_restrict_plus_operands.id));
+}
+
 test "can disable @typescript-eslint/restrict-plus-operands" {
     const source =
         \\const count: number = 1;


### PR DESCRIPTION
## Summary
- add `@typescript-eslint/restrict-plus-operands` parsing for `allowNumberAndString`
- allow number/string mixed `+` operands when the option is enabled
- preserve existing diagnostics for boolean, unknown, and other invalid primitive operands
- document the supported option in the rule status table

Official rule reference: https://typescript-eslint.io/rules/restrict-plus-operands/

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_restrict_plus_operands.zig tests/rules/typescript_eslint_restrict_plus_operands.zig`
- `git diff --check`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`