### PR TITLE
support no-shadow hoist option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -128,6 +128,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-self-compare`](https://eslint.org/docs/latest/rules/no-self-compare) | Implemented |
 | [`no-sequences`](https://eslint.org/docs/latest/rules/no-sequences) | Implemented with optional `allowInParentheses` behavior |
 | [`no-setter-return`](https://eslint.org/docs/latest/rules/no-setter-return) | Implemented |
+| [`no-shadow`](https://eslint.org/docs/latest/rules/no-shadow) | Supports `allow`, `builtinGlobals`, and `hoist` configuration |
 | [`no-shadow-restricted-names`](https://eslint.org/docs/latest/rules/no-shadow-restricted-names) | Implemented |
 | [`no-sparse-arrays`](https://eslint.org/docs/latest/rules/no-sparse-arrays) | Implemented |
 | [`no-tabs`](https://eslint.org/docs/latest/rules/no-tabs) | Implemented |
@@ -285,7 +286,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
-| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Implemented |
+| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, and `hoist` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -336,6 +336,14 @@ pub const NoUseBeforeDefineCheck = enum {
     no,
 };
 
+pub const NoShadowHoist = enum {
+    all,
+    functions,
+    functions_and_types,
+    never,
+    types,
+};
+
 pub const NoUnusedVarsVars = enum {
     all,
     local,
@@ -1147,6 +1155,7 @@ pub const Options = struct {
     no_shadow: bool = true,
     no_shadow_allow: NoShadowAllowNames = .{},
     no_shadow_builtin_globals: bool = false,
+    no_shadow_hoist: NoShadowHoist = .functions,
     no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
     no_sequences_allow_in_parentheses: NoSequencesAllowInParentheses = .yes,
@@ -1384,6 +1393,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
+    typescript_eslint_no_shadow_hoist: NoShadowHoist = .functions_and_types,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
@@ -1652,6 +1662,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-shadow")) {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
             self.no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
+            self.no_shadow_hoist = try noShadowHoistFromConfig(value, .functions);
         }
         if (std.mem.eql(u8, cli_name, "no-underscore-dangle")) {
             self.no_underscore_dangle_allow_after_this = try noUnderscoreDangleBoolOptionFromConfig(value, "allowAfterThis", false);
@@ -1844,6 +1855,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
+            self.typescript_eslint_no_shadow_hoist = try noShadowHoistFromConfig(value, .functions_and_types);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/method-signature-style")) {
             self.typescript_eslint_method_signature_style_style = try typescriptEslintMethodSignatureStyleFromConfig(value);
@@ -3153,6 +3165,30 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noShadowHoistFromConfig(value: std.json.Value, default: NoShadowHoist) RuleConfigError!NoShadowHoist {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const hoist = switch (config.get("hoist") orelse return default) {
+            .string => |hoist| hoist,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        if (std.mem.eql(u8, hoist, "all")) return .all;
+        if (std.mem.eql(u8, hoist, "functions")) return .functions;
+        if (std.mem.eql(u8, hoist, "functions-and-types")) return .functions_and_types;
+        if (std.mem.eql(u8, hoist, "never")) return .never;
+        if (std.mem.eql(u8, hoist, "types")) return .types;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noUnderscoreDangleBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -5829,7 +5865,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"done\"],\"builtinGlobals\":true}]",
+        "[\"error\",{\"allow\":[\"done\"],\"builtinGlobals\":true,\"hoist\":\"all\"}]",
         .{},
     );
     defer no_shadow_config.deinit();
@@ -5838,6 +5874,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_shadow_allow.contains("done"));
     try std.testing.expect(!options.no_shadow_allow.contains("other"));
     try std.testing.expect(options.no_shadow_builtin_globals);
+    try std.testing.expectEqual(NoShadowHoist.all, options.no_shadow_hoist);
 
     var no_underscore_dangle_config = try std.json.parseFromSlice(
         std.json.Value,
@@ -5862,7 +5899,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true}]",
+        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\"}]",
         .{},
     );
     defer typescript_no_shadow_config.deinit();
@@ -5871,6 +5908,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_shadow_allow.contains("value"));
     try std.testing.expect(!options.typescript_eslint_no_shadow_allow.contains("other"));
     try std.testing.expect(options.typescript_eslint_no_shadow_builtin_globals);
+    try std.testing.expectEqual(NoShadowHoist.never, options.typescript_eslint_no_shadow_hoist);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -14,6 +14,7 @@ pub const Options = struct {
     mode: Mode = .javascript,
     allow: core.NoShadowAllowNames = .{},
     builtin_globals: bool = false,
+    hoist: core.NoShadowHoist = .functions,
 };
 
 pub const Mode = enum {
@@ -68,6 +69,8 @@ pub fn runWithOptions(
         const shadowed_id = findShadowedSymbol(scope_tree, symbol_table, symbol.scope, name, entry.id, symbol.flags, options) orelse continue;
         const shadowed_decls = symbol_table.symbolDecls(shadowed_id);
         if (shadowed_decls.len == 0) continue;
+        const shadowed_flags = symbol_table.getSymbol(shadowed_id).flags;
+        if (isAllowedByHoist(tree, decls[0], shadowed_decls[0], shadowed_flags, options)) continue;
 
         const shadowed_position = offsetToLineColumn(tree.source, tree.span(shadowed_decls[0]).start);
         try core.addDiagnosticFmt(
@@ -128,6 +131,27 @@ fn isAllowedTypescriptShadow(
     if (options.mode != .typescript) return false;
     return (self_flags.interface and candidate_flags.class) or
         (self_flags.class and candidate_flags.interface);
+}
+
+fn isAllowedByHoist(
+    tree: *const ast.Tree,
+    self_decl: ast.NodeIndex,
+    shadowed_decl: ast.NodeIndex,
+    shadowed_flags: traverser.semantic.Symbol.Flags,
+    options: Options,
+) bool {
+    if (tree.span(self_decl).start >= tree.span(shadowed_decl).start) return false;
+    return switch (options.hoist) {
+        .all => false,
+        .functions => !shadowed_flags.function,
+        .functions_and_types => !shadowed_flags.function and !isTypeSymbol(shadowed_flags),
+        .never => true,
+        .types => !isTypeSymbol(shadowed_flags),
+    };
+}
+
+fn isTypeSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    return flags.inTypeSpace() or flags.type_import;
 }
 
 fn offsetToLineColumn(source: []const u8, offset: u32) core.SourcePosition {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -772,6 +772,7 @@ pub fn runSemantic(
         try no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .allow = options.no_shadow_allow,
             .builtin_globals = options.no_shadow_builtin_globals,
+            .hoist = options.no_shadow_hoist,
         });
     }
 
@@ -779,6 +780,7 @@ pub fn runSemantic(
         try typescript_eslint_no_shadow.runWithOptions(allocator, diagnostics, tree, semantic_result.scope_tree, semantic_result.symbol_table, .{
             .allow = options.typescript_eslint_no_shadow_allow,
             .builtin_globals = options.typescript_eslint_no_shadow_builtin_globals,
+            .hoist = options.typescript_eslint_no_shadow_hoist,
         });
     }
 

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -31,5 +31,6 @@ pub fn runWithOptions(
         .mode = .typescript,
         .allow = options.allow,
         .builtin_globals = options.builtin_globals,
+        .hoist = options.hoist,
     });
 }

--- a/tests/rules/no_shadow.zig
+++ b/tests/rules/no_shadow.zig
@@ -105,6 +105,60 @@ test "supports configured no-shadow built-in globals" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured no-shadow hoist option" {
+    const source =
+        \\function defaultHoist() {
+        \\  {
+        \\    const laterValue = 1;
+        \\    const laterFunction = 2;
+        \\  }
+        \\  const laterValue = 3;
+        \\  function laterFunction() {}
+        \\}
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.no_shadow.id));
+
+    var all_options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    var all_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"hoist\":\"all\"}]",
+        .{},
+    );
+    defer all_config.deinit();
+    try all_options.setByRuleConfigValue("no-shadow", all_config.value);
+
+    var all_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", all_options);
+    defer all_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(all_result, lint.rules.no_shadow.id));
+
+    var never_options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    var never_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"hoist\":\"never\"}]",
+        .{},
+    );
+    defer never_config.deinit();
+    try never_options.setByRuleConfigValue("no-shadow", never_config.value);
+
+    var never_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", never_options);
+    defer never_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(never_result, lint.rules.no_shadow.id));
+}
+
 test "can disable no-shadow" {
     const source =
         \\let a = 1;

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -123,6 +123,37 @@ test "supports configured @typescript-eslint/no-shadow built-in globals" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow hoist option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"hoist\":\"never\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function f() {
+        \\  {
+        \\    const laterValue = 1;
+        \\  }
+        \\  const laterValue = 2;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable @typescript-eslint/no-shadow and fall back to no-shadow" {
     const source =
         \\const value = 1;


### PR DESCRIPTION
## Summary
- add no-shadow hoist config parsing and behavior for core and @typescript-eslint/no-shadow
- respect declaration order for later outer declarations with functions/all/never/types variants
- add regression coverage and rule-status docs

## Validation
- zig fmt --check src/core.zig src/rules/no_shadow.zig src/rules/root.zig src/rules/typescript_eslint_no_shadow.zig tests/rules/no_shadow.zig tests/rules/typescript_eslint_no_shadow.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check