### PR TITLE
support func-names generators option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -20,7 +20,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |
-| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Implemented for `always`, `as-needed`, and `never` options |
+| [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Supports `always`, `as-needed`, `never`, and `generators` configuration |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -898,6 +898,8 @@ pub const Options = struct {
     func_name_matching_style: FuncNameMatchingStyle = .always,
     func_names: bool = true,
     func_names_style: FuncNamesStyle = .always,
+    func_names_has_generator_style: bool = false,
+    func_names_generator_style: FuncNamesStyle = .always,
     getter_return: bool = true,
     grouped_accessor_pairs: bool = true,
     grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,
@@ -1498,6 +1500,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "func-names")) {
             self.func_names_style = try funcNamesStyleFromConfig(value);
+            const generator_style = try funcNamesGeneratorStyleFromConfig(value);
+            self.func_names_has_generator_style = generator_style != null;
+            self.func_names_generator_style = generator_style orelse self.func_names_style;
         }
         if (std.mem.eql(u8, cli_name, "grouped-accessor-pairs")) {
             self.grouped_accessor_pairs_style = try groupedAccessorPairsStyleFromConfig(value);
@@ -2133,6 +2138,27 @@ pub const Options = struct {
         if (items.len < 2) return .always;
 
         const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always")) return .always;
+        if (std.mem.eql(u8, style, "as-needed")) return .as_needed;
+        if (std.mem.eql(u8, style, "never")) return .never;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn funcNamesGeneratorStyleFromConfig(value: std.json.Value) RuleConfigError!?FuncNamesStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 3) return null;
+
+        const config = switch (items[2]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const style = switch (config.get("generators") orelse return null) {
             .string => |style| style,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -5263,13 +5289,15 @@ test "Options can apply ESLint-style rule config values" {
     var func_names_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\"]",
+        "[\"error\",\"never\",{\"generators\":\"as-needed\"}]",
         .{},
     );
     defer func_names_config.deinit();
     try options.setByRuleConfigValue("func-names", func_names_config.value);
     try std.testing.expect(options.func_names);
     try std.testing.expectEqual(FuncNamesStyle.never, options.func_names_style);
+    try std.testing.expect(options.func_names_has_generator_style);
+    try std.testing.expectEqual(FuncNamesStyle.as_needed, options.func_names_generator_style);
 
     var grouped_accessor_pairs_get_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1040,6 +1040,19 @@ const BasicVisitor = struct {
         };
     }
 
+    fn funcNamesStyle(self: *const BasicVisitor, function: ast.Function) func_names.Style {
+        const style = if (function.generator and self.options.func_names_has_generator_style)
+            self.options.func_names_generator_style
+        else
+            self.options.func_names_style;
+
+        return switch (style) {
+            .always => .always,
+            .as_needed => .as_needed,
+            .never => .never,
+        };
+    }
+
     pub fn enter_node(
         self: *BasicVisitor,
         data: ast.NodeData,
@@ -1172,11 +1185,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_names) {
-            try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, switch (self.options.func_names_style) {
-                .always => .always,
-                .as_needed => .as_needed,
-                .never => .never,
-            });
+            try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, self.funcNamesStyle(function));
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);

--- a/tests/rules/func_names.zig
+++ b/tests/rules/func_names.zig
@@ -168,6 +168,73 @@ test "reports func-names never for named function expressions" {
     try std.testing.expectEqualStrings("Unexpected named function.", result.diagnostics[0].message);
 }
 
+test "supports configured func-names generators option" {
+    const source =
+        \\const regular = function () {
+        \\  return value;
+        \\};
+        \\const inferredGenerator = function* () {
+        \\  yield value;
+        \\};
+        \\(function* () {
+        \\  yield value;
+        \\})();
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"generators\":\"as-needed\"}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    };
+    try options.setByRuleConfigValue("func-names", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.func_names.id));
+}
+
+test "supports configured func-names generators never option" {
+    const source =
+        \\const regular = function () {
+        \\  return value;
+        \\};
+        \\const generator = function* namedGenerator() {
+        \\  yield value;
+        \\};
+        \\const anonymousGenerator = function* () {
+        \\  yield value;
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"generators\":\"never\"}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .func_name_matching = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    };
+    try options.setByRuleConfigValue("func-names", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.func_names.id));
+}
+
 test "allows func-names never for anonymous expressions and declarations" {
     const source =
         \\function declaration() {


### PR DESCRIPTION
## Summary
- parse func-names `generators` style from ESLint-style rule config
- apply generator-specific `always`, `as-needed`, or `never` style when linting generator functions
- document the supported func-names configuration and add regression coverage

## Validation
- zig fmt --check src/core.zig src/rules/root.zig tests/rules/func_names.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check