### PR TITLE
Align no-implied-eval global calls

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -79,7 +79,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-global-is-finite`](https://eslint.org/docs/latest/rules/no-global-is-finite) | Implemented |
 | [`no-global-is-nan`](https://eslint.org/docs/latest/rules/no-global-is-nan) | Implemented |
 | [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Supports `boolean`, `number`, `string`, `allow`, and `disallowTemplateShorthand` configuration |
-| [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented |
+| [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented for global timer and `execScript` calls with evaluated string arguments |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |
 | [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Supports default `functions` mode and `both` mode for nested `var` declarations |

--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -250,9 +250,16 @@ fn hasStringFirstArgument(tree: *const ast.Tree, arguments: ast.IndexRange) bool
     if (arguments.len == 0) return false;
 
     const first = unwrapTransparent(tree, tree.extra(arguments)[0]);
-    return switch (tree.data(first)) {
+    return isEvaluatedString(tree, first);
+}
+
+fn isEvaluatedString(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
         .string_literal => true,
-        .template_literal => |template| template.expressions.len == 0,
+        .template_literal => true,
+        .binary_expression => |expression| expression.operator == .add and
+            (isEvaluatedString(tree, unwrapTransparent(tree, expression.left)) or
+                isEvaluatedString(tree, unwrapTransparent(tree, expression.right))),
         else => false,
     };
 }
@@ -263,6 +270,10 @@ fn isImpliedEvalCallee(
     callee: ast.NodeIndex,
 ) bool {
     const unwrapped = unwrapTransparent(tree, callee);
+
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return isImpliedEvalName(name) and isUnresolvedReference(symbol_table, unwrapped);
+    }
 
     const member = switch (tree.data(unwrapped)) {
         .member_expression => |member| member,
@@ -363,5 +374,8 @@ fn isEvalGlobalObjectName(name: []const u8) bool {
 }
 
 fn isImpliedEvalGlobalObjectName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "globalThis");
+    return std.mem.eql(u8, name, "global") or
+        std.mem.eql(u8, name, "window") or
+        std.mem.eql(u8, name, "globalThis") or
+        std.mem.eql(u8, name, "self");
 }

--- a/tests/rules/no_implied_eval.zig
+++ b/tests/rules/no_implied_eval.zig
@@ -4,6 +4,14 @@ const helpers = @import("../helpers.zig");
 
 test "reports no-implied-eval for string timer and execScript calls" {
     const source =
+        \\setTimeout("alert(1)", 100);
+        \\setInterval(`tick()`, 100);
+        \\execScript("alert(1)");
+        \\setTimeout("alert(" + value + ")", 100);
+        \\setInterval(`tick(${value})`, 100);
+        \\window.setTimeout("alert(1)");
+        \\self.setInterval("tick()", 100);
+        \\global.setTimeout("alert(1)");
         \\globalThis.setTimeout("alert(1)");
         \\globalThis["setInterval"]("tick()", 100);
         \\globalThis[`setInterval`]("tick()", 100);
@@ -19,25 +27,42 @@ test "reports no-implied-eval for string timer and execScript calls" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_implied_eval.id));
+    try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.no_implied_eval.id));
 }
 
-test "does not report no-implied-eval for direct calls function arguments or shadowed calls" {
+test "does not report no-implied-eval for function or dynamic arguments" {
     const source =
-        \\setTimeout("alert(1)", 100);
-        \\setInterval(`tick()`, 100);
-        \\execScript("alert(1)");
         \\setTimeout(() => alert(1), 100);
         \\setInterval(handler, 100);
+        \\setTimeout(1 + timeout, 100);
+        \\setInterval(tagged`tick()`, 100);
+        \\globalThis[`set${suffix}`]("not static");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_alert = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_implied_eval.id));
+}
+
+test "does not report no-implied-eval for shadowed calls" {
+    const source =
         \\const setTimeout = customTimer;
         \\setTimeout("not global");
+        \\const setInterval = customInterval;
+        \\setInterval("not global");
+        \\const execScript = customExec;
+        \\execScript("not global");
         \\const window = sandbox;
         \\window.setTimeout("not global");
         \\window.setInterval("not global");
-        \\global.setTimeout("not global");
-        \\self.setTimeout("not global");
         \\object.setInterval("not global");
-        \\globalThis[`set${suffix}`]("not static");
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary
- report no-implied-eval for bare global setTimeout, setInterval, and execScript calls
- recognize window, self, global, and globalThis timer/execScript members
- treat template literals and string concatenations as evaluated string arguments
- document the expanded global call coverage

## Validation
- zig fmt --check src/rules/global_call_checks.zig tests/rules/no_implied_eval.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check