### PR TITLE
support typedef destructuring options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -288,7 +288,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |
-| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, `arrowParameter`, `variableDeclaration`, and `variableDeclarationIgnoreFunction` configuration |
+| [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, `arrowParameter`, `arrayDestructuring`, `objectDestructuring`, `variableDeclaration`, and `variableDeclarationIgnoreFunction` configuration |
 | [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures/) | Implemented |
 | [`@typescript-eslint/no-unnecessary-parameter-property-assignment`](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/) | Implemented for constructor assignments in the constructor body |
 | [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1308,6 +1308,8 @@ pub const Options = struct {
     typescript_eslint_typedef_member_variable_declaration: bool = false,
     typescript_eslint_typedef_parameter: bool = false,
     typescript_eslint_typedef_arrow_parameter: bool = false,
+    typescript_eslint_typedef_array_destructuring: bool = false,
+    typescript_eslint_typedef_object_destructuring: bool = false,
     typescript_eslint_typedef_variable_declaration: bool = false,
     typescript_eslint_typedef_variable_declaration_ignore_function: bool = false,
     typescript_eslint_unified_signatures: bool = true,
@@ -1755,6 +1757,8 @@ pub const Options = struct {
             self.typescript_eslint_typedef_member_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "memberVariableDeclaration", false);
             self.typescript_eslint_typedef_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "parameter", false);
             self.typescript_eslint_typedef_arrow_parameter = try typescriptEslintTypedefBoolOptionFromConfig(value, "arrowParameter", false);
+            self.typescript_eslint_typedef_array_destructuring = try typescriptEslintTypedefBoolOptionFromConfig(value, "arrayDestructuring", false);
+            self.typescript_eslint_typedef_object_destructuring = try typescriptEslintTypedefBoolOptionFromConfig(value, "objectDestructuring", false);
             self.typescript_eslint_typedef_variable_declaration = try typescriptEslintTypedefBoolOptionFromConfig(value, "variableDeclaration", false);
             self.typescript_eslint_typedef_variable_declaration_ignore_function = try typescriptEslintTypedefBoolOptionFromConfig(value, "variableDeclarationIgnoreFunction", false);
         }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2204,8 +2204,14 @@ const BasicVisitor = struct {
                 .check_const = self.options.one_var_check_const,
             });
         }
-        if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_variable_declaration) {
+        if (self.options.typescript_eslint_typedef and (self.options.typescript_eslint_typedef_variable_declaration or
+            self.options.typescript_eslint_typedef_array_destructuring or
+            self.options.typescript_eslint_typedef_object_destructuring))
+        {
             try typescript_eslint_typedef.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, .{
+                .variable_declaration = self.options.typescript_eslint_typedef_variable_declaration,
+                .array_destructuring = self.options.typescript_eslint_typedef_array_destructuring,
+                .object_destructuring = self.options.typescript_eslint_typedef_object_destructuring,
                 .ignore_function = self.options.typescript_eslint_typedef_variable_declaration_ignore_function,
             });
         }

--- a/src/rules/typescript_eslint_typedef.zig
+++ b/src/rules/typescript_eslint_typedef.zig
@@ -8,6 +8,9 @@ const Allocator = std.mem.Allocator;
 pub const id = "@typescript-eslint/typedef";
 
 pub const VariableDeclarationOptions = struct {
+    variable_declaration: bool = false,
+    array_destructuring: bool = false,
+    object_destructuring: bool = false,
     ignore_function: bool = false,
 };
 
@@ -42,6 +45,7 @@ pub fn checkVariableDeclaration(
             else => continue,
         };
         if (options.ignore_function and isFunctionInitializer(tree, declarator.init)) continue;
+        if (!shouldCheckVariablePattern(tree, declarator.id, options)) continue;
         try checkDeclarationPattern(allocator, diagnostics, tree, declarator.id);
     }
 }
@@ -156,6 +160,19 @@ fn checkParameters(
         const pattern = parameterPattern(tree, parameter_index) orelse continue;
         try checkDeclarationPattern(allocator, diagnostics, tree, pattern);
     }
+}
+
+fn shouldCheckVariablePattern(tree: *const ast.Tree, index: ast.NodeIndex, options: VariableDeclarationOptions) bool {
+    if (index == .null) return false;
+    if (options.variable_declaration) return true;
+
+    return switch (tree.data(index)) {
+        .array_pattern => options.array_destructuring,
+        .object_pattern => options.object_destructuring,
+        .assignment_pattern => |pattern| shouldCheckVariablePattern(tree, pattern.left, options),
+        .binding_rest_element => |element| shouldCheckVariablePattern(tree, element.argument, options),
+        else => false,
+    };
 }
 
 fn isFunctionInitializer(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/typescript_eslint_typedef.zig
+++ b/tests/rules/typescript_eslint_typedef.zig
@@ -86,7 +86,7 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true, "parameter": true, "arrowParameter": true, "variableDeclaration": true, "variableDeclarationIgnoreFunction": true}]
+        \\["error", {"propertyDeclaration": false, "memberVariableDeclaration": true, "parameter": true, "arrowParameter": true, "arrayDestructuring": true, "objectDestructuring": true, "variableDeclaration": true, "variableDeclarationIgnoreFunction": true}]
     ,
         .{},
     );
@@ -100,8 +100,42 @@ test "supports configured @typescript-eslint/typedef declaration options" {
     try std.testing.expect(options.typescript_eslint_typedef_member_variable_declaration);
     try std.testing.expect(options.typescript_eslint_typedef_parameter);
     try std.testing.expect(options.typescript_eslint_typedef_arrow_parameter);
+    try std.testing.expect(options.typescript_eslint_typedef_array_destructuring);
+    try std.testing.expect(options.typescript_eslint_typedef_object_destructuring);
     try std.testing.expect(options.typescript_eslint_typedef_variable_declaration);
     try std.testing.expect(options.typescript_eslint_typedef_variable_declaration_ignore_function);
+}
+
+test "supports configured @typescript-eslint/typedef destructuring options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"propertyDeclaration": false, "arrayDestructuring": true, "objectDestructuring": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/typedef", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_inferrable_types = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const plain = 1;
+        \\const typedPlain: number = 1;
+        \\const { value } = { value: 1 };
+        \\const { typedValue }: { typedValue: number } = { typedValue: 1 };
+        \\const [item] = [1];
+        \\const [typedItem]: [number] = [1];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_typedef.id));
 }
 
 test "supports configured @typescript-eslint/typedef variable declaration option" {


### PR DESCRIPTION
## Summary
- parse `arrayDestructuring` and `objectDestructuring` for `@typescript-eslint/typedef`
- check unannotated array/object variable destructuring when those options are enabled
- keep `variableDeclaration` as the broad variable declaration switch and preserve default behavior
- document the expanded typedef option support

Reference: https://typescript-eslint.io/rules/typedef/

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_typedef.zig tests/rules/typescript_eslint_typedef.zig`
- `git diff --check`