### PR TITLE
support prefer es6 class never mode

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -240,6 +240,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
+| [`react/prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) | Supports `always` and `never` configurations |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -713,6 +713,11 @@ pub const ReactJsxBooleanValueStyle = enum {
     always,
 };
 
+pub const ReactPreferEs6ClassStyle = enum {
+    always,
+    never,
+};
+
 pub const FuncNamesStyle = enum {
     always,
     as_needed,
@@ -1212,6 +1217,7 @@ pub const Options = struct {
     react_no_unescaped_entities_forbid_single_quote: bool = true,
     react_no_unescaped_entities_forbid_closing_brace: bool = true,
     react_prefer_es6_class: bool = true,
+    react_prefer_es6_class_style: ReactPreferEs6ClassStyle = .always,
     react_self_closing_comp: bool = true,
     react_self_closing_comp_component: bool = true,
     react_self_closing_comp_html: bool = true,
@@ -1641,6 +1647,9 @@ pub const Options = struct {
             self.react_no_unescaped_entities_forbid_double_quote = forbid.double_quote;
             self.react_no_unescaped_entities_forbid_single_quote = forbid.single_quote;
             self.react_no_unescaped_entities_forbid_closing_brace = forbid.closing_brace;
+        }
+        if (std.mem.eql(u8, cli_name, "react/prefer-es6-class")) {
+            self.react_prefer_es6_class_style = try reactPreferEs6ClassStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/self-closing-comp")) {
             self.react_self_closing_comp_component = try reactSelfClosingCompBoolOptionFromConfig(value, "component", true);
@@ -3584,6 +3593,22 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
+    fn reactPreferEs6ClassStyleFromConfig(value: std.json.Value) RuleConfigError!ReactPreferEs6ClassStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
     fn reactJsxNoBindBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4651,6 +4676,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.react_no_unescaped_entities_forbid_double_quote);
     try std.testing.expect(!options.react_no_unescaped_entities_forbid_single_quote);
     try std.testing.expect(options.react_no_unescaped_entities_forbid_closing_brace);
+
+    var react_prefer_es6_class_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer react_prefer_es6_class_config.deinit();
+    try options.setByRuleConfigValue("react/prefer-es6-class", react_prefer_es6_class_config.value);
+    try std.testing.expect(options.react_prefer_es6_class);
+    try std.testing.expectEqual(ReactPreferEs6ClassStyle.never, options.react_prefer_es6_class_style);
 
     var react_no_unused_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_prefer_es6_class.zig
+++ b/src/rules/react_prefer_es6_class.zig
@@ -7,13 +7,21 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/prefer-es6-class";
 
+pub const Style = enum {
+    always,
+    never,
+};
+
 pub fn checkObjectExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
     parent: ?ast.NodeIndex,
+    style: Style,
 ) Allocator.Error!void {
+    if (style != .always) return;
+
     const parent_index = parent orelse return;
     const call = switch (tree.data(parent_index)) {
         .call_expression => |call| call,
@@ -30,6 +38,27 @@ pub fn checkObjectExpression(
         .@"error",
         id,
         "Component should use es6 class instead of createClass",
+        tree.span(index),
+    );
+}
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    index: ast.NodeIndex,
+    style: Style,
+) Allocator.Error!void {
+    if (style != .never) return;
+    if (!isReactComponentClass(tree, class)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Component should use createClass instead of es6 class",
         tree.span(index),
     );
 }
@@ -52,6 +81,27 @@ fn isCreateReactClassCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 
     const property = propertyName(tree, member.property) orelse return false;
     return std.mem.eql(u8, property, "createReactClass");
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+
+    const object = identifierReferenceName(tree, member.object) orelse return false;
+    if (!std.mem.eql(u8, object, "React")) return false;
+
+    const property = propertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
 }
 
 fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -351,6 +351,13 @@ fn funcNameMatchingStyle(style: core.FuncNameMatchingStyle) func_name_matching.S
     };
 }
 
+fn reactPreferEs6ClassStyle(style: core.ReactPreferEs6ClassStyle) react_prefer_es6_class.Style {
+    return switch (style) {
+        .always => .always,
+        .never => .never,
+    };
+}
+
 fn isCatchBody(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
     const parent_index = parent orelse return false;
     return switch (tree.data(parent_index)) {
@@ -1200,6 +1207,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_multi_comp) {
             try react_no_multi_comp.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, &self.react_no_multi_comp_state);
+        }
+        if (self.options.react_prefer_es6_class) {
+            try react_prefer_es6_class.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, reactPreferEs6ClassStyle(self.options.react_prefer_es6_class_style));
         }
         if (self.options.react_no_redundant_should_component_update) {
             try react_no_redundant_should_component_update.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, ctx.path.parent());
@@ -3000,7 +3010,7 @@ const BasicVisitor = struct {
             try no_useless_computed_key.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         if (self.options.react_prefer_es6_class) {
-            try react_prefer_es6_class.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, index, ctx.path.ancestor(1));
+            try react_prefer_es6_class.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, index, ctx.path.ancestor(1), reactPreferEs6ClassStyle(self.options.react_prefer_es6_class_style));
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, index, expression, ctx.path.ancestor(1));

--- a/tests/rules/react_prefer_es6_class.zig
+++ b/tests/rules/react_prefer_es6_class.zig
@@ -76,3 +76,49 @@ test "can disable react/prefer-es6-class" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prefer_es6_class.id));
 }
+
+test "supports configured react/prefer-es6-class never mode" {
+    const source =
+        \\class A extends React.Component {
+        \\  render() {
+        \\    return <div />;
+        \\  }
+        \\}
+        \\class B extends PureComponent {
+        \\  render() {
+        \\    return <span />;
+        \\  }
+        \\}
+        \\const C = createReactClass({
+        \\  render() {
+        \\    return <div />;
+        \\  }
+        \\});
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .react_no_danger_with_children = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/prefer-es6-class", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_prefer_es6_class.id));
+    try std.testing.expectEqualStrings(
+        "Component should use createClass instead of es6 class",
+        result.diagnostics[0].message,
+    );
+}


### PR DESCRIPTION
## Summary
- parse `react/prefer-es6-class` `always`/`never` configuration
- keep the default `always` createReactClass diagnostic behavior
- add `never` mode diagnostics for React class components and document support

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_prefer_es6_class.zig tests/rules/react_prefer_es6_class.zig`
- `git diff --check`