### PR TITLE
Align no-inline-comments ignore pattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -81,7 +81,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Supports `boolean`, `number`, `string`, `allow`, and `disallowTemplateShorthand` configuration |
 | [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented for global timer and `execScript` calls with evaluated string arguments |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
-| [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Implemented |
+| [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Supports `ignorePattern` configuration with common regex-like patterns |
 | [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Supports default `functions` mode and `both` mode for nested `var` declarations |
 | [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) | Implemented with optional `allowConstructorFlags` behavior |
 | [`no-irregular-whitespace`](https://eslint.org/docs/latest/rules/no-irregular-whitespace) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -977,6 +977,30 @@ pub const DotNotationAllowKeywords = enum {
     no,
 };
 
+pub const max_no_inline_comments_ignore_pattern_len = 256;
+
+pub const NoInlineCommentsIgnorePatternError = error{
+    NoInlineCommentsIgnorePatternTooLong,
+};
+
+pub const NoInlineCommentsIgnorePattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_no_inline_comments_ignore_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const NoInlineCommentsIgnorePattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *NoInlineCommentsIgnorePattern, pattern_value: []const u8) NoInlineCommentsIgnorePatternError!void {
+        if (pattern_value.len > max_no_inline_comments_ignore_pattern_len) return error.NoInlineCommentsIgnorePatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const max_dot_notation_allow_pattern_len = 256;
 
 pub const DotNotationAllowPatternError = error{
@@ -1225,6 +1249,7 @@ pub const Options = struct {
     no_irregular_whitespace_skip_templates: bool = false,
     no_irregular_whitespace_skip_jsx_text: bool = false,
     no_inline_comments: bool = true,
+    no_inline_comments_ignore_pattern: NoInlineCommentsIgnorePattern = .{},
     no_inner_declarations: bool = true,
     no_inner_declarations_mode: NoInnerDeclarationsMode = .functions,
     no_iterator: bool = true,
@@ -1812,6 +1837,9 @@ pub const Options = struct {
             self.no_irregular_whitespace_skip_reg_exps = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipRegExps", false);
             self.no_irregular_whitespace_skip_templates = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipTemplates", false);
             self.no_irregular_whitespace_skip_jsx_text = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipJSXText", false);
+        }
+        if (std.mem.eql(u8, cli_name, "no-inline-comments")) {
+            self.no_inline_comments_ignore_pattern = try noInlineCommentsIgnorePatternFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-labels")) {
             self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
@@ -4282,6 +4310,28 @@ pub const Options = struct {
         };
     }
 
+    fn noInlineCommentsIgnorePatternFromConfig(value: std.json.Value) RuleConfigError!NoInlineCommentsIgnorePattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get("ignorePattern") orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (pattern_value.len == 0) return .{};
+
+        var pattern = NoInlineCommentsIgnorePattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
+    }
+
     fn noMultiAssignBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6521,6 +6571,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_irregular_whitespace_skip_reg_exps);
     try std.testing.expect(options.no_irregular_whitespace_skip_templates);
     try std.testing.expect(options.no_irregular_whitespace_skip_jsx_text);
+
+    var no_inline_comments_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignorePattern\":\"eslint-disable|istanbul ignore\"}]",
+        .{},
+    );
+    defer no_inline_comments_config.deinit();
+    try options.setByRuleConfigValue("no-inline-comments", no_inline_comments_config.value);
+    try std.testing.expect(options.no_inline_comments);
+    try std.testing.expectEqualStrings("eslint-disable|istanbul ignore", options.no_inline_comments_ignore_pattern.pattern().?);
 
     var no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_inline_comments.zig
+++ b/src/rules/no_inline_comments.zig
@@ -7,10 +7,23 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-inline-comments";
 
+pub const Options = struct {
+    ignore_pattern: core.NoInlineCommentsIgnorePattern = .{},
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     const source = tree.source;
 
@@ -24,6 +37,8 @@ pub fn run(
         const has_code_after = comment.type == .block and end <= line_end and hasNonWhitespace(source[end..line_end]);
 
         if (has_code_before or has_code_after) {
+            if (isIgnoredComment(source[start..end], options.ignore_pattern)) continue;
+
             try core.addDiagnostic(
                 allocator,
                 diagnostics,
@@ -57,4 +72,121 @@ fn hasNonWhitespace(source: []const u8) bool {
         if (char != ' ' and char != '\t' and char != 0x0B and char != 0x0C) return true;
     }
     return false;
+}
+
+fn isIgnoredComment(comment_text: []const u8, pattern: core.NoInlineCommentsIgnorePattern) bool {
+    const custom_pattern = pattern.pattern() orelse return false;
+    return matchesPattern(comment_text, custom_pattern);
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const separator = indexOfUnescapedPipe(pattern[start..]);
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn indexOfUnescapedPipe(pattern: []const u8) ?usize {
+    var index: usize = 0;
+    var escaped = false;
+    while (index < pattern.len) : (index += 1) {
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (pattern[index] == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (pattern[index] == '|') return index;
+    }
+    return null;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$") and !isEscaped(pattern, pattern.len - 1);
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (anchored_start) return matchAt(value, body, 0, 0, anchored_end);
+
+    var start: usize = 0;
+    while (start <= value.len) : (start += 1) {
+        if (matchAt(value, body, start, 0, anchored_end)) return true;
+    }
+    return false;
+}
+
+fn isEscaped(pattern: []const u8, index: usize) bool {
+    if (index == 0) return false;
+    var backslashes: usize = 0;
+    var cursor = index;
+    while (cursor > 0 and pattern[cursor - 1] == '\\') : (cursor -= 1) {
+        backslashes += 1;
+    }
+    return backslashes % 2 == 1;
+}
+
+fn matchAt(value: []const u8, pattern: []const u8, value_index: usize, pattern_index: usize, anchored_end: bool) bool {
+    if (pattern_index >= pattern.len) return !anchored_end or value_index == value.len;
+    if (value_index > value.len) return false;
+
+    const token = readToken(pattern, pattern_index);
+    const quantifier_index = pattern_index + token.pattern_len;
+    const quantifier = if (quantifier_index < pattern.len and (pattern[quantifier_index] == '*' or pattern[quantifier_index] == '+')) pattern[quantifier_index] else 0;
+    const next_pattern_index = quantifier_index + if (quantifier == 0) @as(usize, 0) else @as(usize, 1);
+
+    if (quantifier == 0) {
+        if (value_index >= value.len or !tokenMatches(token, value[value_index])) return false;
+        return matchAt(value, pattern, value_index + 1, next_pattern_index, anchored_end);
+    }
+
+    var max_count: usize = 0;
+    while (value_index + max_count < value.len and tokenMatches(token, value[value_index + max_count])) : (max_count += 1) {}
+
+    const min_count: usize = if (quantifier == '+') 1 else 0;
+    if (max_count < min_count) return false;
+
+    var count = max_count + 1;
+    while (count > min_count) {
+        count -= 1;
+        if (matchAt(value, pattern, value_index + count, next_pattern_index, anchored_end)) return true;
+    }
+    return false;
+}
+
+const PatternToken = struct {
+    kind: enum { literal, any, whitespace },
+    literal: u8 = 0,
+    pattern_len: usize,
+};
+
+fn readToken(pattern: []const u8, index: usize) PatternToken {
+    if (pattern[index] == '.') {
+        return .{ .kind = .any, .pattern_len = 1 };
+    }
+    if (pattern[index] == '\\' and index + 1 < pattern.len) {
+        if (pattern[index + 1] == 's') {
+            return .{ .kind = .whitespace, .pattern_len = 2 };
+        }
+        return .{ .kind = .literal, .literal = pattern[index + 1], .pattern_len = 2 };
+    }
+    return .{ .kind = .literal, .literal = pattern[index], .pattern_len = 1 };
+}
+
+fn tokenMatches(token: PatternToken, char: u8) bool {
+    return switch (token.kind) {
+        .literal => char == token.literal,
+        .any => char != '\n' and char != '\r',
+        .whitespace => std.ascii.isWhitespace(char),
+    };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -521,7 +521,9 @@ pub fn runBasic(
         });
     }
     if (options.no_inline_comments) {
-        try no_inline_comments.run(allocator, diagnostics, tree);
+        try no_inline_comments.runWithOptions(allocator, diagnostics, tree, .{
+            .ignore_pattern = options.no_inline_comments_ignore_pattern,
+        });
     }
     if (options.no_multi_spaces) {
         try no_multi_spaces.runWithOptions(allocator, diagnostics, tree, .{

--- a/tests/rules/no_inline_comments.zig
+++ b/tests/rules/no_inline_comments.zig
@@ -41,6 +41,45 @@ test "does not report no-inline-comments for standalone comments" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_inline_comments.id));
 }
 
+test "supports no-inline-comments ignorePattern option" {
+    const source =
+        "const first = 1; // eslint-disable-line no-console\n" ++
+        "/* istanbul ignore next */ const second = 2;\n" ++
+        "const third = 3; // regular inline\n";
+
+    var options = lint.Options{
+        .capitalized_comments = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.no_inline_comments_ignore_pattern.set("eslint-disable|istanbul ignore");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_inline_comments.id));
+}
+
+test "supports no-inline-comments regex-like ignorePattern syntax" {
+    const source =
+        "import value from './chunk'; /* webpackChunkName: \"admin\" */\n" ++
+        "const other = 1; /* regular inline */\n";
+
+    var options = lint.Options{
+        .capitalized_comments = false,
+        .import_first = false,
+        .import_newline_after_import = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.no_inline_comments_ignore_pattern.set("webpackChunkName:\\s.+");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_inline_comments.id));
+}
+
 test "can disable no-inline-comments" {
     const source = "const value = 1; // inline\n";
 


### PR DESCRIPTION
## Summary
- add `ignorePattern` parsing for the `no-inline-comments` rule config
- route `no-inline-comments` through an options-aware runner
- skip inline comments that match common regex-like ignore patterns such as `eslint-disable|istanbul ignore` and `webpackChunkName:\s.+`

## Validation
- `zig fmt --check src/core.zig src/rules/no_inline_comments.zig src/rules/root.zig tests/rules/no_inline_comments.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`