### PR TITLE
Align no-alert global this detection

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -28,7 +28,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
-| [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented |
+| [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |
 | [`no-array-constructor`](https://eslint.org/docs/latest/rules/no-array-constructor) | Implemented |
 | [`no-async-promise-executor`](https://eslint.org/docs/latest/rules/no-async-promise-executor) | Implemented |
 | [`no-await-in-loop`](https://eslint.org/docs/latest/rules/no-await-in-loop) | Implemented |

--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -61,7 +61,7 @@ const Visitor = struct {
         }
 
         if (self.check_no_alert) {
-            if (alertCalleeName(ctx.tree, self.symbol_table, call.callee)) |name| {
+            if (alertCalleeName(ctx.tree, self.symbol_table, call.callee, ctx)) |name| {
                 try core.addDiagnosticFmt(
                     self.allocator,
                     self.diagnostics,
@@ -188,6 +188,7 @@ fn alertCalleeName(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
     callee: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
 ) ?[]const u8 {
     const unwrapped = unwrapTransparent(tree, callee);
 
@@ -204,8 +205,7 @@ fn alertCalleeName(
     };
 
     const object = unwrapTransparent(tree, member.object);
-    const object_name = identifierReferenceName(tree, object) orelse return null;
-    if (!isAlertGlobalObjectName(object_name) or !isUnresolvedReference(symbol_table, object)) {
+    if (!isAlertGlobalObjectReference(tree, symbol_table, object, ctx)) {
         return null;
     }
 
@@ -213,6 +213,37 @@ fn alertCalleeName(
     if (isAlertName(property_name)) return property_name;
 
     return null;
+}
+
+fn isAlertGlobalObjectReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    object: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) bool {
+    switch (tree.data(object)) {
+        .this_expression => return isTopLevelThis(ctx, tree),
+        else => {},
+    }
+
+    const object_name = identifierReferenceName(tree, object) orelse return false;
+    return isAlertGlobalObjectName(object_name) and isUnresolvedReference(symbol_table, object);
+}
+
+fn isTopLevelThis(ctx: *traverser.basic.Ctx, tree: *const ast.Tree) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .program => return true,
+            .function,
+            .arrow_function_expression,
+            .class,
+            .static_block,
+            => return false,
+            else => {},
+        }
+    }
+    return false;
 }
 
 fn hasStringFirstArgument(tree: *const ast.Tree, arguments: ast.IndexRange) bool {

--- a/tests/rules/no_alert.zig
+++ b/tests/rules/no_alert.zig
@@ -9,6 +9,9 @@ test "reports no-alert for global alert APIs" {
         \\prompt("name");
         \\window.alert("hello");
         \\globalThis.prompt("name");
+        \\this.alert("hello");
+        \\this.confirm("continue?");
+        \\this.prompt("name");
         \\window["confirm"]("continue?");
         \\window[`alert`]("hello");
         \\globalThis[`prompt`]("name");
@@ -23,7 +26,7 @@ test "reports no-alert for global alert APIs" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 9), helpers.countRule(result, lint.rules.no_alert.id));
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.no_alert.id));
 }
 
 test "does not report no-alert for shadowed alert" {
@@ -51,6 +54,36 @@ test "does not report no-alert for dynamic global member names" {
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
         .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_alert.id));
+}
+
+test "does not report no-alert for non-global this members" {
+    const source =
+        \\function insideFunction() {
+        \\  this.alert("hello");
+        \\}
+        \\const insideArrow = () => {
+        \\  this.confirm("continue?");
+        \\};
+        \\class Example {
+        \\  method() {
+        \\    this.prompt("name");
+        \\  }
+        \\  static {
+        \\    this.alert("hello");
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_console = false,
+        .no_empty_function = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary
- report no-alert for top-level this.alert/confirm/prompt calls
- keep this.alert inside functions, arrows, classes, and static blocks ignored
- document global this/window/globalThis handling for no-alert

## Validation
- zig fmt --check src/rules/global_call_checks.zig tests/rules/no_alert.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check