### PR TITLE
support capitalized-comments consecutive option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -8,7 +8,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Supports `setWithoutGet`, `getWithoutSet`, and `enforceForClassMembers` configuration |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
-| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Implemented for `always`, optional `never`, and optional `ignoreInlineComments` behavior |
+| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -918,6 +918,11 @@ pub const CapitalizedCommentsIgnoreInlineComments = enum {
     no,
 };
 
+pub const CapitalizedCommentsIgnoreConsecutiveComments = enum {
+    yes,
+    no,
+};
+
 pub const DotNotationAllowKeywords = enum {
     yes,
     no,
@@ -936,6 +941,7 @@ pub const Options = struct {
     capitalized_comments: bool = true,
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
+    capitalized_comments_ignore_consecutive_comments: CapitalizedCommentsIgnoreConsecutiveComments = .no,
     consistent_return: bool = true,
     consistent_return_treat_undefined_as_unspecified: bool = false,
     constructor_super: bool = true,
@@ -1550,6 +1556,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "capitalized-comments")) {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
+            self.capitalized_comments_ignore_consecutive_comments = try capitalizedCommentsIgnoreConsecutiveCommentsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "consistent-return")) {
             self.consistent_return_treat_undefined_as_unspecified = try consistentReturnTreatUndefinedAsUnspecifiedFromConfig(value);
@@ -2117,26 +2124,35 @@ pub const Options = struct {
     }
 
     fn capitalizedCommentsIgnoreInlineCommentsFromConfig(value: std.json.Value) RuleConfigError!CapitalizedCommentsIgnoreInlineComments {
+        const ignore = try capitalizedCommentsBoolOptionFromConfig(value, "ignoreInlineComments", false);
+        return if (ignore) .yes else .no;
+    }
+
+    fn capitalizedCommentsIgnoreConsecutiveCommentsFromConfig(value: std.json.Value) RuleConfigError!CapitalizedCommentsIgnoreConsecutiveComments {
+        const ignore = try capitalizedCommentsBoolOptionFromConfig(value, "ignoreConsecutiveComments", false);
+        return if (ignore) .yes else .no;
+    }
+
+    fn capitalizedCommentsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return .no,
+            else => return default,
         };
-        if (items.len < 2) return .no;
+        if (items.len < 2) return default;
 
         const config_value = switch (items[1]) {
             .object => items[1],
-            .string => if (items.len >= 3) items[2] else return .no,
+            .string => if (items.len >= 3) items[2] else return default,
             else => return error.UnsupportedRuleConfigValue,
         };
         const config = switch (config_value) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        const ignore = switch (config.get("ignoreInlineComments") orelse return .no) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return if (ignore) .yes else .no;
     }
 
     fn deprecatedDependenceProfileFromConfig(value: std.json.Value) DeprecatedDependenceProfile {
@@ -5396,7 +5412,7 @@ test "Options can apply ESLint-style rule config values" {
     var capitalized_comments_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\",{\"ignoreInlineComments\":true}]",
+        "[\"error\",\"never\",{\"ignoreInlineComments\":true,\"ignoreConsecutiveComments\":true}]",
         .{},
     );
     defer capitalized_comments_config.deinit();
@@ -5404,6 +5420,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.capitalized_comments);
     try std.testing.expectEqual(CapitalizedCommentsMode.never, options.capitalized_comments_mode);
     try std.testing.expectEqual(CapitalizedCommentsIgnoreInlineComments.yes, options.capitalized_comments_ignore_inline_comments);
+    try std.testing.expectEqual(CapitalizedCommentsIgnoreConsecutiveComments.yes, options.capitalized_comments_ignore_consecutive_comments);
 
     var consistent_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -15,6 +15,7 @@ pub const Mode = enum {
 pub const Options = struct {
     mode: Mode = .always,
     ignore_inline_comments: bool = false,
+    ignore_consecutive_comments: bool = false,
 };
 
 pub fn run(
@@ -31,8 +32,17 @@ pub fn runWithOptions(
     tree: *const ast.Tree,
     options: Options,
 ) Allocator.Error!void {
+    var previous_comment: ?ast.Comment = null;
+
     for (tree.comments) |comment| {
+        const consecutive = if (previous_comment) |previous|
+            isConsecutiveComment(tree, previous, comment)
+        else
+            false;
+        previous_comment = comment;
+
         if (options.ignore_inline_comments and isInlineComment(tree, comment)) continue;
+        if (options.ignore_consecutive_comments and consecutive) continue;
 
         const value = trimLeftDecorations(tree.string(comment.value));
         if (isIgnoredComment(value)) continue;
@@ -56,6 +66,15 @@ fn diagnosticMessage(mode: Mode) []const u8 {
         .always => "Comments should start with an uppercase character.",
         .never => "Comments should not start with an uppercase character.",
     };
+}
+
+fn isConsecutiveComment(tree: *const ast.Tree, previous: ast.Comment, current: ast.Comment) bool {
+    if (previous.end > current.start) return false;
+
+    for (tree.source[previous.end..current.start]) |char| {
+        if (!isWhitespace(char)) return false;
+    }
+    return true;
 }
 
 fn violatesMode(first: u8, mode: Mode) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -436,6 +436,7 @@ pub fn runBasic(
                 .never => .never,
             },
             .ignore_inline_comments = options.capitalized_comments_ignore_inline_comments == .yes,
+            .ignore_consecutive_comments = options.capitalized_comments_ignore_consecutive_comments == .yes,
         });
     }
     if (options.no_warning_comments) {

--- a/tests/rules/capitalized_comments.zig
+++ b/tests/rules/capitalized_comments.zig
@@ -94,6 +94,36 @@ test "ignores only inline comments when ignoreInlineComments is enabled" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(ignored_result, lint.rules.capitalized_comments.id));
 }
 
+test "ignores consecutive comments when ignoreConsecutiveComments is enabled" {
+    const source =
+        \\// First comment starts a group
+        \\// second consecutive line comment
+        \\
+        \\/* third consecutive block comment */
+        \\const value = 1;
+        \\// fourth comment starts a new group after code
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(default_result, lint.rules.capitalized_comments.id));
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments_ignore_consecutive_comments = .yes,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer ignored_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(ignored_result, lint.rules.capitalized_comments.id));
+}
+
 test "can disable capitalized-comments" {
     const source =
         \\// lowercase line comment


### PR DESCRIPTION
## Summary
- support `capitalized-comments` `ignoreConsecutiveComments` config parsing
- skip comments whose previous non-whitespace source content is another comment when the option is enabled
- update rule status and tests for the new option

## Validation
- `zig fmt --check src/core.zig src/rules/capitalized_comments.zig src/rules/root.zig tests/rules/capitalized_comments.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`