### PR TITLE
Support default-case commentPattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -12,7 +12,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |
-| [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented |
+| [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -977,6 +977,30 @@ pub const DotNotationAllowKeywords = enum {
     no,
 };
 
+pub const max_default_case_comment_pattern_len = 256;
+
+pub const DefaultCaseCommentPatternError = error{
+    DefaultCaseCommentPatternTooLong,
+};
+
+pub const DefaultCaseCommentPattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_default_case_comment_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const DefaultCaseCommentPattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *DefaultCaseCommentPattern, pattern_value: []const u8) DefaultCaseCommentPatternError!void {
+        if (pattern_value.len > max_default_case_comment_pattern_len) return error.DefaultCaseCommentPatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
@@ -1000,6 +1024,7 @@ pub const Options = struct {
     dot_notation_allow_keywords: DotNotationAllowKeywords = .yes,
     typescript_eslint_dot_notation: bool = true,
     default_case: bool = true,
+    default_case_comment_pattern: DefaultCaseCommentPattern = .{},
     default_case_last: bool = true,
     default_param_last: bool = true,
     eol_last: bool = true,
@@ -1632,6 +1657,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "curly")) {
             self.curly_style = try curlyStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "default-case")) {
+            self.default_case_comment_pattern = try defaultCaseCommentPatternFromConfig(value);
         }
         if (enabled and (std.mem.eql(u8, cli_name, "dot-notation") or std.mem.eql(u8, cli_name, "@typescript-eslint/dot-notation"))) {
             self.dot_notation_allow_keywords = try dotNotationAllowKeywordsFromConfig(value);
@@ -2787,6 +2815,27 @@ pub const Options = struct {
             exceptions.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return exceptions;
+    }
+
+    fn defaultCaseCommentPatternFromConfig(value: std.json.Value) RuleConfigError!DefaultCaseCommentPattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get("commentPattern") orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var pattern = DefaultCaseCommentPattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
     }
 
     fn noBitwiseAllowFromConfig(value: std.json.Value, expected: []const u8) RuleConfigError!bool {

--- a/src/rules/default_case.zig
+++ b/src/rules/default_case.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "default-case";
 
+pub const Options = struct {
+    comment_pattern: core.DefaultCaseCommentPattern = .{},
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,8 +18,19 @@ pub fn check(
     statement: ast.SwitchStatement,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, statement, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.SwitchStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
     if (hasDefaultCase(tree, statement)) return;
-    if (hasNoDefaultComment(tree, index)) return;
+    if (hasNoDefaultComment(tree, index, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -39,7 +54,7 @@ fn hasDefaultCase(tree: *const ast.Tree, statement: ast.SwitchStatement) bool {
     return false;
 }
 
-fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) bool {
     const switch_statement = switch (tree.data(index)) {
         .switch_statement => |statement| statement,
         else => return false,
@@ -54,8 +69,83 @@ fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     for (tree.comments) |comment| {
         if (comment.start < last_case_end or comment.end > switch_end) continue;
         const value = std.mem.trim(u8, tree.string(comment.value), &std.ascii.whitespace);
-        if (std.ascii.eqlIgnoreCase(value, "no default")) return true;
+        if (commentMatchesPattern(value, options.comment_pattern)) return true;
     }
 
     return false;
+}
+
+fn commentMatchesPattern(value: []const u8, pattern: core.DefaultCaseCommentPattern) bool {
+    const custom_pattern = pattern.pattern() orelse return std.ascii.eqlIgnoreCase(value, "no default");
+    return matchesPattern(value, custom_pattern);
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const remainder = pattern[start..];
+        const separator = std.mem.indexOfScalar(u8, remainder, '|');
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$");
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (std.mem.indexOf(u8, body, ".*") != null) {
+        return matchesWildcardSequence(value, body, anchored_start, anchored_end);
+    }
+    if (anchored_start and anchored_end) return std.mem.eql(u8, value, body);
+    if (anchored_start) return std.mem.startsWith(u8, value, body);
+    if (anchored_end) return std.mem.endsWith(u8, value, body);
+    return std.mem.indexOf(u8, value, body) != null;
+}
+
+fn matchesWildcardSequence(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    var value_offset: usize = 0;
+    var pattern_offset: usize = 0;
+    var part_index: usize = 0;
+
+    while (pattern_offset <= pattern.len) : (part_index += 1) {
+        const remainder = pattern[pattern_offset..];
+        const wildcard = std.mem.indexOf(u8, remainder, ".*");
+        const part_end = if (wildcard) |offset| pattern_offset + offset else pattern.len;
+        const part = pattern[pattern_offset..part_end];
+
+        if (part.len > 0) {
+            if (part_index == 0 and anchored_start) {
+                if (!std.mem.startsWith(u8, value[value_offset..], part)) return false;
+                value_offset += part.len;
+            } else {
+                const found = std.mem.indexOf(u8, value[value_offset..], part) orelse return false;
+                value_offset += found + part.len;
+            }
+        }
+
+        if (wildcard == null) break;
+        pattern_offset = part_end + 2;
+    }
+
+    if (!anchored_end) return true;
+    const suffix_start = lastWildcardPartStart(pattern);
+    return std.mem.endsWith(u8, value, pattern[suffix_start..]);
+}
+
+fn lastWildcardPartStart(pattern: []const u8) usize {
+    var offset: usize = 0;
+    var start: usize = 0;
+    while (offset < pattern.len) {
+        const wildcard = std.mem.indexOf(u8, pattern[offset..], ".*") orelse break;
+        start = offset + wildcard + 2;
+        offset = start;
+    }
+    return start;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1974,7 +1974,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.default_case) {
-            try default_case.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try default_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, .{
+                .comment_pattern = self.options.default_case_comment_pattern,
+            });
         }
         if (self.options.default_case_last) {
             try default_case_last.check(self.allocator, self.diagnostics, ctx.tree, statement);

--- a/tests/rules/default_case.zig
+++ b/tests/rules/default_case.zig
@@ -62,6 +62,46 @@ test "does not report default-case when default exists or comment opts out" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.default_case.id));
 }
 
+test "supports configured default-case commentPattern option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"commentPattern\":\"^skip default|covered elsewhere$\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("default-case", config.value);
+
+    const source =
+        \\switch (first) {
+        \\  case 1:
+        \\    runOne();
+        \\  // skip default because values are normalized
+        \\}
+        \\switch (second) {
+        \\  case 1:
+        \\    runOne();
+        \\  // handled by covered elsewhere
+        \\}
+        \\switch (third) {
+        \\  case 1:
+        \\    runOne();
+        \\  // no default
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.default_case.id));
+}
+
 test "can disable default-case" {
     const source =
         \\switch (value) {


### PR DESCRIPTION
## Summary
- add default-case commentPattern config parsing
- pass the configured pattern into default-case checks
- support common anchored, alternation, and .* comment pattern matching for opt-out comments
- document the supported default-case commentPattern behavior

## Notes
This keeps the implementation lightweight instead of adding a full regex engine, while covering common ESLint migration patterns for default-case opt-out comments.

## Validation
- zig fmt --check src/core.zig src/rules/default_case.zig src/rules/root.zig tests/rules/default_case.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check