### PR TITLE
Align no-multi-assign options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -94,7 +94,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-loss-of-precision`](https://eslint.org/docs/latest/rules/no-loss-of-precision) | Implemented |
 | [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Supports `smart-tabs` configuration |
 | [`no-misleading-character-class`](https://eslint.org/docs/latest/rules/no-misleading-character-class) | Implemented |
-| [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Implemented |
+| [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Supports `ignoreNonDeclaration` configuration and class field initializers |
 | [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Supports `ignoreEOLComments` and common `exceptions` configuration |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
 | [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max`, `maxBOF`, and `maxEOF` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1238,6 +1238,7 @@ pub const Options = struct {
     no_loss_of_precision: bool = true,
     no_multi_str: bool = true,
     no_multi_assign: bool = true,
+    no_multi_assign_ignore_non_declaration: bool = false,
     no_multi_spaces: bool = true,
     no_multi_spaces_ignore_eol_comments: NoMultiSpacesIgnoreEOLComments = .no,
     no_multi_spaces_exceptions: NoMultiSpacesExceptions = .{},
@@ -1818,6 +1819,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-mixed-spaces-and-tabs")) {
             self.no_mixed_spaces_and_tabs_smart_tabs = try noMixedSpacesAndTabsSmartTabsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-multi-assign")) {
+            self.no_multi_assign_ignore_non_declaration = try noMultiAssignBoolOptionFromConfig(value, "ignoreNonDeclaration", false);
         }
         if (std.mem.eql(u8, cli_name, "no-multi-spaces")) {
             self.no_multi_spaces_ignore_eol_comments = try noMultiSpacesIgnoreEOLCommentsFromConfig(value);
@@ -4278,6 +4282,23 @@ pub const Options = struct {
         };
     }
 
+    fn noMultiAssignBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn noEvalAllowIndirectFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6130,6 +6151,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-duplicate-imports", no_duplicate_imports_config.value);
     try std.testing.expect(options.no_duplicate_imports);
     try std.testing.expect(options.no_duplicate_imports_allow_separate_type_imports);
+
+    var no_multi_assign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreNonDeclaration\":true}]",
+        .{},
+    );
+    defer no_multi_assign_config.deinit();
+    try options.setByRuleConfigValue("no-multi-assign", no_multi_assign_config.value);
+    try std.testing.expect(options.no_multi_assign);
+    try std.testing.expect(options.no_multi_assign_ignore_non_declaration);
 
     var no_cond_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_multi_assign.zig
+++ b/src/rules/no_multi_assign.zig
@@ -6,6 +6,10 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "no-multi-assign";
 
+pub const Options = struct {
+    ignore_non_declaration: bool = false,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -13,14 +17,23 @@ pub fn check(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, expression, index, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_non_declaration) return;
     if (!isAssignmentExpression(tree, expression.right)) return;
 
-    try core.addDiagnostic(
+    try addDiagnostic(
         allocator,
         diagnostics,
-        .warning,
-        id,
-        "Unexpected chained assignment.",
         tree.span(index),
     );
 }
@@ -33,13 +46,40 @@ pub fn checkVariableDeclarator(
 ) Allocator.Error!void {
     if (!isAssignmentExpression(tree, declarator.init)) return;
 
+    try addDiagnostic(
+        allocator,
+        diagnostics,
+        tree.span(declarator.init),
+    );
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+) Allocator.Error!void {
+    if (!isAssignmentExpression(tree, property.value)) return;
+
+    try addDiagnostic(
+        allocator,
+        diagnostics,
+        tree.span(property.value),
+    );
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    span: ast.Span,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
         "Unexpected chained assignment.",
-        tree.span(declarator.init),
+        span,
     );
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2451,7 +2451,9 @@ const BasicVisitor = struct {
             try no_bitwise.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.no_multi_assign) {
-            try no_multi_assign.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try no_multi_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .ignore_non_declaration = self.options.no_multi_assign_ignore_non_declaration,
+            });
         }
         if (self.options.operator_assignment) {
             try operator_assignment.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
@@ -3383,6 +3385,9 @@ const BasicVisitor = struct {
                 .allow = self.options.no_underscore_dangle_allow,
                 .enforce_in_class_fields = self.options.no_underscore_dangle_enforce_in_class_fields,
             });
+        }
+        if (self.options.no_multi_assign) {
+            try no_multi_assign.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(

--- a/tests/rules/no_multi_assign.zig
+++ b/tests/rules/no_multi_assign.zig
@@ -11,6 +11,7 @@ test "reports no-multi-assign for chained assignments" {
         \\let x = y = z;
         \\const p = q = r;
         \\var m = n = o;
+        \\class C { field = a = b; }
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
@@ -20,7 +21,7 @@ test "reports no-multi-assign for chained assignments" {
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.no_multi_assign.id));
+    try std.testing.expectEqual(@as(usize, 8), helpers.countRule(result, lint.rules.no_multi_assign.id));
 }
 
 test "does not report no-multi-assign for single assignments" {
@@ -57,4 +58,23 @@ test "can disable no-multi-assign" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_assign.id));
+}
+
+test "supports no-multi-assign ignoreNonDeclaration option" {
+    const source =
+        \\let a, b, c, x, y, z;
+        \\a = b = c;
+        \\let value = x = y;
+        \\class C { field = y = z; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_multi_assign_ignore_non_declaration = true,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_multi_assign.id));
 }


### PR DESCRIPTION
## Summary
- add `ignoreNonDeclaration` support for `no-multi-assign` config parsing
- skip non-declaration assignment expressions when that option is enabled
- report chained assignments in class field initializers as declaration contexts

## Validation
- `zig fmt --check src/core.zig src/rules/no_multi_assign.zig src/rules/root.zig tests/rules/no_multi_assign.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`