### PR TITLE
support object-shorthand explicit return arrows

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -161,7 +161,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
-| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, and `ignoreConstructors` configuration |
+| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1244,6 +1244,7 @@ pub const Options = struct {
     object_shorthand_style: ObjectShorthandStyle = .always,
     object_shorthand_avoid_quotes: bool = false,
     object_shorthand_ignore_constructors: bool = false,
+    object_shorthand_avoid_explicit_return_arrows: bool = false,
     one_var: bool = true,
     one_var_check_var: bool = true,
     one_var_check_let: bool = true,
@@ -1768,6 +1769,7 @@ pub const Options = struct {
             self.object_shorthand_style = try objectShorthandStyleFromConfig(value);
             self.object_shorthand_avoid_quotes = try objectShorthandAvoidQuotesFromConfig(value);
             self.object_shorthand_ignore_constructors = try objectShorthandIgnoreConstructorsFromConfig(value);
+            self.object_shorthand_avoid_explicit_return_arrows = try objectShorthandAvoidExplicitReturnArrowsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "one-var")) {
             const config = try oneVarNeverConfigFromConfig(value);
@@ -3757,6 +3759,10 @@ pub const Options = struct {
 
     fn objectShorthandIgnoreConstructorsFromConfig(value: std.json.Value) RuleConfigError!bool {
         return objectShorthandBoolOptionFromConfig(value, "ignoreConstructors");
+    }
+
+    fn objectShorthandAvoidExplicitReturnArrowsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return objectShorthandBoolOptionFromConfig(value, "avoidExplicitReturnArrows");
     }
 
     fn objectShorthandBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
@@ -6067,6 +6073,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(ObjectShorthandStyle.methods, options.object_shorthand_style);
     try std.testing.expect(options.object_shorthand_avoid_quotes);
     try std.testing.expect(options.object_shorthand_ignore_constructors);
+
+    var object_shorthand_arrows_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"avoidExplicitReturnArrows\":true}]",
+        .{},
+    );
+    defer object_shorthand_arrows_config.deinit();
+    try options.setByRuleConfigValue("object-shorthand", object_shorthand_arrows_config.value);
+    try std.testing.expect(options.object_shorthand);
+    try std.testing.expect(options.object_shorthand_avoid_explicit_return_arrows);
 
     var operator_assignment_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -11,6 +11,7 @@ pub const Options = struct {
     style: core.ObjectShorthandStyle = .always,
     avoid_quotes: bool = false,
     ignore_constructors: bool = false,
+    avoid_explicit_return_arrows: bool = false,
 };
 
 pub fn check(
@@ -47,7 +48,7 @@ pub fn checkWithOptions(
     if (property.shorthand or property.method) return;
     if (options.avoid_quotes and isStringLiteralKey(tree, property.key)) return;
 
-    const shorthand_kind = shorthandKind(tree, property) orelse return;
+    const shorthand_kind = shorthandKind(tree, property, options) orelse return;
     if (options.ignore_constructors and shorthand_kind == .method and isConstructorKey(tree, property.key)) return;
     if (!styleAllowsKind(options.style, shorthand_kind)) return;
 
@@ -83,13 +84,14 @@ const ShorthandKind = enum {
     method,
 };
 
-fn shorthandKind(tree: *const ast.Tree, property: ast.ObjectProperty) ?ShorthandKind {
+fn shorthandKind(tree: *const ast.Tree, property: ast.ObjectProperty, options: Options) ?ShorthandKind {
     if (!property.computed) {
         const key_name = propertyKeyName(tree, property.key);
         if (key_name != null and identifierReferenceNamed(tree, property.value, key_name.?)) return .property;
     }
 
     if (isAnonymousFunctionExpression(tree, property.value)) return .method;
+    if (options.avoid_explicit_return_arrows and isExplicitReturnArrowFunction(tree, property.value)) return .method;
     return null;
 }
 
@@ -136,6 +138,60 @@ fn identifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, name: [
 fn isAnonymousFunctionExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .function => |function| function.type == .function_expression and function.id == .null,
+        else => false,
+    };
+}
+
+fn isExplicitReturnArrowFunction(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const arrow = switch (tree.data(unwrapTransparent(tree, index))) {
+        .arrow_function_expression => |arrow| arrow,
+        else => return false,
+    };
+    if (arrow.expression) return false;
+    if (containsLexicalReference(tree, arrow.body)) return false;
+
+    const body = switch (tree.data(arrow.body)) {
+        .function_body => |body| tree.extra(body.body),
+        .block_statement => |block| tree.extra(block.body),
+        else => return false,
+    };
+    if (body.len != 1) return false;
+    return switch (tree.data(body[0])) {
+        .return_statement => |statement| statement.argument != .null,
+        else => false,
+    };
+}
+
+fn containsLexicalReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    switch (tree.data(index)) {
+        .this_expression, .super => return true,
+        .identifier_reference => |identifier| return std.mem.eql(u8, tree.string(identifier.name), "arguments"),
+        .meta_property => |property| return propertyNameEquals(tree, property.meta, "new") and propertyNameEquals(tree, property.property, "target"),
+        .function, .class => return false,
+        inline else => |node| return childrenContainLexicalReference(tree, @TypeOf(node), node),
+    }
+}
+
+fn childrenContainLexicalReference(tree: *const ast.Tree, comptime T: type, node: T) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (containsLexicalReference(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (containsLexicalReference(tree, child)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+fn propertyNameEquals(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3157,6 +3157,7 @@ const BasicVisitor = struct {
                 .style = self.options.object_shorthand_style,
                 .avoid_quotes = self.options.object_shorthand_avoid_quotes,
                 .ignore_constructors = self.options.object_shorthand_ignore_constructors,
+                .avoid_explicit_return_arrows = self.options.object_shorthand_avoid_explicit_return_arrows,
             });
         }
         if (self.options.func_name_matching) {

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -232,6 +232,58 @@ test "supports configured object-shorthand ignoreConstructors option" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.object_shorthand.id));
 }
 
+test "supports configured object-shorthand avoidExplicitReturnArrows option" {
+    const source =
+        \\const obj = {
+        \\  foo: () => {
+        \\    return 1;
+        \\  },
+        \\  asyncFoo: async () => {
+        \\    return foo;
+        \\  },
+        \\  value: value,
+        \\  lexicalThis: () => {
+        \\    return this.value;
+        \\  },
+        \\  lexicalArguments: () => {
+        \\    return arguments[0];
+        \\  },
+        \\  expressionBody: () => value,
+        \\  bareReturn: () => {
+        \\    return;
+        \\  },
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.object_shorthand.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"avoidExplicitReturnArrows\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.object_shorthand.id));
+}
+
 test "can disable object-shorthand" {
     const source =
         \\const obj = {


### PR DESCRIPTION
## Summary
- parse `object-shorthand` `avoidExplicitReturnArrows` from ESLint-style rule config
- report explicit-return arrow function properties as method shorthand candidates when configured
- avoid reporting arrows whose bodies use lexical `this`, `arguments`, `super`, or `new.target`
- update rule status and coverage for the new option

## Validation
- `zig fmt --check src/core.zig src/rules/object_shorthand.zig src/rules/root.zig tests/rules/object_shorthand.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`