### PR TITLE
support no-tabs indentation option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -131,7 +131,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-shadow`](https://eslint.org/docs/latest/rules/no-shadow) | Supports `allow`, `builtinGlobals`, and `hoist` configuration |
 | [`no-shadow-restricted-names`](https://eslint.org/docs/latest/rules/no-shadow-restricted-names) | Implemented |
 | [`no-sparse-arrays`](https://eslint.org/docs/latest/rules/no-sparse-arrays) | Implemented |
-| [`no-tabs`](https://eslint.org/docs/latest/rules/no-tabs) | Implemented |
+| [`no-tabs`](https://eslint.org/docs/latest/rules/no-tabs) | Supports `allowIndentationTabs` configuration |
 | [`no-template-curly-in-string`](https://eslint.org/docs/latest/rules/no-template-curly-in-string) | Implemented |
 | [`no-ternary`](https://eslint.org/docs/latest/rules/no-ternary) | Implemented |
 | [`no-this-before-super`](https://eslint.org/docs/latest/rules/no-this-before-super) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1223,6 +1223,7 @@ pub const Options = struct {
     no_throw_literal: bool = true,
     no_this_before_super: bool = true,
     no_tabs: bool = true,
+    no_tabs_allow_indentation_tabs: bool = false,
     no_trailing_spaces: bool = true,
     no_unreachable: bool = true,
     no_undef_init: bool = true,
@@ -1968,6 +1969,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-undef")) {
             self.no_undef_typeof = try noUndefTypeofFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-tabs")) {
+            self.no_tabs_allow_indentation_tabs = try noTabsAllowIndentationTabsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-unneeded-ternary")) {
             self.no_unneeded_ternary_default_assignment = try noUnneededTernaryDefaultAssignmentFromConfig(value);
@@ -3937,6 +3941,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("typeof") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noTabsAllowIndentationTabsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowIndentationTabs") orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6505,6 +6526,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-undef", no_undef_config.value);
     try std.testing.expect(options.no_undef);
     try std.testing.expect(options.no_undef_typeof);
+
+    var no_tabs_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowIndentationTabs\":true}]",
+        .{},
+    );
+    defer no_tabs_config.deinit();
+    try options.setByRuleConfigValue("no-tabs", no_tabs_config.value);
+    try std.testing.expect(options.no_tabs);
+    try std.testing.expect(options.no_tabs_allow_indentation_tabs);
 
     var no_self_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_tabs.zig
+++ b/src/rules/no_tabs.zig
@@ -7,17 +7,52 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-tabs";
 
+pub const Options = struct {
+    allow_indentation_tabs: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     const source = tree.source;
     var index: usize = 0;
+    var line_indentation = true;
 
-    while (std.mem.indexOfScalarPos(u8, source, index, '\t')) |start| {
-        var end = start + 1;
+    while (index < source.len) {
+        const char = source[index];
+        if (char == '\n' or char == '\r') {
+            index += 1;
+            line_indentation = true;
+            continue;
+        }
+        if (line_indentation and char == ' ') {
+            index += 1;
+            continue;
+        }
+        if (char != '\t') {
+            line_indentation = false;
+            index += 1;
+            continue;
+        }
+
+        const allowed = options.allow_indentation_tabs and line_indentation;
+        var end = index + 1;
         while (end < source.len and source[end] == '\t') : (end += 1) {}
+        if (allowed) {
+            index = end;
+            continue;
+        }
 
         try core.addDiagnostic(
             allocator,
@@ -25,9 +60,10 @@ pub fn run(
             .warning,
             id,
             "Unexpected tab character.",
-            .{ .start = @intCast(start), .end = @intCast(end) },
+            .{ .start = @intCast(index), .end = @intCast(end) },
         );
 
         index = end;
+        line_indentation = false;
     }
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -474,7 +474,9 @@ pub fn runBasic(
         });
     }
     if (options.no_tabs) {
-        try no_tabs.run(allocator, diagnostics, tree);
+        try no_tabs.runWithOptions(allocator, diagnostics, tree, .{
+            .allow_indentation_tabs = options.no_tabs_allow_indentation_tabs,
+        });
     }
     if (options.no_mixed_spaces_and_tabs) {
         try no_mixed_spaces_and_tabs.run(allocator, diagnostics, tree);

--- a/tests/rules/no_tabs.zig
+++ b/tests/rules/no_tabs.zig
@@ -31,6 +31,33 @@ test "does not report no-tabs for spaces" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_tabs.id));
 }
 
+test "supports configured no-tabs allowIndentationTabs option" {
+    const source =
+        "\tconst first = 1;\n" ++
+        "  \tconst second = 2;\n" ++
+        "const\tthird = 3;\n" ++
+        "\tconst fourth\t= 4;\n";
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowIndentationTabs\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-tabs", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_tabs.id));
+}
+
 test "can disable no-tabs" {
     const source = "const\tvalue = 1;\n";
 


### PR DESCRIPTION
## Summary
- parse `no-tabs` `allowIndentationTabs` from ESLint-style rule config
- allow leading indentation tabs when configured while still reporting inline tabs
- update rule status and coverage for the new option

## Validation
- `zig fmt --check src/core.zig src/rules/no_tabs.zig src/rules/root.zig tests/rules/no_tabs.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`