### PR TITLE
support no use before define variables option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -296,7 +296,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
-| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Implemented for fishlint's `functions: false, classes: true` configuration |
+| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, and `variables` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1139,6 +1139,7 @@ pub const Options = struct {
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
+    no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
     no_undef: bool = true,
     no_undef_typeof: bool = false,
     prefer_const: bool = true,
@@ -1314,6 +1315,7 @@ pub const Options = struct {
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
+    typescript_eslint_no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_no_wrapper_object_types: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
@@ -1590,6 +1592,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+            self.no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
         }
         if (std.mem.eql(u8, cli_name, "object-shorthand")) {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
@@ -1748,6 +1751,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-use-before-define")) {
             self.typescript_eslint_no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", false);
             self.typescript_eslint_no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
+            self.typescript_eslint_no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
         }
         if (std.mem.eql(u8, cli_name, "no-void")) {
             self.no_void_allow_as_statement = try noVoidAllowAsStatementFromConfig(value);
@@ -5625,7 +5629,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":false,\"classes\":false}]",
+        "[\"error\",{\"functions\":false,\"classes\":false,\"variables\":false}]",
         .{},
     );
     defer no_use_before_define_config.deinit();
@@ -5633,6 +5637,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_use_before_define);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_classes);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_variables);
 
     var no_use_before_define_nofunc_config = try std.json.parseFromSlice(
         std.json.Value,
@@ -5644,6 +5649,7 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-use-before-define", no_use_before_define_nofunc_config.value);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.no_use_before_define_check_classes);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.no_use_before_define_check_variables);
 
     var no_undef_config = try std.json.parseFromSlice(
         std.json.Value,
@@ -5670,7 +5676,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":true,\"classes\":false}]",
+        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false}]",
         .{},
     );
     defer typescript_no_use_before_define_config.deinit();
@@ -5678,6 +5684,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_use_before_define);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.typescript_eslint_no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_classes);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_variables);
 
     var no_void_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -16,6 +16,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     check_functions: bool = true,
     check_classes: bool = true,
+    check_variables: bool = true,
 };
 
 const InitRange = struct {
@@ -27,15 +28,17 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
-    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+    try runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{});
 }
 
 pub fn runWithOptions(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
@@ -71,6 +74,7 @@ pub fn runWithOptions(
 
         const symbol = symbol_table.getSymbol(symbol_id);
         if (!isLintableSymbol(symbol.flags, options)) continue;
+        if (shouldIgnoreVariableReference(scope_tree, reference.scope, symbol.scope, symbol.flags, options)) continue;
 
         const decls = symbol_table.symbolDecls(symbol_id);
         if (decls.len == 0) continue;
@@ -181,6 +185,38 @@ fn lowerBoundInitRange(init_ranges: []const InitRange, symbol_id: SymbolId) usiz
 
 fn spanInside(span: ast.Span, container: ast.Span) bool {
     return span.start >= container.start and span.end <= container.end;
+}
+
+fn shouldIgnoreVariableReference(
+    scope_tree: traverser.semantic.ScopeTree,
+    reference_scope: traverser.semantic.ScopeId,
+    symbol_scope: traverser.semantic.ScopeId,
+    flags: traverser.semantic.Symbol.Flags,
+    options: Options,
+) bool {
+    if (options.check_variables) return false;
+    if (!isVariableSymbol(flags)) return false;
+    if (reference_scope == symbol_scope) return false;
+    return crossesFunctionScope(scope_tree, reference_scope, symbol_scope);
+}
+
+fn isVariableSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    if (flags.function or flags.class or flags.import) return false;
+    return flags.function_scoped_var or flags.block_scoped_var;
+}
+
+fn crossesFunctionScope(
+    scope_tree: traverser.semantic.ScopeTree,
+    reference_scope: traverser.semantic.ScopeId,
+    symbol_scope: traverser.semantic.ScopeId,
+) bool {
+    var current = reference_scope;
+    while (current != .none and current != symbol_scope) {
+        const scope = scope_tree.getScope(current);
+        if (scope.kind == .function) return true;
+        current = scope.parent;
+    }
+    return false;
 }
 
 fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -945,16 +945,18 @@ pub fn runSemantic(
     }
 
     if (options.no_use_before_define and !options.typescript_eslint_no_use_before_define) {
-        try no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+        try no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .check_functions = options.no_use_before_define_check_functions == .yes,
             .check_classes = options.no_use_before_define_check_classes == .yes,
+            .check_variables = options.no_use_before_define_check_variables == .yes,
         });
     }
 
     if (options.typescript_eslint_no_use_before_define) {
-        try typescript_eslint_no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+        try typescript_eslint_no_use_before_define.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .check_functions = options.typescript_eslint_no_use_before_define_check_functions == .yes,
             .check_classes = options.typescript_eslint_no_use_before_define_check_classes == .yes,
+            .check_variables = options.typescript_eslint_no_use_before_define_check_variables == .yes,
         });
     }
 

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -11,9 +11,10 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
-    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+    try runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
         .check_functions = false,
         .check_classes = true,
     });
@@ -23,13 +24,15 @@ pub fn runWithOptions(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
     symbol_table: traverser.semantic.SymbolTable,
     options: no_use_before_define.Options,
 ) Allocator.Error!void {
-    try no_use_before_define.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+    try no_use_before_define.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
         .check_functions = options.check_functions,
         .check_classes = options.check_classes,
+        .check_variables = options.check_variables,
     });
 }

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -147,6 +147,43 @@ test "supports configured no-use-before-define nofunc style" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "supports configured no-use-before-define variables false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":false,\"classes\":false,\"variables\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-use-before-define", config.value);
+    options.eol_last = false;
+    options.no_empty_block_statements = false;
+    options.no_empty_function = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_use_before_define = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\nested();
+        \\function nested() {
+        \\  outer;
+        \\}
+        \\var outer = 1;
+        \\sameScope;
+        \\var sameScope = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "can disable no-use-before-define" {
     const source =
         \\a;

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -84,6 +84,48 @@ test "uses configured @typescript-eslint/no-use-before-define function and class
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
 }
 
+test "supports configured @typescript-eslint/no-use-before-define variables false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", config.value);
+    options.eol_last = false;
+    options.no_empty_block_statements = false;
+    options.no_empty_function = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.no_new = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\f();
+        \\function f() {}
+        \\
+        \\new C();
+        \\class C {}
+        \\
+        \\function nested() {
+        \\  outer;
+        \\}
+        \\let outer = 1;
+        \\sameScope;
+        \\let sameScope = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+}
+
 test "can disable @typescript-eslint/no-use-before-define and fall back to core rule" {
     const source =
         \\f();


### PR DESCRIPTION
## Summary
- parse `variables` for core `no-use-before-define` and `@typescript-eslint/no-use-before-define` configs
- pass `scope_tree` into the shared implementation so variable checks can distinguish nested function references from same-scope references
- keep same-scope variables reported while allowing `variables: false` to ignore references from nested functions to outer variables
- document the expanded TypeScript rule configuration support

Reference: https://eslint.org/docs/latest/rules/no-use-before-define

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_use_before_define.zig src/rules/typescript_eslint_no_use_before_define.zig tests/rules/no_use_before_define.zig tests/rules/typescript_eslint_no_use_before_define.zig`
- `git diff --check`