### PR TITLE
support no-extra-boolean-cast legacy option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -68,7 +68,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-ex-assign`](https://eslint.org/docs/latest/rules/no-ex-assign) | Implemented |
 | [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Implemented |
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented |
-| [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Implemented |
+| [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
 | [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Implemented with optional `allowEmptyCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -2690,7 +2690,8 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("enforceForInnerExpressions") orelse return false) {
+        const option = config.get("enforceForInnerExpressions") orelse config.get("enforceForLogicalOperands") orelse return false;
+        return switch (option) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -5262,6 +5263,28 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-extra-boolean-cast", no_extra_boolean_cast_config.value);
     try std.testing.expect(options.no_extra_boolean_cast);
     try std.testing.expect(options.no_extra_boolean_cast_enforce_for_inner_expressions);
+
+    var no_extra_boolean_cast_legacy_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForLogicalOperands\":true}]",
+        .{},
+    );
+    defer no_extra_boolean_cast_legacy_config.deinit();
+    options.no_extra_boolean_cast_enforce_for_inner_expressions = false;
+    try options.setByRuleConfigValue("no-extra-boolean-cast", no_extra_boolean_cast_legacy_config.value);
+    try std.testing.expect(options.no_extra_boolean_cast);
+    try std.testing.expect(options.no_extra_boolean_cast_enforce_for_inner_expressions);
+
+    var no_extra_boolean_cast_precedence_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForInnerExpressions\":false,\"enforceForLogicalOperands\":true}]",
+        .{},
+    );
+    defer no_extra_boolean_cast_precedence_config.deinit();
+    try options.setByRuleConfigValue("no-extra-boolean-cast", no_extra_boolean_cast_precedence_config.value);
+    try std.testing.expect(!options.no_extra_boolean_cast_enforce_for_inner_expressions);
 
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -71,6 +71,33 @@ test "reports no-extra-boolean-cast inner expressions when configured" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
 }
 
+test "supports deprecated no-extra-boolean-cast enforceForLogicalOperands option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForLogicalOperands\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-extra-boolean-cast", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (foo && !!bar) { use(bar); }
+        \\if (foo || Boolean(bar)) { use(bar); }
+        \\const value = foo && !!bar;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extra_boolean_cast.id));
+}
+
 test "reports no-extra-boolean-cast inside negated boolean contexts" {
     const source =
         \\if (!Boolean(value)) { use(value); }


### PR DESCRIPTION
## Summary
- parse deprecated `enforceForLogicalOperands` for `no-extra-boolean-cast` as an alias of `enforceForInnerExpressions`
- keep `enforceForInnerExpressions` precedence when both option names are present
- add coverage for the legacy option behavior and document the supported config names

Reference: https://eslint.org/docs/latest/rules/no-extra-boolean-cast

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig tests/rules/no_extra_boolean_cast.zig`
- `git diff --check`