### PR TITLE
support use-isnan options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -182,7 +182,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
-| [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Implemented |
+| [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Supports `enforceForIndexOf` and `enforceForSwitchCase` configuration |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1286,6 +1286,8 @@ pub const Options = struct {
     eqeqeq: bool = true,
     eqeqeq_style: EqeqeqStyle = .strict,
     use_isnan: bool = true,
+    use_isnan_enforce_for_index_of: bool = false,
+    use_isnan_enforce_for_switch_case: bool = true,
     no_unused_vars: bool = true,
     no_unused_vars_vars: NoUnusedVarsVars = .all,
     no_unused_vars_args: NoUnusedVarsArgs = .none,
@@ -1623,6 +1625,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "eqeqeq")) {
             self.eqeqeq_style = try eqeqeqStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "use-isnan")) {
+            self.use_isnan_enforce_for_index_of = try useIsnanBoolOptionFromConfig(value, "enforceForIndexOf", false);
+            self.use_isnan_enforce_for_switch_case = try useIsnanBoolOptionFromConfig(value, "enforceForSwitchCase", true);
         }
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
@@ -3958,6 +3964,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowIndentationTabs") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn useIsnanBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1053,6 +1053,13 @@ const BasicVisitor = struct {
         };
     }
 
+    fn useIsnanOptions(self: *const BasicVisitor) use_isnan.Options {
+        return .{
+            .enforce_for_index_of = self.options.use_isnan_enforce_for_index_of,
+            .enforce_for_switch_case = self.options.use_isnan_enforce_for_switch_case,
+        };
+    }
+
     fn funcNamesStyle(self: *const BasicVisitor, function: ast.Function) func_names.Style {
         const style = if (function.generator and self.options.func_names_has_generator_style)
             self.options.func_names_generator_style
@@ -1954,6 +1961,9 @@ const BasicVisitor = struct {
                 .allow_empty_case = self.options.no_fallthrough_allow_empty_case == .yes,
             });
         }
+        if (self.options.use_isnan) {
+            try use_isnan.checkSwitchStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, self.useIsnanOptions());
+        }
         return .proceed;
     }
 
@@ -1968,6 +1978,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable) {
             try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, switch_case.consequent);
+        }
+        if (self.options.use_isnan) {
+            try use_isnan.checkSwitchCaseWithOptions(self.allocator, self.diagnostics, ctx.tree, switch_case, self.useIsnanOptions());
         }
         return .proceed;
     }
@@ -2523,7 +2536,7 @@ const BasicVisitor = struct {
             try no_unsafe_negation.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.use_isnan) {
-            try use_isnan.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try use_isnan.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.useIsnanOptions());
         }
         if (self.options.valid_typeof) {
             try valid_typeof.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
@@ -2656,6 +2669,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.use_isnan) {
+            try use_isnan.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, self.useIsnanOptions());
         }
         if (self.options.alipay_spmlint_use_labeled_spm) {
             try alipay_spmlint_use_labeled_spm.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);

--- a/src/rules/use_isnan.zig
+++ b/src/rules/use_isnan.zig
@@ -7,6 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "use-isnan";
 
+pub const Options = struct {
+    enforce_for_index_of: bool = false,
+    enforce_for_switch_case: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,25 +19,93 @@ pub fn check(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (!isEqualityOperator(expression.operator)) return;
+    try checkBinaryExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkBinaryExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    _: Options,
+) Allocator.Error!void {
+    if (!isComparisonOperator(expression.operator)) return;
     if (!isNaNReference(tree, expression.left) and !isNaNReference(tree, expression.right)) return;
 
+    try report(allocator, diagnostics, tree, index, "Use Number.isNaN or isNaN to compare with NaN.");
+}
+
+pub fn checkSwitchStatementWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_for_switch_case) return;
+    if (!isNaNReference(tree, statement.discriminant)) return;
+
+    try report(allocator, diagnostics, tree, index, "'switch(NaN)' can never match a case clause.");
+}
+
+pub fn checkSwitchCaseWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    switch_case: ast.SwitchCase,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_for_switch_case) return;
+    if (!isNaNReference(tree, switch_case.@"test")) return;
+
+    try report(allocator, diagnostics, tree, switch_case.@"test", "'case NaN' can never match.");
+}
+
+pub fn checkCallExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.enforce_for_index_of) return;
+    if (!isIndexOfCall(tree, call)) return;
+
+    for (tree.extra(call.arguments)) |argument| {
+        if (!isNaNReference(tree, argument)) continue;
+        try report(allocator, diagnostics, tree, argument, "Use Number.isNaN or isNaN to compare with NaN.");
+    }
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    message: []const u8,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Use Number.isNaN or isNaN to compare with NaN.",
+        message,
         tree.span(index),
     );
 }
 
