### PR TITLE
support no-extend-native exceptions option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -66,7 +66,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-eq-null`](https://eslint.org/docs/latest/rules/no-eq-null) | Implemented |
 | [`no-eval`](https://eslint.org/docs/latest/rules/no-eval) | Supports `allowIndirect` configuration |
 | [`no-ex-assign`](https://eslint.org/docs/latest/rules/no-ex-assign) | Implemented |
-| [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Implemented |
+| [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Supports `exceptions` configuration |
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented |
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -393,6 +393,42 @@ pub const NoParamReassignIgnoredNames = struct {
     }
 };
 
+pub const max_no_extend_native_exceptions = 32;
+pub const max_no_extend_native_exception_len = 128;
+
+pub const NoExtendNativeExceptionsError = error{
+    EmptyNoExtendNativeException,
+    TooManyNoExtendNativeExceptions,
+    NoExtendNativeExceptionTooLong,
+};
+
+pub const NoExtendNativeExceptions = struct {
+    count: usize = 0,
+    lengths: [max_no_extend_native_exceptions]usize = undefined,
+    storage: [max_no_extend_native_exceptions][max_no_extend_native_exception_len]u8 = undefined,
+
+    pub fn contains(self: *const NoExtendNativeExceptions, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoExtendNativeExceptions, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoExtendNativeExceptions, name: []const u8) NoExtendNativeExceptionsError!void {
+        if (name.len == 0) return error.EmptyNoExtendNativeException;
+        if (self.count >= max_no_extend_native_exceptions) return error.TooManyNoExtendNativeExceptions;
+        if (name.len > max_no_extend_native_exception_len) return error.NoExtendNativeExceptionTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_no_shadow_allow_names = 32;
 pub const max_no_shadow_allow_name_len = 128;
 
@@ -971,6 +1007,7 @@ pub const Options = struct {
     no_eval_allow_indirect: bool = false,
     no_ex_assign: bool = true,
     no_extend_native: bool = true,
+    no_extend_native_exceptions: NoExtendNativeExceptions = .{},
     no_extra_bind: bool = true,
     no_extra_label: bool = true,
     no_extra_semi: bool = true,
@@ -1559,6 +1596,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-eval")) {
             self.no_eval_allow_indirect = try noEvalAllowIndirectFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-extend-native")) {
+            self.no_extend_native_exceptions = try noExtendNativeExceptionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
             self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
@@ -3697,6 +3737,34 @@ pub const Options = struct {
         };
     }
 
+    fn noExtendNativeExceptionsFromConfig(value: std.json.Value) RuleConfigError!NoExtendNativeExceptions {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const exceptions_value = config.get("exceptions") orelse return .{};
+        const exceptions_items = switch (exceptions_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var exceptions = NoExtendNativeExceptions{};
+        for (exceptions_items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            exceptions.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return exceptions;
+    }
+
     fn noUselessRenameBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -5506,6 +5574,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-eval", no_eval_config.value);
     try std.testing.expect(options.no_eval);
     try std.testing.expect(options.no_eval_allow_indirect);
+
+    var no_extend_native_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"exceptions\":[\"Array\",\"Object\"]}]",
+        .{},
+    );
+    defer no_extend_native_config.deinit();
+    try options.setByRuleConfigValue("no-extend-native", no_extend_native_config.value);
+    try std.testing.expect(options.no_extend_native);
+    try std.testing.expect(options.no_extend_native_exceptions.contains("Array"));
+    try std.testing.expect(options.no_extend_native_exceptions.contains("Object"));
+    try std.testing.expect(!options.no_extend_native_exceptions.contains("String"));
 
     var no_empty_function_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -8,15 +8,29 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-extend-native";
 
+pub const Options = struct {
+    exceptions: core.NoExtendNativeExceptions = .{},
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     _: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -25,6 +39,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    options: Options,
 
     pub fn enter_assignment_expression(
         self: *Visitor,
@@ -39,6 +54,7 @@ const Visitor = struct {
         if (left_member.optional) return .proceed;
 
         if (nativePrototypeName(ctx.tree, left_member.object, false)) |name| {
+            if (self.options.exceptions.contains(name)) return .proceed;
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 
@@ -57,6 +73,7 @@ const Visitor = struct {
         if (arguments.len == 0) return .proceed;
 
         if (nativePrototypeName(ctx.tree, arguments[0], true)) |name| {
+            if (self.options.exceptions.contains(name)) return .proceed;
             try report(self.allocator, self.diagnostics, ctx.tree, index, name);
         }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -732,7 +732,9 @@ pub fn runSemantic(
     }
 
     if (options.no_extend_native) {
-        try no_extend_native.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_extend_native.runWithOptions(allocator, diagnostics, tree, .{
+            .exceptions = options.no_extend_native_exceptions,
+        });
     }
 
     if (options.no_eval or options.no_alert or options.no_implied_eval) {

--- a/tests/rules/no_extend_native.zig
+++ b/tests/rules/no_extend_native.zig
@@ -99,6 +99,42 @@ test "does not report no-extend-native for ordinary objects or dynamic members" 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extend_native.id));
 }
 
+test "supports configured no-extend-native exceptions" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"exceptions\":[\"Array\",\"Object\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .dot_notation = false,
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+        .typescript_eslint_no_empty_function = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-extend-native", config.value);
+
+    const source =
+        \\Array.prototype.first = function () {};
+        \\Object.defineProperty(Object.prototype, "toJSON", {});
+        \\String.prototype.trimLeft = function () {};
+        \\Object.defineProperty(Date.prototype, "week", {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_extend_native.id));
+}
+
 test "can disable no-extend-native" {
     const source =
         \\String.prototype.trimLeft = function () {};


### PR DESCRIPTION
## Summary
- add no-extend-native exceptions parsing
- skip configured native constructors for prototype assignment and Object.defineProperty checks
- add regression coverage and update rule-status docs

## Validation
- zig fmt --check src/core.zig src/rules/no_extend_native.zig src/rules/root.zig tests/rules/no_extend_native.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check