### PR TITLE
support typedef parameter options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -288,7 +288,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |
-| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Implemented for `propertyDeclaration` and `memberVariableDeclaration` configurations |
+| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, and `arrowParameter` configuration |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1303,6 +1303,8 @@ pub const Options = struct {
     typescript_eslint_typedef: bool = true,
     typescript_eslint_typedef_property_declaration: bool = true,
     typescript_eslint_typedef_member_variable_declaration: bool = false,
+    typescript_eslint_typedef_parameter: bool = false,
+    typescript_eslint_typedef_arrow_parameter: bool = false,
     typescript_eslint_unified_signatures: bool = true,
     typescript_eslint_no_unnecessary_parameter_property_assignment: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
@@ -1740,6 +1742,8 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/typedef")) {
             self.typescript_eslint_typedef_property_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "propertyDeclaration", true);
             self.typescript_eslint_typedef_member_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "memberVariableDeclaration", false);
+            self.typescript_eslint_typedef_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "parameter", false);
+            self.typescript_eslint_typedef_arrow_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "arrowParameter", false);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/restrict-plus-operands")) {
             self.typescript_eslint_restrict_plus_operands_allow_number_and_string = try typescriptEslintRestrictPlusOperandsBoolOptionFromConfig(value, "allowNumberAndString", false);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1169,6 +1169,9 @@ const BasicVisitor = struct {
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
+        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_parameter) {
+            try typescript_eslint_typedef.checkFunctionParameters(self.allocator, self.diagnostics, ctx.tree, function);
+        }
         if (self.options.no_param_reassign) {
             try no_param_reassign.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
                 .props = self.options.no_param_reassign_props == .yes,
@@ -2298,6 +2301,9 @@ const BasicVisitor = struct {
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
+        }
+        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_arrow_parameter) {
+            try typescript_eslint_typedef.checkArrowFunctionParameters(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkFormalParametersWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.params, .{

--- a/src/rules/typescript_eslint_typedef.zig
+++ b/src/rules/typescript_eslint_typedef.zig
@@ -7,6 +7,24 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/typedef";
 
+pub fn checkFunctionParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+) Allocator.Error!void {
+    try checkParameters(allocator, diagnostics, tree, function.params);
+}
+
+pub fn checkArrowFunctionParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+) Allocator.Error!void {
+    try checkParameters(allocator, diagnostics, tree, expression.params);
+}
+
 pub fn checkPropertySignature(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -69,6 +87,77 @@ pub fn checkPropertyDefinition(
         "Expected a type annotation.",
         tree.span(index),
     );
+}
+
+fn checkParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+) Allocator.Error!void {
+    const parameters = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(parameters.items)) |parameter_index| {
+        const pattern = parameterPattern(tree, parameter_index) orelse continue;
+        if (hasTypeAnnotation(tree, pattern)) continue;
+
+        if (bindingName(tree, pattern)) |name| {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .@"error",
+                id,
+                tree.span(pattern),
+                "Expected {s} to have a type annotation.",
+                .{name},
+            );
+            continue;
+        }
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            "Expected a type annotation.",
+            tree.span(pattern),
+        );
+    }
+}
+
+fn parameterPattern(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .formal_parameter => |parameter| parameter.pattern,
+        .ts_parameter_property => |property| property.parameter,
+        else => null,
+    };
+}
+
+fn hasTypeAnnotation(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return true;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| identifier.type_annotation != .null,
+        .assignment_pattern => |pattern| pattern.type_annotation != .null or hasTypeAnnotation(tree, pattern.left),
+        .binding_rest_element => |element| element.type_annotation != .null or hasTypeAnnotation(tree, element.argument),
+        .array_pattern => |pattern| pattern.type_annotation != .null,
+        .object_pattern => |pattern| pattern.type_annotation != .null,
+        .ts_this_parameter => |parameter| parameter.type_annotation != .null,
+        else => true,
+    };
+}
+
+fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .assignment_pattern => |pattern| bindingName(tree, pattern.left),
+        .binding_rest_element => |element| bindingName(tree, element.argument),
+        else => null,
+    };
 }
 
 fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/typescript_eslint_typedef.zig
+++ b/tests/rules/typescript_eslint_typedef.zig
@@ -86,7 +86,7 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true}]
+        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true, "parameter": true, "arrowParameter": true}]
     ,
         .{},
     );
@@ -98,6 +98,53 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     try std.testing.expect(options.typescript_eslint_typedef);
     try std.testing.expect(!options.typescript_eslint_typedef_property_declaration);
     try std.testing.expect(options.typescript_eslint_typedef_member_variable_declaration);
+    try std.testing.expect(options.typescript_eslint_typedef_parameter);
+    try std.testing.expect(options.typescript_eslint_typedef_arrow_parameter);
+}
+
+test "supports configured @typescript-eslint/typedef parameter options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"propertyDeclaration": false, "parameter": true, "arrowParameter": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/typedef", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_inferrable_types = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function named(untyped, typed: string, fallback = 1, rest: string[]) {}
+        \\const arrow = (first, second: number) => first + second;
+        \\const destructured = ({ value }, [item]) => value + item;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
+}
+
+test "allows @typescript-eslint/typedef parameters by default" {
+    const source =
+        \\function named(untyped) {}
+        \\const arrow = (first) => first;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_typedef.id));
 }
 
 test "can disable @typescript-eslint/typedef" {


### PR DESCRIPTION
## Summary
- parse `parameter` and `arrowParameter` for `@typescript-eslint/typedef` configs
- report unannotated ordinary function parameters when `parameter` is enabled
- report unannotated arrow function parameters when `arrowParameter` is enabled
- keep the default behavior unchanged when those options are omitted
- document the expanded supported option set

Reference: https://typescript-eslint.io/rules/typedef/

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_typedef.zig tests/rules/typescript_eslint_typedef.zig`
- `git diff --check`