### PR TITLE
support no-underscore-dangle allow option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -138,7 +138,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
-| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Implemented for default declaration/member-property checks and optional `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` behavior |
+| [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1091,6 +1091,7 @@ pub const Options = struct {
     no_underscore_dangle_allow_in_object_destructuring: NoUnderscoreDangleAllowDestructuring = .yes,
     no_underscore_dangle_enforce_in_method_names: bool = false,
     no_underscore_dangle_enforce_in_class_fields: bool = false,
+    no_underscore_dangle_allow: NoShadowAllowNames = .{},
     no_undefined: bool = true,
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
@@ -1559,6 +1560,7 @@ pub const Options = struct {
             self.no_underscore_dangle_allow_in_object_destructuring = if (try noUnderscoreDangleBoolOptionFromConfig(value, "allowInObjectDestructuring", true)) .yes else .no;
             self.no_underscore_dangle_enforce_in_method_names = try noUnderscoreDangleBoolOptionFromConfig(value, "enforceInMethodNames", false);
             self.no_underscore_dangle_enforce_in_class_fields = try noUnderscoreDangleBoolOptionFromConfig(value, "enforceInClassFields", false);
+            self.no_underscore_dangle_allow = try noUnderscoreDangleAllowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
@@ -3030,6 +3032,34 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noUnderscoreDangleAllowFromConfig(value: std.json.Value) RuleConfigError!NoShadowAllowNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allow") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow = NoShadowAllowNames{};
+        for (allow_items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            allow.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn noPlusplusAllowForLoopAfterthoughtsFromConfig(value: std.json.Value) RuleConfigError!NoPlusplusAllowForLoopAfterthoughts {
@@ -5463,7 +5493,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_underscore_dangle_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowAfterThis\":true,\"allowAfterSuper\":true,\"allowAfterThisConstructor\":true,\"allowFunctionParams\":false,\"allowInArrayDestructuring\":false,\"allowInObjectDestructuring\":false,\"enforceInMethodNames\":true,\"enforceInClassFields\":true}]",
+        "[\"error\",{\"allow\":[\"_allowed\"],\"allowAfterThis\":true,\"allowAfterSuper\":true,\"allowAfterThisConstructor\":true,\"allowFunctionParams\":false,\"allowInArrayDestructuring\":false,\"allowInObjectDestructuring\":false,\"enforceInMethodNames\":true,\"enforceInClassFields\":true}]",
         .{},
     );
     defer no_underscore_dangle_config.deinit();
@@ -5477,6 +5507,8 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnderscoreDangleAllowDestructuring.no, options.no_underscore_dangle_allow_in_object_destructuring);
     try std.testing.expect(options.no_underscore_dangle_enforce_in_method_names);
     try std.testing.expect(options.no_underscore_dangle_enforce_in_class_fields);
+    try std.testing.expect(options.no_underscore_dangle_allow.contains("_allowed"));
+    try std.testing.expect(!options.no_underscore_dangle_allow.contains("_other"));
 
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_underscore_dangle.zig
+++ b/src/rules/no_underscore_dangle.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 pub const id = "no-underscore-dangle";
 
 pub const Options = struct {
+    allow: core.NoShadowAllowNames = .{},
     allow_after_this: bool = false,
     allow_after_super: bool = false,
     allow_after_this_constructor: bool = false,
@@ -35,15 +36,15 @@ pub fn checkVariableDeclaratorWithOptions(
     options: Options,
 ) Allocator.Error!void {
     switch (tree.data(declarator.id)) {
-        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, declarator.id, tree.string(identifier.name), false),
+        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, declarator.id, tree.string(identifier.name), false, options),
         .array_pattern => {
             if (!options.allow_in_array_destructuring) {
-                try checkBinding(allocator, diagnostics, tree, declarator.id);
+                try checkBinding(allocator, diagnostics, tree, declarator.id, options);
             }
         },
         .object_pattern => {
             if (!options.allow_in_object_destructuring) {
-                try checkBinding(allocator, diagnostics, tree, declarator.id);
+                try checkBinding(allocator, diagnostics, tree, declarator.id, options);
             }
         },
         else => {},
@@ -68,7 +69,7 @@ pub fn checkFunctionWithOptions(
 ) Allocator.Error!void {
     if (function.id != .null) {
         if (bindingName(tree, function.id)) |name| {
-            try checkName(allocator, diagnostics, tree, function.id, name, false);
+            try checkName(allocator, diagnostics, tree, function.id, name, false, options);
         }
     }
     try checkFormalParametersWithOptions(allocator, diagnostics, tree, function.params, options);
@@ -86,13 +87,13 @@ pub fn checkFormalParametersWithOptions(
     const params = formalParameters(tree, params_index) orelse return;
     for (tree.extra(params.items)) |item_index| {
         switch (tree.data(item_index)) {
-            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern),
-            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter),
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern, options),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter, options),
             else => {},
         }
     }
 
-    try checkBinding(allocator, diagnostics, tree, params.rest);
+    try checkBinding(allocator, diagnostics, tree, params.rest, options);
 }
 
 pub fn checkClass(
@@ -101,10 +102,20 @@ pub fn checkClass(
     tree: *const ast.Tree,
     class: ast.Class,
 ) Allocator.Error!void {
+    return checkClassWithOptions(allocator, diagnostics, tree, class, .{});
+}
+
+pub fn checkClassWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    options: Options,
+) Allocator.Error!void {
     if (class.id == .null) return;
 
     const name = bindingName(tree, class.id) orelse return;
-    try checkName(allocator, diagnostics, tree, class.id, name, false);
+    try checkName(allocator, diagnostics, tree, class.id, name, false, options);
 }
 
 pub fn checkMemberExpression(
@@ -127,7 +138,7 @@ pub fn checkMemberExpressionWithOptions(
 
     const name = propertyName(tree, member) orelse return;
     if (isAllowedMemberAccess(tree, member, options)) return;
-    try checkName(allocator, diagnostics, tree, member.property, name, true);
+    try checkName(allocator, diagnostics, tree, member.property, name, true, options);
 }
 
 pub fn checkMethodDefinitionWithOptions(
@@ -140,7 +151,7 @@ pub fn checkMethodDefinitionWithOptions(
     if (!options.enforce_in_method_names) return;
 
     const name = staticName(tree, method.key, method.computed) orelse return;
-    try checkName(allocator, diagnostics, tree, method.key, name, false);
+    try checkName(allocator, diagnostics, tree, method.key, name, false, options);
 }
 
 pub fn checkObjectPropertyWithOptions(
@@ -154,7 +165,7 @@ pub fn checkObjectPropertyWithOptions(
     if (!property.method and property.kind == .init) return;
 
     const name = staticName(tree, property.key, property.computed) orelse return;
-    try checkName(allocator, diagnostics, tree, property.key, name, false);
+    try checkName(allocator, diagnostics, tree, property.key, name, false, options);
 }
 
 pub fn checkPropertyDefinitionWithOptions(
@@ -167,7 +178,7 @@ pub fn checkPropertyDefinitionWithOptions(
     if (!options.enforce_in_class_fields) return;
 
     const name = staticName(tree, property.key, property.computed) orelse return;
-    try checkName(allocator, diagnostics, tree, property.key, name, false);
+    try checkName(allocator, diagnostics, tree, property.key, name, false, options);
 }
 
 fn isAllowedMemberAccess(tree: *const ast.Tree, member: ast.MemberExpression, options: Options) bool {
@@ -182,18 +193,19 @@ fn checkBinding(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
-        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, index, tree.string(identifier.name), false),
-        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left),
-        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument),
+        .binding_identifier => |identifier| try checkName(allocator, diagnostics, tree, index, tree.string(identifier.name), false, options),
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left, options),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument, options),
         .array_pattern => |pattern| {
             for (tree.extra(pattern.elements)) |element| {
-                try checkBinding(allocator, diagnostics, tree, element);
+                try checkBinding(allocator, diagnostics, tree, element, options);
             }
-            try checkBinding(allocator, diagnostics, tree, pattern.rest);
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options);
         },
         .object_pattern => |pattern| {
             for (tree.extra(pattern.properties)) |property_index| {
@@ -201,9 +213,9 @@ fn checkBinding(
                     .binding_property => |property| property,
                     else => continue,
                 };
-                try checkBinding(allocator, diagnostics, tree, property.value);
+                try checkBinding(allocator, diagnostics, tree, property.value, options);
             }
-            try checkBinding(allocator, diagnostics, tree, pattern.rest);
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options);
         },
         else => {},
     }
