### PR TITLE
support spaced-comment markers option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -177,7 +177,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Implemented |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
-| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Implemented for `always` and optional `never` behavior |
+| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, and `markers` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -249,6 +249,42 @@ pub const SpacedCommentStyle = enum {
     never,
 };
 
+pub const max_spaced_comment_markers = 32;
+pub const max_spaced_comment_marker_len = 32;
+
+pub const SpacedCommentMarkersError = error{
+    EmptySpacedCommentMarker,
+    TooManySpacedCommentMarkers,
+    SpacedCommentMarkerTooLong,
+};
+
+pub const SpacedCommentMarkers = struct {
+    count: usize = 0,
+    lengths: [max_spaced_comment_markers]usize = undefined,
+    storage: [max_spaced_comment_markers][max_spaced_comment_marker_len]u8 = undefined,
+
+    pub fn matches(self: *const SpacedCommentMarkers, value: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.startsWith(u8, value, self.at(index))) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const SpacedCommentMarkers, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *SpacedCommentMarkers, marker: []const u8) SpacedCommentMarkersError!void {
+        if (marker.len == 0) return error.EmptySpacedCommentMarker;
+        if (self.count >= max_spaced_comment_markers) return error.TooManySpacedCommentMarkers;
+        if (marker.len > max_spaced_comment_marker_len) return error.SpacedCommentMarkerTooLong;
+
+        @memcpy(self.storage[self.count][0..marker.len], marker);
+        self.lengths[self.count] = marker.len;
+        self.count += 1;
+    }
+};
+
 pub const NoVoidAllowAsStatement = enum {
     yes,
     no,
@@ -1247,6 +1283,7 @@ pub const Options = struct {
     require_yield: bool = true,
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
+    spaced_comment_markers: SpacedCommentMarkers = .{},
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
@@ -1790,6 +1827,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "spaced-comment")) {
             self.spaced_comment_style = try spacedCommentStyleFromConfig(value);
+            self.spaced_comment_markers = try spacedCommentMarkersFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "wrap-iife")) {
             self.wrap_iife_style = try wrapIifeStyleFromConfig(value);
@@ -3659,6 +3697,34 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "always")) return .always;
         if (std.mem.eql(u8, style, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn spacedCommentMarkersFromConfig(value: std.json.Value) RuleConfigError!SpacedCommentMarkers {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 3) return .{};
+
+        const config = switch (items[2]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const markers_value = config.get("markers") orelse return .{};
+        const marker_items = switch (markers_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var markers = SpacedCommentMarkers{};
+        for (marker_items) |item| {
+            const marker = switch (item) {
+                .string => |marker| marker,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            markers.append(marker) catch return error.UnsupportedRuleConfigValue;
+        }
+        return markers;
     }
 
     fn reactButtonHasTypeBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -5889,13 +5955,16 @@ test "Options can apply ESLint-style rule config values" {
     var spaced_comment_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\"]",
+        "[\"error\",\"never\",{\"markers\":[\"/\",\"!\"]}]",
         .{},
     );
     defer spaced_comment_config.deinit();
     try options.setByRuleConfigValue("spaced-comment", spaced_comment_config.value);
     try std.testing.expect(options.spaced_comment);
     try std.testing.expectEqual(SpacedCommentStyle.never, options.spaced_comment_style);
+    try std.testing.expect(options.spaced_comment_markers.matches("/ reference"));
+    try std.testing.expect(options.spaced_comment_markers.matches("! license"));
+    try std.testing.expect(!options.spaced_comment_markers.matches("# plain"));
 
     var wrap_iife_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -505,6 +505,7 @@ pub fn runBasic(
                 .always => .always,
                 .never => .never,
             },
+            .markers = options.spaced_comment_markers,
         });
     }
     if (options.typescript_eslint_ban_ts_comment) {

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -14,6 +14,7 @@ pub const Style = enum {
 
 pub const Options = struct {
     style: Style = .always,
+    markers: core.SpacedCommentMarkers = .{},
 };
 
 pub fn run(
@@ -31,7 +32,7 @@ pub fn runWithOptions(
     options: Options,
 ) Allocator.Error!void {
     for (tree.comments) |comment| {
-        if (hasExpectedSpacing(tree, comment, options.style)) continue;
+        if (hasExpectedSpacing(tree, comment, options)) continue;
 
         try core.addDiagnostic(
             allocator,
@@ -44,14 +45,15 @@ pub fn runWithOptions(
     }
 }
 
-fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, style: Style) bool {
+fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, options: Options) bool {
     const value = tree.string(comment.value);
     if (value.len == 0) return true;
 
     const index = spacingIndex(value, comment.type);
     if (index >= value.len) return true;
+    if (options.markers.matches(value[index..])) return true;
 
-    return switch (style) {
+    return switch (options.style) {
         .always => isWhitespace(value[index]),
         .never => !isWhitespace(value[index]),
     };

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -69,6 +69,35 @@ test "reports spaced-comment for spaced comments in never mode" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.spaced_comment.id));
 }
 
+test "supports configured spaced-comment markers" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"markers\":[\"/\",\"!\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("spaced-comment", config.value);
+    options.no_inline_comments = false;
+    options.no_tabs = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\/// <reference path="types.d.ts" />
+        \\/*! license */
+        \\//missing space
+        \\/*missing space */
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.spaced_comment.id));
+}
+
 test "can disable spaced-comment" {
     const source =
         \\//missing space


### PR DESCRIPTION
## Summary
- parse `markers` from the third `spaced-comment` config object
- allow configured marker prefixes such as `///` and `/*!` before applying normal spacing checks
- document the expanded spaced-comment option support

Reference: https://eslint.org/docs/latest/rules/spaced-comment

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/spaced_comment.zig tests/rules/spaced_comment.zig`
- `git diff --check`