### PR TITLE
support no-use-before-define named export option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -144,6 +144,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
+| [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
@@ -296,7 +297,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
-| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, and `variables` configuration |
+| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1188,6 +1188,7 @@ pub const Options = struct {
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
+    no_use_before_define_allow_named_exports: bool = false,
     no_undef: bool = true,
     no_undef_typeof: bool = false,
     prefer_const: bool = true,
@@ -1376,6 +1377,7 @@ pub const Options = struct {
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
+    typescript_eslint_no_use_before_define_allow_named_exports: bool = false,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_no_wrapper_object_types: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
@@ -1673,6 +1675,7 @@ pub const Options = struct {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
             self.no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
             self.no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
+            self.no_use_before_define_allow_named_exports = try noUseBeforeDefineAllowNamedExportsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "object-shorthand")) {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
@@ -1846,6 +1849,7 @@ pub const Options = struct {
             self.typescript_eslint_no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", false);
             self.typescript_eslint_no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
             self.typescript_eslint_no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
+            self.typescript_eslint_no_use_before_define_allow_named_exports = try noUseBeforeDefineAllowNamedExportsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-void")) {
             self.no_void_allow_as_statement = try noVoidAllowAsStatementFromConfig(value);
@@ -3517,6 +3521,24 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enabled) .yes else .no;
+    }
+
+    fn noUseBeforeDefineAllowNamedExportsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            .string => return false,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowNamedExports") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn objectShorthandStyleFromConfig(value: std.json.Value) RuleConfigError!ObjectShorthandStyle {
@@ -6085,7 +6107,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":false,\"classes\":false,\"variables\":false}]",
+        "[\"error\",{\"functions\":false,\"classes\":false,\"variables\":false,\"allowNamedExports\":true}]",
         .{},
     );
     defer no_use_before_define_config.deinit();
@@ -6094,6 +6116,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_classes);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.no_use_before_define_check_variables);
+    try std.testing.expect(options.no_use_before_define_allow_named_exports);
 
     var no_use_before_define_nofunc_config = try std.json.parseFromSlice(
         std.json.Value,
@@ -6132,7 +6155,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false}]",
+        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false,\"allowNamedExports\":true}]",
         .{},
     );
     defer typescript_no_use_before_define_config.deinit();
@@ -6141,6 +6164,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUseBeforeDefineCheck.yes, options.typescript_eslint_no_use_before_define_check_functions);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_classes);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_variables);
+    try std.testing.expect(options.typescript_eslint_no_use_before_define_allow_named_exports);
 
     var no_void_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -10,6 +10,7 @@ pub const id = "no-use-before-define";
 
 const SymbolId = traverser.semantic.SymbolId;
 const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const NodeSet = std.AutoHashMap(ast.NodeIndex, void);
 
 pub const Options = struct {
     rule_id: []const u8 = id,
@@ -17,6 +18,7 @@ pub const Options = struct {
     check_functions: bool = true,
     check_classes: bool = true,
     check_variables: bool = true,
+    allow_named_exports: bool = false,
 };
 
 const InitRange = struct {
@@ -64,10 +66,21 @@ pub fn runWithOptions(
     try traverser.basic.traverse(InitVisitor, tree, &visitor);
     std.mem.sort(InitRange, init_ranges.items, {}, lessThanInitRange);
 
+    var named_export_refs = NodeSet.init(allocator);
+    defer named_export_refs.deinit();
+
+    if (options.allow_named_exports) {
+        var named_export_visitor = NamedExportVisitor{
+            .refs = &named_export_refs,
+        };
+        try traverser.basic.traverse(NamedExportVisitor, tree, &named_export_visitor);
+    }
+
     var reference_iter = symbol_table.iterReferences();
     while (reference_iter.next()) |entry| {
         const reference = entry.reference;
         if (reference.kind != .value) continue;
+        if (options.allow_named_exports and named_export_refs.contains(reference.node)) continue;
 
         const symbol_id = symbol_table.referenceSymbol(entry.id);
         if (symbol_id == .none) continue;
@@ -149,6 +162,31 @@ const InitVisitor = struct {
             },
             else => {},
         }
+    }
+};
+
+const NamedExportVisitor = struct {
+    refs: *NodeSet,
+
+    pub fn enter_export_specifier(
+        self: *NamedExportVisitor,
+        specifier: ast.ExportSpecifier,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (specifier.export_kind == .type) return .proceed;
+
+        if (ctx.path.parent()) |parent| {
+            const parent_data = ctx.tree.data(parent);
+            if (parent_data == .export_named_declaration and
+                parent_data.export_named_declaration.source == .null and
+                parent_data.export_named_declaration.export_kind != .type)
+            {
+                try self.refs.put(specifier.local, {});
+            }
+        }
+
+        return .proceed;
     }
 };
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -955,6 +955,7 @@ pub fn runSemantic(
             .check_functions = options.no_use_before_define_check_functions == .yes,
             .check_classes = options.no_use_before_define_check_classes == .yes,
             .check_variables = options.no_use_before_define_check_variables == .yes,
+            .allow_named_exports = options.no_use_before_define_allow_named_exports,
         });
     }
 
@@ -963,6 +964,7 @@ pub fn runSemantic(
             .check_functions = options.typescript_eslint_no_use_before_define_check_functions == .yes,
             .check_classes = options.typescript_eslint_no_use_before_define_check_classes == .yes,
             .check_variables = options.typescript_eslint_no_use_before_define_check_variables == .yes,
+            .allow_named_exports = options.typescript_eslint_no_use_before_define_allow_named_exports,
         });
     }
 

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -34,5 +34,6 @@ pub fn runWithOptions(
         .check_functions = options.check_functions,
         .check_classes = options.check_classes,
         .check_variables = options.check_variables,
+        .allow_named_exports = options.allow_named_exports,
     });
 }

--- a/tests/rules/no_use_before_define.zig
+++ b/tests/rules/no_use_before_define.zig
@@ -184,6 +184,52 @@ test "supports configured no-use-before-define variables false" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "supports configured no-use-before-define allowNamedExports" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowNamedExports\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-use-before-define", config.value);
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_use_before_define = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\export { allowed };
+        \\reported;
+        \\const allowed = 1;
+        \\const reported = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
+test "reports no-use-before-define named exports by default" {
+    const source =
+        \\export { reported };
+        \\const reported = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_use_before_define = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "can disable no-use-before-define" {
     const source =
         \\a;

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -126,6 +126,35 @@ test "supports configured @typescript-eslint/no-use-before-define variables fals
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
 }
 
+test "supports configured @typescript-eslint/no-use-before-define allowNamedExports" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowNamedExports\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", config.value);
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\export { allowed };
+        \\reported;
+        \\const allowed = 1;
+        \\const reported = 2;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+}
+
 test "can disable @typescript-eslint/no-use-before-define and fall back to core rule" {
     const source =
         \\f();


### PR DESCRIPTION
## Summary
- add allowNamedExports parsing for no-use-before-define and @typescript-eslint/no-use-before-define
- skip local named export specifier references when the option is enabled
- add core and TypeScript regression coverage plus rule-status docs

## Validation
- zig fmt --check src/core.zig src/rules/no_use_before_define.zig src/rules/typescript_eslint_no_use_before_define.zig src/rules/root.zig tests/rules/no_use_before_define.zig tests/rules/typescript_eslint_no_use_before_define.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check