### PR TITLE
Align no-useless-escape template handling

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -154,7 +154,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented for adjacent static string and template literals in concatenation chains |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
-| [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration |
+| [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration and ESLint template escape handling |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |

--- a/src/rules/no_useless_escape.zig
+++ b/src/rules/no_useless_escape.zig
@@ -29,7 +29,10 @@ pub fn checkTemplateLiteral(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     literal: ast.TemplateLiteral,
+    parent: ast.NodeIndex,
 ) Allocator.Error!void {
+    if (isTaggedTemplateParent(tree, parent)) return;
+
     const quasis = tree.extra(literal.quasis);
 
     for (quasis) |quasi| {
@@ -102,6 +105,9 @@ fn isNecessaryStringEscape(
     if (is_template and escaped == '$') {
         return offset + 2 < source.len and source[offset + 2] == '{';
     }
+    if (is_template and escaped == '{') {
+        return offset > 0 and source[offset - 1] == '$';
+    }
 
     return switch (escaped) {
         '0'...'9',
@@ -116,6 +122,14 @@ fn isNecessaryStringEscape(
         '\n',
         '\r',
         => true,
+        else => false,
+    };
+}
+
+fn isTaggedTemplateParent(tree: *const ast.Tree, parent: ast.NodeIndex) bool {
+    if (parent == .null) return false;
+    return switch (tree.data(parent)) {
+        .tagged_template_expression => true,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2359,7 +2359,7 @@ const BasicVisitor = struct {
             try no_script_url.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.no_useless_escape) {
-            try no_useless_escape.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);
+            try no_useless_escape.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal, ctx.path.parent() orelse .null);
         }
         if (self.options.alipay_ant_disallow_typos) {
             try alipay_ant_disallow_typos.checkTemplateLiteral(self.allocator, self.diagnostics, ctx.tree, literal);

--- a/tests/rules/no_useless_escape.zig
+++ b/tests/rules/no_useless_escape.zig
@@ -8,6 +8,7 @@ test "reports no-useless-escape for unnecessary string and template escapes" {
         \\const b = '\"';
         \\const c = `\#`;
         \\const d = `\a ${value}`;
+        \\const e = `\{literal}`;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -17,7 +18,7 @@ test "reports no-useless-escape for unnecessary string and template escapes" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_useless_escape.id));
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_escape.id));
 }
 
 test "reports no-useless-escape for unnecessary regular expression escapes" {
@@ -83,6 +84,8 @@ test "does not report no-useless-escape for necessary escapes" {
         \\const h = /[a\-z]/;
         \\const i = /[\^]/;
         \\const j = /[\^a]/;
+        \\const k = `$\{literal}`;
+        \\const l = tag`\# ${value}`;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary
- skip no-useless-escape checks for tagged templates so raw template escapes remain available
- treat `$\{` in template literals as a necessary escape while still reporting standalone `\{`
- document the aligned template escape behavior

## Validation
- zig fmt --check src/rules/no_useless_escape.zig src/rules/root.zig tests/rules/no_useless_escape.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check