### PR TITLE
support typedef variable declaration options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -288,7 +288,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |
-| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, and `arrowParameter` configuration |
+| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, `arrowParameter`, `variableDeclaration`, and `variableDeclarationIgnoreFunction` configuration |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1308,6 +1308,8 @@ pub const Options = struct {
     typescript_eslint_typedef_member_variable_declaration: bool = false,
     typescript_eslint_typedef_parameter: bool = false,
     typescript_eslint_typedef_arrow_parameter: bool = false,
+    typescript_eslint_typedef_variable_declaration: bool = false,
+    typescript_eslint_typedef_variable_declaration_ignore_function: bool = false,
     typescript_eslint_unified_signatures: bool = true,
     typescript_eslint_no_unnecessary_parameter_property_assignment: bool = true,
     typescript_eslint_no_unnecessary_type_constraint: bool = true,
@@ -1753,6 +1755,8 @@ pub const Options = struct {
             self.typescript_eslint_typedef_member_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "memberVariableDeclaration", false);
             self.typescript_eslint_typedef_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "parameter", false);
             self.typescript_eslint_typedef_arrow_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "arrowParameter", false);
+            self.typescript_eslint_typedef_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "variableDeclaration", false);
+            self.typescript_eslint_typedef_variable_declaration_ignore_function = try typescriptEslintTypedefBoolOptionFromConfig(value, "variableDeclarationIgnoreFunction", false);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/restrict-plus-operands")) {
             self.typescript_eslint_restrict_plus_operands_allow_number_and_string = try typescriptEslintRestrictPlusOperandsBoolOptionFromConfig(value, "allowNumberAndString", false);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2204,6 +2204,11 @@ const BasicVisitor = struct {
                 .check_const = self.options.one_var_check_const,
             });
         }
+        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_variable_declaration) {
+            try typescript_eslint_typedef.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, .{
+                .ignore_function = self.options.typescript_eslint_typedef_variable_declaration_ignore_function,
+            });
+        }
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkVariableDeclarationWithOptions(self.allocator, self.diagnostics, ctx.tree, declaration, .{
                 .variable_declarator_array = self.options.prefer_destructuring_variable_declarator_array,

--- a/src/rules/typescript_eslint_typedef.zig
+++ b/src/rules/typescript_eslint_typedef.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/typedef";
 
+pub const VariableDeclarationOptions = struct {
+    ignore_function: bool = false,
+};
+
 pub fn checkFunctionParameters(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -23,6 +27,23 @@ pub fn checkArrowFunctionParameters(
     expression: ast.ArrowFunctionExpression,
 ) Allocator.Error!void {
     try checkParameters(allocator, diagnostics, tree, expression.params);
+}
+
+pub fn checkVariableDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    options: VariableDeclarationOptions,
+) Allocator.Error!void {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+        if (options.ignore_function and isFunctionInitializer(tree, declarator.init)) continue;
+        try checkDeclarationPattern(allocator, diagnostics, tree, declarator.id);
+    }
 }
 
 pub fn checkPropertySignature(
@@ -89,6 +110,37 @@ pub fn checkPropertyDefinition(
     );
 }
 
+fn checkDeclarationPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.NodeIndex,
+) Allocator.Error!void {
+    if (hasTypeAnnotation(tree, pattern)) return;
+
+    if (bindingName(tree, pattern)) |name| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .@"error",
+            id,
+            tree.span(pattern),
+            "Expected {s} to have a type annotation.",
+            .{name},
+        );
+        return;
+    }
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        "Expected a type annotation.",
+        tree.span(pattern),
+    );
+}
+
 fn checkParameters(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -102,30 +154,16 @@ fn checkParameters(
 
     for (tree.extra(parameters.items)) |parameter_index| {
         const pattern = parameterPattern(tree, parameter_index) orelse continue;
-        if (hasTypeAnnotation(tree, pattern)) continue;
-
-        if (bindingName(tree, pattern)) |name| {
-            try core.addDiagnosticFmt(
-                allocator,
-                diagnostics,
-                .@"error",
-                id,
-                tree.span(pattern),
-                "Expected {s} to have a type annotation.",
-                .{name},
-            );
-            continue;
-        }
-
-        try core.addDiagnostic(
-            allocator,
-            diagnostics,
-            .@"error",
-            id,
-            "Expected a type annotation.",
-            tree.span(pattern),
-        );
+        try checkDeclarationPattern(allocator, diagnostics, tree, pattern);
     }
+}
+
+fn isFunctionInitializer(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function, .arrow_function_expression => true,
+        else => false,
+    };
 }
 
 fn parameterPattern(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
@@ -158,6 +196,18 @@ fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
         .binding_rest_element => |element| bindingName(tree, element.argument),
         else => null,
     };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
 }
 
 fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/typescript_eslint_typedef.zig
+++ b/tests/rules/typescript_eslint_typedef.zig
@@ -86,7 +86,7 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true, "parameter": true, "arrowParameter": true}]
+        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true, "parameter": true, "arrowParameter": true, "variableDeclaration": true, "variableDeclarationIgnoreFunction": true}]
     ,
         .{},
     );
@@ -100,6 +100,69 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     try std.testing.expect(options.typescript_eslint_typedef_member_variable_declaration);
     try std.testing.expect(options.typescript_eslint_typedef_parameter);
     try std.testing.expect(options.typescript_eslint_typedef_arrow_parameter);
+    try std.testing.expect(options.typescript_eslint_typedef_variable_declaration);
+    try std.testing.expect(options.typescript_eslint_typedef_variable_declaration_ignore_function);
+}
+
+test "supports configured @typescript-eslint/typedef variable declaration option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"propertyDeclaration": false, "variableDeclaration": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/typedef", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_inferrable_types = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const untyped = 1;
+        \\const typed: number = 1;
+        \\const fallback = () => 1;
+        \\const destructured = { value: 1 };
+        \\const { value } = destructured;
+        \\const [item] = [1];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
+}
+
+test "supports configured @typescript-eslint/typedef variable declaration ignore function option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"propertyDeclaration": false, "variableDeclaration": true, "variableDeclarationIgnoreFunction": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/typedef", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_inferrable_types = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const untyped = 1;
+        \\const fallback = () => 1;
+        \\const named = function () { return 1; };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
 }
 
 test "supports configured @typescript-eslint/typedef parameter options" {


### PR DESCRIPTION
## Summary
- parse `variableDeclaration` and `variableDeclarationIgnoreFunction` for `@typescript-eslint/typedef`
- report unannotated variable declarators when variable declaration checks are enabled
- skip function and arrow function initializers when the ignore function option is enabled
- document the expanded typedef option support

Reference: https://typescript-eslint.io/rules/typedef/

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_typedef.zig tests/rules/typescript_eslint_typedef.zig`
- `git diff --check`