### PR TITLE
support no-useless-rename ignore options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -153,7 +153,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Implemented |
-| [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Implemented |
+| [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1145,6 +1145,9 @@ pub const Options = struct {
     no_useless_catch: bool = true,
     no_useless_escape: bool = true,
     no_useless_rename: bool = true,
+    no_useless_rename_ignore_destructuring: bool = false,
+    no_useless_rename_ignore_import: bool = false,
+    no_useless_rename_ignore_export: bool = false,
     no_unused_expressions: bool = true,
     no_unused_expressions_allow_short_circuit: NoUnusedExpressionsAllowShortCircuit = .no,
     no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .no,
@@ -1590,6 +1593,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-useless-rename")) {
+            self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
+            self.no_useless_rename_ignore_import = try noUselessRenameBoolOptionFromConfig(value, "ignoreImport");
+            self.no_useless_rename_ignore_export = try noUselessRenameBoolOptionFromConfig(value, "ignoreExport");
         }
         if (std.mem.eql(u8, cli_name, "no-shadow")) {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -3584,6 +3592,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowIndirect") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noUselessRenameBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -5748,6 +5773,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("radix", radix_config.value);
     try std.testing.expect(options.radix);
     try std.testing.expectEqual(RadixStyle.as_needed, options.radix_style);
+
+    var no_useless_rename_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreDestructuring\":true,\"ignoreImport\":true,\"ignoreExport\":true}]",
+        .{},
+    );
+    defer no_useless_rename_config.deinit();
+    try options.setByRuleConfigValue("no-useless-rename", no_useless_rename_config.value);
+    try std.testing.expect(options.no_useless_rename);
+    try std.testing.expect(options.no_useless_rename_ignore_destructuring);
+    try std.testing.expect(options.no_useless_rename_ignore_import);
+    try std.testing.expect(options.no_useless_rename_ignore_export);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_useless_rename.zig
+++ b/src/rules/no_useless_rename.zig
@@ -7,6 +7,12 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-useless-rename";
 
+pub const Options = struct {
+    ignore_destructuring: bool = false,
+    ignore_import: bool = false,
+    ignore_export: bool = false,
+};
+
 pub fn checkImportSpecifier(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,6 +20,18 @@ pub fn checkImportSpecifier(
     specifier: ast.ImportSpecifier,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkImportSpecifierWithOptions(allocator, diagnostics, tree, specifier, index, .{});
+}
+
+pub fn checkImportSpecifierWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportSpecifier,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_import) return;
     if (!hasAsBetween(tree, specifier.imported, specifier.local)) return;
 
     const imported = propertyName(tree, specifier.imported) orelse return;
@@ -30,6 +48,18 @@ pub fn checkExportSpecifier(
     specifier: ast.ExportSpecifier,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkExportSpecifierWithOptions(allocator, diagnostics, tree, specifier, index, .{});
+}
+
+pub fn checkExportSpecifierWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ExportSpecifier,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_export) return;
     if (!hasAsBetween(tree, specifier.local, specifier.exported)) return;
 
     const local = referenceOrPropertyName(tree, specifier.local) orelse return;
@@ -45,6 +75,17 @@ pub fn checkObjectPattern(
     tree: *const ast.Tree,
     pattern: ast.ObjectPattern,
 ) Allocator.Error!void {
+    try checkObjectPatternWithOptions(allocator, diagnostics, tree, pattern, .{});
+}
+
+pub fn checkObjectPatternWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_destructuring) return;
     for (tree.extra(pattern.properties)) |property_index| {
         const property = switch (tree.data(property_index)) {
             .binding_property => |property| property,
@@ -66,6 +107,17 @@ pub fn checkAssignmentExpression(
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
 ) Allocator.Error!void {
+    try checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, .{});
+}
+
+pub fn checkAssignmentExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_destructuring) return;
     if (expression.operator != .assign) return;
 
     switch (tree.data(unwrapTransparent(tree, expression.left))) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1019,6 +1019,14 @@ const BasicVisitor = struct {
         };
     }
 
+    fn noUselessRenameOptions(self: *const BasicVisitor) no_useless_rename.Options {
+        return .{
+            .ignore_destructuring = self.options.no_useless_rename_ignore_destructuring,
+            .ignore_import = self.options.no_useless_rename_ignore_import,
+            .ignore_export = self.options.no_useless_rename_ignore_export,
+        };
+    }
+
     fn noBitwiseOptions(self: *const BasicVisitor) no_bitwise.Options {
         return .{
             .allow_bitwise_and = self.options.no_bitwise_allow_bitwise_and,
@@ -2394,7 +2402,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.no_useless_rename) {
-            try no_useless_rename.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+            try no_useless_rename.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, self.noUselessRenameOptions());
         }
         if (self.options.no_self_assign) {
             try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
@@ -3148,7 +3156,7 @@ const BasicVisitor = struct {
             try no_empty_pattern.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, index);
         }
         if (self.options.no_useless_rename) {
-            try no_useless_rename.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+            try no_useless_rename.checkObjectPatternWithOptions(self.allocator, self.diagnostics, ctx.tree, pattern, self.noUselessRenameOptions());
         }
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
@@ -3361,7 +3369,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_rename) {
-            try no_useless_rename.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, index);
+            try no_useless_rename.checkImportSpecifierWithOptions(self.allocator, self.diagnostics, ctx.tree, specifier, index, self.noUselessRenameOptions());
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
@@ -3400,7 +3408,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_rename) {
-            try no_useless_rename.checkExportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, index);
+            try no_useless_rename.checkExportSpecifierWithOptions(self.allocator, self.diagnostics, ctx.tree, specifier, index, self.noUselessRenameOptions());
         }
         return .proceed;
     }

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -40,6 +40,34 @@ test "does not report no-useless-rename for meaningful aliases or shorthand" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_rename.id));
 }
 
+test "supports configured no-useless-rename ignore options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreDestructuring\":true,\"ignoreImport\":true,\"ignoreExport\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-useless-rename", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\import { foo as foo } from "mod";
+        \\export { foo as foo };
+        \\const { bar: bar, baz: baz = fallback } = source;
+        \\({ qux: qux } = source);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_rename.id));
+}
+
 test "can disable no-useless-rename" {
     const source =
         \\import { foo as foo } from "mod";


### PR DESCRIPTION
## Summary
- parse ESLint `no-useless-rename` ignore options for destructuring, imports, and exports
- pass those options through the root visitor to each no-useless-rename check
- document the supported no-useless-rename configuration

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/no_useless_rename.zig tests/rules/no_useless_rename.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check