### PR TITLE
support valid-typeof requireStringLiterals option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -181,7 +181,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |
-| [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Implemented |
+| [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented for `never` and optional `always` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1376,6 +1376,7 @@ pub const Options = struct {
     typescript_eslint_restrict_plus_operands_allow_number_and_string: bool = false,
     parser_semantic_errors: bool = true,
     valid_typeof: bool = true,
+    valid_typeof_require_string_literals: bool = false,
     vars_on_top: bool = true,
     wrap_iife: bool = true,
     wrap_iife_style: WrapIifeStyle = .outside,
@@ -1830,6 +1831,9 @@ pub const Options = struct {
             self.no_warning_comments_location = try noWarningCommentsLocationFromConfig(value);
             self.no_warning_comments_decoration = try noWarningCommentsDecorationFromConfig(value);
             self.no_warning_comments_terms = try noWarningCommentsTermsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "valid-typeof")) {
+            self.valid_typeof_require_string_literals = try validTypeofRequireStringLiteralsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "spaced-comment")) {
             self.spaced_comment_style = try spacedCommentStyleFromConfig(value);
@@ -3722,6 +3726,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "always")) return .always;
         if (std.mem.eql(u8, style, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn validTypeofRequireStringLiteralsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("requireStringLiterals") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn spacedCommentMarkersFromConfig(value: std.json.Value) RuleConfigError!SpacedCommentMarkers {
@@ -6005,6 +6026,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(@as(usize, 2), options.no_warning_comments_terms.len());
     try std.testing.expectEqualStrings("review", options.no_warning_comments_terms.at(0));
     try std.testing.expectEqualStrings("blocked by upstream", options.no_warning_comments_terms.at(1));
+
+    var valid_typeof_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"requireStringLiterals\":true}]",
+        .{},
+    );
+    defer valid_typeof_config.deinit();
+    try options.setByRuleConfigValue("valid-typeof", valid_typeof_config.value);
+    try std.testing.expect(options.valid_typeof);
+    try std.testing.expect(options.valid_typeof_require_string_literals);
 
     var spaced_comment_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2477,7 +2477,9 @@ const BasicVisitor = struct {
             try use_isnan.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.valid_typeof) {
-            try valid_typeof.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try valid_typeof.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .require_string_literals = self.options.valid_typeof_require_string_literals,
+            });
         }
         if (self.options.no_useless_concat) {
             try no_useless_concat.check(self.allocator, self.diagnostics, ctx.tree, expression, index);

--- a/src/rules/valid_typeof.zig
+++ b/src/rules/valid_typeof.zig
@@ -7,12 +7,27 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "valid-typeof";
 
+pub const Options = struct {
+    require_string_literals: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (!isTypeofComparisonOperator(expression.operator)) return;
 
@@ -21,17 +36,18 @@ pub fn check(
     if (left_typeof == right_typeof) return;
 
     const value_index = if (left_typeof) expression.right else expression.left;
-    switch (comparisonValueState(tree, value_index)) {
+    const message = switch (comparisonValueState(tree, value_index, options.require_string_literals)) {
         .valid, .unknown => return,
-        .invalid => {},
-    }
+        .invalid => "Invalid typeof comparison value.",
+        .not_string => "Typeof comparisons should be to string literals.",
+    };
 
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .@"error",
         id,
-        "Invalid typeof comparison value.",
+        message,
         tree.span(index),
     );
 }
@@ -39,6 +55,7 @@ pub fn check(
 const ComparisonValueState = enum {
     valid,
     invalid,
+    not_string,
     unknown,
 };
 
@@ -72,7 +89,7 @@ fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     };
 }
 
-fn comparisonValueState(tree: *const ast.Tree, index: ast.NodeIndex) ComparisonValueState {
+fn comparisonValueState(tree: *const ast.Tree, index: ast.NodeIndex, require_string_literals: bool) ComparisonValueState {
     if (index == .null) return .unknown;
 
     const unwrapped = unwrapTransparent(tree, index);
@@ -81,14 +98,16 @@ fn comparisonValueState(tree: *const ast.Tree, index: ast.NodeIndex) ComparisonV
     }
 
     return switch (tree.data(unwrapped)) {
-        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined")) .invalid else .unknown,
+        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined"))
+            if (require_string_literals) .not_string else .invalid
+        else if (require_string_literals) .not_string else .unknown,
         .null_literal,
         .boolean_literal,
         .numeric_literal,
         .bigint_literal,
         .regexp_literal,
         => .invalid,
-        else => .unknown,
+        else => if (require_string_literals) .not_string else .unknown,
     };
 }
 

--- a/tests/rules/valid_typeof.zig
+++ b/tests/rules/valid_typeof.zig
@@ -53,6 +53,38 @@ test "does not report valid-typeof for valid values or unrelated comparisons" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.valid_typeof.id));
 }
 
+test "supports configured valid-typeof requireStringLiterals option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"requireStringLiterals\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("valid-typeof", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const suffix = "ing";
+        \\if (typeof value === "string") { use(value); }
+        \\if (typeof value === `number`) { use(value); }
+        \\if (typeof value === typeof other) { use(value); }
+        \\if (typeof value === expectedType) { use(value); }
+        \\if (typeof value === `str${suffix}`) { use(value); }
+        \\if (typeof value === undefined) { use(value); }
+        \\if (typeof value === 1) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.valid_typeof.id));
+}
+
 test "can disable valid-typeof" {
     const source =
         \\if (typeof value === "strnig") { use(value); }


### PR DESCRIPTION
## Summary
- parse the ESLint `valid-typeof` `requireStringLiterals` option
- report non-string-literal typeof comparison values when the option is enabled
- document the supported valid-typeof configuration

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/valid_typeof.zig tests/rules/valid_typeof.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check