### PR TITLE
Align no-unused-vars ignore pattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -148,7 +148,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `varsIgnorePattern` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
@@ -297,7 +297,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
-| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, and `ignoreRestSiblings` configuration |
+| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `varsIgnorePattern` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -501,6 +501,30 @@ pub const NoShadowAllowNames = struct {
     }
 };
 
+pub const max_no_unused_vars_ignore_pattern_len = 256;
+
+pub const NoUnusedVarsIgnorePatternError = error{
+    NoUnusedVarsIgnorePatternTooLong,
+};
+
+pub const NoUnusedVarsIgnorePattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_no_unused_vars_ignore_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const NoUnusedVarsIgnorePattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *NoUnusedVarsIgnorePattern, pattern_value: []const u8) NoUnusedVarsIgnorePatternError!void {
+        if (pattern_value.len > max_no_unused_vars_ignore_pattern_len) return error.NoUnusedVarsIgnorePatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const max_no_useless_escape_allow_regex_characters = 32;
 
 pub const NoUselessEscapeAllowRegexCharactersError = error{
@@ -1428,6 +1452,7 @@ pub const Options = struct {
     no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     no_unused_vars_ignore_rest_siblings: bool = false,
+    no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
     no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -1618,6 +1643,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_vars_args: NoUnusedVarsArgs = .after_used,
     typescript_eslint_no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     typescript_eslint_no_unused_vars_ignore_rest_siblings: bool = true,
+    typescript_eslint_no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
@@ -1989,6 +2015,7 @@ pub const Options = struct {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
             self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
+            self.no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
             self.no_use_before_define_check_functions = try noUseBeforeDefineCheckFromConfig(value, "functions", true);
@@ -2141,6 +2168,7 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .after_used);
             self.typescript_eslint_no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
+            self.typescript_eslint_no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/triple-slash-reference")) {
             self.typescript_eslint_triple_slash_reference_path = try typescriptEslintTripleSlashReferenceModeFromConfig(value, "path", .never);
@@ -4125,6 +4153,28 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn noUnusedVarsIgnorePatternFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!NoUnusedVarsIgnorePattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get(key) orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (pattern_value.len == 0) return .{};
+
+        var pattern = NoUnusedVarsIgnorePattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
     }
 
     fn noUseBeforeDefineCheckFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!NoUseBeforeDefineCheck {
@@ -7014,7 +7064,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":true}]",
+        "[\"error\",{\"args\":\"all\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":true,\"varsIgnorePattern\":\"^ignored\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -7024,11 +7074,12 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
+    try std.testing.expectEqualStrings("^ignored", options.no_unused_vars_vars_ignore_pattern.pattern().?);
 
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":false}]",
+        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"caughtErrors\":\"none\",\"ignoreRestSiblings\":false,\"varsIgnorePattern\":\"Ignored$\"}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
@@ -7038,6 +7089,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
+    try std.testing.expectEqualStrings("Ignored$", options.typescript_eslint_no_unused_vars_vars_ignore_pattern.pattern().?);
 
     var typescript_ban_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -22,6 +22,7 @@ pub const Options = struct {
     check_type_parameters: bool = false,
     react_jsx_uses_react: bool = false,
     react_jsx_uses_vars: bool = true,
+    vars_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
 };
 
 const JSXReactUsage = struct {
@@ -121,6 +122,7 @@ pub fn runWithOptions(
 
         const name = tree.string(symbol.name);
         if (std.mem.startsWith(u8, name, "_")) continue;
+        if (isIgnoredVariableName(name, flags, options)) continue;
         if (isUsedByReactJSX(name, jsx_react_usage)) continue;
 
         const decls = symbol_table.symbolDecls(entry.id);
@@ -137,6 +139,88 @@ pub fn runWithOptions(
             .{name},
         );
     }
+}
+
+fn isIgnoredVariableName(name: []const u8, flags: traverser.semantic.Symbol.Flags, options: Options) bool {
+    if (flags.parameter or flags.catch_var) return false;
+    return matchesPatternOption(name, options.vars_ignore_pattern);
+}
+
+fn matchesPatternOption(name: []const u8, pattern: core.NoUnusedVarsIgnorePattern) bool {
+    const custom_pattern = pattern.pattern() orelse return false;
+    return matchesPattern(name, custom_pattern);
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const remainder = pattern[start..];
+        const separator = std.mem.indexOfScalar(u8, remainder, '|');
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$");
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (std.mem.indexOf(u8, body, ".*") != null) {
+        return matchesWildcardSequence(value, body, anchored_start, anchored_end);
+    }
+    if (anchored_start and anchored_end) return std.mem.eql(u8, value, body);
+    if (anchored_start) return std.mem.startsWith(u8, value, body);
+    if (anchored_end) return std.mem.endsWith(u8, value, body);
+    return std.mem.indexOf(u8, value, body) != null;
+}
+
+fn matchesWildcardSequence(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    var value_offset: usize = 0;
+    var pattern_offset: usize = 0;
+    var part_index: usize = 0;
+
+    while (pattern_offset <= pattern.len) : (part_index += 1) {
+        const remainder = pattern[pattern_offset..];
+        const wildcard = std.mem.indexOf(u8, remainder, ".*");
+        const part_end = if (wildcard) |offset| pattern_offset + offset else pattern.len;
+        const part = pattern[pattern_offset..part_end];
+
+        if (part.len > 0) {
+            if (part_index == 0 and anchored_start) {
+                if (!std.mem.startsWith(u8, value[value_offset..], part)) return false;
+                value_offset += part.len;
+            } else {
+                const found = std.mem.indexOf(u8, value[value_offset..], part) orelse return false;
+                value_offset += found + part.len;
+            }
+        }
+
+        if (wildcard == null) break;
+        pattern_offset = part_end + 2;
+    }
+
+    if (!anchored_end) return true;
+    const suffix_start = lastWildcardPartStart(pattern);
+    return std.mem.endsWith(u8, value, pattern[suffix_start..]);
+}
+
+fn lastWildcardPartStart(pattern: []const u8) usize {
+    var offset: usize = 0;
+    var start: usize = 0;
+    while (offset < pattern.len) {
+        const wildcard = std.mem.indexOf(u8, pattern[offset..], ".*") orelse break;
+        start = offset + wildcard + 2;
+        offset = start;
+    }
+    return start;
 }
 
 fn isGlobalVariable(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -970,6 +970,7 @@ pub fn runSemantic(
             .ignore_rest_siblings = options.no_unused_vars_ignore_rest_siblings,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
+            .vars_ignore_pattern = options.no_unused_vars_vars_ignore_pattern,
         });
     }
 
@@ -986,6 +987,7 @@ pub fn runSemantic(
             options.typescript_eslint_no_unused_vars_args,
             options.typescript_eslint_no_unused_vars_caught_errors,
             options.typescript_eslint_no_unused_vars_ignore_rest_siblings,
+            options.typescript_eslint_no_unused_vars_vars_ignore_pattern,
         );
     }
 

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -19,6 +19,7 @@ pub fn run(
     args: core.NoUnusedVarsArgs,
     caught_errors: core.NoUnusedVarsCaughtErrors,
     ignore_rest_siblings: bool,
+    vars_ignore_pattern: core.NoUnusedVarsIgnorePattern,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
         .rule_id = id,
@@ -31,5 +32,6 @@ pub fn run(
         .check_type_parameters = true,
         .react_jsx_uses_react = react_jsx_uses_react,
         .react_jsx_uses_vars = react_jsx_uses_vars,
+        .vars_ignore_pattern = vars_ignore_pattern,
     });
 }

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -155,3 +155,37 @@ test "supports configured no-unused-vars ignoreRestSiblings" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars varsIgnorePattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"varsIgnorePattern\":\"^ignored\",\"args\":\"all\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_empty = false;
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const ignoredValue = 1;
+        \\const unusedValue = 2;
+        \\function demo(ignoredParam) {
+        \\  try {
+        \\    run();
+        \\  } catch (ignoredError) {
+        \\  }
+        \\}
+        \\demo();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}


### PR DESCRIPTION
Summary:
- add no-unused-vars varsIgnorePattern config parsing
- apply common regex-like varsIgnorePattern matching for ordinary variables
- pass the same option through @typescript-eslint/no-unused-vars wrapper
- cover core behavior and config parsing in tests and status docs

Validation:
- zig fmt --check src/core.zig src/rules/no_unused_vars.zig src/rules/root.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check