### PR TITLE
support spaced-comment exceptions option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -177,7 +177,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Implemented |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
-| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, and `markers` configuration |
+| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1284,6 +1284,7 @@ pub const Options = struct {
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
     spaced_comment_markers: SpacedCommentMarkers = .{},
+    spaced_comment_exceptions: SpacedCommentMarkers = .{},
     symbol_description: bool = true,
     typescript_eslint_adjacent_overload_signatures: bool = true,
     typescript_eslint_array_type: bool = true,
@@ -1828,6 +1829,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "spaced-comment")) {
             self.spaced_comment_style = try spacedCommentStyleFromConfig(value);
             self.spaced_comment_markers = try spacedCommentMarkersFromConfig(value);
+            self.spaced_comment_exceptions = try spacedCommentExceptionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "wrap-iife")) {
             self.wrap_iife_style = try wrapIifeStyleFromConfig(value);
@@ -3700,6 +3702,14 @@ pub const Options = struct {
     }
 
     fn spacedCommentMarkersFromConfig(value: std.json.Value) RuleConfigError!SpacedCommentMarkers {
+        return spacedCommentPatternsFromConfig(value, "markers");
+    }
+
+    fn spacedCommentExceptionsFromConfig(value: std.json.Value) RuleConfigError!SpacedCommentMarkers {
+        return spacedCommentPatternsFromConfig(value, "exceptions");
+    }
+
+    fn spacedCommentPatternsFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!SpacedCommentMarkers {
         const items = switch (value) {
             .array => |array| array.items,
             else => return .{},
@@ -3710,21 +3720,21 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        const markers_value = config.get("markers") orelse return .{};
-        const marker_items = switch (markers_value) {
+        const patterns_value = config.get(key) orelse return .{};
+        const pattern_items = switch (patterns_value) {
             .array => |array| array.items,
             else => return error.UnsupportedRuleConfigValue,
         };
 
-        var markers = SpacedCommentMarkers{};
-        for (marker_items) |item| {
-            const marker = switch (item) {
-                .string => |marker| marker,
+        var patterns = SpacedCommentMarkers{};
+        for (pattern_items) |item| {
+            const pattern = switch (item) {
+                .string => |pattern| pattern,
                 else => return error.UnsupportedRuleConfigValue,
             };
-            markers.append(marker) catch return error.UnsupportedRuleConfigValue;
+            patterns.append(pattern) catch return error.UnsupportedRuleConfigValue;
         }
-        return markers;
+        return patterns;
     }
 
     fn reactButtonHasTypeBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -5955,7 +5965,7 @@ test "Options can apply ESLint-style rule config values" {
     var spaced_comment_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\",{\"markers\":[\"/\",\"!\"]}]",
+        "[\"error\",\"never\",{\"markers\":[\"/\",\"!\"],\"exceptions\":[\"-\",\"+\"]}]",
         .{},
     );
     defer spaced_comment_config.deinit();
@@ -5965,6 +5975,9 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.spaced_comment_markers.matches("/ reference"));
     try std.testing.expect(options.spaced_comment_markers.matches("! license"));
     try std.testing.expect(!options.spaced_comment_markers.matches("# plain"));
+    try std.testing.expect(options.spaced_comment_exceptions.matches("- separator"));
+    try std.testing.expect(options.spaced_comment_exceptions.matches("+ separator"));
+    try std.testing.expect(!options.spaced_comment_exceptions.matches("# plain"));
 
     var wrap_iife_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -506,6 +506,7 @@ pub fn runBasic(
                 .never => .never,
             },
             .markers = options.spaced_comment_markers,
+            .exceptions = options.spaced_comment_exceptions,
         });
     }
     if (options.typescript_eslint_ban_ts_comment) {

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -15,6 +15,7 @@ pub const Style = enum {
 pub const Options = struct {
     style: Style = .always,
     markers: core.SpacedCommentMarkers = .{},
+    exceptions: core.SpacedCommentMarkers = .{},
 };
 
 pub fn run(
@@ -52,6 +53,7 @@ fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, options: Opti
     const index = spacingIndex(value, comment.type);
     if (index >= value.len) return true;
     if (options.markers.matches(value[index..])) return true;
+    if (options.style == .always and matchesException(options.exceptions, value[index..])) return true;
 
     return switch (options.style) {
         .always => isWhitespace(value[index]),
@@ -69,6 +71,24 @@ fn message(style: Style) []const u8 {
         .always => "Expected space or tab after comment marker.",
         .never => "Expected no space or tab after comment marker.",
     };
+}
+
+fn matchesException(exceptions: core.SpacedCommentMarkers, value: []const u8) bool {
+    for (0..exceptions.count) |index| {
+        if (matchesRepeatedException(value, exceptions.at(index))) return true;
+    }
+    return false;
+}
+
+fn matchesRepeatedException(value: []const u8, exception: []const u8) bool {
+    if (exception.len == 0) return false;
+
+    var index: usize = 0;
+    while (index + exception.len <= value.len and std.mem.eql(u8, value[index .. index + exception.len], exception)) {
+        index += exception.len;
+    }
+
+    return index > 0 and index == value.len;
 }
 
 fn isWhitespace(char: u8) bool {

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -98,6 +98,35 @@ test "supports configured spaced-comment markers" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.spaced_comment.id));
 }
 
+test "supports configured spaced-comment exceptions" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"exceptions\":[\"-\",\"+\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("spaced-comment", config.value);
+    options.no_inline_comments = false;
+    options.no_tabs = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\//----------------
+        \\//++++
+        \\//+ heading
+        \\//missing space
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.spaced_comment.id));
+}
+
 test "can disable spaced-comment" {
     const source =
         \\//missing space


### PR DESCRIPTION
## Summary
- parse spaced-comment top-level exceptions arrays from ESLint-style config
- allow always-mode comments made only of repeated configured exception strings
- document the newly supported spaced-comment option

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/spaced_comment.zig tests/rules/spaced_comment.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check