### PR TITLE
support prefer-promise-reject-errors empty reject option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -168,7 +168,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
-| [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Implemented |
+| [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Supports `allowEmptyReject` configuration |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Implemented |
 | [`prefer-rest-params`](https://eslint.org/docs/latest/rules/prefer-rest-params) | Implemented |
 | [`prefer-spread`](https://eslint.org/docs/latest/rules/prefer-spread) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1196,6 +1196,7 @@ pub const Options = struct {
     prefer_numeric_literals: bool = true,
     prefer_object_has_own: bool = true,
     prefer_promise_reject_errors: bool = true,
+    prefer_promise_reject_errors_allow_empty_reject: bool = false,
     prefer_destructuring: bool = true,
     prefer_destructuring_variable_declarator_array: bool = true,
     prefer_destructuring_variable_declarator_object: bool = true,
@@ -1632,6 +1633,9 @@ pub const Options = struct {
             self.prefer_destructuring_assignment_expression_array = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "array", true);
             self.prefer_destructuring_assignment_expression_object = try preferDestructuringOptionFromConfig(value, "AssignmentExpression", "object", true);
             self.prefer_destructuring_enforce_for_renamed_properties = try preferDestructuringEnforceForRenamedPropertiesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "prefer-promise-reject-errors")) {
+            self.prefer_promise_reject_errors_allow_empty_reject = try preferPromiseRejectErrorsAllowEmptyRejectFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "radix")) {
             self.radix_style = try radixStyleFromConfig(value);
@@ -3248,6 +3252,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("enforceForRenamedProperties") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn preferPromiseRejectErrorsAllowEmptyRejectFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowEmptyReject") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -5801,6 +5822,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.prefer_destructuring_assignment_expression_array);
     try std.testing.expect(options.prefer_destructuring_assignment_expression_object);
     try std.testing.expect(options.prefer_destructuring_enforce_for_renamed_properties);
+
+    var prefer_promise_reject_errors_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowEmptyReject\":true}]",
+        .{},
+    );
+    defer prefer_promise_reject_errors_config.deinit();
+    try options.setByRuleConfigValue("prefer-promise-reject-errors", prefer_promise_reject_errors_config.value);
+    try std.testing.expect(options.prefer_promise_reject_errors);
+    try std.testing.expect(options.prefer_promise_reject_errors_allow_empty_reject);
 
     var radix_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -8,16 +8,31 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-promise-reject-errors";
 
+pub const Options = struct {
+    allow_empty_reject: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +42,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -35,7 +51,7 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (isGlobalPromiseRejectCall(ctx.tree, self.symbol_table, call)) {
-            try checkRejectArgument(self.allocator, self.diagnostics, ctx.tree, call.arguments, index);
+            try checkRejectArgument(self.allocator, self.diagnostics, ctx.tree, call.arguments, index, self.options);
         }
 
         return .proceed;
@@ -51,7 +67,7 @@ const Visitor = struct {
         const executor = promiseExecutor(ctx.tree, expression.arguments) orelse return .proceed;
         const reject_name = executorRejectName(ctx.tree, executor) orelse return .proceed;
 
-        try scanExecutor(self.allocator, self.diagnostics, ctx.tree, reject_name, executor);
+        try scanExecutor(self.allocator, self.diagnostics, ctx.tree, reject_name, executor, self.options);
         return .proceed;
     }
 };
@@ -115,10 +131,11 @@ fn scanExecutor(
     tree: *const ast.Tree,
     reject_name: []const u8,
     executor: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     switch (tree.data(executor)) {
-        .function => |function| try scanNode(allocator, diagnostics, tree, reject_name, function.body),
-        .arrow_function_expression => |arrow| try scanNode(allocator, diagnostics, tree, reject_name, arrow.body),
+        .function => |function| try scanNode(allocator, diagnostics, tree, reject_name, function.body, options),
+        .arrow_function_expression => |arrow| try scanNode(allocator, diagnostics, tree, reject_name, arrow.body, options),
         else => {},
     }
 }
@@ -129,21 +146,22 @@ fn scanNode(
     tree: *const ast.Tree,
     reject_name: []const u8,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
         .call_expression => |call| {
             if (isRejectCall(tree, reject_name, call)) {
-                try checkRejectArgument(allocator, diagnostics, tree, call.arguments, index);
+                try checkRejectArgument(allocator, diagnostics, tree, call.arguments, index, options);
             }
-            try scanChildren(allocator, diagnostics, tree, reject_name, call);
+            try scanChildren(allocator, diagnostics, tree, reject_name, call, options);
         },
         .function,
         .arrow_function_expression,
         .class,
         => return,
-        inline else => |node| try scanChildren(allocator, diagnostics, tree, reject_name, node),
+        inline else => |node| try scanChildren(allocator, diagnostics, tree, reject_name, node, options),
     }
 }
 
