### PR TITLE
support no-useless-escape regex allow

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -154,7 +154,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
-| [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Implemented |
+| [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -485,6 +485,35 @@ pub const NoShadowAllowNames = struct {
     }
 };
 
+pub const max_no_useless_escape_allow_regex_characters = 32;
+
+pub const NoUselessEscapeAllowRegexCharactersError = error{
+    EmptyNoUselessEscapeAllowRegexCharacter,
+    TooManyNoUselessEscapeAllowRegexCharacters,
+    NoUselessEscapeAllowRegexCharacterTooLong,
+};
+
+pub const NoUselessEscapeAllowRegexCharacters = struct {
+    count: usize = 0,
+    characters: [max_no_useless_escape_allow_regex_characters]u8 = undefined,
+
+    pub fn contains(self: *const NoUselessEscapeAllowRegexCharacters, character: u8) bool {
+        for (0..self.count) |index| {
+            if (self.characters[index] == character) return true;
+        }
+        return false;
+    }
+
+    pub fn append(self: *NoUselessEscapeAllowRegexCharacters, character: []const u8) NoUselessEscapeAllowRegexCharactersError!void {
+        if (character.len == 0) return error.EmptyNoUselessEscapeAllowRegexCharacter;
+        if (character.len > 1) return error.NoUselessEscapeAllowRegexCharacterTooLong;
+        if (self.count >= max_no_useless_escape_allow_regex_characters) return error.TooManyNoUselessEscapeAllowRegexCharacters;
+
+        self.characters[self.count] = character[0];
+        self.count += 1;
+    }
+};
+
 pub const max_no_this_alias_allowed_names = 32;
 pub const max_no_this_alias_allowed_name_len = 128;
 
@@ -1220,6 +1249,7 @@ pub const Options = struct {
     no_useless_constructor: bool = true,
     no_useless_catch: bool = true,
     no_useless_escape: bool = true,
+    no_useless_escape_allow_regex_characters: NoUselessEscapeAllowRegexCharacters = .{},
     no_useless_rename: bool = true,
     no_useless_rename_ignore_destructuring: bool = false,
     no_useless_rename_ignore_import: bool = false,
@@ -1695,6 +1725,9 @@ pub const Options = struct {
             self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
             self.no_useless_rename_ignore_import = try noUselessRenameBoolOptionFromConfig(value, "ignoreImport");
             self.no_useless_rename_ignore_export = try noUselessRenameBoolOptionFromConfig(value, "ignoreExport");
+        }
+        if (std.mem.eql(u8, cli_name, "no-useless-escape")) {
+            self.no_useless_escape_allow_regex_characters = try noUselessEscapeAllowRegexCharactersFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-shadow")) {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -2699,6 +2732,34 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noUselessEscapeAllowRegexCharactersFromConfig(value: std.json.Value) RuleConfigError!NoUselessEscapeAllowRegexCharacters {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow_value = config.get("allowRegexCharacters") orelse return .{};
+        const allow_items = switch (allow_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var allow = NoUselessEscapeAllowRegexCharacters{};
+        for (allow_items) |item| {
+            const character = switch (item) {
+                .string => |character| character,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            allow.append(character) catch return error.UnsupportedRuleConfigValue;
+        }
+        return allow;
     }
 
     fn noInvalidRegexpAllowConstructorFlagsFromConfig(value: std.json.Value) RuleConfigError!NoInvalidRegexpAllowConstructorFlags {
@@ -6181,6 +6242,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_useless_rename_ignore_destructuring);
     try std.testing.expect(options.no_useless_rename_ignore_import);
     try std.testing.expect(options.no_useless_rename_ignore_export);
+
+    var no_useless_escape_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowRegexCharacters\":[\"#\",\"-\"]}]",
+        .{},
+    );
+    defer no_useless_escape_config.deinit();
+    try options.setByRuleConfigValue("no-useless-escape", no_useless_escape_config.value);
+    try std.testing.expect(options.no_useless_escape);
+    try std.testing.expect(options.no_useless_escape_allow_regex_characters.contains('#'));
+    try std.testing.expect(options.no_useless_escape_allow_regex_characters.contains('-'));
+    try std.testing.expect(!options.no_useless_escape_allow_regex_characters.contains('^'));
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_useless_escape.zig
+++ b/src/rules/no_useless_escape.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-useless-escape";
 
+pub const Options = struct {
+    allow_regex_characters: core.NoUselessEscapeAllowRegexCharacters = .{},
+};
+
 pub fn checkStringLiteral(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -41,11 +45,23 @@ pub fn checkRegExpLiteral(
     literal: ast.RegExpLiteral,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkRegExpLiteralWithOptions(allocator, diagnostics, tree, literal, index, .{});
+}
+
+pub fn checkRegExpLiteralWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     try checkRegExpPattern(
         allocator,
         diagnostics,
         tree.string(literal.pattern),
         tree.span(index),
+        options,
     );
 }
 
@@ -109,6 +125,7 @@ fn checkRegExpPattern(
     diagnostics: *core.DiagnosticList,
     pattern: []const u8,
     span: ast.Span,
+    options: Options,
 ) Allocator.Error!void {
     var offset: usize = 0;
     var in_class = false;
@@ -131,6 +148,10 @@ fn checkRegExpPattern(
         }
 
         const escaped = pattern[offset + 1];
+        if (options.allow_regex_characters.contains(escaped)) {
+            offset += 2;
+            continue;
+        }
         if (!isNecessaryRegExpEscape(pattern, offset, escaped, in_class, class_start)) {
             try addDiagnostic(allocator, diagnostics, span, escaped);
         }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3490,7 +3490,9 @@ const BasicVisitor = struct {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.no_useless_escape) {
-            try no_useless_escape.checkRegExpLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+            try no_useless_escape.checkRegExpLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, .{
+                .allow_regex_characters = self.options.no_useless_escape_allow_regex_characters,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/no_useless_escape.zig
+++ b/tests/rules/no_useless_escape.zig
@@ -43,6 +43,35 @@ test "reports no-useless-escape for unnecessary regular expression escapes" {
     try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, lint.rules.no_useless_escape.id));
 }
 
+test "supports configured no-useless-escape allowRegexCharacters" {
+    const source =
+        \\const a = /\#/;
+        \\const b = /[\#]/;
+        \\const c = /\-/;
+        \\const d = /[\-]/;
+        \\const e = /\@/;
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowRegexCharacters\":[\"#\",\"-\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-useless-escape", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_useless_escape.id));
+}
+
 test "does not report no-useless-escape for necessary escapes" {
     const source =
         \\const a = "\"";


### PR DESCRIPTION
## Summary
- parse `no-useless-escape` `allowRegexCharacters` from ESLint-style rule config
- pass allowed regex characters into regexp literal escape checks
- update rule status and add coverage for allowed and still-reported regex escapes

## Validation
- `zig fmt --check src/core.zig src/rules/no_useless_escape.zig src/rules/root.zig tests/rules/no_useless_escape.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`