### PR TITLE
support no-eval allowIndirect option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -64,7 +64,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-empty-pattern`](https://eslint.org/docs/latest/rules/no-empty-pattern) | Implemented |
 | [`no-empty-static-block`](https://eslint.org/docs/latest/rules/no-empty-static-block) | Implemented |
 | [`no-eq-null`](https://eslint.org/docs/latest/rules/no-eq-null) | Implemented |
-| [`no-eval`](https://eslint.org/docs/latest/rules/no-eval) | Implemented |
+| [`no-eval`](https://eslint.org/docs/latest/rules/no-eval) | Supports `allowIndirect` configuration |
 | [`no-ex-assign`](https://eslint.org/docs/latest/rules/no-ex-assign) | Implemented |
 | [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Implemented |
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -966,6 +966,7 @@ pub const Options = struct {
     no_else_return_allow_else_if: bool = true,
     no_eq_null: bool = true,
     no_eval: bool = true,
+    no_eval_allow_indirect: bool = false,
     no_ex_assign: bool = true,
     no_extend_native: bool = true,
     no_extra_bind: bool = true,
@@ -1541,6 +1542,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-empty-function")) {
             self.no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-eval")) {
+            self.no_eval_allow_indirect = try noEvalAllowIndirectFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
             self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
@@ -3564,6 +3568,23 @@ pub const Options = struct {
         };
     }
 
+    fn noEvalAllowIndirectFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowIndirect") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noUnneededTernaryDefaultAssignmentFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -5326,6 +5347,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-empty", no_empty_config.value);
     try std.testing.expect(options.no_empty);
     try std.testing.expectEqual(NoEmptyAllowEmptyCatch.yes, options.no_empty_allow_empty_catch);
+
+    var no_eval_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowIndirect\":true}]",
+        .{},
+    );
+    defer no_eval_config.deinit();
+    try options.setByRuleConfigValue("no-eval", no_eval_config.value);
+    try std.testing.expect(options.no_eval);
+    try std.testing.expect(options.no_eval_allow_indirect);
 
     var no_empty_function_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -15,6 +15,7 @@ pub fn run(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
     check_no_eval: bool,
+    no_eval_allow_indirect: bool,
     check_no_alert: bool,
     check_no_implied_eval: bool,
 ) Allocator.Error!void {
@@ -25,6 +26,7 @@ pub fn run(
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
         .check_no_eval = check_no_eval,
+        .no_eval_allow_indirect = no_eval_allow_indirect,
         .check_no_alert = check_no_alert,
         .check_no_implied_eval = check_no_implied_eval,
     };
@@ -37,6 +39,7 @@ const Visitor = struct {
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
     check_no_eval: bool,
+    no_eval_allow_indirect: bool,
     check_no_alert: bool,
     check_no_implied_eval: bool,
 
@@ -46,7 +49,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (self.check_no_eval and isEvalCall(ctx.tree, self.symbol_table, call.callee)) {
+        if (self.check_no_eval and isEvalCall(ctx.tree, self.symbol_table, call.callee, self.no_eval_allow_indirect)) {
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,
@@ -95,6 +98,7 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (!self.check_no_eval) return .proceed;
+        if (self.no_eval_allow_indirect) return .proceed;
         if (!std.mem.eql(u8, ctx.tree.string(identifier.name), "eval")) return .proceed;
         if (isCallCalleeReference(ctx.tree, index, ctx)) return .proceed;
 
@@ -115,12 +119,15 @@ fn isEvalCall(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
     callee: ast.NodeIndex,
+    allow_indirect: bool,
 ) bool {
     const unwrapped = unwrapTransparent(tree, callee);
 
     if (identifierReferenceName(tree, unwrapped)) |name| {
         return std.mem.eql(u8, name, "eval");
     }
+
+    if (allow_indirect) return false;
 
     switch (tree.data(unwrapped)) {
         .sequence_expression => |sequence| {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -742,6 +742,7 @@ pub fn runSemantic(
             tree,
             semantic_result.symbol_table,
             options.no_eval,
+            options.no_eval_allow_indirect,
             options.no_alert,
             options.no_implied_eval,
         );

--- a/tests/rules/no_eval.zig
+++ b/tests/rules/no_eval.zig
@@ -73,6 +73,40 @@ test "does not report no-eval for non-global eval members" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_eval.id));
 }
 
+test "supports configured no-eval allowIndirect option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowIndirect\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-eval", config.value);
+    options.no_comma_operator = false;
+    options.no_sequences = false;
+    options.no_var = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\eval("code");
+        \\(eval)("code");
+        \\(0, eval)("code");
+        \\globalThis["eval"]("code");
+        \\globalThis[`eval`]("code");
+        \\var evalAlias = eval;
+        \\foo(eval);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_eval.id));
+}
+
 test "can disable no-eval" {
     const source =
         \\eval("code");


### PR DESCRIPTION
## Summary
- parse the ESLint `no-eval` `allowIndirect` option
- keep direct `eval(...)` calls reported while allowing indirect eval calls and references when configured
- document the supported no-eval option

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/global_call_checks.zig tests/rules/no_eval.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check