@@ -216,9 +228,10 @@ fn checkName(
     node: ast.NodeIndex,
     name: []const u8,
     allow_proto: bool,
+    options: Options,
 ) Allocator.Error!void {
     if (!hasDanglingUnderscore(name)) return;
-    if (isAllowedName(name, allow_proto)) return;
+    if (isAllowedName(name, allow_proto, options)) return;
 
     try core.addDiagnosticFmt(
         allocator,
@@ -236,7 +249,8 @@ fn hasDanglingUnderscore(name: []const u8) bool {
     return name[0] == '_' or name[name.len - 1] == '_';
 }
 
-fn isAllowedName(name: []const u8, allow_proto: bool) bool {
+fn isAllowedName(name: []const u8, allow_proto: bool, options: Options) bool {
+    if (options.allow.contains(name)) return true;
     if (std.mem.eql(u8, name, "_")) return true;
     if (std.mem.eql(u8, name, "__dirname")) return true;
     if (std.mem.eql(u8, name, "__filename")) return true;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1151,6 +1151,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .allow_function_params = self.options.no_underscore_dangle_allow_function_params == .yes,
             });
         }
@@ -1214,7 +1215,9 @@ const BasicVisitor = struct {
             try constructor_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         if (self.options.no_underscore_dangle) {
-            try no_underscore_dangle.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+            try no_underscore_dangle.checkClassWithOptions(self.allocator, self.diagnostics, ctx.tree, class, .{
+                .allow = self.options.no_underscore_dangle_allow,
+            });
         }
         if (self.options.react_require_render_return) {
             try react_require_render_return.checkClass(self.allocator, self.diagnostics, ctx.tree, class, self.react_require_render_return_state);
@@ -1556,6 +1559,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .allow_in_array_destructuring = self.options.no_underscore_dangle_allow_in_array_destructuring == .yes,
                 .allow_in_object_destructuring = self.options.no_underscore_dangle_allow_in_object_destructuring == .yes,
             });
@@ -2323,6 +2327,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkFormalParametersWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.params, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .allow_function_params = self.options.no_underscore_dangle_allow_function_params == .yes,
             });
         }
