### PR TITLE
support yoda except range

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -186,7 +186,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
-| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Implemented for `never` and optional `always` behavior |
+| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Supports `never`, `always`, `onlyEquality`, and `exceptRange` configuration |
 
 ## Import plugin rules
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -1524,6 +1524,7 @@ pub const Options = struct {
     yoda: bool = true,
     yoda_style: YodaStyle = .never,
     yoda_only_equality: bool = false,
+    yoda_except_range: bool = false,
 
     pub fn allDisabled() Options {
         var options = Options{};
@@ -2047,6 +2048,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "yoda")) {
             self.yoda_style = try yodaStyleFromConfig(value);
             self.yoda_only_equality = try yodaOnlyEqualityFromConfig(value);
+            self.yoda_except_range = try yodaExceptRangeFromConfig(value);
         }
     }
 
@@ -4789,6 +4791,23 @@ pub const Options = struct {
         return switch (config.get("onlyEquality") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn yodaExceptRangeFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 3) return false;
+
+        const config = switch (items[2]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("exceptRange") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
         };
     }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2582,6 +2582,8 @@ const BasicVisitor = struct {
                     .always => .always,
                 },
                 .only_equality = self.options.yoda_only_equality,
+                .except_range = self.options.yoda_except_range,
+                .parent = ctx.path.parent() orelse .null,
             });
         }
         if (self.options.typescript_eslint_no_confusing_non_null_assertion) {

--- a/src/rules/yoda.zig
+++ b/src/rules/yoda.zig
@@ -1,8 +1,9 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "yoda";
 
@@ -14,6 +15,8 @@ pub const Style = enum {
 pub const Options = struct {
     style: Style = .never,
     only_equality: bool = false,
+    except_range: bool = false,
+    parent: ast.NodeIndex = .null,
 };
 
 pub fn check(
@@ -47,6 +50,7 @@ pub fn checkWithOptions(
 ) Allocator.Error!void {
     if (!isComparisonOperator(expression.operator)) return;
     if (options.only_equality and !isEqualityOperator(expression.operator)) return;
+    if (options.except_range and isRangeComparison(tree, expression, index, options.parent)) return;
 
     const left_literal = isLiteralLike(tree, expression.left);
     const right_literal = isLiteralLike(tree, expression.right);
@@ -102,6 +106,55 @@ fn isEqualityOperator(operator: ast.BinaryOperator) bool {
         => true,
         else => false,
     };
+}
+
+fn isRelationalOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        => true,
+        else => false,
+    };
+}
+
+fn isRangeComparison(tree: *const ast.Tree, expression: ast.BinaryExpression, index: ast.NodeIndex, parent_index: ast.NodeIndex) bool {
+    if (!isRelationalOperator(expression.operator)) return false;
+
+    const logical = switch (tree.data(parent_index)) {
+        .logical_expression => |logical| logical,
+        else => return false,
+    };
+    if (logical.operator != .@"and" and logical.operator != .@"or") return false;
+
+    const sibling_index = if (logical.left == index) logical.right else if (logical.right == index) logical.left else return false;
+    const sibling = switch (tree.data(unwrapTransparent(tree, sibling_index))) {
+        .binary_expression => |binary| binary,
+        else => return false,
+    };
+    if (!isRelationalOperator(sibling.operator)) return false;
+
+    const current_subject = comparisonSubject(tree, expression) orelse return false;
+    const sibling_subject = comparisonSubject(tree, sibling) orelse return false;
+    return sameNodeSource(tree, current_subject, sibling_subject);
+}
+
+fn comparisonSubject(tree: *const ast.Tree, expression: ast.BinaryExpression) ?ast.NodeIndex {
+    const left_literal = isLiteralLike(tree, expression.left);
+    const right_literal = isLiteralLike(tree, expression.right);
+    if (left_literal == right_literal) return null;
+    return if (left_literal) unwrapTransparent(tree, expression.right) else unwrapTransparent(tree, expression.left);
+}
+
+fn sameNodeSource(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    const left_span = tree.span(left);
+    const right_span = tree.span(right);
+    return std.mem.eql(
+        u8,
+        tree.source[left_span.start..left_span.end],
+        tree.source[right_span.start..right_span.end],
+    );
 }
 
 fn isLiteralLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -126,6 +126,37 @@ test "supports configured yoda onlyEquality option" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.yoda.id));
 }
 
+test "supports configured yoda exceptRange option" {
+    const source =
+        \\if (0 <= age && age < 18) {}
+        \\if (age >= 65 || 12 > age) {}
+        \\if (0 < count) {}
+    ;
+
+    var options = lint.Options{
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\",{\"exceptRange\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("yoda", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.yoda.id));
+}
+
 test "can disable yoda" {
     const source =
         \\if ("red" === color) {}


### PR DESCRIPTION
## Summary
- add yoda support for exceptRange configuration
- skip Yoda diagnostics for simple range comparisons in logical expressions
- document and test configured behavior

## Validation
- zig fmt --check src/core.zig src/rules/yoda.zig src/rules/root.zig tests/rules/yoda.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check