### PR TITLE
Align no-return-await tail positions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -122,7 +122,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
-| [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented |
+| [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented for return statements, async arrow expression bodies, and nested tail expressions |
 | [`no-script-url`](https://eslint.org/docs/latest/rules/no-script-url) | Implemented |
 | [`no-self-assign`](https://eslint.org/docs/latest/rules/no-self-assign) | Supports `props` configuration |
 | [`no-self-compare`](https://eslint.org/docs/latest/rules/no-self-compare) | Implemented |

--- a/src/rules/no_return_await.zig
+++ b/src/rules/no_return_await.zig
@@ -11,13 +11,12 @@ pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    statement: ast.ReturnStatement,
+    _: ast.AwaitExpression,
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
-    if (!isAwaitExpression(tree, statement.argument)) return;
-    if (!isInsideAsyncFunction(tree, ctx)) return;
-    if (isInsideTryBlock(tree, ctx)) return;
+    if (!isInTailReturnPosition(tree, ctx, 0)) return;
+    if (hasErrorHandler(tree, ctx, 0)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -29,37 +28,45 @@ pub fn check(
     );
 }
 
-fn isAwaitExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
-    if (index == .null) return false;
-    return switch (tree.data(index)) {
-        .await_expression => true,
+fn isInTailReturnPosition(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, depth: usize) bool {
+    const current = ctx.path.ancestor(depth) orelse return false;
+    const parent_index = ctx.path.ancestor(depth + 1) orelse return false;
+
+    return switch (tree.data(parent_index)) {
+        .return_statement => |statement| statement.argument == current and !hasErrorHandler(tree, ctx, depth + 1),
+        .arrow_function_expression => |expression| expression.async and expression.expression and expression.body == current,
+        .conditional_expression => |expression| if (expression.consequent == current or expression.alternate == current)
+            isInTailReturnPosition(tree, ctx, depth + 1)
+        else
+            false,
+        .logical_expression => |expression| expression.right == current and isInTailReturnPosition(tree, ctx, depth + 1),
+        .sequence_expression => |expression| blk: {
+            const expressions = tree.extra(expression.expressions);
+            if (expressions.len == 0) break :blk false;
+            break :blk expressions[expressions.len - 1] == current and isInTailReturnPosition(tree, ctx, depth + 1);
+        },
+        .parenthesized_expression => |expression| expression.expression == current and isInTailReturnPosition(tree, ctx, depth + 1),
+        .chain_expression => |expression| expression.expression == current and isInTailReturnPosition(tree, ctx, depth + 1),
         else => false,
     };
 }
 
-fn isInsideAsyncFunction(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
-    var depth: usize = 1;
+fn hasErrorHandler(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, start_depth: usize) bool {
+    var depth = start_depth;
     while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
         switch (tree.data(ancestor)) {
-            .arrow_function_expression => |function| return function.async,
-            .function => |function| return function.async,
+            .function,
+            .arrow_function_expression,
+            .program,
+            => return false,
             else => {},
         }
-    }
 
-    return false;
-}
-
-fn isInsideTryBlock(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
-    var depth: usize = 1;
-    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
-        switch (tree.data(ancestor)) {
-            .arrow_function_expression,
-            .function,
-            => return false,
+        const parent_index = ctx.path.ancestor(depth + 1) orelse return false;
+        switch (tree.data(parent_index)) {
             .try_statement => |statement| {
-                const child = ctx.path.ancestor(depth - 1) orelse return false;
-                return statement.block == child;
+                if (statement.block == ancestor) return true;
+                if (statement.handler == ancestor and statement.finalizer != .null) return true;
             },
             else => {},
         }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2062,9 +2062,6 @@ const BasicVisitor = struct {
         if (self.options.no_setter_return) {
             try no_setter_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
-        if (self.options.no_return_await) {
-            try no_return_await.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
-        }
         if (self.options.no_useless_return) {
             try no_useless_return.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
@@ -2849,10 +2846,13 @@ const BasicVisitor = struct {
 
     pub fn enter_await_expression(
         self: *BasicVisitor,
-        _: ast.AwaitExpression,
+        expression: ast.AwaitExpression,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_return_await) {
+            try no_return_await.check(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
+        }
         if (self.options.no_await_in_loop) {
             try no_await_in_loop.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
         }

--- a/tests/rules/no_return_await.zig
+++ b/tests/rules/no_return_await.zig
@@ -10,6 +10,16 @@ test "reports no-return-await for async return await outside try blocks" {
         \\const second = async () => {
         \\  return await value;
         \\};
+        \\const third = async () => await value;
+        \\async function fourth() {
+        \\  return ready ? await first : await second;
+        \\}
+        \\async function fifth() {
+        \\  return ready && await value;
+        \\}
+        \\async function sixth() {
+        \\  return (prepare(), await value);
+        \\}
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -19,7 +29,7 @@ test "reports no-return-await for async return await outside try blocks" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_return_await.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_return_await.id));
 }
 
 test "does not report no-return-await outside async functions or inside try blocks" {
@@ -38,6 +48,18 @@ test "does not report no-return-await outside async functions or inside try bloc
         \\  function inner() {
         \\    return value;
         \\  }
+        \\}
+        \\async function catchWithFinally() {
+        \\  try {
+        \\    risky();
+        \\  } catch (error) {
+        \\    return await recover();
+        \\  } finally {
+        \\    cleanup();
+        \\  }
+        \\}
+        \\async function nonTailPositions() {
+        \\  return (await first) + second;
         \\}
     ;
 


### PR DESCRIPTION
## Summary
- move no-return-await checking to await expressions so nested tail positions are covered
- report async arrow expression bodies and tail await expressions in conditionals, logical expressions, and sequences
- preserve error-handler exceptions for try blocks and catch clauses with finally blocks
- update rule status and coverage

## Validation
- zig fmt --check src/rules/no_return_await.zig src/rules/root.zig tests/rules/no_return_await.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check