### PR TITLE
Align no-global-assign exceptions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -75,7 +75,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
 | [`no-func-assign`](https://eslint.org/docs/latest/rules/no-func-assign) | Implemented |
-| [`no-global-assign`](https://eslint.org/docs/latest/rules/no-global-assign) | Implemented |
+| [`no-global-assign`](https://eslint.org/docs/latest/rules/no-global-assign) | Supports `exceptions` configuration |
 | [`no-global-is-finite`](https://eslint.org/docs/latest/rules/no-global-is-finite) | Implemented |
 | [`no-global-is-nan`](https://eslint.org/docs/latest/rules/no-global-is-nan) | Implemented |
 | [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Supports `boolean`, `number`, `string`, `allow`, and `disallowTemplateShorthand` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1174,6 +1174,7 @@ pub const Options = struct {
     no_for_in: bool = true,
     no_func_assign: bool = true,
     no_global_assign: bool = true,
+    no_global_assign_exceptions: NoShadowAllowNames = .{},
     no_global_is_finite: bool = true,
     no_global_is_nan: bool = true,
     no_implicit_coercion: bool = true,
@@ -1798,6 +1799,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-extend-native")) {
             self.no_extend_native_exceptions = try noExtendNativeExceptionsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-global-assign")) {
+            self.no_global_assign_exceptions = try noGlobalAssignExceptionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-empty-function")) {
             self.typescript_eslint_no_empty_function_allow = try noEmptyFunctionAllowFromConfig(value);
@@ -4396,6 +4400,34 @@ pub const Options = struct {
         return exceptions;
     }
 
+    fn noGlobalAssignExceptionsFromConfig(value: std.json.Value) RuleConfigError!NoShadowAllowNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const exceptions_value = config.get("exceptions") orelse return .{};
+        const exception_items = switch (exceptions_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var exceptions = NoShadowAllowNames{};
+        for (exception_items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            exceptions.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return exceptions;
+    }
+
     fn noUselessRenameBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6302,6 +6334,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_extend_native_exceptions.contains("Array"));
     try std.testing.expect(options.no_extend_native_exceptions.contains("Object"));
     try std.testing.expect(!options.no_extend_native_exceptions.contains("String"));
+
+    var no_global_assign_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"exceptions\":[\"Object\",\"NaN\"]}]",
+        .{},
+    );
+    defer no_global_assign_config.deinit();
+    try options.setByRuleConfigValue("no-global-assign", no_global_assign_config.value);
+    try std.testing.expect(options.no_global_assign);
+    try std.testing.expect(options.no_global_assign_exceptions.contains("Object"));
+    try std.testing.expect(options.no_global_assign_exceptions.contains("NaN"));
+    try std.testing.expect(!options.no_global_assign_exceptions.contains("undefined"));
 
     var no_empty_function_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -8,16 +8,31 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-global-assign";
 
+pub const Options = struct {
+    exceptions: core.NoShadowAllowNames = .{},
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -27,6 +42,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 
     pub fn enter_assignment_expression(
         self: *Visitor,
@@ -88,6 +104,7 @@ const Visitor = struct {
     ) Allocator.Error!void {
         const name = tree.string(name_string);
         if (!isReadonlyGlobal(name)) return;
+        if (self.options.exceptions.contains(name)) return;
         if (!isUnresolvedReference(self.symbol_table, node)) return;
 
         try core.addDiagnosticFmt(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -821,7 +821,9 @@ pub fn runSemantic(
     }
 
     if (options.no_global_assign) {
-        try no_global_assign.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try no_global_assign.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .exceptions = options.no_global_assign_exceptions,
+        });
     }
 
     if (options.no_global_is_finite or options.no_global_is_nan) {

--- a/tests/rules/no_global_assign.zig
+++ b/tests/rules/no_global_assign.zig
@@ -108,6 +108,28 @@ test "does not report no-global-assign for shadowed names or property writes" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_global_assign.id));
 }
 
+test "supports no-global-assign exceptions option" {
+    const source =
+        \\Object = null;
+        \\NaN = 1;
+        \\undefined = 2;
+    ;
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_undefined = false,
+        .parser_semantic_errors = false,
+    };
+    try options.no_global_assign_exceptions.append("Object");
+    try options.no_global_assign_exceptions.append("NaN");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_global_assign.id));
+}
+
 test "can disable no-global-assign" {
     const source =
         \\Object = null;


### PR DESCRIPTION
## Summary
- add `exceptions` parsing for ESLint-style `no-global-assign` configuration
- route `no-global-assign` through an options-aware runner
- skip configured readonly globals while preserving default diagnostics for the rest

## Validation
- `zig fmt --check src/core.zig src/rules/no_global_assign.zig src/rules/root.zig tests/rules/no_global_assign.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`