### PR TITLE
Align new-cap exception patterns

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -26,7 +26,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
-| [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Implemented |
+| [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |
 | [`no-array-constructor`](https://eslint.org/docs/latest/rules/no-array-constructor) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -814,6 +814,30 @@ pub const NewCapExceptionNames = struct {
     }
 };
 
+pub const max_new_cap_exception_pattern_len = 256;
+
+pub const NewCapExceptionPatternError = error{
+    NewCapExceptionPatternTooLong,
+};
+
+pub const NewCapExceptionPattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_new_cap_exception_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const NewCapExceptionPattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *NewCapExceptionPattern, pattern_value: []const u8) NewCapExceptionPatternError!void {
+        if (pattern_value.len > max_new_cap_exception_pattern_len) return error.NewCapExceptionPatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const NoUselessComputedKeyEnforceForClassMembers = enum {
     yes,
     no,
@@ -1103,6 +1127,8 @@ pub const Options = struct {
     new_cap_properties: bool = true,
     new_cap_new_is_cap_exceptions: NewCapExceptionNames = .{},
     new_cap_cap_is_new_exceptions: NewCapExceptionNames = .{},
+    new_cap_new_is_cap_exception_pattern: NewCapExceptionPattern = .{},
+    new_cap_cap_is_new_exception_pattern: NewCapExceptionPattern = .{},
     new_parens: bool = true,
     no_async_promise_executor: bool = true,
     no_array_constructor: bool = true,
@@ -1762,6 +1788,8 @@ pub const Options = struct {
             self.new_cap_properties = try newCapBoolOptionFromConfig(value, "properties", true);
             self.new_cap_new_is_cap_exceptions = try newCapExceptionNamesFromConfig(value, "newIsCapExceptions");
             self.new_cap_cap_is_new_exceptions = try newCapExceptionNamesFromConfig(value, "capIsNewExceptions");
+            self.new_cap_new_is_cap_exception_pattern = try newCapExceptionPatternFromConfig(value, "newIsCapExceptionPattern");
+            self.new_cap_cap_is_new_exception_pattern = try newCapExceptionPatternFromConfig(value, "capIsNewExceptionPattern");
         }
         if (std.mem.eql(u8, cli_name, "no-bitwise")) {
             self.no_bitwise_allow_bitwise_and = try noBitwiseAllowFromConfig(value, "&");
@@ -2909,6 +2937,28 @@ pub const Options = struct {
             exceptions.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return exceptions;
+    }
+
+    fn newCapExceptionPatternFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!NewCapExceptionPattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get(key) orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (pattern_value.len == 0) return .{};
+
+        var pattern = NewCapExceptionPattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
     }
 
     fn defaultCaseCommentPatternFromConfig(value: std.json.Value) RuleConfigError!DefaultCaseCommentPattern {
@@ -6521,7 +6571,7 @@ test "Options can apply ESLint-style rule config values" {
     var new_cap_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false,\"properties\":false,\"newIsCapExceptions\":[\"lowerFactory\"],\"capIsNewExceptions\":[\"UpperFactory\"]}]",
+        "[\"error\",{\"newIsCap\":false,\"capIsNew\":false,\"properties\":false,\"newIsCapExceptions\":[\"lowerFactory\"],\"capIsNewExceptions\":[\"UpperFactory\"],\"newIsCapExceptionPattern\":\"^lower.*Factory$\",\"capIsNewExceptionPattern\":\"^Upper.*Factory$\"}]",
         .{},
     );
     defer new_cap_config.deinit();
@@ -6534,6 +6584,8 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.new_cap_new_is_cap_exceptions.contains("otherFactory"));
     try std.testing.expect(options.new_cap_cap_is_new_exceptions.contains("UpperFactory"));
     try std.testing.expect(!options.new_cap_cap_is_new_exceptions.contains("OtherFactory"));
+    try std.testing.expectEqualStrings("^lower.*Factory$", options.new_cap_new_is_cap_exception_pattern.pattern().?);
+    try std.testing.expectEqualStrings("^Upper.*Factory$", options.new_cap_cap_is_new_exception_pattern.pattern().?);
 
     var no_multi_spaces_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/new_cap.zig
+++ b/src/rules/new_cap.zig
@@ -13,6 +13,8 @@ pub const Options = struct {
     properties: bool = true,
     new_is_cap_exceptions: core.NewCapExceptionNames = .{},
     cap_is_new_exceptions: core.NewCapExceptionNames = .{},
+    new_is_cap_exception_pattern: core.NewCapExceptionPattern = .{},
+    cap_is_new_exception_pattern: core.NewCapExceptionPattern = .{},
 };
 
 pub fn checkNewExpression(
@@ -36,7 +38,7 @@ pub fn checkNewExpressionWithOptions(
     if (!options.new_is_cap) return;
 
     const name = constructorName(tree, expression.callee, options) orelse return;
-    if (options.new_is_cap_exceptions.contains(name)) return;
+    if (isNewIsCapException(name, options)) return;
     if (nameCase(name) != .lower) return;
 
     try core.addDiagnostic(
@@ -71,7 +73,7 @@ pub fn checkCallExpressionWithOptions(
 
     const callee = unwrapTransparent(tree, expression.callee);
     const name = constructorName(tree, callee, options) orelse return;
-    if (options.cap_is_new_exceptions.contains(name)) return;
+    if (isCapIsNewException(name, options)) return;
     if (nameCase(name) != .upper) return;
     if (isAllowedCallableBuiltin(tree, callee, name)) return;
 
@@ -143,6 +145,93 @@ fn isAllowedCallableBuiltin(tree: *const ast.Tree, callee: ast.NodeIndex, name: 
     }
 
     return false;
+}
+
+fn isNewIsCapException(name: []const u8, options: Options) bool {
+    if (options.new_is_cap_exceptions.contains(name)) return true;
+    return matchesPatternOption(name, options.new_is_cap_exception_pattern);
+}
+
+fn isCapIsNewException(name: []const u8, options: Options) bool {
+    if (options.cap_is_new_exceptions.contains(name)) return true;
+    return matchesPatternOption(name, options.cap_is_new_exception_pattern);
+}
+
+fn matchesPatternOption(name: []const u8, pattern: core.NewCapExceptionPattern) bool {
+    const custom_pattern = pattern.pattern() orelse return false;
+    return matchesPattern(name, custom_pattern);
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const remainder = pattern[start..];
+        const separator = std.mem.indexOfScalar(u8, remainder, '|');
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$");
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (std.mem.indexOf(u8, body, ".*") != null) {
+        return matchesWildcardSequence(value, body, anchored_start, anchored_end);
+    }
+    if (anchored_start and anchored_end) return std.mem.eql(u8, value, body);
+    if (anchored_start) return std.mem.startsWith(u8, value, body);
+    if (anchored_end) return std.mem.endsWith(u8, value, body);
+    return std.mem.indexOf(u8, value, body) != null;
+}
+
+fn matchesWildcardSequence(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    var value_offset: usize = 0;
+    var pattern_offset: usize = 0;
+    var part_index: usize = 0;
+
+    while (pattern_offset <= pattern.len) : (part_index += 1) {
+        const remainder = pattern[pattern_offset..];
+        const wildcard = std.mem.indexOf(u8, remainder, ".*");
+        const part_end = if (wildcard) |offset| pattern_offset + offset else pattern.len;
+        const part = pattern[pattern_offset..part_end];
+
+        if (part.len > 0) {
+            if (part_index == 0 and anchored_start) {
+                if (!std.mem.startsWith(u8, value[value_offset..], part)) return false;
+                value_offset += part.len;
+            } else {
+                const found = std.mem.indexOf(u8, value[value_offset..], part) orelse return false;
+                value_offset += found + part.len;
+            }
+        }
+
+        if (wildcard == null) break;
+        pattern_offset = part_end + 2;
+    }
+
+    if (!anchored_end) return true;
+    const suffix_start = lastWildcardPartStart(pattern);
+    return std.mem.endsWith(u8, value, pattern[suffix_start..]);
+}
+
+fn lastWildcardPartStart(pattern: []const u8) usize {
+    var offset: usize = 0;
+    var start: usize = 0;
+    while (offset < pattern.len) {
+        const wildcard = std.mem.indexOf(u8, pattern[offset..], ".*") orelse break;
+        start = offset + wildcard + 2;
+        offset = start;
+    }
+    return start;
 }
 
 const NameCase = enum {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2795,6 +2795,8 @@ const BasicVisitor = struct {
                 .properties = self.options.new_cap_properties,
                 .new_is_cap_exceptions = self.options.new_cap_new_is_cap_exceptions,
                 .cap_is_new_exceptions = self.options.new_cap_cap_is_new_exceptions,
+                .new_is_cap_exception_pattern = self.options.new_cap_new_is_cap_exception_pattern,
+                .cap_is_new_exception_pattern = self.options.new_cap_cap_is_new_exception_pattern,
             });
         }
         if (self.options.no_extra_bind) {
@@ -2845,6 +2847,8 @@ const BasicVisitor = struct {
                 .properties = self.options.new_cap_properties,
                 .new_is_cap_exceptions = self.options.new_cap_new_is_cap_exceptions,
                 .cap_is_new_exceptions = self.options.new_cap_cap_is_new_exceptions,
+                .new_is_cap_exception_pattern = self.options.new_cap_new_is_cap_exception_pattern,
+                .cap_is_new_exception_pattern = self.options.new_cap_cap_is_new_exception_pattern,
             });
         }
         if (self.options.new_parens) {

--- a/tests/rules/new_cap.zig
+++ b/tests/rules/new_cap.zig
@@ -167,3 +167,34 @@ test "supports configured new-cap exception name options" {
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.new_cap.id));
 }
+
+test "supports configured new-cap exception pattern options" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"newIsCapExceptionPattern\":\"^lower.*Factory$\",\"capIsNewExceptionPattern\":\"^Upper.*Factory$\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("new-cap", config.value);
+    options.no_new = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\new lowerWidgetFactory();
+        \\new otherFactory();
+        \\UpperWidgetFactory();
+        \\OtherFactory();
+        \\new namespace.lowerWidgetFactory();
+        \\namespace.UpperWidgetFactory();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.new_cap.id));
+}


### PR DESCRIPTION
Summary:
- add new-cap newIsCapExceptionPattern and capIsNewExceptionPattern config parsing
- apply exception patterns alongside exact exception name lists
- cover pattern-based exceptions in rule tests and status docs

Validation:
- zig fmt --check src/core.zig src/rules/new_cap.zig src/rules/root.zig tests/rules/new_cap.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check