### PR TITLE
support no-implicit-coercion template option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -78,7 +78,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-global-assign`](https://eslint.org/docs/latest/rules/no-global-assign) | Implemented |
 | [`no-global-is-finite`](https://eslint.org/docs/latest/rules/no-global-is-finite) | Implemented |
 | [`no-global-is-nan`](https://eslint.org/docs/latest/rules/no-global-is-nan) | Implemented |
-| [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Implemented with optional `boolean`, `number`, and `string` category behavior |
+| [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Supports `boolean`, `number`, `string`, `allow`, and `disallowTemplateShorthand` configuration |
 | [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1042,9 +1042,11 @@ pub const Options = struct {
     no_implicit_coercion_string: NoImplicitCoercionString = .yes,
     no_implicit_coercion_allow_double_negation: bool = false,
     no_implicit_coercion_allow_bitwise_not: bool = false,
-    no_implicit_coercion_allow_unary_plus: bool = false,
+    no_implicit_coercion_allow_plus: bool = false,
     no_implicit_coercion_allow_multiply: bool = false,
     no_implicit_coercion_allow_subtract: bool = false,
+    no_implicit_coercion_allow_double_negative: bool = false,
+    no_implicit_coercion_disallow_template_shorthand: bool = false,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
@@ -1636,9 +1638,11 @@ pub const Options = struct {
             self.no_implicit_coercion_string = try noImplicitCoercionStringFromConfig(value);
             self.no_implicit_coercion_allow_double_negation = try noImplicitCoercionAllowFromConfig(value, "!!");
             self.no_implicit_coercion_allow_bitwise_not = try noImplicitCoercionAllowFromConfig(value, "~");
-            self.no_implicit_coercion_allow_unary_plus = try noImplicitCoercionAllowFromConfig(value, "+");
+            self.no_implicit_coercion_allow_plus = try noImplicitCoercionAllowFromConfig(value, "+");
             self.no_implicit_coercion_allow_multiply = try noImplicitCoercionAllowFromConfig(value, "*");
             self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
+            self.no_implicit_coercion_allow_double_negative = try noImplicitCoercionAllowFromConfig(value, "- -");
+            self.no_implicit_coercion_disallow_template_shorthand = try noImplicitCoercionDisallowTemplateShorthandFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-invalid-regexp")) {
             self.no_invalid_regexp_allow_constructor_flags = try noInvalidRegexpAllowConstructorFlagsFromConfig(value);
@@ -2929,6 +2933,23 @@ pub const Options = struct {
         return if (enabled) .yes else .no;
     }
 
+    fn noImplicitCoercionDisallowTemplateShorthandFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("disallowTemplateShorthand") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noImplicitCoercionOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -2980,7 +3001,8 @@ pub const Options = struct {
             std.mem.eql(u8, value, "~") or
             std.mem.eql(u8, value, "+") or
             std.mem.eql(u8, value, "*") or
-            std.mem.eql(u8, value, "-");
+            std.mem.eql(u8, value, "-") or
+            std.mem.eql(u8, value, "- -");
     }
 
     fn noLabelsAllowLoopFromConfig(value: std.json.Value) RuleConfigError!NoLabelsAllowLoop {
@@ -5787,16 +5809,18 @@ test "Options can apply ESLint-style rule config values" {
     var no_implicit_coercion_allow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\"]}]",
+        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\",\"- -\"],\"disallowTemplateShorthand\":true}]",
         .{},
     );
     defer no_implicit_coercion_allow_config.deinit();
     try options.setByRuleConfigValue("no-implicit-coercion", no_implicit_coercion_allow_config.value);
     try std.testing.expect(options.no_implicit_coercion_allow_double_negation);
     try std.testing.expect(options.no_implicit_coercion_allow_bitwise_not);
-    try std.testing.expect(options.no_implicit_coercion_allow_unary_plus);
+    try std.testing.expect(options.no_implicit_coercion_allow_plus);
     try std.testing.expect(options.no_implicit_coercion_allow_multiply);
     try std.testing.expect(options.no_implicit_coercion_allow_subtract);
+    try std.testing.expect(options.no_implicit_coercion_allow_double_negative);
+    try std.testing.expect(options.no_implicit_coercion_disallow_template_shorthand);
 
     var no_labels_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_implicit_coercion.zig
+++ b/src/rules/no_implicit_coercion.zig
@@ -13,9 +13,11 @@ pub const Options = struct {
     string: bool = true,
     allow_double_negation: bool = false,
     allow_bitwise_not: bool = false,
-    allow_unary_plus: bool = false,
+    allow_plus: bool = false,
     allow_multiply: bool = false,
     allow_subtract: bool = false,
+    allow_double_negative: bool = false,
+    disallow_template_shorthand: bool = false,
 };
 
 pub fn checkUnaryExpression(
@@ -48,12 +50,12 @@ pub fn checkUnaryExpressionWithOptions(
             }
         },
         .positive => {
-            if (options.number and !options.allow_unary_plus and !isNumeric(tree, expression.argument)) {
+            if (options.number and !options.allow_plus and !isNumeric(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of unary plus.");
             }
         },
         .negate => {
-            if (options.number and isNegatedExpression(tree, expression.argument)) {
+            if (options.number and !options.allow_double_negative and isNegatedExpression(tree, expression.argument)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `Number()` instead of double negation.");
             }
         },
@@ -81,7 +83,7 @@ pub fn checkBinaryExpressionWithOptions(
 ) Allocator.Error!void {
     switch (expression.operator) {
         .add => {
-            if (options.string and isConcatWithEmptyString(tree, expression)) {
+            if (options.string and !options.allow_plus and isConcatWithEmptyString(tree, expression)) {
                 try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of string concatenation.");
             }
         },
@@ -119,9 +121,33 @@ pub fn checkAssignmentExpressionWithOptions(
     index: ast.NodeIndex,
     options: Options,
 ) Allocator.Error!void {
-    if (options.string and expression.operator == .add_assign and isEmptyStringLiteral(tree, expression.right)) {
+    if (options.string and !options.allow_plus and expression.operator == .add_assign and isEmptyStringLiteral(tree, expression.right)) {
         try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of appending an empty string.");
     }
+}
+
+pub fn checkTemplateLiteralWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.TemplateLiteral,
+    index: ast.NodeIndex,
+    parent: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.string or !options.disallow_template_shorthand) return;
+    if (isTaggedTemplateParent(tree, parent)) return;
+    if (!isTemplateShorthand(tree, literal)) return;
+
+    try addDiagnostic(allocator, diagnostics, tree, index, "Use `String()` instead of template string expression.");
+}
+
+fn isTaggedTemplateParent(tree: *const ast.Tree, parent: ast.NodeIndex) bool {
+    if (parent == .null) return false;
+    return switch (tree.data(parent)) {
+        .tagged_template_expression => true,
+        else => false,
+    };
 }
 
 fn isDoubleNegation(tree: *const ast.Tree, expression: ast.UnaryExpression) bool {
@@ -180,6 +206,23 @@ fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]c
         .template_element => |element| tree.string(element.cooked),
         else => null,
     };
+}
+
+fn isTemplateShorthand(tree: *const ast.Tree, literal: ast.TemplateLiteral) bool {
+    if (literal.expressions.len != 1) return false;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 2) return false;
+
+    for (quasis) |quasi_index| {
+        switch (tree.data(quasi_index)) {
+            .template_element => |element| {
+                if (element.is_cooked_undefined or tree.string(element.cooked).len != 0) return false;
+            },
+            else => return false,
+        }
+    }
+    return true;
 }
 
 fn isEmptyStringLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2309,6 +2309,9 @@ const BasicVisitor = struct {
         if (self.options.alipay_ant_disallow_typos) {
             try alipay_ant_disallow_typos.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);
         }
+        if (self.options.no_implicit_coercion) {
+            try no_implicit_coercion.checkTemplateLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, ctx.path.parent() orelse .null, self.noImplicitCoercionOptions());
+        }
         return .proceed;
     }
 
@@ -2565,9 +2568,11 @@ const BasicVisitor = struct {
             .string = self.options.no_implicit_coercion_string == .yes,
             .allow_double_negation = self.options.no_implicit_coercion_allow_double_negation,
             .allow_bitwise_not = self.options.no_implicit_coercion_allow_bitwise_not,
-            .allow_unary_plus = self.options.no_implicit_coercion_allow_unary_plus,
+            .allow_plus = self.options.no_implicit_coercion_allow_plus,
             .allow_multiply = self.options.no_implicit_coercion_allow_multiply,
             .allow_subtract = self.options.no_implicit_coercion_allow_subtract,
+            .allow_double_negative = self.options.no_implicit_coercion_allow_double_negative,
+            .disallow_template_shorthand = self.options.no_implicit_coercion_disallow_template_shorthand,
         };
     }
 

--- a/tests/rules/no_implicit_coercion.zig
+++ b/tests/rules/no_implicit_coercion.zig
@@ -158,7 +158,7 @@ test "supports no-implicit-coercion allow option" {
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\"]}]",
+        "[\"error\",{\"allow\":[\"!!\",\"~\",\"+\",\"*\",\"-\",\"- -\"]}]",
         .{},
     );
     defer config.deinit();
@@ -185,7 +185,71 @@ test "supports no-implicit-coercion allow option" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implicit_coercion.id));
+}
+
+test "supports distinct no-implicit-coercion numeric allow tokens" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"+\",\"-\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-implicit-coercion", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const first = +value;
+        \\const second = value - 0;
+        \\const third = -(-value);
+        \\const fourth = value + "";
+        \\let fifth = value;
+        \\fifth += "";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expectEqualStrings("Use `Number()` instead of double negation.", result.diagnostics[0].message);
+}
+
+test "supports no-implicit-coercion disallowTemplateShorthand option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"disallowTemplateShorthand\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-implicit-coercion", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const first = `${value}`;
+        \\const second = `${value}${other}`;
+        \\const third = `prefix${value}`;
+        \\const fourth = `${value}suffix`;
+        \\const fifth = tag`${value}`;
+        \\const sixth = `${value + other}`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_implicit_coercion.id));
+    try std.testing.expectEqualStrings("Use `String()` instead of template string expression.", result.diagnostics[0].message);
 }
 
 test "can disable no-implicit-coercion" {


### PR DESCRIPTION
## Summary
- support `no-implicit-coercion` `disallowTemplateShorthand` for pure template coercions
- align `allow` handling for `+` and add the distinct `- -` token
- update rule status and coverage for the new config paths

## Validation
- `zig fmt --check src/rules/no_implicit_coercion.zig src/rules/root.zig src/core.zig tests/rules/no_implicit_coercion.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`