### PR TITLE
support prefer-destructuring renamed properties

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -163,7 +163,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |
-| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Implemented for object and array variable declarators and assignment expressions |
+| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1156,6 +1156,7 @@ pub const Options = struct {
     prefer_destructuring_variable_declarator_object: bool = true,
     prefer_destructuring_assignment_expression_array: bool = true,
     prefer_destructuring_assignment_expression_object: bool = true,
+    prefer_destructuring_enforce_for_renamed_properties: bool = false,
     prefer_regex_literals: bool = true,
     prefer_rest_params: bool = true,
     prefer_object_spread: bool = true,
@@ -1570,6 +1571,7 @@ pub const Options = struct {
             self.prefer_destructuring_variable_declarator_object = try preferDestructuringOptionFromConfig(value, "VariableDeclarator", "object", true);
             self.prefer_destructuring_assignment_expression_array = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "array", true);
             self.prefer_destructuring_assignment_expression_object = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "object", true);
+            self.prefer_destructuring_enforce_for_renamed_properties = try preferDestructuringEnforceForRenamedPropertiesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "radix")) {
             self.radix_style = try radixStyleFromConfig(value);
@@ -3113,6 +3115,23 @@ pub const Options = struct {
             };
         }
         return switch (config.get(kind_key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn preferDestructuringEnforceForRenamedPropertiesFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 3) return false;
+
+        const config = switch (items[2]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("enforceForRenamedProperties") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -5530,11 +5549,12 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.prefer_destructuring_variable_declarator_object);
     try std.testing.expect(options.prefer_destructuring_assignment_expression_array);
     try std.testing.expect(!options.prefer_destructuring_assignment_expression_object);
+    try std.testing.expect(!options.prefer_destructuring_enforce_for_renamed_properties);
 
     var prefer_destructuring_top_level_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"array\":false,\"object\":true}]",
+        "[\"error\",{\"array\":false,\"object\":true},{\"enforceForRenamedProperties\":true}]",
         .{},
     );
     defer prefer_destructuring_top_level_config.deinit();
@@ -5543,6 +5563,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.prefer_destructuring_variable_declarator_object);
     try std.testing.expect(!options.prefer_destructuring_assignment_expression_array);
     try std.testing.expect(options.prefer_destructuring_assignment_expression_object);
+    try std.testing.expect(options.prefer_destructuring_enforce_for_renamed_properties);
 
     var radix_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -17,6 +17,7 @@ pub const Options = struct {
     variable_declarator_object: bool = true,
     assignment_expression_array: bool = true,
     assignment_expression_object: bool = true,
+    enforce_for_renamed_properties: bool = false,
 };
 
 pub fn checkVariableDeclaration(
@@ -40,7 +41,7 @@ pub fn checkVariableDeclarationWithOptions(
             .variable_declarator => |declarator| declarator,
             else => continue,
         };
-        const kind = preferredDestructuringKind(tree, declarator) orelse continue;
+        const kind = preferredDestructuringKind(tree, declarator, options) orelse continue;
         if (!allowsVariableDeclarator(options, kind)) continue;
 
         try core.addDiagnostic(
@@ -72,7 +73,7 @@ pub fn checkAssignmentExpressionWithOptions(
 ) Allocator.Error!void {
     if (expression.operator != .assign) return;
 
-    const kind = preferredAssignmentDestructuringKind(tree, expression) orelse return;
+    const kind = preferredAssignmentDestructuringKind(tree, expression, options) orelse return;
     if (!allowsAssignmentExpression(options, kind)) return;
 
     try core.addDiagnostic(
@@ -85,7 +86,7 @@ pub fn checkAssignmentExpressionWithOptions(
     );
 }
 
-fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDeclarator) ?DestructuringKind {
+fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDeclarator, options: Options) ?DestructuringKind {
     if (declarator.init == .null) return null;
 
     const local_name = bindingIdentifierName(tree, declarator.id) orelse return null;
@@ -99,10 +100,10 @@ fn preferredDestructuringKind(tree: *const ast.Tree, declarator: ast.VariableDec
     if (isArrayIndexProperty(tree, member)) return .array;
 
     const property_name = propertyName(tree, member) orelse return null;
-    return if (std.mem.eql(u8, local_name, property_name)) .object else null;
+    return if (options.enforce_for_renamed_properties or std.mem.eql(u8, local_name, property_name)) .object else null;
 }
 
-fn preferredAssignmentDestructuringKind(tree: *const ast.Tree, expression: ast.AssignmentExpression) ?DestructuringKind {
+fn preferredAssignmentDestructuringKind(tree: *const ast.Tree, expression: ast.AssignmentExpression, options: Options) ?DestructuringKind {
     const target_name = identifierReferenceName(tree, expression.left) orelse return null;
 
     const member = switch (tree.data(unwrapTransparent(tree, expression.right))) {
@@ -114,7 +115,7 @@ fn preferredAssignmentDestructuringKind(tree: *const ast.Tree, expression: ast.A
     if (isArrayIndexProperty(tree, member)) return .array;
 
     const property_name = propertyName(tree, member) orelse return null;
-    return if (std.mem.eql(u8, target_name, property_name)) .object else null;
+    return if (options.enforce_for_renamed_properties or std.mem.eql(u8, target_name, property_name)) .object else null;
 }
 
 fn diagnosticMessage(kind: DestructuringKind) []const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2221,6 +2221,7 @@ const BasicVisitor = struct {
                 .variable_declarator_object = self.options.prefer_destructuring_variable_declarator_object,
                 .assignment_expression_array = self.options.prefer_destructuring_assignment_expression_array,
                 .assignment_expression_object = self.options.prefer_destructuring_assignment_expression_object,
+                .enforce_for_renamed_properties = self.options.prefer_destructuring_enforce_for_renamed_properties,
             });
         }
         return .proceed;
@@ -2381,6 +2382,7 @@ const BasicVisitor = struct {
                 .variable_declarator_object = self.options.prefer_destructuring_variable_declarator_object,
                 .assignment_expression_array = self.options.prefer_destructuring_assignment_expression_array,
                 .assignment_expression_object = self.options.prefer_destructuring_assignment_expression_object,
+                .enforce_for_renamed_properties = self.options.prefer_destructuring_enforce_for_renamed_properties,
             });
         }
         if (self.options.no_useless_rename) {

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -150,6 +150,38 @@ test "supports top-level prefer-destructuring kind options" {
     try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[1].message);
 }
 
+test "supports configured prefer-destructuring renamed property enforcement" {
+    const source =
+        \\let alias = object.first;
+        \\alias = object.second;
+        \\let item = array[0];
+    ;
+
+    var options = lint.Options{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_dot_notation = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"object\":true,\"array\":false},{\"enforceForRenamedProperties\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("prefer-destructuring", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Use object destructuring.", result.diagnostics[1].message);
+}
+
 test "can disable prefer-destructuring" {
     const source =
         \\const first = object.first;


### PR DESCRIPTION
## Summary
- parse `enforceForRenamedProperties` from the second `prefer-destructuring` options object
- report renamed object property variable declarations and assignments when enabled
- keep default renamed-property behavior unchanged
- document the expanded prefer-destructuring config support

Reference: https://eslint.org/docs/latest/rules/prefer-destructuring

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/prefer_destructuring.zig tests/rules/prefer_destructuring.zig`
- `git diff --check`