### PR TITLE
Align no-unsafe-finally local exits

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -143,7 +143,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
-| [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented |
+| [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |

--- a/src/rules/no_unsafe_finally.zig
+++ b/src/rules/no_unsafe_finally.zig
@@ -1,8 +1,9 @@
 const parser = @import("parser");
 const core = @import("../core.zig");
+const std = @import("std");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-unsafe-finally";
 
@@ -17,19 +18,63 @@ pub fn check(
     try scanNode(allocator, diagnostics, tree, statement.finalizer);
 }
 
+const ScanState = struct {
+    break_boundaries: usize = 0,
+    continue_boundaries: usize = 0,
+    labels: [64][]const u8 = undefined,
+    label_count: usize = 0,
+
+    fn withBreakBoundary(self: ScanState) ScanState {
+        var next = self;
+        next.break_boundaries += 1;
+        return next;
+    }
+
+    fn withLoopBoundary(self: ScanState) ScanState {
+        var next = self;
+        next.break_boundaries += 1;
+        next.continue_boundaries += 1;
+        return next;
+    }
+
+    fn withLabel(self: ScanState, label: []const u8) ScanState {
+        var next = self;
+        if (next.label_count < next.labels.len) {
+            next.labels[next.label_count] = label;
+            next.label_count += 1;
+        }
+        return next;
+    }
+
+    fn containsLabel(self: ScanState, label: []const u8) bool {
+        for (self.labels[0..self.label_count]) |current| {
+            if (std.mem.eql(u8, current, label)) return true;
+        }
+        return false;
+    }
+};
+
 fn scanNode(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    return scanNodeWithState(allocator, diagnostics, tree, index, .{});
+}
+
+fn scanNodeWithState(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: ScanState,
+) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
         .return_statement,
         .throw_statement,
-        .break_statement,
-        .continue_statement,
         => try core.addDiagnostic(
             allocator,
             diagnostics,
@@ -38,36 +83,51 @@ fn scanNode(
             "Control flow statements in finally blocks are unsafe.",
             tree.span(index),
         ),
-        .block_statement => |block| try scanRange(allocator, diagnostics, tree, block.body),
-        .static_block => |block| try scanRange(allocator, diagnostics, tree, block.body),
+        .break_statement => |statement| {
+            if (breakIsLocal(tree, statement, state)) return;
+            try addDiagnostic(allocator, diagnostics, tree, index);
+        },
+        .continue_statement => |statement| {
+            if (continueIsLocal(tree, statement, state)) return;
+            try addDiagnostic(allocator, diagnostics, tree, index);
+        },
+        .block_statement => |block| try scanRange(allocator, diagnostics, tree, block.body, state),
+        .static_block => |block| try scanRange(allocator, diagnostics, tree, block.body, state),
         .if_statement => |statement| {
-            try scanNode(allocator, diagnostics, tree, statement.consequent);
-            try scanNode(allocator, diagnostics, tree, statement.alternate);
+            try scanNodeWithState(allocator, diagnostics, tree, statement.consequent, state);
+            try scanNodeWithState(allocator, diagnostics, tree, statement.alternate, state);
         },
         .switch_statement => |statement| {
+            const switch_state = state.withBreakBoundary();
             for (tree.extra(statement.cases)) |case_index| {
                 const switch_case = switch (tree.data(case_index)) {
                     .switch_case => |switch_case| switch_case,
                     else => continue,
                 };
-                try scanRange(allocator, diagnostics, tree, switch_case.consequent);
+                try scanRange(allocator, diagnostics, tree, switch_case.consequent, switch_state);
             }
         },
-        .for_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .for_in_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .for_of_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .do_while_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .with_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
-        .labeled_statement => |statement| try scanNode(allocator, diagnostics, tree, statement.body),
+        .for_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state.withLoopBoundary()),
+        .for_in_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state.withLoopBoundary()),
+        .for_of_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state.withLoopBoundary()),
+        .while_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state.withLoopBoundary()),
+        .do_while_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state.withLoopBoundary()),
+        .with_statement => |statement| try scanNodeWithState(allocator, diagnostics, tree, statement.body, state),
+        .labeled_statement => |statement| {
+            const next_state = if (labelName(tree, statement.label)) |label|
+                state.withLabel(label)
+            else
+                state;
+            try scanNodeWithState(allocator, diagnostics, tree, statement.body, next_state);
+        },
         .try_statement => |statement| {
-            try scanNode(allocator, diagnostics, tree, statement.block);
+            try scanNodeWithState(allocator, diagnostics, tree, statement.block, state);
             if (statement.handler != .null) {
                 const handler = switch (tree.data(statement.handler)) {
                     .catch_clause => |handler| handler,
                     else => return,
                 };
-                try scanNode(allocator, diagnostics, tree, handler.body);
+                try scanNodeWithState(allocator, diagnostics, tree, handler.body, state);
             }
         },
         .function,
@@ -77,13 +137,49 @@ fn scanNode(
     }
 }
 
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Control flow statements in finally blocks are unsafe.",
+        tree.span(index),
+    );
+}
+
+fn breakIsLocal(tree: *const ast.Tree, statement: ast.BreakStatement, state: ScanState) bool {
+    if (labelName(tree, statement.label)) |label| return state.containsLabel(label);
+    return state.break_boundaries > 0;
+}
+
+fn continueIsLocal(tree: *const ast.Tree, statement: ast.ContinueStatement, state: ScanState) bool {
+    if (labelName(tree, statement.label)) |label| return state.containsLabel(label);
+    return state.continue_boundaries > 0;
+}
+
+fn labelName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .label_identifier => |label| tree.string(label.name),
+        else => null,
+    };
+}
+
 fn scanRange(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     range: ast.IndexRange,
+    state: ScanState,
 ) Allocator.Error!void {
     for (tree.extra(range)) |child| {
-        try scanNode(allocator, diagnostics, tree, child);
+        try scanNodeWithState(allocator, diagnostics, tree, child, state);
     }
 }

--- a/tests/rules/no_unsafe_finally.zig
+++ b/tests/rules/no_unsafe_finally.zig
@@ -53,6 +53,53 @@ test "does not report no-unsafe-finally for nested function control flow" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_finally.id));
 }
 
+test "does not report no-unsafe-finally for local loop switch or label exits" {
+    const source =
+        \\function outer() {
+        \\  try { use(); } finally {
+        \\    while (ready) { break; }
+        \\    for (;;) { continue; }
+        \\    switch (value) { case 1: break; }
+        \\    local: { break local; }
+        \\    loop: while (ready) { continue loop; }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_finally.id));
+}
+
+test "reports no-unsafe-finally for labeled exits leaving finally blocks" {
+    const source =
+        \\function outer() {
+        \\  outerLoop: while (ready) {
+        \\    try { use(); } finally { break outerLoop; }
+        \\  }
+        \\}
+        \\function second() {
+        \\  outerLoop: while (ready) {
+        \\    try { use(); } finally { continue outerLoop; }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unsafe_finally.id));
+}
+
 test "reports no-unsafe-finally once for nested finally blocks" {
     const source =
         \\function outer() {


### PR DESCRIPTION
## Summary
- track local loop, switch, and label boundaries while scanning finally blocks
- avoid reporting break/continue statements that only leave constructs inside the same finally block
- keep reporting return/throw and labeled exits that leave the finally block

## Validation
- zig fmt --check src/rules/no_unsafe_finally.zig tests/rules/no_unsafe_finally.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check