### PR TITLE
support unicode-bom always

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -181,7 +181,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
-| [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Implemented |
+| [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Supports `enforceForIndexOf` and `enforceForSwitchCase` configuration |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -49,6 +49,11 @@ pub const EolLastStyle = enum {
     never,
 };
 
+pub const UnicodeBomStyle = enum {
+    never,
+    always,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -1287,6 +1292,7 @@ pub const Options = struct {
     no_void_allow_as_statement: NoVoidAllowAsStatement = .no,
     no_with: bool = true,
     no_var: bool = true,
+    unicode_bom_style: UnicodeBomStyle = .never,
     object_shorthand: bool = true,
     object_shorthand_style: ObjectShorthandStyle = .always,
     object_shorthand_avoid_quotes: bool = false,
@@ -1767,6 +1773,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-useless-escape")) {
             self.no_useless_escape_allow_regex_characters = try noUselessEscapeAllowRegexCharactersFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "unicode-bom")) {
+            self.unicode_bom_style = try unicodeBomStyleFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-shadow")) {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -4155,6 +4164,22 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn unicodeBomStyleFromConfig(value: std.json.Value) RuleConfigError!UnicodeBomStyle {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .never,
+        };
+        if (items.len < 2) return .never;
+
+        const style = switch (items[1]) {
+            .string => |style| style,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, style, "never")) return .never;
+        if (std.mem.eql(u8, style, "always")) return .always;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn noUnneededTernaryDefaultAssignmentFromConfig(value: std.json.Value) RuleConfigError!bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -472,7 +472,12 @@ pub fn runBasic(
         try eslint_comments_no_restricted_disable.run(allocator, diagnostics, tree, options.eslint_comments_no_restricted_disable_no_nested_ternary);
     }
     if (options.unicode_bom) {
-        try unicode_bom.run(allocator, diagnostics, tree);
+        try unicode_bom.runWithOptions(allocator, diagnostics, tree, .{
+            .style = switch (options.unicode_bom_style) {
+                .never => .never,
+                .always => .always,
+            },
+        });
     }
     if (options.wrap_iife) {
         try wrap_iife.runWithStyle(allocator, diagnostics, tree, switch (options.wrap_iife_style) {

--- a/src/rules/unicode_bom.zig
+++ b/src/rules/unicode_bom.zig
@@ -9,19 +9,55 @@ pub const id = "unicode-bom";
 
 const bom = "\xEF\xBB\xBF";
 
+pub const Style = enum {
+    never,
+    always,
+};
+
+pub const Options = struct {
+    style: Style = .never,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
 ) Allocator.Error!void {
-    if (!std.mem.startsWith(u8, tree.source, bom)) return;
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
 
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
+    const has_bom = std.mem.startsWith(u8, tree.source, bom);
+    switch (options.style) {
+        .never => {
+            if (!has_bom) return;
+            try addDiagnostic(allocator, diagnostics, 0, bom.len, "Unexpected Unicode BOM (Byte Order Mark).");
+        },
+        .always => {
+            if (has_bom) return;
+            try addDiagnostic(allocator, diagnostics, 0, @min(tree.source.len, 1), "Expected Unicode BOM (Byte Order Mark).");
+        },
+    }
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    start: usize,
+    end: usize,
+    message: []const u8,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Unexpected Unicode BOM (Byte Order Mark).",
-        .{ .start = 0, .end = bom.len },
+        message,
+        .{ .start = @intCast(start), .end = @intCast(end) },
     );
 }

--- a/tests/rules/unicode_bom.zig
+++ b/tests/rules/unicode_bom.zig
@@ -30,6 +30,52 @@ test "does not report unicode-bom for ordinary source" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.unicode_bom.id));
 }
 
+test "supports configured unicode-bom always" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("unicode-bom", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, "const value = 1;\n", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.unicode_bom.id));
+    try std.testing.expectEqualStrings(
+        "Expected Unicode BOM (Byte Order Mark).",
+        result.diagnostics[0].message,
+    );
+}
+
+test "allows unicode-bom when configured always and BOM is present" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("unicode-bom", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, "\xEF\xBB\xBFconst value = 1;\n", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.unicode_bom.id));
+}
+
 test "can disable unicode-bom" {
     const source = "\xEF\xBB\xBFconst value = 1;\n";
 


### PR DESCRIPTION
## Summary
- add unicode-bom support for always configuration
- parse never and always ESLint-style options
- document and test configured behavior

## Validation
- zig fmt --check src/core.zig src/rules/unicode_bom.zig src/rules/root.zig tests/rules/unicode_bom.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check