-fn isEqualityOperator(operator: ast.BinaryOperator) bool {
+fn isComparisonOperator(operator: ast.BinaryOperator) bool {
     return switch (operator) {
         .equal,
         .not_equal,
         .strict_equal,
         .strict_not_equal,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
         => true,
         else => false,
     };
@@ -43,8 +116,56 @@ fn isNaNReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
 
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "NaN"),
+        .member_expression => |member| isNumberNaNMember(tree, member),
         .chain_expression => |chain| isNaNReference(tree, chain.expression),
         .parenthesized_expression => |parenthesized| isNaNReference(tree, parenthesized.expression),
+        .sequence_expression => |sequence| {
+            const expressions = tree.extra(sequence.expressions);
+            return expressions.len > 0 and isNaNReference(tree, expressions[expressions.len - 1]);
+        },
         else => false,
+    };
+}
+
+fn isNumberNaNMember(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    const object_name = identifierReferenceName(tree, member.object) orelse return false;
+    if (!std.mem.eql(u8, object_name, "Number")) return false;
+
+    const property_name = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property_name, "NaN");
+}
+
+fn isIndexOfCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = switch (tree.data(call.callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property_name = propertyName(tree, callee.property, callee.computed) orelse return false;
+    return std.mem.eql(u8, property_name, "indexOf") or
+        std.mem.eql(u8, property_name, "lastIndexOf");
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .chain_expression => |chain| identifierReferenceName(tree, chain.expression),
+        .parenthesized_expression => |parenthesized| identifierReferenceName(tree, parenthesized.expression),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null) return null;
+    if (computed) {
+        return switch (tree.data(index)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .parenthesized_expression => |parenthesized| propertyName(tree, parenthesized.expression, true),
+            else => null,
+        };
+    }
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
     };
 }

--- a/tests/rules/use_isnan.zig
+++ b/tests/rules/use_isnan.zig
@@ -2,11 +2,38 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports use-isnan for equality comparisons with NaN" {
+test "reports use-isnan for comparisons with NaN" {
     const source =
         \\if (value == NaN) { use(value); }
         \\if (NaN !== value) { use(value); }
         \\if ((value) != (NaN)) { use(value); }
+        \\if (value > NaN) { use(value); }
+        \\if (Number.NaN <= value) { use(value); }
+        \\if (value === Number["NaN"]) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.use_isnan.id));
+}
+
+test "reports use-isnan for switch cases by default" {
+    const source =
+        \\switch (value) {
+        \\  case NaN:
+        \\    use(value);
+        \\  case Number.NaN:
+        \\    use(value);
+        \\}
+        \\switch (NaN) {
+        \\  case value:
+        \\    use(value);
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,9 +46,68 @@ test "reports use-isnan for equality comparisons with NaN" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.use_isnan.id));
 }
 
-test "does not report use-isnan for non-equality comparisons or Number.isNaN" {
+test "supports configured use-isnan switch case enforcement false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForSwitchCase\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("use-isnan", config.value);
+
     const source =
-        \\if (value > NaN) { use(value); }
+        \\switch (value) {
+        \\  case NaN:
+        \\    use(value);
+        \\}
+        \\if (value === NaN) { use(value); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.use_isnan.id));
+}
+
+test "supports configured use-isnan indexOf enforcement" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForIndexOf\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("use-isnan", config.value);
+
+    const source =
+        \\values.indexOf(NaN);
+        \\values.lastIndexOf(Number.NaN);
+        \\values.includes(NaN);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.use_isnan.id));
+}
+
+test "does not report use-isnan for indexOf by default or Number.isNaN" {
+    const source =
+        \\values.indexOf(NaN);
+        \\values.lastIndexOf(Number.NaN);
         \\if (Number.isNaN(value)) { use(value); }
         \\if (isNaN(value)) { use(value); }
     ;


### PR DESCRIPTION
## Summary
- expand use-isnan comparisons to cover relational operators and Number.NaN references
- add default switch/case enforcement plus enforceForSwitchCase config
- add optional enforceForIndexOf handling for indexOf/lastIndexOf calls

## Validation
- zig fmt --check src/core.zig src/rules/use_isnan.zig src/rules/root.zig tests/rules/use_isnan.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check