### PR TITLE
support accessor-pairs class member option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -5,7 +5,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
-| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Implemented for optional `setWithoutGet` and `getWithoutSet` behavior |
+| [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Supports `setWithoutGet`, `getWithoutSet`, and `enforceForClassMembers` configuration |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always`, optional `never`, and optional `ignoreInlineComments` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -785,6 +785,11 @@ pub const AccessorPairsSetWithoutGet = enum {
     no,
 };
 
+pub const AccessorPairsEnforceForClassMembers = enum {
+    yes,
+    no,
+};
+
 pub const GroupedAccessorPairsStyle = enum {
     any_order,
     get_before_set,
@@ -922,6 +927,7 @@ pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
     accessor_pairs_set_without_get: AccessorPairsSetWithoutGet = .yes,
+    accessor_pairs_enforce_for_class_members: AccessorPairsEnforceForClassMembers = .yes,
     array_callback_return: bool = true,
     array_callback_return_allow_implicit: ArrayCallbackReturnAllowImplicit = .no,
     array_callback_return_check_for_each: ArrayCallbackReturnCheckForEach = .no,
@@ -1534,6 +1540,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "accessor-pairs")) {
             self.accessor_pairs_get_without_set = try accessorPairsGetWithoutSetFromConfig(value);
             self.accessor_pairs_set_without_get = try accessorPairsSetWithoutGetFromConfig(value);
+            self.accessor_pairs_enforce_for_class_members = try accessorPairsEnforceForClassMembersFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "array-callback-return")) {
             self.array_callback_return_allow_implicit = try arrayCallbackReturnAllowImplicitFromConfig(value);
@@ -2035,6 +2042,11 @@ pub const Options = struct {
 
     fn accessorPairsSetWithoutGetFromConfig(value: std.json.Value) RuleConfigError!AccessorPairsSetWithoutGet {
         const enabled = try accessorPairsOptionFromConfig(value, "setWithoutGet", true);
+        return if (enabled) .yes else .no;
+    }
+
+    fn accessorPairsEnforceForClassMembersFromConfig(value: std.json.Value) RuleConfigError!AccessorPairsEnforceForClassMembers {
+        const enabled = try accessorPairsOptionFromConfig(value, "enforceForClassMembers", true);
         return if (enabled) .yes else .no;
     }
 
@@ -5465,7 +5477,7 @@ test "Options can apply ESLint-style rule config values" {
     var accessor_pairs_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"getWithoutSet\":true,\"setWithoutGet\":false}]",
+        "[\"error\",{\"getWithoutSet\":true,\"setWithoutGet\":false,\"enforceForClassMembers\":false}]",
         .{},
     );
     defer accessor_pairs_config.deinit();
@@ -5473,6 +5485,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.accessor_pairs);
     try std.testing.expectEqual(AccessorPairsGetWithoutSet.yes, options.accessor_pairs_get_without_set);
     try std.testing.expectEqual(AccessorPairsSetWithoutGet.no, options.accessor_pairs_set_without_get);
+    try std.testing.expectEqual(AccessorPairsEnforceForClassMembers.no, options.accessor_pairs_enforce_for_class_members);
 
     var profile_a_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/accessor_pairs.zig
+++ b/src/rules/accessor_pairs.zig
@@ -10,6 +10,7 @@ pub const id = "accessor-pairs";
 pub const Options = struct {
     get_without_set: bool = false,
     set_without_get: bool = true,
+    enforce_for_class_members: bool = true,
 };
 
 const Accessor = struct {
@@ -70,6 +71,8 @@ pub fn checkClassBodyWithOptions(
     body: ast.ClassBody,
     options: Options,
 ) Allocator.Error!void {
+    if (!options.enforce_for_class_members) return;
+
     var accessors: std.ArrayList(Accessor) = .empty;
     defer accessors.deinit(allocator);
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3086,6 +3086,7 @@ const BasicVisitor = struct {
             try accessor_pairs.checkObjectExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
                 .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
+                .enforce_for_class_members = self.options.accessor_pairs_enforce_for_class_members == .yes,
             });
         }
         if (self.options.grouped_accessor_pairs) {
@@ -3202,6 +3203,7 @@ const BasicVisitor = struct {
             try accessor_pairs.checkClassBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, body, .{
                 .get_without_set = self.options.accessor_pairs_get_without_set == .yes,
                 .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
+                .enforce_for_class_members = self.options.accessor_pairs_enforce_for_class_members == .yes,
             });
         }
         if (self.options.grouped_accessor_pairs) {

--- a/tests/rules/accessor_pairs.zig
+++ b/tests/rules/accessor_pairs.zig
@@ -265,6 +265,41 @@ test "supports configured accessor-pairs getWithoutSet and setWithoutGet" {
     try std.testing.expectEqualStrings("Getter must be accompanied by a setter.", result.diagnostics[0].message);
 }
 
+test "supports configured accessor-pairs enforceForClassMembers option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForClassMembers\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("accessor-pairs", config.value);
+    options.eol_last = false;
+    options.no_empty_function = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const object = {
+        \\  set value(next) {},
+        \\};
+        \\class Example {
+        \\  set value(next) {}
+        \\}
+        \\Object.defineProperty(target, "value", {
+        \\  set(next) {}
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.accessor_pairs.id));
+}
+
 test "does not treat ordinary descriptor-looking objects as property descriptors" {
     const source =
         \\const object = {


### PR DESCRIPTION
## Summary
- support `accessor-pairs` `enforceForClassMembers` config parsing
- skip class accessor checks when `enforceForClassMembers: false` while keeping object and descriptor checks active
- update rule status and tests for the new option

## Validation
- `zig fmt --check src/core.zig src/rules/accessor_pairs.zig src/rules/root.zig tests/rules/accessor_pairs.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`