### PR TITLE
support no-self-assign props option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -124,7 +124,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
 | [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented |
 | [`no-script-url`](https://eslint.org/docs/latest/rules/no-script-url) | Implemented |
-| [`no-self-assign`](https://eslint.org/docs/latest/rules/no-self-assign) | Implemented |
+| [`no-self-assign`](https://eslint.org/docs/latest/rules/no-self-assign) | Supports `props` configuration |
 | [`no-self-compare`](https://eslint.org/docs/latest/rules/no-self-compare) | Implemented |
 | [`no-sequences`](https://eslint.org/docs/latest/rules/no-sequences) | Implemented with optional `allowInParentheses` behavior |
 | [`no-setter-return`](https://eslint.org/docs/latest/rules/no-setter-return) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1207,6 +1207,7 @@ pub const Options = struct {
     no_useless_return: bool = true,
     no_script_url: bool = true,
     no_self_assign: bool = true,
+    no_self_assign_props: bool = true,
     no_self_compare: bool = true,
     no_setter_return: bool = true,
     no_shadow: bool = true,
@@ -1720,6 +1721,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-self-assign")) {
+            self.no_self_assign_props = try noSelfAssignPropsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-useless-rename")) {
             self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
@@ -3995,6 +3999,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get(key) orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noSelfAssignPropsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("props") orelse return true) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6484,6 +6505,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-undef", no_undef_config.value);
     try std.testing.expect(options.no_undef);
     try std.testing.expect(options.no_undef_typeof);
+
+    var no_self_assign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"props\":false}]",
+        .{},
+    );
+    defer no_self_assign_config.deinit();
+    try options.setByRuleConfigValue("no-self-assign", no_self_assign_config.value);
+    try std.testing.expect(options.no_self_assign);
+    try std.testing.expect(!options.no_self_assign_props);
 
     var no_unneeded_ternary_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_self_assign.zig
+++ b/src/rules/no_self_assign.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-self-assign";
 
+pub const Options = struct {
+    props: bool = true,
+};
+
 const Reference = union(enum) {
     this,
     identifier: []const u8,
@@ -23,6 +27,17 @@ pub fn check(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (!isSelfAssignOperator(expression.operator)) return;
 
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -31,6 +46,7 @@ pub fn check(
 
     if (try referenceFromExpression(arena_allocator, tree, expression.left)) |left| {
         if (try referenceFromExpression(arena_allocator, tree, expression.right)) |right| {
+            if (!options.props and (isMemberReference(left) or isMemberReference(right))) return;
             if (referencesEqual(left, right)) {
                 try addDiagnostic(allocator, diagnostics, tree, index);
                 return;
@@ -41,6 +57,13 @@ pub fn check(
     if (expression.operator == .assign) {
         try checkPatternSelfAssign(allocator, diagnostics, tree, arena_allocator, expression.left, expression.right);
     }
+}
+
+fn isMemberReference(reference: *const Reference) bool {
+    return switch (reference.*) {
+        .member => true,
+        else => false,
+    };
 }
 
 fn addDiagnostic(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2442,7 +2442,9 @@ const BasicVisitor = struct {
             try no_useless_rename.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, self.noUselessRenameOptions());
         }
         if (self.options.no_self_assign) {
-            try no_self_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_self_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .props = self.options.no_self_assign_props,
+            });
         }
         if (self.options.no_implicit_coercion) {
             try no_implicit_coercion.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noImplicitCoercionOptions());

--- a/tests/rules/no_self_assign.zig
+++ b/tests/rules/no_self_assign.zig
@@ -50,6 +50,34 @@ test "does not report no-self-assign for different references or effectful objec
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_self_assign.id));
 }
 
+test "supports configured no-self-assign props false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"props\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-self-assign", config.value);
+
+    const source =
+        \\foo = foo;
+        \\object.value = object.value;
+        \\this.value = this["value"];
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_self_assign.id));
+}
+
 test "can disable no-self-assign" {
     const source =
         \\foo = foo;


### PR DESCRIPTION
## Summary
- parse `no-self-assign` `props` from ESLint-style rule config
- skip member self-assignment reports when `props: false` while still reporting identifier self-assignments
- update rule status and coverage for the new option

## Validation
- `zig fmt --check src/core.zig src/rules/no_self_assign.zig src/rules/root.zig tests/rules/no_self_assign.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`