### PR TITLE
Align no-promise-executor-return allowVoid

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -117,7 +117,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented with optional `allowForLoopAfterthoughts` behavior |
 | [`no-process-env`](https://eslint.org/docs/latest/rules/no-process-env) | Implemented |
 | [`no-process-exit`](https://eslint.org/docs/latest/rules/no-process-exit) | Implemented |
-| [`no-promise-executor-return`](https://eslint.org/docs/latest/rules/no-promise-executor-return) | Implemented |
+| [`no-promise-executor-return`](https://eslint.org/docs/latest/rules/no-promise-executor-return) | Supports `allowVoid` configuration |
 | [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) | Implemented |
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1323,6 +1323,7 @@ pub const Options = struct {
     no_plusplus: bool = true,
     no_plusplus_allow_for_loop_afterthoughts: NoPlusplusAllowForLoopAfterthoughts = .no,
     no_promise_executor_return: bool = true,
+    no_promise_executor_return_allow_void: bool = false,
     no_proto: bool = true,
     no_process_env: bool = true,
     no_process_exit: bool = true,
@@ -1939,6 +1940,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-plusplus")) {
             self.no_plusplus_allow_for_loop_afterthoughts = try noPlusplusAllowForLoopAfterthoughtsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-promise-executor-return")) {
+            self.no_promise_executor_return_allow_void = try noPromiseExecutorReturnAllowVoidFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "prefer-const")) {
             self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
@@ -3874,6 +3878,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowEmptyReject") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noPromiseExecutorReturnAllowVoidFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowVoid") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -6836,6 +6857,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("prefer-promise-reject-errors", prefer_promise_reject_errors_config.value);
     try std.testing.expect(options.prefer_promise_reject_errors);
     try std.testing.expect(options.prefer_promise_reject_errors_allow_empty_reject);
+
+    var no_promise_executor_return_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowVoid\":true}]",
+        .{},
+    );
+    defer no_promise_executor_return_config.deinit();
+    try options.setByRuleConfigValue("no-promise-executor-return", no_promise_executor_return_config.value);
+    try std.testing.expect(options.no_promise_executor_return);
+    try std.testing.expect(options.no_promise_executor_return_allow_void);
 
     var prefer_regex_literals_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -16,6 +16,7 @@ pub fn run(
     symbol_table: traverser.semantic.SymbolTable,
     check_no_async_promise_executor: bool,
     check_no_promise_executor_return: bool,
+    no_promise_executor_return_allow_void: bool,
     check_prefer_promise_reject_errors: bool,
     prefer_promise_reject_errors_allow_empty_reject: bool,
 ) Allocator.Error!void {
@@ -29,6 +30,7 @@ pub fn run(
         .symbol_table = symbol_table,
         .check_no_async_promise_executor = check_no_async_promise_executor,
         .check_no_promise_executor_return = check_no_promise_executor_return,
+        .no_promise_executor_return_allow_void = no_promise_executor_return_allow_void,
         .check_prefer_promise_reject_errors = check_prefer_promise_reject_errors,
         .prefer_promise_reject_errors_allow_empty_reject = prefer_promise_reject_errors_allow_empty_reject,
     };
@@ -42,6 +44,7 @@ const Visitor = struct {
     symbol_table: traverser.semantic.SymbolTable,
     check_no_async_promise_executor: bool,
     check_no_promise_executor_return: bool,
+    no_promise_executor_return_allow_void: bool,
     check_prefer_promise_reject_errors: bool,
     prefer_promise_reject_errors_allow_empty_reject: bool,
 
@@ -92,7 +95,9 @@ const Visitor = struct {
         }
 
         if (is_global_promise and self.check_no_promise_executor_return and executor != null) {
-            try checkExecutorReturn(self.allocator, self.diagnostics, ctx.tree, executor.?);
+            try checkExecutorReturn(self.allocator, self.diagnostics, ctx.tree, executor.?, .{
+                .allow_void = self.no_promise_executor_return_allow_void,
+            });
         }
 
         if (self.check_prefer_promise_reject_errors and
@@ -112,6 +117,10 @@ const Visitor = struct {
 
         return .proceed;
     }
+};
+
+const NoPromiseExecutorReturnOptions = struct {
+    allow_void: bool = false,
 };
 
 fn isPromiseRejectCall(
@@ -153,16 +162,18 @@ fn checkExecutorReturn(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     executor: ast.NodeIndex,
+    options: NoPromiseExecutorReturnOptions,
 ) Allocator.Error!void {
     switch (tree.data(executor)) {
         .arrow_function_expression => |arrow| {
             if (arrow.expression) {
+                if (options.allow_void and isVoidExpression(tree, arrow.body)) return;
                 try addPromiseReturnDiagnostic(allocator, diagnostics, tree, arrow.body);
             } else {
-                try scanFunctionBodyForReturns(allocator, diagnostics, tree, arrow.body);
+                try scanFunctionBodyForReturns(allocator, diagnostics, tree, arrow.body, options);
             }
         },
-        .function => |function| try scanFunctionBodyForReturns(allocator, diagnostics, tree, function.body),
+        .function => |function| try scanFunctionBodyForReturns(allocator, diagnostics, tree, function.body, options),
         else => {},
     }
 }
@@ -172,6 +183,7 @@ fn scanFunctionBodyForReturns(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     body_index: ast.NodeIndex,
+    options: NoPromiseExecutorReturnOptions,
 ) Allocator.Error!void {
     if (body_index == .null) return;
 
@@ -180,7 +192,7 @@ fn scanFunctionBodyForReturns(
         else => return,
     };
 
-    try scanReturnRange(allocator, diagnostics, tree, body.body);
+    try scanReturnRange(allocator, diagnostics, tree, body.body, options);
 }
 
 fn scanReturnNode(
@@ -188,20 +200,22 @@ fn scanReturnNode(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    options: NoPromiseExecutorReturnOptions,
 ) Allocator.Error!void {
     if (index == .null) return;
 
     switch (tree.data(index)) {
         .return_statement => |statement| {
             if (statement.argument != .null) {
+                if (options.allow_void and isVoidExpression(tree, statement.argument)) return;
                 try addPromiseReturnDiagnostic(allocator, diagnostics, tree, index);
             }
         },
-        .block_statement => |block| try scanReturnRange(allocator, diagnostics, tree, block.body),
-        .static_block => |block| try scanReturnRange(allocator, diagnostics, tree, block.body),
+        .block_statement => |block| try scanReturnRange(allocator, diagnostics, tree, block.body, options),
+        .static_block => |block| try scanReturnRange(allocator, diagnostics, tree, block.body, options),
         .if_statement => |statement| {
-            try scanReturnNode(allocator, diagnostics, tree, statement.consequent);
-            try scanReturnNode(allocator, diagnostics, tree, statement.alternate);
+            try scanReturnNode(allocator, diagnostics, tree, statement.consequent, options);
+            try scanReturnNode(allocator, diagnostics, tree, statement.alternate, options);
         },
         .switch_statement => |statement| {
             for (tree.extra(statement.cases)) |case_index| {
@@ -209,26 +223,26 @@ fn scanReturnNode(
                     .switch_case => |switch_case| switch_case,
                     else => continue,
                 };
-                try scanReturnRange(allocator, diagnostics, tree, switch_case.consequent);
+                try scanReturnRange(allocator, diagnostics, tree, switch_case.consequent, options);
             }
         },
-        .for_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .for_in_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .for_of_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .while_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .do_while_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .with_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
-        .labeled_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body),
+        .for_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .for_in_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .for_of_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .while_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .do_while_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .with_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
+        .labeled_statement => |statement| try scanReturnNode(allocator, diagnostics, tree, statement.body, options),
         .try_statement => |statement| {
-            try scanReturnNode(allocator, diagnostics, tree, statement.block);
+            try scanReturnNode(allocator, diagnostics, tree, statement.block, options);
             if (statement.handler != .null) {
                 const handler = switch (tree.data(statement.handler)) {
                     .catch_clause => |handler| handler,
                     else => return,
                 };
-                try scanReturnNode(allocator, diagnostics, tree, handler.body);
+                try scanReturnNode(allocator, diagnostics, tree, handler.body, options);
             }
-            try scanReturnNode(allocator, diagnostics, tree, statement.finalizer);
+            try scanReturnNode(allocator, diagnostics, tree, statement.finalizer, options);
         },
         .function,
         .arrow_function_expression,
@@ -243,10 +257,18 @@ fn scanReturnRange(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     range: ast.IndexRange,
+    options: NoPromiseExecutorReturnOptions,
 ) Allocator.Error!void {
     for (tree.extra(range)) |child| {
-        try scanReturnNode(allocator, diagnostics, tree, child);
+        try scanReturnNode(allocator, diagnostics, tree, child, options);
     }
+}
+
+fn isVoidExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .unary_expression => |expression| expression.operator == .void,
+        else => false,
+    };
 }
 
 fn addPromiseReturnDiagnostic(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -920,6 +920,7 @@ pub fn runSemantic(
             semantic_result.symbol_table,
             options.no_async_promise_executor,
             options.no_promise_executor_return,
+            options.no_promise_executor_return_allow_void,
             options.prefer_promise_reject_errors,
             options.prefer_promise_reject_errors_allow_empty_reject,
         );

--- a/tests/rules/no_promise_executor_return.zig
+++ b/tests/rules/no_promise_executor_return.zig
@@ -47,6 +47,41 @@ test "does not report no-promise-executor-return for bare returns nested functio
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_promise_executor_return.id));
 }
 
+test "supports configured no-promise-executor-return allowVoid" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowVoid\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_new = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .no_void = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-promise-executor-return", config.value);
+
+    const source =
+        \\new Promise((resolve) => void resolve());
+        \\new Promise(function (resolve) {
+        \\  return void resolve();
+        \\});
+        \\new Promise((resolve) => resolve());
+        \\new Promise(function (resolve) {
+        \\  return resolve();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_promise_executor_return.id));
+}
+
 test "can disable no-promise-executor-return" {
     const source =
         \\new Promise((resolve) => resolve());


### PR DESCRIPTION
Summary:
- add no-promise-executor-return allowVoid config parsing
- pass allowVoid into shared Promise checks
- allow void Promise executor returns while preserving diagnostics for value returns
- cover allowVoid behavior in rule tests and status docs

Validation:
- zig fmt --check src/core.zig src/rules/promise_checks.zig src/rules/root.zig tests/rules/no_promise_executor_return.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check