### PR TITLE
support no unused vars vars option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -146,7 +146,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Implemented |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
@@ -295,7 +295,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
-| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Implemented for fishlint's `args: after-used, ignoreRestSiblings: true` configuration |
+| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -299,6 +299,11 @@ pub const NoUseBeforeDefineCheck = enum {
     no,
 };
 
+pub const NoUnusedVarsVars = enum {
+    all,
+    local,
+};
+
 pub const NoUnusedVarsArgs = enum {
     none,
     after_used,
@@ -1127,6 +1132,7 @@ pub const Options = struct {
     eqeqeq_style: EqeqeqStyle = .strict,
     use_isnan: bool = true,
     no_unused_vars: bool = true,
+    no_unused_vars_vars: NoUnusedVarsVars = .all,
     no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     no_unused_vars_ignore_rest_siblings: bool = false,
@@ -1301,6 +1307,7 @@ pub const Options = struct {
     typescript_eslint_no_useless_constructor: bool = true,
     typescript_eslint_no_useless_empty_export: bool = true,
     typescript_eslint_no_unused_vars: bool = true,
+    typescript_eslint_no_unused_vars_vars: NoUnusedVarsVars = .all,
     typescript_eslint_no_unused_vars_args: NoUnusedVarsArgs = .after_used,
     typescript_eslint_no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     typescript_eslint_no_unused_vars_ignore_rest_siblings: bool = true,
@@ -1575,6 +1582,7 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_expressions_allow_tagged_templates = try noUnusedExpressionsAllowTaggedTemplatesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-unused-vars")) {
+            self.no_unused_vars_vars = try noUnusedVarsVarsFromConfig(value, .all);
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
             self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
@@ -1714,6 +1722,7 @@ pub const Options = struct {
             self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
+            self.typescript_eslint_no_unused_vars_vars = try noUnusedVarsVarsFromConfig(value, .all);
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
             self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
@@ -3221,6 +3230,26 @@ pub const Options = struct {
         if (std.mem.eql(u8, args, "none")) return .none;
         if (std.mem.eql(u8, args, "after-used")) return .after_used;
         if (std.mem.eql(u8, args, "all")) return .all;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noUnusedVarsVarsFromConfig(value: std.json.Value, default: NoUnusedVarsVars) RuleConfigError!NoUnusedVarsVars {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const vars = switch (config.get("vars") orelse return default) {
+            .string => |vars| vars,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, vars, "all")) return .all;
+        if (std.mem.eql(u8, vars, "local")) return .local;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -5482,6 +5511,7 @@ test "Options can apply ESLint-style rule config values" {
     defer no_unused_vars_config.deinit();
     try options.setByRuleConfigValue("no-unused-vars", no_unused_vars_config.value);
     try std.testing.expect(options.no_unused_vars);
+    try std.testing.expectEqual(NoUnusedVarsVars.all, options.no_unused_vars_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
@@ -5489,12 +5519,13 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"none\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":false}]",
+        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":false}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
     try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", typescript_no_unused_vars_config.value);
     try std.testing.expect(options.typescript_eslint_no_unused_vars);
+    try std.testing.expectEqual(NoUnusedVarsVars.local, options.typescript_eslint_no_unused_vars_vars);
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -16,6 +16,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     check_parameters: bool = false,
     args_after_used: bool = false,
+    vars: core.NoUnusedVarsVars = .all,
     check_caught_errors: bool = true,
     ignore_rest_siblings: bool = false,
     check_type_parameters: bool = false,
@@ -70,15 +71,17 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
-    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+    try runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{});
 }
 
 pub fn runWithOptions(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
@@ -108,6 +111,7 @@ pub fn runWithOptions(
 
         if (!isLintableSymbol(flags, options)) continue;
         if (flags.exported or flags.ambient) continue;
+        if (options.vars == .local and isGlobalVariable(scope_tree, symbol.scope, flags)) continue;
         if (flags.catch_var and !options.check_caught_errors) continue;
         if (flags.parameter) {
             if (!options.check_parameters) continue;
@@ -133,6 +137,18 @@ pub fn runWithOptions(
             .{name},
         );
     }
+}
+
+fn isGlobalVariable(
+    scope_tree: traverser.semantic.ScopeTree,
+    scope_id: traverser.semantic.ScopeId,
+    flags: traverser.semantic.Symbol.Flags,
+) bool {
+    if (flags.catch_var or flags.parameter) return false;
+    if (flags.type_parameter) return false;
+    if (scope_id == .none) return false;
+    const scope = scope_tree.getScope(scope_id);
+    return scope.kind == .global;
 }
 
 fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -917,7 +917,8 @@ pub fn runSemantic(
     }
 
     if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {
-        try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+        try no_unused_vars.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
+            .vars = options.no_unused_vars_vars,
             .check_parameters = options.no_unused_vars_args != .none,
             .args_after_used = options.no_unused_vars_args == .after_used,
             .check_caught_errors = options.no_unused_vars_caught_errors == .all,
@@ -932,9 +933,11 @@ pub fn runSemantic(
             allocator,
             diagnostics,
             tree,
+            semantic_result.scope_tree,
             semantic_result.symbol_table,
             options.react_jsx_uses_react,
             options.react_jsx_uses_vars,
+            options.typescript_eslint_no_unused_vars_vars,
             options.typescript_eslint_no_unused_vars_args,
             options.typescript_eslint_no_unused_vars_caught_errors,
             options.typescript_eslint_no_unused_vars_ignore_rest_siblings,

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -11,16 +11,19 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
     react_jsx_uses_react: bool,
     react_jsx_uses_vars: bool,
+    vars: core.NoUnusedVarsVars,
     args: core.NoUnusedVarsArgs,
     caught_errors: core.NoUnusedVarsCaughtErrors,
     ignore_rest_siblings: bool,
 ) Allocator.Error!void {
-    try no_unused_vars.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+    try no_unused_vars.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
+        .vars = vars,
         .check_parameters = args != .none,
         .args_after_used = args == .after_used,
         .check_caught_errors = caught_errors == .all,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -72,6 +72,35 @@ test "supports configured no-unused-vars args all" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unused_vars.id));
 }
 
+test "supports configured no-unused-vars vars local" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"vars\":\"local\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const globalUnused = 1;
+        \\function demo() {
+        \\  const localUnused = 2;
+        \\}
+        \\demo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}
+
 test "supports configured no-unused-vars caughtErrors none" {
     var config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -105,6 +105,36 @@ test "supports configured @typescript-eslint/no-unused-vars args none" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars vars local" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"vars\":\"local\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\type GlobalUnused = string;
+        \\const globalUnused = 1;
+        \\function demo() {
+        \\  type LocalUnused = number;
+        \\  const localUnused = 2;
+        \\}
+        \\demo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "supports configured @typescript-eslint/no-unused-vars caughtErrors none" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- parse `vars` for core `no-unused-vars` and `@typescript-eslint/no-unused-vars` rule configs
- thread the option into the shared unused-vars implementation
- skip global-scope variables for `vars: "local"` while preserving module-scope reporting
- document the expanded supported options

Reference: https://eslint.org/docs/latest/rules/no-unused-vars

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_unused_vars.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `git diff --check`