### PR TITLE
support no-mixed-spaces smart tabs

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -92,7 +92,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-lonely-if`](https://eslint.org/docs/latest/rules/no-lonely-if) | Implemented |
 | [`no-loop-func`](https://eslint.org/docs/latest/rules/no-loop-func) | Implemented |
 | [`no-loss-of-precision`](https://eslint.org/docs/latest/rules/no-loss-of-precision) | Implemented |
-| [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Implemented |
+| [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Supports `smart-tabs` configuration |
 | [`no-misleading-character-class`](https://eslint.org/docs/latest/rules/no-misleading-character-class) | Implemented |
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
 | [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Supports `ignoreEOLComments` and common `exceptions` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1174,6 +1174,7 @@ pub const Options = struct {
     no_multi_spaces_ignore_eol_comments: NoMultiSpacesIgnoreEOLComments = .no,
     no_multi_spaces_exceptions: NoMultiSpacesExceptions = .{},
     no_mixed_spaces_and_tabs: bool = true,
+    no_mixed_spaces_and_tabs_smart_tabs: bool = false,
     no_misleading_character_class: bool = true,
     no_multiple_empty_lines: bool = true,
     no_multiple_empty_lines_max: usize = 2,
@@ -1723,6 +1724,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-labels")) {
             self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
             self.no_labels_allow_switch = try noLabelsAllowSwitchFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-mixed-spaces-and-tabs")) {
+            self.no_mixed_spaces_and_tabs_smart_tabs = try noMixedSpacesAndTabsSmartTabsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
             self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
@@ -3191,6 +3195,21 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noMixedSpacesAndTabsSmartTabsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "smart-tabs")) return true;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noMultiSpacesIgnoreEOLCommentsFromConfig(value: std.json.Value) RuleConfigError!NoMultiSpacesIgnoreEOLComments {

--- a/src/rules/no_mixed_spaces_and_tabs.zig
+++ b/src/rules/no_mixed_spaces_and_tabs.zig
@@ -7,10 +7,23 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-mixed-spaces-and-tabs";
 
+pub const Options = struct {
+    smart_tabs: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
     var line_start: usize = 0;
@@ -19,7 +32,7 @@ pub fn run(
     while (line_start <= source.len) : (line_number += 1) {
         const line_end = findLineEnd(source, line_start);
         if (!isIgnoredCommentLine(source, tree.comments, line_number)) {
-            if (mixedIndentSpan(source, line_start, line_end)) |span| {
+            if (mixedIndentSpan(source, line_start, line_end, options.smart_tabs)) |span| {
                 if (!isInsideIgnoredLiteral(tree, span.start)) {
                     try core.addDiagnostic(
                         allocator,
@@ -42,7 +55,7 @@ pub fn run(
     }
 }
 
-fn mixedIndentSpan(source: []const u8, line_start: usize, line_end: usize) ?ast.Span {
+fn mixedIndentSpan(source: []const u8, line_start: usize, line_end: usize, smart_tabs: bool) ?ast.Span {
     if (line_start >= line_end) return null;
 
     const first = source[line_start];
@@ -52,6 +65,7 @@ fn mixedIndentSpan(source: []const u8, line_start: usize, line_end: usize) ?ast.
     while (index < line_end and source[index] == first) : (index += 1) {}
 
     if (index >= line_end or !isIndent(source[index])) return null;
+    if (smart_tabs and first == '\t' and source[index] == ' ') return null;
 
     const end = index + 1;
     return .{

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -482,7 +482,9 @@ pub fn runBasic(
         });
     }
     if (options.no_mixed_spaces_and_tabs) {
-        try no_mixed_spaces_and_tabs.run(allocator, diagnostics, tree);
+        try no_mixed_spaces_and_tabs.runWithOptions(allocator, diagnostics, tree, .{
+            .smart_tabs = options.no_mixed_spaces_and_tabs_smart_tabs,
+        });
     }
     if (options.linebreak_style) {
         try linebreak_style.runWithOptions(allocator, diagnostics, tree, .{

--- a/tests/rules/no_mixed_spaces_and_tabs.zig
+++ b/tests/rules/no_mixed_spaces_and_tabs.zig
@@ -39,6 +39,35 @@ test "does not report no-mixed-spaces-and-tabs for pure spaces or tabs" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
 }
 
+test "supports configured no-mixed-spaces-and-tabs smart tabs" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"smart-tabs\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-mixed-spaces-and-tabs", config.value);
+
+    const source =
+        "if (ok) {\n" ++
+        "\t  alignedWithSpaces();\n" ++
+        " \tbadIndent();\n" ++
+        "}\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_mixed_spaces_and_tabs.id));
+}
+
 test "ignores mixed indentation inside block comment continuation and template literals" {
     const source =
         "/* block\n" ++


### PR DESCRIPTION
## Summary
- add no-mixed-spaces-and-tabs support for the smart-tabs option
- parse smart-tabs from ESLint-style rule config
- document and test the configured behavior

## Validation
- zig fmt --check src/core.zig src/rules/no_mixed_spaces_and_tabs.zig src/rules/root.zig tests/rules/no_mixed_spaces_and_tabs.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check