### PR TITLE
support default props required defaults option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -222,6 +222,7 @@ Each rule links to the corresponding ESLint rule reference.
 | Rule | Status |
 | --- | --- |
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
+| [`react/default-props-match-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md) | Supports `allowRequiredDefaults` configuration |
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1152,6 +1152,7 @@ pub const Options = struct {
     prefer_spread: bool = true,
     prefer_template: bool = true,
     react_default_props_match_prop_types: bool = true,
+    react_default_props_match_prop_types_allow_required_defaults: bool = false,
     react_display_name: bool = true,
     react_jsx_boolean_value: bool = true,
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
@@ -1586,6 +1587,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "operator-assignment")) {
             self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/default-props-match-prop-types")) {
+            self.react_default_props_match_prop_types_allow_required_defaults = try reactDefaultPropsMatchPropTypesAllowRequiredDefaultsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/button-has-type")) {
             self.react_button_has_type_button = try reactButtonHasTypeBoolOptionFromConfig(value, "button", true);
@@ -3609,6 +3613,23 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
+    fn reactDefaultPropsMatchPropTypesAllowRequiredDefaultsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowRequiredDefaults") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxNoBindBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4539,6 +4560,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.react_forbid_prop_types_forbid_any);
     try std.testing.expect(options.react_forbid_prop_types_forbid_array);
     try std.testing.expect(!options.react_forbid_prop_types_forbid_object);
+
+    var react_default_props_match_prop_types_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowRequiredDefaults\":true}]",
+        .{},
+    );
+    defer react_default_props_match_prop_types_config.deinit();
+    try options.setByRuleConfigValue("react/default-props-match-prop-types", react_default_props_match_prop_types_config.value);
+    try std.testing.expect(options.react_default_props_match_prop_types);
+    try std.testing.expect(options.react_default_props_match_prop_types_allow_required_defaults);
 
     var react_jsx_filename_extension_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_default_props_match_prop_types.zig
+++ b/src/rules/react_default_props_match_prop_types.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "react/default-props-match-prop-types";
 
+pub const Options = struct {
+    allow_required_defaults: bool = false,
+};
+
 const PropInfo = struct {
     name: []const u8,
     required: bool,
@@ -220,6 +224,7 @@ pub fn finish(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     for (state.components.items) |component| {
         if (!component.detected) continue;
@@ -238,7 +243,7 @@ pub fn finish(
                     "defaultProp \"{s}\" has no corresponding propTypes declaration.",
                     .{default_prop.name},
                 );
-            } else if (prop.?.required) {
+            } else if (prop.?.required and !options.allow_required_defaults) {
                 try core.addDiagnosticFmt(
                     allocator,
                     diagnostics,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1122,7 +1122,9 @@ const BasicVisitor = struct {
             react_display_name.finish(self.allocator, self.diagnostics, ctx.tree, &self.react_display_name_state) catch {};
         }
         if (self.options.react_default_props_match_prop_types) {
-            react_default_props_match_prop_types.finish(self.allocator, self.diagnostics, ctx.tree, &self.react_default_props_match_prop_types_state) catch {};
+            react_default_props_match_prop_types.finish(self.allocator, self.diagnostics, ctx.tree, &self.react_default_props_match_prop_types_state, .{
+                .allow_required_defaults = self.options.react_default_props_match_prop_types_allow_required_defaults,
+            }) catch {};
         }
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1007,6 +1007,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_default_props_match_prop_types.zig");
+}
+
+comptime {
     _ = @import("rules/react_require_render_return.zig");
 }
 

--- a/tests/rules/react_default_props_match_prop_types.zig
+++ b/tests/rules/react_default_props_match_prop_types.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn defaultPropsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_default_props_match_prop_types = true;
+    return options;
+}
+
+test "reports react/default-props-match-prop-types for missing and required propTypes" {
+    const source =
+        \\function Foo() {
+        \\  return <div />;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string.isRequired,
+        \\  age: PropTypes.number,
+        \\};
+        \\Foo.defaultProps = {
+        \\  name: "Ada",
+        \\  extra: true,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", defaultPropsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_default_props_match_prop_types.id));
+    try std.testing.expectEqualStrings(
+        "defaultProp \"name\" defined for isRequired propType.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "defaultProp \"extra\" has no corresponding propTypes declaration.",
+        result.diagnostics[1].message,
+    );
+}
+
+test "supports configured react/default-props-match-prop-types allowRequiredDefaults" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowRequiredDefaults\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("react/default-props-match-prop-types", config.value);
+
+    const source =
+        \\function Foo() {
+        \\  return <div />;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string.isRequired,
+        \\  age: PropTypes.number,
+        \\};
+        \\Foo.defaultProps = {
+        \\  name: "Ada",
+        \\  extra: true,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_default_props_match_prop_types.id));
+    try std.testing.expectEqualStrings(
+        "defaultProp \"extra\" has no corresponding propTypes declaration.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "can disable react/default-props-match-prop-types" {
+    const source =
+        \\function Foo() {
+        \\  return <div />;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string.isRequired,
+        \\};
+        \\Foo.defaultProps = {
+        \\  name: "Ada",
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .react_default_props_match_prop_types = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_default_props_match_prop_types.id));
+}


### PR DESCRIPTION
## Summary
- parse `react/default-props-match-prop-types` `allowRequiredDefaults` configuration
- skip required defaultProps diagnostics when the option is enabled
- add dedicated rule coverage and document the supported option

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_default_props_match_prop_types.zig tests/all.zig tests/rules/react_default_props_match_prop_types.zig`
- `git diff --check`