### PR TITLE
support object-shorthand ignoreConstructors option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -159,7 +159,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
-| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Implemented |
+| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, and `ignoreConstructors` configuration |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1167,6 +1167,7 @@ pub const Options = struct {
     object_shorthand: bool = true,
     object_shorthand_style: ObjectShorthandStyle = .always,
     object_shorthand_avoid_quotes: bool = false,
+    object_shorthand_ignore_constructors: bool = false,
     one_var: bool = true,
     one_var_check_var: bool = true,
     one_var_check_let: bool = true,
@@ -1663,6 +1664,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "object-shorthand")) {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
             self.object_shorthand_avoid_quotes = try objectShorthandAvoidQuotesFromConfig(value);
+            self.object_shorthand_ignore_constructors = try objectShorthandIgnoreConstructorsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "one-var")) {
             const config = try oneVarNeverConfigFromConfig(value);
@@ -3469,6 +3471,14 @@ pub const Options = struct {
     }
 
     fn objectShorthandAvoidQuotesFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return objectShorthandBoolOptionFromConfig(value, "avoidQuotes");
+    }
+
+    fn objectShorthandIgnoreConstructorsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return objectShorthandBoolOptionFromConfig(value, "ignoreConstructors");
+    }
+
+    fn objectShorthandBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return false,
@@ -3484,7 +3494,7 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("avoidQuotes") orelse return false) {
+        return switch (config.get(key) orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -5703,7 +5713,7 @@ test "Options can apply ESLint-style rule config values" {
     var object_shorthand_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"methods\",{\"avoidQuotes\":true}]",
+        "[\"error\",\"methods\",{\"avoidQuotes\":true,\"ignoreConstructors\":true}]",
         .{},
     );
     defer object_shorthand_config.deinit();
@@ -5711,6 +5721,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.object_shorthand);
     try std.testing.expectEqual(ObjectShorthandStyle.methods, options.object_shorthand_style);
     try std.testing.expect(options.object_shorthand_avoid_quotes);
+    try std.testing.expect(options.object_shorthand_ignore_constructors);
 
     var operator_assignment_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -10,6 +10,7 @@ pub const id = "object-shorthand";
 pub const Options = struct {
     style: core.ObjectShorthandStyle = .always,
     avoid_quotes: bool = false,
+    ignore_constructors: bool = false,
 };
 
 pub fn check(
@@ -47,6 +48,7 @@ pub fn checkWithOptions(
     if (options.avoid_quotes and isStringLiteralKey(tree, property.key)) return;
 
     const shorthand_kind = shorthandKind(tree, property) orelse return;
+    if (options.ignore_constructors and shorthand_kind == .method and isConstructorKey(tree, property.key)) return;
     if (!styleAllowsKind(options.style, shorthand_kind)) return;
 
     try addDiagnostic(allocator, diagnostics, tree, index, shorthand_kind, options.style);
@@ -105,6 +107,15 @@ fn isStringLiteralKey(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .string_literal => true,
         else => false,
     };
+}
+
+fn isConstructorKey(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const name = propertyKeyName(tree, index) orelse return false;
+    for (name) |char| {
+        if (char == '_' or char == '$' or (char >= '0' and char <= '9')) continue;
+        return std.ascii.toUpper(char) == char;
+    }
+    return false;
 }
 
 fn propertyKeyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3116,6 +3116,7 @@ const BasicVisitor = struct {
             try object_shorthand.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, property, index, .{
                 .style = self.options.object_shorthand_style,
                 .avoid_quotes = self.options.object_shorthand_avoid_quotes,
+                .ignore_constructors = self.options.object_shorthand_ignore_constructors,
             });
         }
         if (self.options.func_name_matching) {

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -188,6 +188,50 @@ test "supports configured object-shorthand avoidQuotes option" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
 }
 
+test "supports configured object-shorthand ignoreConstructors option" {
+    const source =
+        \\const obj = {
+        \\  ConstructorFunction: function () {
+        \\    return this.value;
+        \\  },
+        \\  $1_ConstructorFunction: function () {
+        \\    return this.value;
+        \\  },
+        \\  ordinaryFunction: function () {
+        \\    return 1;
+        \\  },
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(default_result, lint.rules.object_shorthand.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"ignoreConstructors\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
 test "can disable object-shorthand" {
     const source =
         \\const obj = {


### PR DESCRIPTION
## Summary
- parse object-shorthand ignoreConstructors from ESLint-style rule config
- skip constructor-named anonymous function properties when method shorthand is required
- document the supported object-shorthand configuration and add regression coverage

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/object_shorthand.zig tests/rules/object_shorthand.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check