### PR TITLE
support jsx key fragment shorthand option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -227,7 +227,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |
-| [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` configuration |
+| [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` and `checkFragmentShorthand` configuration |
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1178,6 +1178,7 @@ pub const Options = struct {
     react_jsx_no_bind_ignore_dom_components: bool = false,
     react_jsx_key: bool = true,
     react_jsx_key_check_key_must_before_spread: bool = false,
+    react_jsx_key_check_fragment_shorthand: bool = false,
     react_button_has_type: bool = true,
     react_button_has_type_button: bool = true,
     react_button_has_type_submit: bool = true,
@@ -1637,6 +1638,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-key")) {
             self.react_jsx_key_check_key_must_before_spread = try reactJsxKeyCheckKeyMustBeforeSpreadFromConfig(value);
+            self.react_jsx_key_check_fragment_shorthand = try reactJsxKeyCheckFragmentShorthandFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
@@ -3737,6 +3739,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactJsxKeyCheckFragmentShorthandFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("checkFragmentShorthand") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactNoStringRefsNoTemplateLiteralsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -4680,13 +4699,14 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_key_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"checkKeyMustBeforeSpread\":true}]",
+        "[\"error\",{\"checkKeyMustBeforeSpread\":true,\"checkFragmentShorthand\":true}]",
         .{},
     );
     defer react_jsx_key_config.deinit();
     try options.setByRuleConfigValue("react/jsx-key", react_jsx_key_config.value);
     try std.testing.expect(options.react_jsx_key);
     try std.testing.expect(options.react_jsx_key_check_key_must_before_spread);
+    try std.testing.expect(options.react_jsx_key_check_fragment_shorthand);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_key.zig
+++ b/src/rules/react_jsx_key.zig
@@ -17,6 +17,7 @@ pub const State = struct {
 
 pub const Options = struct {
     check_key_must_before_spread: bool = false,
+    check_fragment_shorthand: bool = false,
 };
 
 pub fn collectProgram(tree: *const ast.Tree, state: *State) void {
@@ -59,6 +60,12 @@ pub fn checkArrayExpression(
         if (element_index == .null) continue;
         const element = switch (tree.data(unwrapTransparent(tree, element_index))) {
             .jsx_element => |element| element,
+            .jsx_fragment => {
+                if (options.check_fragment_shorthand) {
+                    try report(allocator, diagnostics, tree, element_index, missing_array_key_message);
+                }
+                continue;
+            },
             else => continue,
         };
         if (hasKeyProp(tree, element, options)) continue;
@@ -100,6 +107,9 @@ fn checkIteratorExpression(
     const current = unwrapTransparent(tree, index);
     switch (tree.data(current)) {
         .jsx_element => |element| try checkIteratorElement(allocator, diagnostics, tree, element, current, options),
+        .jsx_fragment => if (options.check_fragment_shorthand) {
+            try report(allocator, diagnostics, tree, current, missing_iter_key_message);
+        },
         .conditional_expression => |conditional| {
             try checkIteratorExpression(allocator, diagnostics, tree, conditional.consequent, options);
             try checkIteratorExpression(allocator, diagnostics, tree, conditional.alternate, options);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2648,6 +2648,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_key) {
             try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state, .{
                 .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
+                .check_fragment_shorthand = self.options.react_jsx_key_check_fragment_shorthand,
             });
         }
         if (self.options.new_cap) {
@@ -2808,6 +2809,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_key and self.react_jsx_key_state.children_to_array_depth == 0) {
             try react_jsx_key.checkArrayExpression(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
+                .check_fragment_shorthand = self.options.react_jsx_key_check_fragment_shorthand,
             });
         }
         return .proceed;

--- a/tests/rules/react_jsx_key.zig
+++ b/tests/rules/react_jsx_key.zig
@@ -64,6 +64,47 @@ test "supports configured react jsx key must appear before spread" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
 }
 
+test "supports configured react jsx key fragment shorthand" {
+    const source =
+        \\const nodes = [
+        \\  <></>,
+        \\  <Item key="stable" />,
+        \\];
+        \\items.map((item) => <>{item.name}</>);
+        \\items.map((item) => <Item key={item.id} />);
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkFragmentShorthand\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-key", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
+}
+
+test "allows react jsx key fragment shorthand by default" {
+    const source =
+        \\const nodes = [
+        \\  <></>,
+        \\];
+        \\items.map((item) => <>{item.name}</>);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", test_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_key.id));
+}
+
 test "reports JSX elements without keys in block callback returns" {
     const source =
         \\items.map(function (item) {


### PR DESCRIPTION
## Summary
- parse `checkFragmentShorthand` for `react/jsx-key`
- report JSX fragment shorthand in arrays and iterator callback returns when the option is enabled
- keep the default behavior unchanged by allowing shorthand fragments unless configured
- document the expanded supported option set

Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_key.zig tests/rules/react_jsx_key.zig`
- `git diff --check`