### PR TITLE
support display name context option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -223,6 +223,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
 | [`react/default-props-match-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md) | Supports `allowRequiredDefaults` configuration |
+| [`react/display-name`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) | Supports `checkContextObjects` configuration |
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1154,6 +1154,7 @@ pub const Options = struct {
     react_default_props_match_prop_types: bool = true,
     react_default_props_match_prop_types_allow_required_defaults: bool = false,
     react_display_name: bool = true,
+    react_display_name_check_context_objects: bool = false,
     react_jsx_boolean_value: bool = true,
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
@@ -1590,6 +1591,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/default-props-match-prop-types")) {
             self.react_default_props_match_prop_types_allow_required_defaults = try reactDefaultPropsMatchPropTypesAllowRequiredDefaultsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/display-name")) {
+            self.react_display_name_check_context_objects = try reactDisplayNameBoolOptionFromConfig(value, "checkContextObjects", false);
         }
         if (std.mem.eql(u8, cli_name, "react/button-has-type")) {
             self.react_button_has_type_button = try reactButtonHasTypeBoolOptionFromConfig(value, "button", true);
@@ -3630,6 +3634,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactDisplayNameBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxNoBindBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4571,6 +4592,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/default-props-match-prop-types", react_default_props_match_prop_types_config.value);
     try std.testing.expect(options.react_default_props_match_prop_types);
     try std.testing.expect(options.react_default_props_match_prop_types_allow_required_defaults);
+
+    var react_display_name_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkContextObjects\":true}]",
+        .{},
+    );
+    defer react_display_name_config.deinit();
+    try options.setByRuleConfigValue("react/display-name", react_display_name_config.value);
+    try std.testing.expect(options.react_display_name);
+    try std.testing.expect(options.react_display_name_check_context_objects);
 
     var react_jsx_filename_extension_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_display_name.zig
+++ b/src/rules/react_display_name.zig
@@ -10,6 +10,10 @@ pub const id = "react/display-name";
 
 const message = "Component definition is missing display name";
 
+pub const Options = struct {
+    check_context_objects: bool = false,
+};
+
 const Component = struct {
     node: ast.NodeIndex,
     name: ?[]const u8,
@@ -165,6 +169,30 @@ pub fn checkMemberExpression(allocator: Allocator, tree: *const ast.Tree, member
     if (identifierReferenceName(tree, unwrapTransparent(tree, member.object))) |name| {
         try state.markName(allocator, name);
     }
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    index: ast.NodeIndex,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.check_context_objects) return;
+    if (declarator.init == .null) return;
+    const name = bindingIdentifierName(tree, declarator.id) orelse return;
+    const call = switch (tree.data(unwrapTransparent(tree, declarator.init))) {
+        .call_expression => |call| call,
+        else => return,
+    };
+    if (!isCreateContextCall(tree, call)) return;
+
+    try state.addComponent(allocator, .{
+        .node = index,
+        .name = name,
+        .has_display_name = false,
+    });
 }
 
 pub fn finish(
@@ -327,6 +355,23 @@ fn isComponentWrapperCall(tree: *const ast.Tree, call: ast.CallExpression) bool 
     if (member.computed) return false;
     const property = propertyName(tree, member.property, false) orelse return false;
     return std.mem.eql(u8, property, "memo") or std.mem.eql(u8, property, "forwardRef");
+}
+
+fn isCreateContextCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createContext");
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    const object = identifierReferenceName(tree, unwrapTransparent(tree, member.object)) orelse return false;
+    if (!std.mem.eql(u8, object, "React")) return false;
+    const property = propertyName(tree, member.property, false) orelse return false;
+    return std.mem.eql(u8, property, "createContext");
 }
 
 fn functionReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1568,6 +1568,11 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_no_bind) {
             try react_jsx_no_bind.checkVariableDeclarator(self.allocator, ctx.tree, declarator, ctx.path.ancestor(1), &self.react_jsx_no_bind_state);
         }
+        if (self.options.react_display_name) {
+            try react_display_name.checkVariableDeclarator(self.allocator, ctx.tree, declarator, index, &self.react_display_name_state, .{
+                .check_context_objects = self.options.react_display_name_check_context_objects,
+            });
+        }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }

--- a/tests/rules/react_display_name.zig
+++ b/tests/rules/react_display_name.zig
@@ -63,6 +63,42 @@ test "tracks react/display-name assignments before component definitions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_display_name.id));
 }
 
+test "supports configured react/display-name checkContextObjects" {
+    const source =
+        \\const MissingContext = React.createContext(null);
+        \\const NamedContext = createContext(null);
+        \\NamedContext.displayName = 'NamedContext';
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkContextObjects\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/display-name", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_display_name.id));
+    try std.testing.expect(hasMessage(result, "Component definition is missing display name"));
+}
+
+test "allows react/display-name context objects by default" {
+    const source =
+        \\const ThemeContext = React.createContext(null);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_display_name.id));
+}
+
 test "can disable react/display-name" {
     const source =
         \\export default () => <div />;


### PR DESCRIPTION
## Summary
- parse `react/display-name` `checkContextObjects` configuration
- report missing display names for `React.createContext` / `createContext` variables when enabled
- keep context object checks disabled by default and document the supported option

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_display_name.zig tests/rules/react_display_name.zig`
- `git diff --check`