### PR TITLE
Align curly multi style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -11,7 +11,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
-| [`curly`](https://eslint.org/docs/latest/rules/curly) | Implemented |
+| [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, and `multi` configuration |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -25,6 +25,7 @@ pub const EqeqeqStyle = enum {
 pub const CurlyStyle = enum {
     all,
     multi_line,
+    multi,
 };
 
 pub const ObjectShorthandStyle = enum {
@@ -2212,6 +2213,7 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "all")) return .all;
         if (std.mem.eql(u8, style, "multi-line")) return .multi_line;
+        if (std.mem.eql(u8, style, "multi")) return .multi;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -6022,6 +6024,16 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("curly", curly_config.value);
     try std.testing.expect(options.curly);
     try std.testing.expectEqual(CurlyStyle.multi_line, options.curly_style);
+
+    var curly_multi_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi\"]",
+        .{},
+    );
+    defer curly_multi_config.deinit();
+    try options.setByRuleConfigValue("curly", curly_multi_config.value);
+    try std.testing.expectEqual(CurlyStyle.multi, options.curly_style);
 
     var eqeqeq_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/curly.zig
+++ b/src/rules/curly.zig
@@ -52,9 +52,42 @@ pub fn checkBodyWithOptions(
     options: Options,
 ) Allocator.Error!void {
     if (body == .null) return;
-    if (tree.data(body) == .block_statement) return;
-    if (options.style == .multi_line and !isMultiLineBody(tree, body)) return;
+    switch (tree.data(body)) {
+        .block_statement => |block| {
+            if (options.style != .multi) return;
+            if (!isUnnecessaryMultiBlock(tree, block)) return;
 
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unnecessary block statement.",
+                tree.span(body),
+            );
+            return;
+        },
+        else => {},
+    }
+
+    if (options.style == .multi_line or options.style == .multi) {
+        if (!isMultiLineBody(tree, body)) return;
+    }
+
+    try addExpectedBlockDiagnostic(
+        allocator,
+        diagnostics,
+        tree,
+        body,
+    );
+}
+
+fn addExpectedBlockDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -63,6 +96,24 @@ pub fn checkBodyWithOptions(
         "Expected a block statement.",
         tree.span(body),
     );
+}
+
+fn isUnnecessaryMultiBlock(tree: *const ast.Tree, block: ast.BlockStatement) bool {
+    if (block.body.len != 1) return false;
+    const statements = tree.extra(block.body);
+    return !hasBlockScopedDeclaration(tree, statements[0]);
+}
+
+fn hasBlockScopedDeclaration(tree: *const ast.Tree, statement: ast.NodeIndex) bool {
+    return switch (tree.data(statement)) {
+        .variable_declaration => |declaration| switch (declaration.kind) {
+            .@"var" => false,
+            .let, .@"const", .using, .await_using => true,
+        },
+        .class => |class| class.type == .class_declaration,
+        .function => |function| function.type == .function_declaration,
+        else => false,
+    };
 }
 
 fn isMultiLineBody(tree: *const ast.Tree, body: ast.NodeIndex) bool {

--- a/tests/rules/curly.zig
+++ b/tests/rules/curly.zig
@@ -90,6 +90,40 @@ test "supports configured curly multi-line style" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.curly.id));
 }
 
+test "supports configured curly multi style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_for_in = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (ready) run();
+        \\if (ready)
+        \\  run();
+        \\if (ready) { run(); }
+        \\while (ready) { run(); }
+        \\while (ready) { run(); step(); }
+        \\for (const item of items) { run(); }
+        \\if (ready) { let scoped = value; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.curly.id));
+}
+
 test "can disable curly" {
     const source =
         \\if (ready) run();


### PR DESCRIPTION
## Summary
- add `curly` config parsing for the ESLint `multi` style
- report multiline unbraced control bodies under `multi`
- report unnecessary single-statement blocks under `multi` while preserving block-scoped declarations

## Validation
- `zig fmt --check src/core.zig src/rules/curly.zig tests/rules/curly.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`