### PR TITLE
Align no-useless-concat chain handling

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -152,7 +152,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
-| [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented |
+| [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented for adjacent static string and template literals in concatenation chains |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |

--- a/src/rules/no_useless_concat.zig
+++ b/src/rules/no_useless_concat.zig
@@ -14,9 +14,12 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     if (expression.operator != .add) return;
-    if (!isStringLikeLiteral(tree, expression.left)) return;
-    if (!isStringLikeLiteral(tree, expression.right)) return;
-    if (!sameLine(tree, expression.left, expression.right)) return;
+
+    const left = rightMostConcatOperand(tree, expression.left);
+    const right = leftMostConcatOperand(tree, expression.right);
+    if (!isStringLikeLiteral(tree, left)) return;
+    if (!isStringLikeLiteral(tree, right)) return;
+    if (!sameLine(tree, left, right)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -28,12 +31,38 @@ pub fn check(
     );
 }
 
+fn rightMostConcatOperand(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = unwrapTransparent(tree, index);
+    while (true) {
+        switch (tree.data(current)) {
+            .binary_expression => |expression| {
+                if (expression.operator != .add) return current;
+                current = unwrapTransparent(tree, expression.right);
+            },
+            else => return current,
+        }
+    }
+}
+
+fn leftMostConcatOperand(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = unwrapTransparent(tree, index);
+    while (true) {
+        switch (tree.data(current)) {
+            .binary_expression => |expression| {
+                if (expression.operator != .add) return current;
+                current = unwrapTransparent(tree, expression.left);
+            },
+            else => return current,
+        }
+    }
+}
+
 fn isStringLikeLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .string_literal => true,
-        .template_literal => true,
+        .template_literal => |literal| literal.expressions.len == 0,
         else => false,
     };
 }

--- a/tests/rules/no_useless_concat.zig
+++ b/tests/rules/no_useless_concat.zig
@@ -8,7 +8,9 @@ test "reports no-useless-concat for same line string literal concatenation" {
         \\const second = `foo` + "bar";
         \\const third = "foo" + `bar`;
         \\const fourth = `foo` + `bar`;
-        \\const fifth = `foo ${value}` + "bar";
+        \\const fifth = "foo" + "bar" + value;
+        \\const sixth = value + "foo" + "bar";
+        \\const seventh = "foo" + ("bar" + value);
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -18,12 +20,13 @@ test "reports no-useless-concat for same line string literal concatenation" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_concat.id));
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_useless_concat.id));
 }
 
 test "does not report no-useless-concat for dynamic or multiline concatenation" {
     const source =
         \\const dynamic = "foo" + value;
+        \\const dynamicTemplate = `foo ${value}` + "bar";
         \\const multiline = "foo" +
         \\  "bar";
     ;


### PR DESCRIPTION
## Summary
- compare adjacent static string operands across concatenation chains
- avoid reporting template literals that contain expressions
- document no-useless-concat static chain coverage

## Validation
- zig fmt --check src/rules/no_useless_concat.zig tests/rules/no_useless_concat.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check