@@ -2778,6 +2783,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkMemberExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, member, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .allow_after_this = self.options.no_underscore_dangle_allow_after_this,
                 .allow_after_super = self.options.no_underscore_dangle_allow_after_super,
                 .allow_after_this_constructor = self.options.no_underscore_dangle_allow_after_this_constructor,
@@ -3106,6 +3112,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
             });
         }
@@ -3188,6 +3195,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkMethodDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, method, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
             });
         }
@@ -3249,6 +3257,7 @@ const BasicVisitor = struct {
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
+                .allow = self.options.no_underscore_dangle_allow,
                 .enforce_in_class_fields = self.options.no_underscore_dangle_enforce_in_class_fields,
             });
         }

--- a/tests/rules/no_underscore_dangle.zig
+++ b/tests/rules/no_underscore_dangle.zig
@@ -126,6 +126,40 @@ test "supports configured no-underscore-dangle options" {
     try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
 }
 
+test "allows configured no-underscore-dangle allow names" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"Allowed_\",\"_method\",\"_field\",\"_member\",\"_param\",\"_local\",\"_array\",\"_object\"],\"allowFunctionParams\":false,\"allowInArrayDestructuring\":false,\"allowInObjectDestructuring\":false,\"enforceInMethodNames\":true,\"enforceInClassFields\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-underscore-dangle", config.value);
+    options.no_empty_function = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\class Allowed_ {
+        \\  _method(_param) {
+        \\    const _local = _param;
+        \\    const [_array] = values;
+        \\    const { _object } = record;
+        \\    const _blocked = object._blocked;
+        \\  }
+        \\  _field = this._member;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_underscore_dangle.id));
+}
+
 test "allows default names and skipped forms" {
     const source =
         \\const _ = 1;


### PR DESCRIPTION
## Summary
- parse `allow` for `no-underscore-dangle` configurations
- apply allowed names across declarations, parameters, destructuring, member properties, method names, and class fields
- keep the existing built-in allowed names and context-specific options unchanged
- document the expanded no-underscore-dangle option support

Reference: https://eslint.org/docs/latest/rules/no-underscore-dangle

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_underscore_dangle.zig tests/rules/no_underscore_dangle.zig`
- `git diff --check`