### PR TITLE
support one var never config

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -160,7 +160,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
-| [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Implemented for fishlint's `never` configuration |
+| [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators and assignment expressions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1126,6 +1126,9 @@ pub const Options = struct {
     object_shorthand_style: ObjectShorthandStyle = .always,
     object_shorthand_avoid_quotes: bool = false,
     one_var: bool = true,
+    one_var_check_var: bool = true,
+    one_var_check_let: bool = true,
+    one_var_check_const: bool = true,
     operator_assignment: bool = true,
     operator_assignment_style: OperatorAssignmentStyle = .always,
     eqeqeq: bool = true,
@@ -1600,6 +1603,12 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "object-shorthand")) {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
             self.object_shorthand_avoid_quotes = try objectShorthandAvoidQuotesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "one-var")) {
+            const config = try oneVarNeverConfigFromConfig(value);
+            self.one_var_check_var = config.@"var";
+            self.one_var_check_let = config.let;
+            self.one_var_check_const = config.@"const";
         }
         if (std.mem.eql(u8, cli_name, "operator-assignment")) {
             self.operator_assignment_style = try operatorAssignmentStyleFromConfig(value);
@@ -3363,6 +3372,63 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    const OneVarNeverConfig = struct {
+        @"var": bool = true,
+        let: bool = true,
+        @"const": bool = true,
+    };
+
+    fn oneVarNeverConfigFromConfig(value: std.json.Value) RuleConfigError!OneVarNeverConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        return switch (items[1]) {
+            .string => |style| {
+                if (!std.mem.eql(u8, style, "never")) return error.UnsupportedRuleConfigValue;
+                return .{};
+            },
+            .object => |object| oneVarNeverObjectConfig(object),
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn oneVarNeverObjectConfig(object: std.json.ObjectMap) RuleConfigError!OneVarNeverConfig {
+        var config = OneVarNeverConfig{
+            .@"var" = false,
+            .let = false,
+            .@"const" = false,
+        };
+        var matched = false;
+
+        if (object.get("var")) |value| {
+            config.@"var" = try oneVarNeverOption(value);
+            matched = true;
+        }
+        if (object.get("let")) |value| {
+            config.let = try oneVarNeverOption(value);
+            matched = true;
+        }
+        if (object.get("const")) |value| {
+            config.@"const" = try oneVarNeverOption(value);
+            matched = true;
+        }
+
+        if (!matched) return error.UnsupportedRuleConfigValue;
+        return config;
+    }
+
+    fn oneVarNeverOption(value: std.json.Value) RuleConfigError!bool {
+        const style = switch (value) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (!std.mem.eql(u8, style, "never")) return error.UnsupportedRuleConfigValue;
+        return true;
     }
 
     fn operatorAssignmentStyleFromConfig(value: std.json.Value) RuleConfigError!OperatorAssignmentStyle {

--- a/src/rules/one_var.zig
+++ b/src/rules/one_var.zig
@@ -7,6 +7,12 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "one-var";
 
+pub const Options = struct {
+    check_var: bool = true,
+    check_let: bool = true,
+    check_const: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -15,6 +21,19 @@ pub fn check(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, declaration, index, ctx, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (!shouldCheckKind(declaration.kind, options)) return;
     if (declaration.declarators.len < 2) return;
     if (isForStatementInit(tree, index, ctx)) return;
 
@@ -26,6 +45,15 @@ pub fn check(
         "Split variable declarations into multiple statements.",
         tree.span(index),
     );
+}
+
+fn shouldCheckKind(kind: ast.VariableKind, options: Options) bool {
+    return switch (kind) {
+        .@"var" => options.check_var,
+        .let => options.check_let,
+        .@"const" => options.check_const,
+        .using, .await_using => true,
+    };
 }
 
 fn isForStatementInit(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2198,7 +2198,11 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
         if (self.options.one_var) {
-            try one_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
+            try one_var.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx, .{
+                .check_var = self.options.one_var_check_var,
+                .check_let = self.options.one_var_check_let,
+                .check_const = self.options.one_var_check_const,
+            });
         }
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkVariableDeclarationWithOptions(self.allocator, self.diagnostics, ctx.tree, declaration, .{

--- a/tests/rules/one_var.zig
+++ b/tests/rules/one_var.zig
@@ -36,6 +36,58 @@ test "does not report one-var for separate declarations or for loop init" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.one_var.id));
 }
 
+test "supports configured one-var never style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("one-var", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\var first = 1, second = 2;
+        \\let third = 3, fourth = 4;
+        \\const fifth = 5, sixth = 6;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.one_var.id));
+}
+
+test "supports configured one-var per-kind never style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"let\":\"never\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("one-var", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\var first = 1, second = 2;
+        \\let third = 3, fourth = 4;
+        \\const fifth = 5, sixth = 6;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.one_var.id));
+}
+
 test "can disable one-var" {
     const source =
         \\let first = 1, second = 2;


### PR DESCRIPTION
## Summary
- parse explicit `one-var` string `never` config
- parse per-kind `var` / `let` / `const` object entries when they are set to `never`
- pass the parsed per-kind checks into the existing split-declaration implementation
- leave `always` and `consecutive` unsupported rather than claiming behavior not implemented yet

Reference: https://eslint.org/docs/latest/rules/one-var

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/one_var.zig tests/rules/one_var.zig`
- `git diff --check`