### PR TITLE
Align no-unused-labels shadowing

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -147,7 +147,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
-| [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented |
+| [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |

--- a/src/rules/no_unused_labels.zig
+++ b/src/rules/no_unused_labels.zig
@@ -62,7 +62,10 @@ fn containsLabelReference(tree: *const ast.Tree, index: ast.NodeIndex, label_nam
         .while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
         .do_while_statement => |statement| containsLabelReference(tree, statement.body, label_name),
         .with_statement => |statement| containsLabelReference(tree, statement.body, label_name),
-        .labeled_statement => |statement| containsLabelReference(tree, statement.body, label_name),
+        .labeled_statement => |statement| {
+            if (sameLabel(tree, statement.label, label_name)) return false;
+            return containsLabelReference(tree, statement.body, label_name);
+        },
         .try_statement => |statement| {
             if (containsLabelReference(tree, statement.block, label_name)) return true;
             if (statement.handler != .null) {

--- a/tests/rules/no_unused_labels.zig
+++ b/tests/rules/no_unused_labels.zig
@@ -70,6 +70,27 @@ test "does not count label references inside nested functions" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_labels.id));
 }
 
+test "does not count references to shadowed nested labels" {
+    const source =
+        \\outer: while (ready) {
+        \\  outer: {
+        \\    break outer;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_labels.id));
+}
+
 test "can disable no-unused-labels" {
     const source =
         \\outer: while (ready) {


### PR DESCRIPTION
## Summary
- stop counting references inside nested labels with the same name as usage of the outer label
- add coverage for shadowed label scopes
- document nested label shadowing support

## Validation
- zig fmt --check src/rules/no_unused_labels.zig tests/rules/no_unused_labels.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check