### PR TITLE
support eqeqeq smart option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -17,7 +17,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Implemented |
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
-| [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Implemented |
+| [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always`, `as-needed`, and `never` options |

--- a/src/core.zig
+++ b/src/core.zig
@@ -19,6 +19,7 @@ pub const Severity = enum {
 pub const EqeqeqStyle = enum {
     strict,
     allow_null,
+    smart,
 };
 
 pub const CurlyStyle = enum {
@@ -1906,6 +1907,7 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "always")) return .strict;
         if (std.mem.eql(u8, style, "allow-null")) return .allow_null;
+        if (std.mem.eql(u8, style, "smart")) return .smart;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -5116,6 +5118,16 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("eqeqeq", eqeqeq_config.value);
     try std.testing.expect(options.eqeqeq);
     try std.testing.expectEqual(EqeqeqStyle.allow_null, options.eqeqeq_style);
+
+    var eqeqeq_smart_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"smart\"]",
+        .{},
+    );
+    defer eqeqeq_smart_config.deinit();
+    try options.setByRuleConfigValue("eqeqeq", eqeqeq_smart_config.value);
+    try std.testing.expectEqual(EqeqeqStyle.smart, options.eqeqeq_style);
 
     var accessor_pairs_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/eqeqeq.zig
+++ b/src/rules/eqeqeq.zig
@@ -35,6 +35,7 @@ pub fn checkWithOptions(
     {
         return;
     }
+    if (options.style == .smart and isSmartException(tree, expression)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -46,10 +47,46 @@ pub fn checkWithOptions(
     );
 }
 
+fn isSmartException(tree: *const ast.Tree, expression: ast.BinaryExpression) bool {
+    if (isNullLiteral(tree, expression.left) or isNullLiteral(tree, expression.right)) return true;
+    if (isTypeofExpression(tree, expression.left) or isTypeofExpression(tree, expression.right)) return true;
+    const left_kind = literalKind(tree, expression.left) orelse return false;
+    const right_kind = literalKind(tree, expression.right) orelse return false;
+    return left_kind == right_kind;
+}
+
 fn isNullLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .null_literal => true,
         else => false,
+    };
+}
+
+fn isTypeofExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |unary| unary.operator == .typeof,
+        else => false,
+    };
+}
+
+const LiteralKind = enum {
+    bigint,
+    boolean,
+    null,
+    number,
+    object,
+    string,
+};
+
+fn literalKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralKind {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .bigint_literal => .bigint,
+        .boolean_literal => .boolean,
+        .null_literal => .null,
+        .numeric_literal => .number,
+        .regexp_literal => .object,
+        .string_literal => .string,
+        else => null,
     };
 }
 

--- a/tests/rules/eqeqeq.zig
+++ b/tests/rules/eqeqeq.zig
@@ -47,3 +47,36 @@ test "supports configured eqeqeq allow-null style" {
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.eqeqeq.id));
 }
+
+test "supports configured eqeqeq smart style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"smart\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("eqeqeq", config.value);
+    options.no_eq_null = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (value == null) { use(value); }
+        \\if (typeof value == "undefined") { use(value); }
+        \\if ("number" != typeof value) { use(value); }
+        \\if (1 == 1) { use(value); }
+        \\if (true != false) { use(value); }
+        \\if ("text" == 1) { use(value); }
+        \\if (value == 1) { use(value); }
+        \\if (value != other) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.eqeqeq.id));
+}


### PR DESCRIPTION
## Summary
- parse the ESLint `eqeqeq` `smart` option
- skip eqeqeq diagnostics for smart-mode null comparisons, typeof comparisons, and same-type literal comparisons
- document the supported eqeqeq configurations

## Validation
- zig fmt --check src/core.zig src/rules/eqeqeq.zig tests/rules/eqeqeq.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check