### PR TITLE
support no-trailing-spaces options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -136,7 +136,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-ternary`](https://eslint.org/docs/latest/rules/no-ternary) | Implemented |
 | [`no-this-before-super`](https://eslint.org/docs/latest/rules/no-this-before-super) | Implemented |
 | [`no-throw-literal`](https://eslint.org/docs/latest/rules/no-throw-literal) | Implemented |
-| [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Implemented |
+| [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Supports `skipBlankLines` and `ignoreComments` configuration |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1225,6 +1225,8 @@ pub const Options = struct {
     no_tabs: bool = true,
     no_tabs_allow_indentation_tabs: bool = false,
     no_trailing_spaces: bool = true,
+    no_trailing_spaces_skip_blank_lines: bool = false,
+    no_trailing_spaces_ignore_comments: bool = false,
     no_unreachable: bool = true,
     no_undef_init: bool = true,
     no_underscore_dangle: bool = true,
@@ -1731,6 +1733,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-self-assign")) {
             self.no_self_assign_props = try noSelfAssignPropsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-trailing-spaces")) {
+            self.no_trailing_spaces_skip_blank_lines = try noTrailingSpacesBoolOptionFromConfig(value, "skipBlankLines");
+            self.no_trailing_spaces_ignore_comments = try noTrailingSpacesBoolOptionFromConfig(value, "ignoreComments");
         }
         if (std.mem.eql(u8, cli_name, "no-useless-rename")) {
             self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
@@ -3981,6 +3987,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noTrailingSpacesBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };

--- a/src/rules/no_trailing_spaces.zig
+++ b/src/rules/no_trailing_spaces.zig
@@ -7,10 +7,24 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-trailing-spaces";
 
+pub const Options = struct {
+    skip_blank_lines: bool = false,
+    ignore_comments: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
     var line_start: usize = 0;
@@ -25,7 +39,11 @@ pub fn run(
         }
 
         if (trailing_start < line_end) {
-            try addDiagnostic(allocator, diagnostics, trailing_start, line_end);
+            const skip_blank_line = options.skip_blank_lines and isOnlyTrailingWhitespace(source[line_start..line_end]);
+            const skip_comment = options.ignore_comments and hasIgnoredCommentOnLine(tree.comments, line_start, line_end);
+            if (!skip_blank_line and !skip_comment) {
+                try addDiagnostic(allocator, diagnostics, trailing_start, line_end);
+            }
         }
 
         if (line_end >= source.len) break;
@@ -62,4 +80,28 @@ fn addDiagnostic(
 
 fn isTrailingWhitespace(char: u8) bool {
     return char == ' ' or char == '\t' or char == 0x0B or char == 0x0C;
+}
+
+fn isOnlyTrailingWhitespace(source: []const u8) bool {
+    for (source) |char| {
+        if (!isTrailingWhitespace(char)) return false;
+    }
+    return true;
+}
+
+fn hasIgnoredCommentOnLine(comments: []const ast.Comment, line_start: usize, line_end: usize) bool {
+    for (comments) |comment| {
+        const start: usize = comment.start;
+        const end: usize = comment.end;
+
+        switch (comment.type) {
+            .line => {
+                if (line_start <= start and start <= line_end) return true;
+            },
+            .block => {
+                if (start < line_end and end > line_end) return true;
+            },
+        }
+    }
+    return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -455,7 +455,10 @@ pub fn runBasic(
         });
     }
     if (options.no_trailing_spaces) {
-        try no_trailing_spaces.run(allocator, diagnostics, tree);
+        try no_trailing_spaces.runWithOptions(allocator, diagnostics, tree, .{
+            .skip_blank_lines = options.no_trailing_spaces_skip_blank_lines,
+            .ignore_comments = options.no_trailing_spaces_ignore_comments,
+        });
     }
     if (options.eol_last) {
         try eol_last.run(allocator, diagnostics, tree);

--- a/tests/rules/no_trailing_spaces.zig
+++ b/tests/rules/no_trailing_spaces.zig
@@ -35,6 +35,35 @@ test "does not report no-trailing-spaces for clean lines" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_trailing_spaces.id));
 }
 
+test "supports configured no-trailing-spaces blank line and comment ignores" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipBlankLines\":true,\"ignoreComments\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-trailing-spaces", config.value);
+
+    const source =
+        "const value = 1; \n" ++
+        "   \n" ++
+        "// comment   \n" ++
+        "/* start   \n" ++
+        " * middle\t\n" ++
+        " */   \n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_trailing_spaces.id));
+}
+
 test "can disable no-trailing-spaces" {
     const source = "const value = 1; \n";
 


### PR DESCRIPTION
## Summary
- add no-trailing-spaces support for skipBlankLines and ignoreComments options
- parse both options from ESLint-style rule config
- document and test the configured behavior

## Validation
- zig fmt --check src/core.zig src/rules/no_trailing_spaces.zig src/rules/root.zig tests/rules/no_trailing_spaces.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check