### PR TITLE
Align no-duplicate-imports type imports

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -55,7 +55,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-dupe-else-if`](https://eslint.org/docs/latest/rules/no-dupe-else-if) | Implemented |
 | [`no-dupe-keys`](https://eslint.org/docs/latest/rules/no-dupe-keys) | Implemented |
 | [`no-duplicate-case`](https://eslint.org/docs/latest/rules/no-duplicate-case) | Implemented |
-| [`no-duplicate-imports`](https://eslint.org/docs/latest/rules/no-duplicate-imports) | Implemented |
+| [`no-duplicate-imports`](https://eslint.org/docs/latest/rules/no-duplicate-imports) | Supports `allowSeparateTypeImports` configuration |
 | [`no-else-return`](https://eslint.org/docs/latest/rules/no-else-return) | Implemented |
 | [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented with optional `allowEmptyCatch` behavior |
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1118,6 +1118,7 @@ pub const Options = struct {
     typescript_eslint_no_dupe_class_members: bool = true,
     no_dupe_keys: bool = true,
     no_duplicate_imports: bool = true,
+    no_duplicate_imports_allow_separate_type_imports: bool = false,
     no_delete_var: bool = true,
     no_div_regex: bool = true,
     no_empty: bool = true,
@@ -1746,6 +1747,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-console")) {
             self.no_console_allow = try noConsoleAllowFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-duplicate-imports")) {
+            self.no_duplicate_imports_allow_separate_type_imports = try noDuplicateImportsBoolOptionFromConfig(value, "allowSeparateTypeImports", false);
         }
         if (std.mem.eql(u8, cli_name, "no-cond-assign")) {
             self.no_cond_assign_style = try noCondAssignStyleFromConfig(value);
@@ -3351,6 +3355,23 @@ pub const Options = struct {
     }
 
     fn noLabelsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noDuplicateImportsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return default,
@@ -6098,6 +6119,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_console_allow.contains("warn"));
     try std.testing.expect(options.no_console_allow.contains("error"));
     try std.testing.expect(!options.no_console_allow.contains("log"));
+
+    var no_duplicate_imports_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowSeparateTypeImports\":true}]",
+        .{},
+    );
+    defer no_duplicate_imports_config.deinit();
+    try options.setByRuleConfigValue("no-duplicate-imports", no_duplicate_imports_config.value);
+    try std.testing.expect(options.no_duplicate_imports);
+    try std.testing.expect(options.no_duplicate_imports_allow_separate_type_imports);
 
     var no_cond_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_duplicate_imports.zig
+++ b/src/rules/no_duplicate_imports.zig
@@ -7,6 +7,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-duplicate-imports";
 
+pub const Options = struct {
+    allow_separate_type_imports: bool = false,
+};
+
 const ImportKind = enum {
     named_only,
     namespace_only,
@@ -16,6 +20,7 @@ const ImportKind = enum {
 const SeenImport = struct {
     source: []const u8,
     kind: ImportKind,
+    import_kind: ast.ImportOrExportKind,
 };
 
 pub fn check(
@@ -23,6 +28,16 @@ pub fn check(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     program: ast.Program,
+) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, program, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    options: Options,
 ) Allocator.Error!void {
     var seen: std.ArrayList(SeenImport) = .empty;
     defer seen.deinit(allocator);
@@ -35,7 +50,7 @@ pub fn check(
         const source = importSource(tree, declaration) orelse continue;
         const kind = importKind(tree, declaration);
 
-        if (hasDuplicate(seen.items, source, kind)) {
+        if (hasDuplicate(seen.items, source, kind, declaration.import_kind, options)) {
             try core.addDiagnosticFmt(
                 allocator,
                 diagnostics,
@@ -48,7 +63,11 @@ pub fn check(
             continue;
         }
 
-        try seen.append(allocator, .{ .source = source, .kind = kind });
+        try seen.append(allocator, .{
+            .source = source,
+            .kind = kind,
+            .import_kind = declaration.import_kind,
+        });
     }
 }
 
@@ -70,9 +89,16 @@ fn importKind(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ImportK
     return .named_only;
 }
 
-fn hasDuplicate(items: []const SeenImport, source: []const u8, kind: ImportKind) bool {
+fn hasDuplicate(
+    items: []const SeenImport,
+    source: []const u8,
+    kind: ImportKind,
+    import_kind: ast.ImportOrExportKind,
+    options: Options,
+) bool {
     for (items) |item| {
         if (!std.mem.eql(u8, item.source, source)) continue;
+        if (options.allow_separate_type_imports and canSeparateTypeImports(item.import_kind, import_kind)) continue;
         if (canCoexist(item.kind, kind)) continue;
         return true;
     }
@@ -82,4 +108,9 @@ fn hasDuplicate(items: []const SeenImport, source: []const u8, kind: ImportKind)
 fn canCoexist(a: ImportKind, b: ImportKind) bool {
     return (a == .namespace_only and b == .named_only) or
         (a == .named_only and b == .namespace_only);
+}
+
+fn canSeparateTypeImports(a: ast.ImportOrExportKind, b: ast.ImportOrExportKind) bool {
+    return (a == .type and b == .value) or
+        (a == .value and b == .type);
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1180,7 +1180,9 @@ const BasicVisitor = struct {
             self.react_style_prop_object_bindings = react_style_prop_object.bindingsFromProgram(ctx.tree, program);
         }
         if (self.options.no_duplicate_imports and !self.options.import_no_duplicates) {
-            try no_duplicate_imports.check(self.allocator, self.diagnostics, ctx.tree, program);
+            try no_duplicate_imports.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, program, .{
+                .allow_separate_type_imports = self.options.no_duplicate_imports_allow_separate_type_imports,
+            });
         }
         if (self.options.typescript_eslint_adjacent_overload_signatures) {
             try typescript_eslint_adjacent_overload_signatures.checkRange(self.allocator, self.diagnostics, ctx.tree, program.body);

--- a/tests/rules/no_duplicate_imports.zig
+++ b/tests/rules/no_duplicate_imports.zig
@@ -78,6 +78,55 @@ test "reports no-duplicate-imports for namespace imports that can be merged" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
 }
 
+test "reports no-duplicate-imports for separate type imports by default" {
+    const source =
+        \\import type { Foo } from "alpha";
+        \\import { foo } from "alpha";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .import_no_duplicates = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
+}
+
+test "supports configured no-duplicate-imports allowSeparateTypeImports" {
+    const source =
+        \\import type { Foo } from "alpha";
+        \\import { foo } from "alpha";
+        \\import type { Bar } from "beta";
+        \\import type { Baz } from "beta";
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowSeparateTypeImports\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .import_no_duplicates = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-duplicate-imports", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
+}
+
 test "can disable no-duplicate-imports" {
     const source =
         \\import foo from "alpha";


### PR DESCRIPTION
## Summary
- add no-duplicate-imports support for `allowSeparateTypeImports`
- keep default duplicate detection for separate type/value imports
- allow `import type` and value imports from the same source when configured while still reporting duplicate type imports

## Validation
- zig fmt --check src/core.zig src/rules/no_duplicate_imports.zig src/rules/root.zig tests/rules/no_duplicate_imports.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check