### PR TITLE
support linebreak-style windows

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -24,7 +24,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
-| [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Implemented |
+| [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -39,6 +39,11 @@ pub const OperatorAssignmentStyle = enum {
     never,
 };
 
+pub const LinebreakStyle = enum {
+    unix,
+    windows,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -1002,6 +1007,7 @@ pub const Options = struct {
     grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,
     guard_for_in: bool = true,
     linebreak_style: bool = true,
+    linebreak_style_style: LinebreakStyle = .unix,
     logical_assignment_operators: bool = true,
     logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
@@ -1628,6 +1634,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "eqeqeq")) {
             self.eqeqeq_style = try eqeqeqStyleFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "linebreak-style")) {
+            self.linebreak_style_style = try linebreakStyleFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "use-isnan")) {
             self.use_isnan_enforce_for_index_of = try useIsnanBoolOptionFromConfig(value, "enforceForIndexOf", false);
             self.use_isnan_enforce_for_switch_case = try useIsnanBoolOptionFromConfig(value, "enforceForSwitchCase", true);
@@ -2086,6 +2095,22 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "always")) return .strict;
         if (std.mem.eql(u8, style, "allow-null")) return .allow_null;
         if (std.mem.eql(u8, style, "smart")) return .smart;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn linebreakStyleFromConfig(value: std.json.Value) RuleConfigError!LinebreakStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .unix,
+        };
+        if (items.len < 2) return .unix;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "unix")) return .unix;
+        if (std.mem.eql(u8, style, "windows")) return .windows;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/linebreak_style.zig
+++ b/src/rules/linebreak_style.zig
@@ -7,24 +7,80 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "linebreak-style";
 
+pub const Style = enum {
+    unix,
+    windows,
+};
+
+pub const Options = struct {
+    style: Style = .unix,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
     const source = tree.source;
     var index: usize = 0;
 
-    while (std.mem.indexOfPos(u8, source, index, "\r\n")) |start| {
-        try core.addDiagnostic(
-            allocator,
-            diagnostics,
-            .warning,
-            id,
-            "Expected linebreaks to be 'LF' but found 'CRLF'.",
-            .{ .start = @intCast(start), .end = @intCast(start + 2) },
-        );
+    while (findLinebreak(source, index)) |linebreak| {
+        if (!linebreakMatchesStyle(linebreak, options.style)) {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                messageForStyle(options.style),
+                .{ .start = @intCast(linebreak.start), .end = @intCast(linebreak.end) },
+            );
+        }
 
-        index = start + 2;
+        index = linebreak.end;
     }
+}
+
+const Linebreak = struct {
+    start: usize,
+    end: usize,
+    style: Style,
+};
+
+fn findLinebreak(source: []const u8, start: usize) ?Linebreak {
+    var index = start;
+    while (index < source.len) : (index += 1) {
+        if (source[index] == '\n') {
+            return .{ .start = index, .end = index + 1, .style = .unix };
+        }
+        if (source[index] == '\r') {
+            if (index + 1 < source.len and source[index + 1] == '\n') {
+                return .{ .start = index, .end = index + 2, .style = .windows };
+            }
+            return .{ .start = index, .end = index + 1, .style = .windows };
+        }
+    }
+    return null;
+}
+
+fn linebreakMatchesStyle(linebreak: Linebreak, style: Style) bool {
+    return switch (style) {
+        .unix => linebreak.style == .unix,
+        .windows => linebreak.style == .windows and linebreak.end == linebreak.start + 2,
+    };
+}
+
+fn messageForStyle(style: Style) []const u8 {
+    return switch (style) {
+        .unix => "Expected linebreaks to be 'LF' but found 'CRLF'.",
+        .windows => "Expected linebreaks to be 'CRLF' but found 'LF'.",
+    };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -485,7 +485,12 @@ pub fn runBasic(
         try no_mixed_spaces_and_tabs.run(allocator, diagnostics, tree);
     }
     if (options.linebreak_style) {
-        try linebreak_style.run(allocator, diagnostics, tree);
+        try linebreak_style.runWithOptions(allocator, diagnostics, tree, .{
+            .style = switch (options.linebreak_style_style) {
+                .unix => .unix,
+                .windows => .windows,
+            },
+        });
     }
     if (options.no_irregular_whitespace) {
         try no_irregular_whitespace.run(allocator, diagnostics, tree);

--- a/tests/rules/linebreak_style.zig
+++ b/tests/rules/linebreak_style.zig
@@ -34,6 +34,36 @@ test "does not report linebreak-style for LF line endings" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.linebreak_style.id));
 }
 
+test "supports configured linebreak-style windows" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"windows\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("linebreak-style", config.value);
+
+    const source =
+        "const first = 1;\n" ++
+        "const second = 2;\r\n" ++
+        "const third = 3;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.linebreak_style.id));
+    try std.testing.expectEqualStrings(
+        "Expected linebreaks to be 'CRLF' but found 'LF'.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable linebreak-style" {
     const source = "const value = 1;\r\n";
 


### PR DESCRIPTION
## Summary
- add linebreak-style support for the windows option
- report LF endings when CRLF is configured
- document and test unix/windows rule config behavior

## Validation
- zig fmt --check src/core.zig src/rules/linebreak_style.zig src/rules/root.zig tests/rules/linebreak_style.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check