### PR TITLE
support no-inner-declarations both mode

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -82,7 +82,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |
-| [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Implemented |
+| [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Supports default `functions` mode and `both` mode for nested `var` declarations |
 | [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) | Implemented with optional `allowConstructorFlags` behavior |
 | [`no-irregular-whitespace`](https://eslint.org/docs/latest/rules/no-irregular-whitespace) | Implemented |
 | [`no-iterator`](https://eslint.org/docs/latest/rules/no-iterator) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -155,6 +155,11 @@ pub const NoInvalidRegexpAllowConstructorFlags = struct {
     }
 };
 
+pub const NoInnerDeclarationsMode = enum {
+    functions,
+    both,
+};
+
 pub const NoMultiSpacesIgnoreEOLComments = enum {
     yes,
     no,
@@ -1118,6 +1123,7 @@ pub const Options = struct {
     no_irregular_whitespace: bool = true,
     no_inline_comments: bool = true,
     no_inner_declarations: bool = true,
+    no_inner_declarations_mode: NoInnerDeclarationsMode = .functions,
     no_iterator: bool = true,
     no_label_var: bool = true,
     no_labels: bool = true,
@@ -1657,6 +1663,9 @@ pub const Options = struct {
             self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
             self.no_implicit_coercion_allow_double_negative = try noImplicitCoercionAllowFromConfig(value, "- -");
             self.no_implicit_coercion_disallow_template_shorthand = try noImplicitCoercionDisallowTemplateShorthandFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-inner-declarations")) {
+            self.no_inner_declarations_mode = try noInnerDeclarationsModeFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-invalid-regexp")) {
             self.no_invalid_regexp_allow_constructor_flags = try noInvalidRegexpAllowConstructorFlagsFromConfig(value);
@@ -3031,6 +3040,22 @@ pub const Options = struct {
             std.mem.eql(u8, value, "*") or
             std.mem.eql(u8, value, "-") or
             std.mem.eql(u8, value, "- -");
+    }
+
+    fn noInnerDeclarationsModeFromConfig(value: std.json.Value) RuleConfigError!NoInnerDeclarationsMode {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .functions,
+        };
+        if (items.len < 2) return .functions;
+
+        const mode = switch (items[1]) {
+            .string => |mode| mode,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, mode, "functions")) return .functions;
+        if (std.mem.eql(u8, mode, "both")) return .both;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noLabelsAllowLoopFromConfig(value: std.json.Value) RuleConfigError!NoLabelsAllowLoop {
@@ -5851,6 +5876,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_implicit_coercion_allow_subtract);
     try std.testing.expect(options.no_implicit_coercion_allow_double_negative);
     try std.testing.expect(options.no_implicit_coercion_disallow_template_shorthand);
+
+    var no_inner_declarations_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"both\"]",
+        .{},
+    );
+    defer no_inner_declarations_config.deinit();
+    try options.setByRuleConfigValue("no-inner-declarations", no_inner_declarations_config.value);
+    try std.testing.expect(options.no_inner_declarations);
+    try std.testing.expectEqual(NoInnerDeclarationsMode.both, options.no_inner_declarations_mode);
 
     var no_labels_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_inner_declarations.zig
+++ b/src/rules/no_inner_declarations.zig
@@ -8,6 +8,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-inner-declarations";
 
+pub const Mode = enum {
+    functions,
+    both,
+};
+
 pub fn checkFunction(
     _: Allocator,
     _: *core.DiagnosticList,
@@ -16,3 +21,40 @@ pub fn checkFunction(
     _: ast.NodeIndex,
     _: *traverser.basic.Ctx,
 ) Allocator.Error!void {}
+
+pub fn checkVariableDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    mode: Mode,
+) Allocator.Error!void {
+    if (mode != .both or declaration.kind != .@"var") return;
+    if (isAllowedDeclarationParent(tree, ctx.path.parent(), ctx.path.ancestor(2))) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Move variable declaration to program or function body root.",
+        tree.span(index),
+    );
+}
+
+fn isAllowedDeclarationParent(tree: *const ast.Tree, parent: ?ast.NodeIndex, grandparent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return true;
+    switch (tree.data(parent_index)) {
+        .program, .function_body, .static_block => return true,
+        .export_named_declaration, .export_default_declaration => {
+            const grandparent_index = grandparent orelse return false;
+            return switch (tree.data(grandparent_index)) {
+                .program, .function_body => true,
+                else => false,
+            };
+        },
+        else => return false,
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2232,6 +2232,20 @@ const BasicVisitor = struct {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
+        if (self.options.no_inner_declarations) {
+            try no_inner_declarations.checkVariableDeclaration(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                declaration,
+                index,
+                ctx,
+                switch (self.options.no_inner_declarations_mode) {
+                    .functions => .functions,
+                    .both => .both,
+                },
+            );
+        }
         if (self.options.one_var) {
             try one_var.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx, .{
                 .check_var = self.options.one_var_check_var,

--- a/tests/rules/no_inner_declarations.zig
+++ b/tests/rules/no_inner_declarations.zig
@@ -46,6 +46,76 @@ test "does not report no-inner-declarations for root function declarations" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inner_declarations.id));
 }
 
+test "does not report no-inner-declarations for nested var declarations by default" {
+    const source =
+        \\if (foo) {
+        \\  var nested = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_var = false,
+        .parser_semantic_errors = false,
+        .vars_on_top = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inner_declarations.id));
+}
+
+test "reports no-inner-declarations for nested var declarations in both mode" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"both\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-inner-declarations", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.no_var = false;
+    options.parser_semantic_errors = false;
+    options.vars_on_top = false;
+
+    const source =
+        \\var top = 1;
+        \\function outer() {
+        \\  var local = 1;
+        \\  if (foo) {
+        \\    var nested = 1;
+        \\  }
+        \\}
+        \\class Example {
+        \\  static {
+        \\    var staticLocal = 1;
+        \\  }
+        \\}
+        \\if (foo) {
+        \\  var nestedTop = 1;
+        \\}
+        \\for (var index = 0; index < 1; index += 1) {}
+        \\for (;;) {
+        \\  var nestedLoop = 1;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_inner_declarations.id));
+    try std.testing.expectEqualStrings(
+        "Move variable declaration to program or function body root.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable no-inner-declarations" {
     const source =
         \\if (foo) {


### PR DESCRIPTION
## Summary
- support `no-inner-declarations` `"both"` mode parsing
- report nested `var` declarations outside program/function/static-block roots in both mode
- update rule status and coverage for the new mode

## Validation
- `zig fmt --check src/core.zig src/rules/no_inner_declarations.zig src/rules/root.zig tests/rules/no_inner_declarations.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`