### PR TITLE
Support no-irregular-whitespace skip options

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -1167,6 +1167,11 @@ pub const Options = struct {
     no_invalid_regexp: bool = true,
     no_invalid_regexp_allow_constructor_flags: NoInvalidRegexpAllowConstructorFlags = .{},
     no_irregular_whitespace: bool = true,
+    no_irregular_whitespace_skip_strings: bool = true,
+    no_irregular_whitespace_skip_comments: bool = false,
+    no_irregular_whitespace_skip_reg_exps: bool = false,
+    no_irregular_whitespace_skip_templates: bool = false,
+    no_irregular_whitespace_skip_jsx_text: bool = false,
     no_inline_comments: bool = true,
     no_inner_declarations: bool = true,
     no_inner_declarations_mode: NoInnerDeclarationsMode = .functions,
@@ -1736,6 +1741,13 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-invalid-regexp")) {
             self.no_invalid_regexp_allow_constructor_flags = try noInvalidRegexpAllowConstructorFlagsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-irregular-whitespace")) {
+            self.no_irregular_whitespace_skip_strings = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipStrings", true);
+            self.no_irregular_whitespace_skip_comments = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipComments", false);
+            self.no_irregular_whitespace_skip_reg_exps = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipRegExps", false);
+            self.no_irregular_whitespace_skip_templates = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipTemplates", false);
+            self.no_irregular_whitespace_skip_jsx_text = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipJSXText", false);
         }
         if (std.mem.eql(u8, cli_name, "no-labels")) {
             self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
@@ -4089,6 +4101,23 @@ pub const Options = struct {
         };
     }
 
+    fn noIrregularWhitespaceBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noEvalAllowIndirectFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6263,6 +6292,21 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-redeclare", no_redeclare_config.value);
     try std.testing.expect(options.no_redeclare);
     try std.testing.expectEqual(NoRedeclareBuiltinGlobals.yes, options.no_redeclare_builtin_globals);
+
+    var no_irregular_whitespace_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipStrings\":false,\"skipComments\":true,\"skipRegExps\":true,\"skipTemplates\":true,\"skipJSXText\":true}]",
+        .{},
+    );
+    defer no_irregular_whitespace_config.deinit();
+    try options.setByRuleConfigValue("no-irregular-whitespace", no_irregular_whitespace_config.value);
+    try std.testing.expect(options.no_irregular_whitespace);
+    try std.testing.expect(!options.no_irregular_whitespace_skip_strings);
+    try std.testing.expect(options.no_irregular_whitespace_skip_comments);
+    try std.testing.expect(options.no_irregular_whitespace_skip_reg_exps);
+    try std.testing.expect(options.no_irregular_whitespace_skip_templates);
+    try std.testing.expect(options.no_irregular_whitespace_skip_jsx_text);
 
     var no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_irregular_whitespace.zig
+++ b/src/rules/no_irregular_whitespace.zig
@@ -7,10 +7,27 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-irregular-whitespace";
 