@@ -153,16 +171,17 @@ fn scanChildren(
     tree: *const ast.Tree,
     reject_name: []const u8,
     node: anytype,
+    options: Options,
 ) Allocator.Error!void {
     const T = @TypeOf(node);
     if (@typeInfo(T) != .@"struct") return;
 
     inline for (@typeInfo(T).@"struct".fields) |field| {
         if (field.type == ast.NodeIndex) {
-            try scanNode(allocator, diagnostics, tree, reject_name, @field(node, field.name));
+            try scanNode(allocator, diagnostics, tree, reject_name, @field(node, field.name), options);
         } else if (field.type == ast.IndexRange) {
             for (tree.extra(@field(node, field.name))) |child| {
-                try scanNode(allocator, diagnostics, tree, reject_name, child);
+                try scanNode(allocator, diagnostics, tree, reject_name, child, options);
             }
         }
     }
@@ -179,11 +198,26 @@ fn checkRejectArgument(
     tree: *const ast.Tree,
     arguments: ast.IndexRange,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
-    if (arguments.len == 0) return;
+    if (arguments.len == 0) {
+        if (!options.allow_empty_reject) {
+            try addDiagnostic(allocator, diagnostics, tree, index);
+        }
+        return;
+    }
     const argument = tree.extra(arguments)[0];
     if (!isInvalidRejectReason(tree, unwrapTransparent(tree, argument))) return;
 
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -17,6 +17,7 @@ pub fn run(
     check_no_async_promise_executor: bool,
     check_no_promise_executor_return: bool,
     check_prefer_promise_reject_errors: bool,
+    prefer_promise_reject_errors_allow_empty_reject: bool,
 ) Allocator.Error!void {
     if (!check_no_async_promise_executor and
         !check_no_promise_executor_return and
@@ -29,6 +30,7 @@ pub fn run(
         .check_no_async_promise_executor = check_no_async_promise_executor,
         .check_no_promise_executor_return = check_no_promise_executor_return,
         .check_prefer_promise_reject_errors = check_prefer_promise_reject_errors,
+        .prefer_promise_reject_errors_allow_empty_reject = prefer_promise_reject_errors_allow_empty_reject,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -41,6 +43,7 @@ const Visitor = struct {
     check_no_async_promise_executor: bool,
     check_no_promise_executor_return: bool,
     check_prefer_promise_reject_errors: bool,
+    prefer_promise_reject_errors_allow_empty_reject: bool,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -51,7 +54,14 @@ const Visitor = struct {
         if (self.check_prefer_promise_reject_errors and
             isPromiseRejectCall(ctx.tree, call))
         {
-            try checkRejectArgument(self.allocator, self.diagnostics, ctx.tree, call.arguments, index);
+            try checkRejectArgument(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                call.arguments,
+                index,
+                .{ .allow_empty_reject = self.prefer_promise_reject_errors_allow_empty_reject },
+            );
         }
 
         return .proceed;
@@ -90,7 +100,14 @@ const Visitor = struct {
             executor != null)
         {
             const reject_name = executorRejectName(ctx.tree, executor.?) orelse return .proceed;
-            try scanExecutorRejects(self.allocator, self.diagnostics, ctx.tree, reject_name, executor.?);
+            try scanExecutorRejects(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                reject_name,
+                executor.?,
+                .{ .allow_empty_reject = self.prefer_promise_reject_errors_allow_empty_reject },
+            );
         }
 
         return .proceed;
@@ -277,10 +294,11 @@ fn scanExecutorRejects(
     tree: *const ast.Tree,
     reject_name: []const u8,
     executor: ast.NodeIndex,
+    options: prefer_promise_reject_errors.Options,
 ) Allocator.Error!void {
     switch (tree.data(executor)) {
-        .function => |function| try scanRejectNode(allocator, diagnostics, tree, reject_name, function.body),
-        .arrow_function_expression => |arrow| try scanRejectNode(allocator, diagnostics, tree, reject_name, arrow.body),
+        .function => |function| try scanRejectNode(allocator, diagnostics, tree, reject_name, function.body, options),
+        .arrow_function_expression => |arrow| try scanRejectNode(allocator, diagnostics, tree, reject_name, arrow.body, options),
         else => {},
     }
 }
@@ -291,21 +309,22 @@ fn scanRejectNode(
     tree: *const ast.Tree,
     reject_name: []const u8,
     index: ast.NodeIndex,
+    options: prefer_promise_reject_errors.Options,
 ) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
         .call_expression => |call| {
             if (isRejectCall(tree, reject_name, call)) {
-                try checkRejectArgument(allocator, diagnostics, tree, call.arguments, index);
+                try checkRejectArgument(allocator, diagnostics, tree, call.arguments, index, options);
             }
-            try scanRejectChildren(allocator, diagnostics, tree, reject_name, call);
+            try scanRejectChildren(allocator, diagnostics, tree, reject_name, call, options);
         },
         .function,
         .arrow_function_expression,
         .class,
         => return,
-        inline else => |node| try scanRejectChildren(allocator, diagnostics, tree, reject_name, node),
+        inline else => |node| try scanRejectChildren(allocator, diagnostics, tree, reject_name, node, options),
     }
 }
 
@@ -315,16 +334,17 @@ fn scanRejectChildren(
     tree: *const ast.Tree,
     reject_name: []const u8,
     node: anytype,
+    options: prefer_promise_reject_errors.Options,
 ) Allocator.Error!void {
     const T = @TypeOf(node);
     if (@typeInfo(T) != .@"struct") return;
 
     inline for (@typeInfo(T).@"struct".fields) |field| {
         if (field.type == ast.NodeIndex) {
-            try scanRejectNode(allocator, diagnostics, tree, reject_name, @field(node, field.name));
+            try scanRejectNode(allocator, diagnostics, tree, reject_name, @field(node, field.name), options);
         } else if (field.type == ast.IndexRange) {
             for (tree.extra(@field(node, field.name))) |child| {
-                try scanRejectNode(allocator, diagnostics, tree, reject_name, child);
+                try scanRejectNode(allocator, diagnostics, tree, reject_name, child, options);
             }
         }
     }
@@ -340,11 +360,26 @@ fn checkRejectArgument(
     tree: *const ast.Tree,
     arguments: ast.IndexRange,
     index: ast.NodeIndex,
+    options: prefer_promise_reject_errors.Options,
 ) Allocator.Error!void {
-    if (arguments.len == 0) return;
+    if (arguments.len == 0) {
+        if (!options.allow_empty_reject) {
+            try addPreferPromiseRejectErrorsDiagnostic(allocator, diagnostics, tree, index);
+        }
+        return;
+    }
     const argument = tree.extra(arguments)[0];
     if (!isInvalidRejectReason(tree, unwrapTransparent(tree, argument))) return;
 
+    try addPreferPromiseRejectErrorsDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addPreferPromiseRejectErrorsDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -883,6 +883,7 @@ pub fn runSemantic(
             options.no_async_promise_executor,
             options.no_promise_executor_return,
             options.prefer_promise_reject_errors,
+            options.prefer_promise_reject_errors_allow_empty_reject,
         );
     }
 

--- a/tests/rules/prefer_promise_reject_errors.zig
+++ b/tests/rules/prefer_promise_reject_errors.zig
@@ -115,6 +115,54 @@ test "does not report prefer-promise-reject-errors for dynamic Promise members o
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_promise_reject_errors.id));
 }
 
+test "reports prefer-promise-reject-errors for empty reject calls by default" {
+    const source =
+        \\Promise.reject();
+        \\new Promise((resolve, reject) => {
+        \\  reject();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
+test "supports configured prefer-promise-reject-errors allowEmptyReject option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowEmptyReject\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("prefer-promise-reject-errors", config.value);
+
+    const source =
+        \\Promise.reject();
+        \\Promise.reject("failed");
+        \\new Promise((resolve, reject) => {
+        \\  reject();
+        \\  reject("failed");
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_promise_reject_errors.id));
+}
+
 test "can disable prefer-promise-reject-errors" {
     const source =
         \\Promise.reject("failed");


### PR DESCRIPTION
## Summary
- parse prefer-promise-reject-errors `allowEmptyReject` from ESLint-style rule config
- report empty `Promise.reject()` and executor `reject()` calls by default
- allow empty reject calls only when `allowEmptyReject: true` is configured

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/promise_checks.zig src/rules/prefer_promise_reject_errors.zig tests/rules/prefer_promise_reject_errors.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check