### PR TITLE
Support no-empty-pattern parameter option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -61,7 +61,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |
 | [`no-empty-character-class`](https://eslint.org/docs/latest/rules/no-empty-character-class) | Implemented |
 | [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) | Implemented with `allow` behavior for functions, arrow functions, async/generator functions, methods, async/generator methods, getters, setters, and constructors |
-| [`no-empty-pattern`](https://eslint.org/docs/latest/rules/no-empty-pattern) | Implemented |
+| [`no-empty-pattern`](https://eslint.org/docs/latest/rules/no-empty-pattern) | Implemented with optional `allowObjectPatternsAsParameters` behavior |
 | [`no-empty-static-block`](https://eslint.org/docs/latest/rules/no-empty-static-block) | Implemented |
 | [`no-eq-null`](https://eslint.org/docs/latest/rules/no-eq-null) | Implemented |
 | [`no-eval`](https://eslint.org/docs/latest/rules/no-eval) | Supports `allowIndirect` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1077,6 +1077,7 @@ pub const Options = struct {
     no_empty_function: bool = true,
     no_empty_function_allow: NoEmptyFunctionAllow = .{},
     no_empty_pattern: bool = true,
+    no_empty_pattern_allow_object_patterns_as_parameters: bool = false,
     no_empty_static_block: bool = true,
     no_else_return: bool = true,
     no_else_return_allow_else_if: bool = true,
@@ -1714,6 +1715,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
             self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-empty-pattern")) {
+            self.no_empty_pattern_allow_object_patterns_as_parameters = try noEmptyPatternAllowObjectPatternsAsParametersFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-else-return")) {
             self.no_else_return_allow_else_if = try noElseReturnAllowElseIfFromConfig(value);
@@ -3038,6 +3042,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowElseIf") orelse return true) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noEmptyPatternAllowObjectPatternsAsParametersFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowObjectPatternsAsParameters") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -6100,6 +6121,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-else-return", no_else_return_config.value);
     try std.testing.expect(options.no_else_return);
     try std.testing.expect(!options.no_else_return_allow_else_if);
+
+    var no_empty_pattern_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowObjectPatternsAsParameters\":true}]",
+        .{},
+    );
+    defer no_empty_pattern_config.deinit();
+    try options.setByRuleConfigValue("no-empty-pattern", no_empty_pattern_config.value);
+    try std.testing.expect(options.no_empty_pattern);
+    try std.testing.expect(options.no_empty_pattern_allow_object_patterns_as_parameters);
 
     var no_extra_boolean_cast_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_empty_pattern.zig
+++ b/src/rules/no_empty_pattern.zig
@@ -6,6 +6,10 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-empty-pattern";
 
+pub const Options = struct {
+    allow_object_patterns_as_parameters: bool = false,
+};
+
 pub fn checkObjectPattern(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -13,7 +17,21 @@ pub fn checkObjectPattern(
     pattern: ast.ObjectPattern,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkObjectPatternWithOptions(allocator, diagnostics, tree, pattern, index, null, null, .{});
+}
+
+pub fn checkObjectPatternWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+    grandparent_index: ?ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (pattern.properties.len > 0 or pattern.rest != .null) return;
+    if (options.allow_object_patterns_as_parameters and isAllowedObjectParameter(tree, index, parent_index, grandparent_index)) return;
 
     try addDiagnostic(allocator, diagnostics, tree, index, "object");
 }
@@ -46,4 +64,32 @@ fn addDiagnostic(
         "Unexpected empty {s} pattern.",
         .{pattern_type},
     );
+}
+
+fn isAllowedObjectParameter(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    parent_index: ?ast.NodeIndex,
+    grandparent_index: ?ast.NodeIndex,
+) bool {
+    const parent = parent_index orelse return false;
+    return switch (tree.data(parent)) {
+        .formal_parameter => |parameter| parameter.pattern == index,
+        .assignment_pattern => |assignment| blk: {
+            if (assignment.left != index or !isEmptyObjectExpression(tree, assignment.right)) break :blk false;
+            const grandparent = grandparent_index orelse break :blk false;
+            break :blk switch (tree.data(grandparent)) {
+                .formal_parameter => |parameter| parameter.pattern == parent,
+                else => false,
+            };
+        },
+        else => false,
+    };
+}
+
+fn isEmptyObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .object_expression => |expression| expression.properties.len == 0,
+        else => false,
+    };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3243,7 +3243,18 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_empty_pattern) {
-            try no_empty_pattern.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, index);
+            try no_empty_pattern.checkObjectPatternWithOptions(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                pattern,
+                index,
+                ctx.path.parent(),
+                ctx.path.ancestor(2),
+                .{
+                    .allow_object_patterns_as_parameters = self.options.no_empty_pattern_allow_object_patterns_as_parameters,
+                },
+            );
         }
         if (self.options.no_useless_rename) {
             try no_useless_rename.checkObjectPatternWithOptions(self.allocator, self.diagnostics, ctx.tree, pattern, self.noUselessRenameOptions());

--- a/tests/rules/no_empty_pattern.zig
+++ b/tests/rules/no_empty_pattern.zig
@@ -39,6 +39,28 @@ test "does not report no-empty-pattern for non-empty destructuring patterns" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_empty_pattern.id));
 }
 
+test "supports no-empty-pattern allowObjectPatternsAsParameters option" {
+    const source =
+        \\function direct({}) {}
+        \\const arrow = ({}) => {};
+        \\function withDefault({} = {}) {}
+        \\function withNonEmptyDefault({} = fallback) {}
+        \\function nested({ value: {} }) {}
+        \\function array([]) {}
+        \\const {} = object;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty_pattern_allow_object_patterns_as_parameters = true,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_empty_pattern.id));
+}
+
 test "can disable no-empty-pattern" {
     const source =
         \\const {} = object;


### PR DESCRIPTION
## Summary
- add no-empty-pattern support for allowObjectPatternsAsParameters
- only skip direct empty object parameters and empty-object default parameter patterns, matching ESLint behavior
- wire the option through rule config parsing, root dispatch, tests, and rule status docs

## Validation
- zig fmt --check src/rules/no_empty_pattern.zig src/rules/root.zig src/core.zig tests/rules/no_empty_pattern.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check