+pub const Options = struct {
+    skip_strings: bool = true,
+    skip_comments: bool = false,
+    skip_reg_exps: bool = false,
+    skip_templates: bool = false,
+    skip_jsx_text: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
     var index: usize = 0;
@@ -18,7 +35,7 @@ pub fn run(
     while (index < source.len) {
         if (irregularWhitespaceLen(source[index..])) |len| {
             const end = index + len;
-            if (!isInsideStringLiteral(tree, @intCast(index))) {
+            if (!isInsideIgnoredSpan(tree, @intCast(index), options)) {
                 try core.addDiagnostic(
                     allocator,
                     diagnostics,
@@ -73,18 +90,37 @@ fn startsWith(source: []const u8, bytes: []const u8) bool {
     return std.mem.startsWith(u8, source, bytes);
 }
 
-fn isInsideStringLiteral(tree: *const ast.Tree, offset: u32) bool {
+fn isInsideIgnoredSpan(tree: *const ast.Tree, offset: u32, options: Options) bool {
+    if (options.skip_comments) {
+        for (tree.comments) |comment| {
+            if (comment.start <= offset and offset < comment.end) return true;
+        }
+    }
+
     const data = tree.nodes.items(.data);
     const spans = tree.nodes.items(.span);
 
     for (data, spans) |node, span| {
         switch (node) {
             .string_literal => {
-                if (span.start <= offset and offset < span.end) return true;
+                if (options.skip_strings and containsOffset(span, offset)) return true;
+            },
+            .regexp_literal => {
+                if (options.skip_reg_exps and containsOffset(span, offset)) return true;
+            },
+            .template_element => {
+                if (options.skip_templates and containsOffset(span, offset)) return true;
+            },
+            .jsx_text => {
+                if (options.skip_jsx_text and containsOffset(span, offset)) return true;
             },
             else => {},
         }
     }
 
     return false;
+}
+
+fn containsOffset(span: ast.Span, offset: u32) bool {
+    return span.start <= offset and offset < span.end;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -505,7 +505,13 @@ pub fn runBasic(
         });
     }
     if (options.no_irregular_whitespace) {
-        try no_irregular_whitespace.run(allocator, diagnostics, tree);
+        try no_irregular_whitespace.runWithOptions(allocator, diagnostics, tree, .{
+            .skip_strings = options.no_irregular_whitespace_skip_strings,
+            .skip_comments = options.no_irregular_whitespace_skip_comments,
+            .skip_reg_exps = options.no_irregular_whitespace_skip_reg_exps,
+            .skip_templates = options.no_irregular_whitespace_skip_templates,
+            .skip_jsx_text = options.no_irregular_whitespace_skip_jsx_text,
+        });
     }
     if (options.no_multiple_empty_lines) {
         try no_multiple_empty_lines.runWithOptions(allocator, diagnostics, tree, .{

--- a/tests/rules/no_irregular_whitespace.zig
+++ b/tests/rules/no_irregular_whitespace.zig
@@ -36,6 +36,20 @@ test "does not report no-irregular-whitespace inside strings by default" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_irregular_whitespace.id));
 }
 
+test "reports no-irregular-whitespace inside strings when configured" {
+    const nbsp = "\xC2\xA0";
+    const source = "const value = \"hello" ++ nbsp ++ "world\";\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_irregular_whitespace_skip_strings = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_irregular_whitespace.id));
+}
+
 test "reports no-irregular-whitespace inside template literals" {
     const nbsp = "\xC2\xA0";
     const source = "const value = `hello" ++ nbsp ++ "world`;\n";
@@ -47,6 +61,27 @@ test "reports no-irregular-whitespace inside template literals" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_irregular_whitespace.id));
+}
+
+test "skips configured no-irregular-whitespace syntax spans" {
+    const nbsp = "\xC2\xA0";
+    const source =
+        "// comment" ++ nbsp ++ "\n" ++
+        "const pattern = /hello" ++ nbsp ++ "world/;\n" ++
+        "const message = `hello" ++ nbsp ++ "world`;\n" ++
+        "const element = <div>hello" ++ nbsp ++ "world</div>;\n";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .no_irregular_whitespace_skip_comments = true,
+        .no_irregular_whitespace_skip_reg_exps = true,
+        .no_irregular_whitespace_skip_templates = true,
+        .no_irregular_whitespace_skip_jsx_text = true,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_irregular_whitespace.id));
 }
 
 test "can disable no-irregular-whitespace" {


### PR DESCRIPTION
## Summary
- add ESLint-compatible no-irregular-whitespace skip options for strings, comments, regexps, templates, and JSX text
- wire those options through rule config parsing and root rule dispatch
- add coverage for default string behavior, configured string reporting, skipped syntax spans, and JSON config parsing

## Validation
- zig fmt --check src/rules/no_irregular_whitespace.zig src/core.zig src/rules/root.zig tests/rules/no_irregular_whitespace.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check