### PR TITLE
Align no-lone-blocks scoped blocks

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -88,7 +88,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-iterator`](https://eslint.org/docs/latest/rules/no-iterator) | Implemented |
 | [`no-label-var`](https://eslint.org/docs/latest/rules/no-label-var) | Implemented |
 | [`no-labels`](https://eslint.org/docs/latest/rules/no-labels) | Implemented |
-| [`no-lone-blocks`](https://eslint.org/docs/latest/rules/no-lone-blocks) | Implemented |
+| [`no-lone-blocks`](https://eslint.org/docs/latest/rules/no-lone-blocks) | Implemented with block-scoped binding exceptions |
 | [`no-lonely-if`](https://eslint.org/docs/latest/rules/no-lonely-if) | Implemented |
 | [`no-loop-func`](https://eslint.org/docs/latest/rules/no-loop-func) | Implemented |
 | [`no-loss-of-precision`](https://eslint.org/docs/latest/rules/no-loss-of-precision) | Implemented |

--- a/src/rules/no_lone_blocks.zig
+++ b/src/rules/no_lone_blocks.zig
@@ -15,7 +15,7 @@ pub fn check(
     parent: ast.NodeIndex,
 ) Allocator.Error!void {
     if (!isStatementListParent(tree.data(parent))) return;
-    if (tree.data(parent) == .program and hasBlockScopedBinding(tree, block)) return;
+    if (hasBlockScopedBinding(tree, block)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -32,6 +32,7 @@ fn isStatementListParent(data: ast.NodeData) bool {
         .program,
         .block_statement,
         .function_body,
+        .static_block,
         => true,
         else => false,
     };

--- a/tests/rules/no_lone_blocks.zig
+++ b/tests/rules/no_lone_blocks.zig
@@ -12,6 +12,13 @@ test "reports no-lone-blocks for unnecessary block statements" {
         \\    run();
         \\  }
         \\}
+        \\class Example {
+        \\  static {
+        \\    {
+        \\      run();
+        \\    }
+        \\  }
+        \\}
         \\function scoped() {
         \\  { let value = getValue(); }
         \\  { const value = getValue(); }
@@ -28,7 +35,7 @@ test "reports no-lone-blocks for unnecessary block statements" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_lone_blocks.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_lone_blocks.id));
 }
 
 test "does not report no-lone-blocks for scoped declarations" {
@@ -48,6 +55,17 @@ test "does not report no-lone-blocks for scoped declarations" {
         \\{
         \\  function scoped() {}
         \\  use(scoped);
+        \\}
+        \\function nestedBlocks() {
+        \\  { let value = getValue(); }
+        \\  { const value = getValue(); }
+        \\  { class Scoped {} }
+        \\  { function scoped() {} }
+        \\}
+        \\class Holder {
+        \\  static {
+        \\    { let value = getValue(); }
+        \\  }
         \\}
     ;
 


### PR DESCRIPTION
## Summary
- allow lone blocks with block-scoped declarations in nested statement lists
- check unnecessary blocks nested inside class static blocks
- document the block-scoped binding exception for no-lone-blocks

## Validation
- zig fmt --check src/rules/no_lone_blocks.zig tests/rules/no_lone_blocks.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check