### PR TITLE
Align no-unsafe-negation ordering option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -144,7 +144,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
-| [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Implemented |
+| [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1320,6 +1320,7 @@ pub const Options = struct {
     no_unused_labels: bool = true,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
+    no_unsafe_negation_enforce_for_ordering_relations: bool = false,
     no_useless_computed_key: bool = true,
     no_useless_computed_key_enforce_for_class_members: NoUselessComputedKeyEnforceForClassMembers = .yes,
     no_useless_call: bool = true,
@@ -1836,6 +1837,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-trailing-spaces")) {
             self.no_trailing_spaces_skip_blank_lines = try noTrailingSpacesBoolOptionFromConfig(value, "skipBlankLines");
             self.no_trailing_spaces_ignore_comments = try noTrailingSpacesBoolOptionFromConfig(value, "ignoreComments");
+        }
+        if (std.mem.eql(u8, cli_name, "no-unsafe-negation")) {
+            self.no_unsafe_negation_enforce_for_ordering_relations = try noUnsafeNegationBoolOptionFromConfig(value, "enforceForOrderingRelations", false);
         }
         if (std.mem.eql(u8, cli_name, "no-useless-rename")) {
             self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
@@ -4214,6 +4218,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get(key) orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noUnsafeNegationBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6629,6 +6650,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_useless_escape_allow_regex_characters.contains('#'));
     try std.testing.expect(options.no_useless_escape_allow_regex_characters.contains('-'));
     try std.testing.expect(!options.no_useless_escape_allow_regex_characters.contains('^'));
+
+    var no_unsafe_negation_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForOrderingRelations\":true}]",
+        .{},
+    );
+    defer no_unsafe_negation_config.deinit();
+    try options.setByRuleConfigValue("no-unsafe-negation", no_unsafe_negation_config.value);
+    try std.testing.expect(options.no_unsafe_negation);
+    try std.testing.expect(options.no_unsafe_negation_enforce_for_ordering_relations);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_unsafe_negation.zig
+++ b/src/rules/no_unsafe_negation.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-unsafe-negation";
 
+pub const Options = struct {
+    enforce_for_ordering_relations: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -14,7 +18,18 @@ pub fn check(
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (expression.operator != .in and expression.operator != .instanceof) return;
+    return checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (!isUnsafeOperator(expression.operator, options)) return;
     if (!isLogicalNot(tree, expression.left)) return;
 
     try core.addDiagnostic(
@@ -25,6 +40,20 @@ pub fn check(
         "The negation operator is used unsafely on the left side of this binary expression.",
         tree.span(index),
     );
+}
+
+fn isUnsafeOperator(operator: ast.BinaryOperator, options: Options) bool {
+    return switch (operator) {
+        .in,
+        .instanceof,
+        => true,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        => options.enforce_for_ordering_relations,
+        else => false,
+    };
 }
 
 fn isLogicalNot(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2558,7 +2558,9 @@ const BasicVisitor = struct {
             try no_self_compare.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.no_unsafe_negation) {
-            try no_unsafe_negation.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_unsafe_negation.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .enforce_for_ordering_relations = self.options.no_unsafe_negation_enforce_for_ordering_relations,
+            });
         }
         if (self.options.use_isnan) {
             try use_isnan.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.useIsnanOptions());

--- a/tests/rules/no_unsafe_negation.zig
+++ b/tests/rules/no_unsafe_negation.zig
@@ -38,6 +38,36 @@ test "does not report no-unsafe-negation for other unary expressions" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_negation.id));
 }
 
+test "supports configured no-unsafe-negation ordering relations" {
+    const source =
+        \\!value < limit;
+        \\!value <= limit;
+        \\!value > limit;
+        \\!value >= limit;
+        \\(!value) < limit;
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForOrderingRelations\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-unsafe-negation", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unsafe_negation.id));
+}
+
 test "can disable no-unsafe-negation" {
     const source =
         \\!value in object;


### PR DESCRIPTION
## Summary
- add no-unsafe-negation support for `enforceForOrderingRelations`
- report unsafe negation before `<`, `<=`, `>`, and `>=` only when configured
- cover ESLint-style config parsing and document the supported option

## Validation
- zig fmt --check src/core.zig src/rules/no_unsafe_negation.zig src/rules/root.zig tests/rules/no_unsafe_negation.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check