### PR TITLE
support prefer-regex-literals redundant wrapping option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -169,7 +169,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Supports `allowEmptyReject` configuration |
-| [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Implemented |
+| [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Supports `disallowRedundantWrapping` configuration |
 | [`prefer-rest-params`](https://eslint.org/docs/latest/rules/prefer-rest-params) | Implemented |
 | [`prefer-spread`](https://eslint.org/docs/latest/rules/prefer-spread) | Implemented |
 | [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1204,6 +1204,7 @@ pub const Options = struct {
     prefer_destructuring_assignment_expression_object: bool = true,
     prefer_destructuring_enforce_for_renamed_properties: bool = false,
     prefer_regex_literals: bool = true,
+    prefer_regex_literals_disallow_redundant_wrapping: bool = false,
     prefer_rest_params: bool = true,
     prefer_object_spread: bool = true,
     prefer_spread: bool = true,
@@ -1636,6 +1637,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "prefer-promise-reject-errors")) {
             self.prefer_promise_reject_errors_allow_empty_reject = try preferPromiseRejectErrorsAllowEmptyRejectFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "prefer-regex-literals")) {
+            self.prefer_regex_literals_disallow_redundant_wrapping = try preferRegexLiteralsDisallowRedundantWrappingFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "radix")) {
             self.radix_style = try radixStyleFromConfig(value);
@@ -3269,6 +3273,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowEmptyReject") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn preferRegexLiteralsDisallowRedundantWrappingFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("disallowRedundantWrapping") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -5833,6 +5854,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("prefer-promise-reject-errors", prefer_promise_reject_errors_config.value);
     try std.testing.expect(options.prefer_promise_reject_errors);
     try std.testing.expect(options.prefer_promise_reject_errors_allow_empty_reject);
+
+    var prefer_regex_literals_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"disallowRedundantWrapping\":true}]",
+        .{},
+    );
+    defer prefer_regex_literals_config.deinit();
+    try options.setByRuleConfigValue("prefer-regex-literals", prefer_regex_literals_config.value);
+    try std.testing.expect(options.prefer_regex_literals);
+    try std.testing.expect(options.prefer_regex_literals_disallow_redundant_wrapping);
 
     var radix_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/prefer_regex_literals.zig
+++ b/src/rules/prefer_regex_literals.zig
@@ -8,16 +8,31 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-regex-literals";
 
+pub const Options = struct {
+    disallow_redundant_wrapping: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +42,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -34,7 +50,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments)) {
+        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments, self.options)) {
             try self.report(ctx.tree, index);
         }
 
@@ -47,7 +63,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments)) {
+        if (isStaticRegExpConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments, self.options)) {
             try self.report(ctx.tree, index);
         }
 
@@ -71,12 +87,14 @@ fn isStaticRegExpConstructor(
     symbol_table: traverser.semantic.SymbolTable,
     callee: ast.NodeIndex,
     argument_range: ast.IndexRange,
+    options: Options,
 ) bool {
     const arguments = tree.extra(argument_range);
     if (arguments.len == 0 or arguments.len > 2) return false;
     if (!isGlobalRegExpReference(tree, symbol_table, callee)) return false;
 
     const pattern = arguments[0];
+    if (options.disallow_redundant_wrapping and isRedundantlyWrappedRegexLiteral(tree, arguments)) return true;
     if (!isStaticLiteral(tree, pattern)) return false;
 
     if (arguments.len == 2 and !isStaticLiteral(tree, arguments[1])) return false;
@@ -97,6 +115,18 @@ fn isStaticLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
         .template_literal => |literal| literal.expressions.len == 0,
+        else => false,
+    };
+}
+
+fn isRedundantlyWrappedRegexLiteral(tree: *const ast.Tree, arguments: []const ast.NodeIndex) bool {
+    if (!isRegexLiteral(tree, arguments[0])) return false;
+    return arguments.len == 1 or isStaticLiteral(tree, arguments[1]);
+}
+
+fn isRegexLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .regexp_literal => true,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -892,7 +892,9 @@ pub fn runSemantic(
     }
 
     if (options.prefer_regex_literals) {
-        try prefer_regex_literals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try prefer_regex_literals.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .disallow_redundant_wrapping = options.prefer_regex_literals_disallow_redundant_wrapping,
+        });
     }
 
     if (options.prefer_numeric_literals) {

--- a/tests/rules/prefer_regex_literals.zig
+++ b/tests/rules/prefer_regex_literals.zig
@@ -55,6 +55,47 @@ test "does not report prefer-regex-literals for dynamic patterns or shadowed Reg
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_regex_literals.id));
 }
 
+test "supports configured prefer-regex-literals disallowRedundantWrapping option" {
+    const source =
+        \\new RegExp(/abc/);
+        \\new RegExp(/abc/, "u");
+        \\RegExp(/abc/, `u`);
+        \\RegExp(/abc/, flags);
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.prefer_regex_literals.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"disallowRedundantWrapping\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .eol_last = false,
+        .no_new = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("prefer-regex-literals", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_regex_literals.id));
+}
+
 test "can disable prefer-regex-literals" {
     const source =
         \\RegExp("abc");


### PR DESCRIPTION
## Summary
- parse prefer-regex-literals `disallowRedundantWrapping` from ESLint-style rule config
- report redundant `RegExp(/pattern/)` wrapping when the option is enabled
- keep dynamic flags such as `RegExp(/pattern/, flags)` allowed

## Validation
- zig fmt --check src/core.zig src/rules/root.zig src/rules/prefer_regex_literals.zig tests/rules/prefer_regex_literals.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check