### PR TITLE
support eol-last never

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -16,7 +16,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Implemented |
-| [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Implemented |
+| [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -44,6 +44,11 @@ pub const LinebreakStyle = enum {
     windows,
 };
 
+pub const EolLastStyle = enum {
+    always,
+    never,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -993,6 +998,7 @@ pub const Options = struct {
     default_case_last: bool = true,
     default_param_last: bool = true,
     eol_last: bool = true,
+    eol_last_style: EolLastStyle = .always,
     eslint_comments_no_restricted_disable: bool = true,
     eslint_comments_no_restricted_disable_no_nested_ternary: bool = false,
     for_direction: bool = true,
@@ -1617,6 +1623,9 @@ pub const Options = struct {
         if (enabled and (std.mem.eql(u8, cli_name, "dot-notation") or std.mem.eql(u8, cli_name, "@typescript-eslint/dot-notation"))) {
             self.dot_notation_allow_keywords = try dotNotationAllowKeywordsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "eol-last")) {
+            self.eol_last_style = try eolLastStyleFromConfig(value);
+        }
         if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
@@ -2082,6 +2091,22 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "all")) return .all;
         if (std.mem.eql(u8, style, "multi-line")) return .multi_line;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn eolLastStyleFromConfig(value: std.json.Value) RuleConfigError!EolLastStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "always") or std.mem.eql(u8, style, "unix") or std.mem.eql(u8, style, "windows")) return .always;
+        if (std.mem.eql(u8, style, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
     }
 

--- a/src/rules/eol_last.zig
+++ b/src/rules/eol_last.zig
@@ -7,21 +7,74 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "eol-last";
 
+pub const Style = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    style: Style = .always,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
-    const source = tree.source;
-    if (source.len == 0 or source[source.len - 1] == '\n') return;
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
 
-    const start = source.len - 1;
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
+    const source = tree.source;
+    if (source.len == 0) return;
+
+    switch (options.style) {
+        .always => {
+            if (source[source.len - 1] == '\n') return;
+            try addDiagnostic(allocator, diagnostics, source.len - 1, source.len, "Newline required at end of file but not found.");
+        },
+        .never => {
+            const span = finalLinebreakSpan(source) orelse return;
+            try addDiagnostic(allocator, diagnostics, span.start, span.end, "Newline not allowed at end of file.");
+        },
+    }
+}
+
+const Span = struct {
+    start: usize,
+    end: usize,
+};
+
+fn finalLinebreakSpan(source: []const u8) ?Span {
+    if (source.len == 0) return null;
+    if (source[source.len - 1] == '\n') {
+        const start = if (source.len >= 2 and source[source.len - 2] == '\r') source.len - 2 else source.len - 1;
+        return .{ .start = start, .end = source.len };
+    }
+    if (source[source.len - 1] == '\r') {
+        return .{ .start = source.len - 1, .end = source.len };
+    }
+    return null;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    start: usize,
+    end: usize,
+    message: []const u8,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Newline required at end of file but not found.",
-        .{ .start = @intCast(start), .end = @intCast(source.len) },
+        message,
+        .{ .start = @intCast(start), .end = @intCast(end) },
     );
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -461,7 +461,12 @@ pub fn runBasic(
         });
     }
     if (options.eol_last) {
-        try eol_last.run(allocator, diagnostics, tree);
+        try eol_last.runWithOptions(allocator, diagnostics, tree, .{
+            .style = switch (options.eol_last_style) {
+                .always => .always,
+                .never => .never,
+            },
+        });
     }
     if (options.eslint_comments_no_restricted_disable) {
         try eslint_comments_no_restricted_disable.run(allocator, diagnostics, tree, options.eslint_comments_no_restricted_disable_no_nested_ternary);

--- a/tests/rules/eol_last.zig
+++ b/tests/rules/eol_last.zig
@@ -40,6 +40,52 @@ test "does not report eol-last for empty source" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.eol_last.id));
 }
 
+test "supports configured eol-last never" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("eol-last", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, "const value = 1;\n", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.eol_last.id));
+    try std.testing.expectEqualStrings(
+        "Newline not allowed at end of file.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "supports configured eol-last unix alias" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"unix\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("eol-last", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, "const value = 1;", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.eol_last.id));
+}
+
 test "can disable eol-last" {
     const source = "const value = 1;";
 


### PR DESCRIPTION
## Summary
- add eol-last support for never configuration
- parse always, never, unix, and windows ESLint-style options
- document and test configured behavior

## Validation
- zig fmt --check src/core.zig src/rules/eol_last.zig src/rules/root.zig tests/rules/eol_last.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check