### PR TITLE
support display name transpiler option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -223,7 +223,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
 | [`react/default-props-match-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md) | Supports `allowRequiredDefaults` configuration |
-| [`react/display-name`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) | Supports `checkContextObjects` configuration |
+| [`react/display-name`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) | Supports `checkContextObjects` and `ignoreTranspilerName` configuration |
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1155,6 +1155,7 @@ pub const Options = struct {
     react_default_props_match_prop_types_allow_required_defaults: bool = false,
     react_display_name: bool = true,
     react_display_name_check_context_objects: bool = false,
+    react_display_name_ignore_transpiler_name: bool = false,
     react_jsx_boolean_value: bool = true,
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
@@ -1594,6 +1595,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/display-name")) {
             self.react_display_name_check_context_objects = try reactDisplayNameBoolOptionFromConfig(value, "checkContextObjects", false);
+            self.react_display_name_ignore_transpiler_name = try reactDisplayNameBoolOptionFromConfig(value, "ignoreTranspilerName", false);
         }
         if (std.mem.eql(u8, cli_name, "react/button-has-type")) {
             self.react_button_has_type_button = try reactButtonHasTypeBoolOptionFromConfig(value, "button", true);
@@ -4603,6 +4605,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/display-name", react_display_name_config.value);
     try std.testing.expect(options.react_display_name);
     try std.testing.expect(options.react_display_name_check_context_objects);
+
+    var react_display_name_ignore_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTranspilerName\":true}]",
+        .{},
+    );
+    defer react_display_name_ignore_config.deinit();
+    try options.setByRuleConfigValue("react/display-name", react_display_name_ignore_config.value);
+    try std.testing.expect(options.react_display_name);
+    try std.testing.expect(options.react_display_name_ignore_transpiler_name);
 
     var react_jsx_filename_extension_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_display_name.zig
+++ b/src/rules/react_display_name.zig
@@ -12,6 +12,7 @@ const message = "Component definition is missing display name";
 
 pub const Options = struct {
     check_context_objects: bool = false,
+    ignore_transpiler_name: bool = false,
 };
 
 const Component = struct {
@@ -80,13 +81,14 @@ pub fn checkClass(
     index: ast.NodeIndex,
     parent_index: ?ast.NodeIndex,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     if (!isReactComponentClass(tree, class)) return;
     const name = componentNameFromClass(tree, class, parent_index);
     try state.addComponent(allocator, .{
         .node = index,
         .name = name,
-        .has_display_name = name != null or classHasStaticDisplayName(tree, class),
+        .has_display_name = (!options.ignore_transpiler_name and name != null) or classHasStaticDisplayName(tree, class),
     });
 }
 
@@ -97,6 +99,7 @@ pub fn checkFunction(
     index: ast.NodeIndex,
     parent_index: ?ast.NodeIndex,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     if (!functionReturnsJSXOrNull(tree, index)) return;
     if (!isFunctionComponent(tree, function, parent_index)) return;
@@ -104,7 +107,7 @@ pub fn checkFunction(
     try state.addComponent(allocator, .{
         .node = index,
         .name = name,
-        .has_display_name = name != null,
+        .has_display_name = !options.ignore_transpiler_name and name != null,
     });
 }
 
@@ -114,6 +117,7 @@ pub fn checkArrowFunction(
     index: ast.NodeIndex,
     parent_index: ?ast.NodeIndex,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     if (!functionReturnsJSXOrNull(tree, index)) return;
     if (!functionExpressionHasComponentParent(tree, parent_index)) return;
@@ -121,7 +125,7 @@ pub fn checkArrowFunction(
     try state.addComponent(allocator, .{
         .node = index,
         .name = name,
-        .has_display_name = name != null,
+        .has_display_name = !options.ignore_transpiler_name and name != null,
     });
 }
 
@@ -132,6 +136,7 @@ pub fn checkCallExpression(
     index: ast.NodeIndex,
     parent_index: ?ast.NodeIndex,
     state: *State,
+    options: Options,
 ) Allocator.Error!void {
     if (isCreateClassCall(tree, call)) {
         const arguments = tree.extra(call.arguments);
@@ -145,7 +150,7 @@ pub fn checkCallExpression(
         try state.addComponent(allocator, .{
             .node = object_index,
             .name = name,
-            .has_display_name = name != null or objectHasDisplayName(tree, object),
+            .has_display_name = (!options.ignore_transpiler_name and name != null) or objectHasDisplayName(tree, object),
         });
         return;
     }
@@ -159,7 +164,7 @@ pub fn checkCallExpression(
     try state.addComponent(allocator, .{
         .node = index,
         .name = name,
-        .has_display_name = name != null,
+        .has_display_name = !options.ignore_transpiler_name and name != null,
     });
 }
 
@@ -253,7 +258,7 @@ fn functionExpressionHasComponentParent(tree: *const ast.Tree, parent_index: ?as
         .variable_declarator => |declarator| identifierBindingStartsUppercase(tree, declarator.id),
         .assignment_expression => |expression| identifierReferenceStartsUppercase(tree, expression.left),
         .export_default_declaration => true,
-        .object_property => true,
+        .object_property => |property| if (propertyName(tree, property.key, property.computed)) |name| startsUppercase(name) else false,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -358,6 +358,13 @@ fn reactPreferEs6ClassStyle(style: core.ReactPreferEs6ClassStyle) react_prefer_e
     };
 }
 
+fn reactDisplayNameOptions(options: core.Options) react_display_name.Options {
+    return .{
+        .check_context_objects = options.react_display_name_check_context_objects,
+        .ignore_transpiler_name = options.react_display_name_ignore_transpiler_name,
+    };
+}
+
 fn isCatchBody(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
     const parent_index = parent orelse return false;
     return switch (tree.data(parent_index)) {
@@ -1179,7 +1186,7 @@ const BasicVisitor = struct {
             try react_jsx_no_bind.checkFunctionDeclaration(self.allocator, ctx.tree, function, &self.react_jsx_no_bind_state);
         }
         if (self.options.react_display_name) {
-            try react_display_name.checkFunction(self.allocator, ctx.tree, function, index, ctx.path.parent(), &self.react_display_name_state);
+            try react_display_name.checkFunction(self.allocator, ctx.tree, function, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
         }
         if (self.options.react_no_multi_comp) {
             try react_no_multi_comp.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, &self.react_no_multi_comp_state, .{
@@ -1205,7 +1212,7 @@ const BasicVisitor = struct {
             try react_require_render_return.checkClass(self.allocator, self.diagnostics, ctx.tree, class, self.react_require_render_return_state);
         }
         if (self.options.react_display_name) {
-            try react_display_name.checkClass(self.allocator, ctx.tree, class, index, ctx.path.parent(), &self.react_display_name_state);
+            try react_display_name.checkClass(self.allocator, ctx.tree, class, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
         }
         if (self.options.react_no_multi_comp) {
             try react_no_multi_comp.checkClass(self.allocator, self.diagnostics, ctx.tree, class, index, &self.react_no_multi_comp_state);
@@ -1571,6 +1578,7 @@ const BasicVisitor = struct {
         if (self.options.react_display_name) {
             try react_display_name.checkVariableDeclarator(self.allocator, ctx.tree, declarator, index, &self.react_display_name_state, .{
                 .check_context_objects = self.options.react_display_name_check_context_objects,
+                .ignore_transpiler_name = self.options.react_display_name_ignore_transpiler_name,
             });
         }
         if (self.options.react_no_deprecated) {
@@ -2306,7 +2314,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.react_display_name) {
-            try react_display_name.checkArrowFunction(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_display_name_state);
+            try react_display_name.checkArrowFunction(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
         }
         return .proceed;
     }
@@ -2605,7 +2613,7 @@ const BasicVisitor = struct {
             try react_no_unused_state.checkCallExpression(self.allocator, ctx.tree, call, &self.react_no_unused_state_state);
         }
         if (self.options.react_display_name) {
-            try react_display_name.checkCallExpression(self.allocator, ctx.tree, call, index, ctx.path.parent(), &self.react_display_name_state);
+            try react_display_name.checkCallExpression(self.allocator, ctx.tree, call, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
         }
         if (self.options.react_button_has_type) {
             try react_button_has_type.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_button_has_type_state, .{

--- a/tests/rules/react_display_name.zig
+++ b/tests/rules/react_display_name.zig
@@ -99,6 +99,44 @@ test "allows react/display-name context objects by default" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_display_name.id));
 }
 
+test "supports configured react/display-name ignoreTranspilerName" {
+    const source =
+        \\function FunctionView() {
+        \\  return <div />;
+        \\}
+        \\class ClassView extends React.Component {
+        \\  render() { return <div />; }
+        \\}
+        \\const ArrowView = () => <div />;
+        \\const CreatedView = React.createClass({
+        \\  render() { return <div />; },
+        \\});
+        \\const ExplicitView = React.memo(() => <div />);
+        \\ExplicitView.displayName = 'ExplicitView';
+        \\class StaticView extends React.Component {
+        \\  static displayName = 'StaticView';
+        \\  render() { return <div />; }
+        \\}
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTranspilerName\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/display-name", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.react_display_name.id));
+    try std.testing.expect(hasMessage(result, "Component definition is missing display name"));
+}
+
 test "can disable react/display-name" {
     const source =
         \\export default () => <div />;


### PR DESCRIPTION
## Summary
- parse `react/display-name` `ignoreTranspilerName` configuration
- require explicit display names for named/transpiler-inferred components when enabled
- avoid treating lowercase object properties like createClass `render` methods as standalone components
- document the supported display-name options

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_display_name.zig tests/rules/react_display_name.zig`
- `git diff --check`