### PR TITLE
Align no-fallthrough unused comments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -71,7 +71,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
-| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Implemented with optional `allowEmptyCase` behavior |
+| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase` and `reportUnusedFallthroughComment` configuration |
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
 | [`no-func-assign`](https://eslint.org/docs/latest/rules/no-func-assign) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1197,6 +1197,7 @@ pub const Options = struct {
     no_floating_decimal: bool = true,
     no_fallthrough: bool = true,
     no_fallthrough_allow_empty_case: NoFallthroughAllowEmptyCase = .no,
+    no_fallthrough_report_unused_fallthrough_comment: bool = false,
     no_for_in: bool = true,
     no_func_assign: bool = true,
     no_global_assign: bool = true,
@@ -1846,6 +1847,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
+            self.no_fallthrough_report_unused_fallthrough_comment = try noFallthroughReportUnusedFallthroughCommentFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-implicit-coercion")) {
             self.no_implicit_coercion_boolean = try noImplicitCoercionBooleanFromConfig(value);
@@ -3280,21 +3282,29 @@ pub const Options = struct {
     }
 
     fn noFallthroughAllowEmptyCaseFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughAllowEmptyCase {
+        const allow = try noFallthroughBoolOptionFromConfig(value, "allowEmptyCase", false);
+        return if (allow) .yes else .no;
+    }
+
+    fn noFallthroughReportUnusedFallthroughCommentFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return noFallthroughBoolOptionFromConfig(value, "reportUnusedFallthroughComment", false);
+    }
+
+    fn noFallthroughBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return .no,
+            else => return default,
         };
-        if (items.len < 2) return .no;
+        if (items.len < 2) return default;
 
         const config = switch (items[1]) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        const allow = switch (config.get("allowEmptyCase") orelse return .no) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return if (allow) .yes else .no;
     }
 
     fn importNewlineAfterImportCountFromConfig(value: std.json.Value) RuleConfigError!usize {
@@ -6529,13 +6539,14 @@ test "Options can apply ESLint-style rule config values" {
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowEmptyCase\":true}]",
+        "[\"error\",{\"allowEmptyCase\":true,\"reportUnusedFallthroughComment\":true}]",
         .{},
     );
     defer no_fallthrough_config.deinit();
     try options.setByRuleConfigValue("no-fallthrough", no_fallthrough_config.value);
     try std.testing.expect(options.no_fallthrough);
     try std.testing.expectEqual(NoFallthroughAllowEmptyCase.yes, options.no_fallthrough_allow_empty_case);
+    try std.testing.expect(options.no_fallthrough_report_unused_fallthrough_comment);
 
     var no_implicit_coercion_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -9,6 +9,7 @@ pub const id = "no-fallthrough";
 
 pub const Options = struct {
     allow_empty_case: bool = false,
+    report_unused_fallthrough_comment: bool = false,
 };
 
 pub fn check(
@@ -39,7 +40,12 @@ pub fn checkWithOptions(
         if (switch_case.consequent.len == 0) {
             if (allowsEmptyCase(tree, case_index, next_case_index, options)) continue;
         } else {
-            if (caseAlwaysExits(tree, switch_case)) continue;
+            if (caseAlwaysExits(tree, switch_case)) {
+                if (options.report_unused_fallthrough_comment and hasFallthroughComment(tree, switch_case, next_case_index)) {
+                    try addUnusedFallthroughCommentDiagnostic(allocator, diagnostics, tree, case_index);
+                }
+                continue;
+            }
             if (hasFallthroughComment(tree, switch_case, next_case_index)) continue;
         }
 
@@ -52,6 +58,22 @@ pub fn checkWithOptions(
             tree.span(case_index),
         );
     }
+}
+
+fn addUnusedFallthroughCommentDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Found a fallthrough comment, but this case cannot fall through.",
+        tree.span(index),
+    );
 }
 
 fn allowsEmptyCase(tree: *const ast.Tree, case_index: ast.NodeIndex, next_case_index: ast.NodeIndex, options: Options) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1994,6 +1994,7 @@ const BasicVisitor = struct {
         if (self.options.no_fallthrough) {
             try no_fallthrough.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, .{
                 .allow_empty_case = self.options.no_fallthrough_allow_empty_case == .yes,
+                .report_unused_fallthrough_comment = self.options.no_fallthrough_report_unused_fallthrough_comment,
             });
         }
         if (self.options.use_isnan) {

--- a/tests/rules/no_fallthrough.zig
+++ b/tests/rules/no_fallthrough.zig
@@ -150,6 +150,41 @@ test "allows separated empty cases when configured" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_fallthrough.id));
 }
 
+test "supports configured no-fallthrough reportUnusedFallthroughComment" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"reportUnusedFallthroughComment\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-fallthrough", config.value);
+
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    one();
+        \\    break;
+        \\    // falls through
+        \\  case 2:
+        \\    two();
+        \\  case 3:
+        \\    three();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_fallthrough.id));
+}
+
 test "can disable no-fallthrough" {
     const source =
         \\switch (value) {


### PR DESCRIPTION
Summary:
- add no-fallthrough reportUnusedFallthroughComment config parsing
- report fallthrough comments on cases that already exit
- preserve existing fallthrough-comment allow behavior for real fallthroughs
- cover the option in rule tests and status docs

Validation:
- zig fmt --check src/core.zig src/rules/no_fallthrough.zig src/rules/root.zig tests/rules/no_fallthrough.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check