### PR TITLE
Align no-unreachable initialized vars

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -142,7 +142,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
-| [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented |
+| [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |

--- a/src/rules/no_unreachable.zig
+++ b/src/rules/no_unreachable.zig
@@ -61,7 +61,15 @@ fn rangeAlwaysExits(tree: *const ast.Tree, range: ast.IndexRange) bool {
 fn isHoistedDeclaration(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(index)) {
         .function => |function| function.type == .function_declaration or function.type == .ts_declare_function,
-        .variable_declaration => |declaration| declaration.kind == .@"var",
+        .variable_declaration => |declaration| declaration.kind == .@"var" and !hasInitializedDeclarator(tree, declaration),
         else => false,
     };
+}
+
+fn hasInitializedDeclarator(tree: *const ast.Tree, declaration: ast.VariableDeclaration) bool {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = tree.data(declarator_index).variable_declarator;
+        if (declarator.init != .null) return true;
+    }
+    return false;
 }

--- a/tests/rules/no_unreachable.zig
+++ b/tests/rules/no_unreachable.zig
@@ -96,7 +96,7 @@ test "does not report no-unreachable for reachable statements or hoisted declara
         \\function second() {
         \\  return;
         \\  function later() {}
-        \\  var hoisted = 1;
+        \\  var hoisted;
         \\}
         \\function third() {
         \\  try { call(); } catch (error) { return recover(error); }
@@ -114,6 +114,29 @@ test "does not report no-unreachable for reachable statements or hoisted declara
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable.id));
+}
+
+test "reports no-unreachable for initialized var declarations after exits" {
+    const source =
+        \\function first() {
+        \\  return;
+        \\  var initialized = sideEffect();
+        \\}
+        \\function second() {
+        \\  throw error;
+        \\  var first, second = sideEffect();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unreachable.id));
 }
 
 test "reports no-unreachable in switch cases" {


### PR DESCRIPTION
## Summary
- report unreachable `var` declarations when any declarator has an initializer
- keep uninitialized `var` declarations and function declarations treated as hoisted
- document the hoisted declaration behavior for no-unreachable

## Validation
- zig fmt --check src/rules/no_unreachable.zig tests/rules/no_unreachable.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check