### PR TITLE
align no-fallthrough comment pattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -71,7 +71,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
-| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase` and `reportUnusedFallthroughComment` configuration |
+| [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase`, common `commentPattern`, and `reportUnusedFallthroughComment` configuration |
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
 | [`no-func-assign`](https://eslint.org/docs/latest/rules/no-func-assign) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1098,6 +1098,30 @@ pub const DefaultCaseCommentPattern = struct {
     }
 };
 
+pub const max_no_fallthrough_comment_pattern_len = 256;
+
+pub const NoFallthroughCommentPatternError = error{
+    NoFallthroughCommentPatternTooLong,
+};
+
+pub const NoFallthroughCommentPattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_no_fallthrough_comment_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const NoFallthroughCommentPattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *NoFallthroughCommentPattern, pattern_value: []const u8) NoFallthroughCommentPatternError!void {
+        if (pattern_value.len > max_no_fallthrough_comment_pattern_len) return error.NoFallthroughCommentPatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const Options = struct {
     accessor_pairs: bool = true,
     accessor_pairs_get_without_set: AccessorPairsGetWithoutSet = .no,
@@ -1221,6 +1245,7 @@ pub const Options = struct {
     no_floating_decimal: bool = true,
     no_fallthrough: bool = true,
     no_fallthrough_allow_empty_case: NoFallthroughAllowEmptyCase = .no,
+    no_fallthrough_comment_pattern: NoFallthroughCommentPattern = .{},
     no_fallthrough_report_unused_fallthrough_comment: bool = false,
     no_for_in: bool = true,
     no_func_assign: bool = true,
@@ -1873,6 +1898,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-fallthrough")) {
             self.no_fallthrough_allow_empty_case = try noFallthroughAllowEmptyCaseFromConfig(value);
+            self.no_fallthrough_comment_pattern = try noFallthroughCommentPatternFromConfig(value);
             self.no_fallthrough_report_unused_fallthrough_comment = try noFallthroughReportUnusedFallthroughCommentFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-implicit-coercion")) {
@@ -3316,6 +3342,27 @@ pub const Options = struct {
 
     fn noFallthroughReportUnusedFallthroughCommentFromConfig(value: std.json.Value) RuleConfigError!bool {
         return noFallthroughBoolOptionFromConfig(value, "reportUnusedFallthroughComment", false);
+    }
+
+    fn noFallthroughCommentPatternFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughCommentPattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get("commentPattern") orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var pattern = NoFallthroughCommentPattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
     }
 
     fn noFallthroughBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -6589,13 +6636,14 @@ test "Options can apply ESLint-style rule config values" {
     var no_fallthrough_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowEmptyCase\":true,\"reportUnusedFallthroughComment\":true}]",
+        "[\"error\",{\"allowEmptyCase\":true,\"commentPattern\":\"^ intentional fallthrough$\",\"reportUnusedFallthroughComment\":true}]",
         .{},
     );
     defer no_fallthrough_config.deinit();
     try options.setByRuleConfigValue("no-fallthrough", no_fallthrough_config.value);
     try std.testing.expect(options.no_fallthrough);
     try std.testing.expectEqual(NoFallthroughAllowEmptyCase.yes, options.no_fallthrough_allow_empty_case);
+    try std.testing.expectEqualStrings(" intentional fallthrough", options.no_fallthrough_comment_pattern.pattern().?);
     try std.testing.expect(options.no_fallthrough_report_unused_fallthrough_comment);
 
     var no_implicit_coercion_config = try std.json.parseFromSlice(

--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -9,6 +9,7 @@ pub const id = "no-fallthrough";
 
 pub const Options = struct {
     allow_empty_case: bool = false,
+    comment_pattern: core.NoFallthroughCommentPattern = .{},
     report_unused_fallthrough_comment: bool = false,
 };
 
@@ -41,12 +42,12 @@ pub fn checkWithOptions(
             if (allowsEmptyCase(tree, case_index, next_case_index, options)) continue;
         } else {
             if (caseAlwaysExits(tree, switch_case)) {
-                if (options.report_unused_fallthrough_comment and hasFallthroughComment(tree, switch_case, next_case_index)) {
+                if (options.report_unused_fallthrough_comment and hasFallthroughComment(tree, switch_case, next_case_index, options)) {
                     try addUnusedFallthroughCommentDiagnostic(allocator, diagnostics, tree, case_index);
                 }
                 continue;
             }
-            if (hasFallthroughComment(tree, switch_case, next_case_index)) continue;
+            if (hasFallthroughComment(tree, switch_case, next_case_index, options)) continue;
         }
 
         try core.addDiagnostic(
@@ -79,7 +80,7 @@ fn addUnusedFallthroughCommentDiagnostic(
 fn allowsEmptyCase(tree: *const ast.Tree, case_index: ast.NodeIndex, next_case_index: ast.NodeIndex, options: Options) bool {
     if (options.allow_empty_case) return true;
     if (caseLabelsAreAdjacent(tree, case_index, next_case_index)) return true;
-    return hasFallthroughCommentBetween(tree, tree.span(case_index).end, tree.span(next_case_index).start);
+    return hasFallthroughCommentBetween(tree, tree.span(case_index).end, tree.span(next_case_index).start, options);
 }
 
 fn caseLabelsAreAdjacent(tree: *const ast.Tree, case_index: ast.NodeIndex, next_case_index: ast.NodeIndex) bool {
@@ -123,7 +124,7 @@ fn rangeAlwaysExits(tree: *const ast.Tree, range: ast.IndexRange) bool {
     return alwaysExits(tree, statements[statements.len - 1]);
 }
 
-fn hasFallthroughComment(tree: *const ast.Tree, switch_case: ast.SwitchCase, next_case_index: ast.NodeIndex) bool {
+fn hasFallthroughComment(tree: *const ast.Tree, switch_case: ast.SwitchCase, next_case_index: ast.NodeIndex, options: Options) bool {
     const statements = tree.extra(switch_case.consequent);
     if (statements.len == 0) return false;
 
@@ -133,21 +134,23 @@ fn hasFallthroughComment(tree: *const ast.Tree, switch_case: ast.SwitchCase, nex
     const end: u32 = next_span.start;
     if (start > end) return false;
 
-    return hasFallthroughCommentBetween(tree, start, end);
+    return hasFallthroughCommentBetween(tree, start, end, options);
 }
 
-fn hasFallthroughCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+fn hasFallthroughCommentBetween(tree: *const ast.Tree, start: u32, end: u32, options: Options) bool {
     if (start > end) return false;
 
     for (tree.comments) |comment| {
         if (comment.start < start or comment.end > end) continue;
-        if (isFallthroughComment(tree.string(comment.value))) return true;
+        if (isFallthroughComment(tree.string(comment.value), options.comment_pattern)) return true;
     }
 
     return false;
 }
 
-fn isFallthroughComment(comment: []const u8) bool {
+fn isFallthroughComment(comment: []const u8, comment_pattern: core.NoFallthroughCommentPattern) bool {
+    if (comment_pattern.pattern()) |pattern| return matchesPattern(comment, pattern);
+
     var buffer: [256]u8 = undefined;
     const len = @min(comment.len, buffer.len);
 
@@ -159,6 +162,78 @@ fn isFallthroughComment(comment: []const u8) bool {
     return std.mem.indexOf(u8, lower, "fallthrough") != null or
         std.mem.indexOf(u8, lower, "fall through") != null or
         std.mem.indexOf(u8, lower, "falls through") != null;
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const remainder = pattern[start..];
+        const separator = std.mem.indexOfScalar(u8, remainder, '|');
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$");
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (std.mem.indexOf(u8, body, ".*") != null) {
+        return matchesWildcardSequence(value, body, anchored_start, anchored_end);
+    }
+    if (anchored_start and anchored_end) return std.mem.eql(u8, value, body);
+    if (anchored_start) return std.mem.startsWith(u8, value, body);
+    if (anchored_end) return std.mem.endsWith(u8, value, body);
+    return std.mem.indexOf(u8, value, body) != null;
+}
+
+fn matchesWildcardSequence(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    var value_offset: usize = 0;
+    var pattern_offset: usize = 0;
+    var part_index: usize = 0;
+
+    while (pattern_offset <= pattern.len) : (part_index += 1) {
+        const remainder = pattern[pattern_offset..];
+        const wildcard = std.mem.indexOf(u8, remainder, ".*");
+        const part_end = if (wildcard) |offset| pattern_offset + offset else pattern.len;
+        const part = pattern[pattern_offset..part_end];
+
+        if (part.len > 0) {
+            if (part_index == 0 and anchored_start) {
+                if (!std.mem.startsWith(u8, value[value_offset..], part)) return false;
+                value_offset += part.len;
+            } else {
+                const found = std.mem.indexOf(u8, value[value_offset..], part) orelse return false;
+                value_offset += found + part.len;
+            }
+        }
+
+        if (wildcard == null) break;
+        pattern_offset = part_end + 2;
+    }
+
+    if (!anchored_end) return true;
+    const suffix_start = lastWildcardPartStart(pattern);
+    return std.mem.endsWith(u8, value, pattern[suffix_start..]);
+}
+
+fn lastWildcardPartStart(pattern: []const u8) usize {
+    var offset: usize = 0;
+    var start: usize = 0;
+    while (offset < pattern.len) {
+        const wildcard = std.mem.indexOf(u8, pattern[offset..], ".*") orelse break;
+        start = offset + wildcard + 2;
+        offset = start;
+    }
+    return start;
 }
 
 fn offsetToLine(source: []const u8, offset: u32) usize {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1996,6 +1996,7 @@ const BasicVisitor = struct {
         if (self.options.no_fallthrough) {
             try no_fallthrough.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, .{
                 .allow_empty_case = self.options.no_fallthrough_allow_empty_case == .yes,
+                .comment_pattern = self.options.no_fallthrough_comment_pattern,
                 .report_unused_fallthrough_comment = self.options.no_fallthrough_report_unused_fallthrough_comment,
             });
         }

--- a/tests/rules/no_fallthrough.zig
+++ b/tests/rules/no_fallthrough.zig
@@ -185,6 +185,41 @@ test "supports configured no-fallthrough reportUnusedFallthroughComment" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_fallthrough.id));
 }
 
+test "supports configured no-fallthrough commentPattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"commentPattern\":\"^ intentional fallthrough$\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-fallthrough", config.value);
+
+    const source =
+        \\switch (value) {
+        \\  case 1:
+        \\    one();
+        \\    // intentional fallthrough
+        \\  case 2:
+        \\    two();
+        \\    // falls through
+        \\  default:
+        \\    done();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_fallthrough.id));
+}
+
 test "can disable no-fallthrough" {
     const source =
         \\switch (value) {


### PR DESCRIPTION
## Summary
- parse `no-fallthrough` `commentPattern` from ESLint-style rule config
- apply configured fallthrough comment matching during switch-case analysis
- document and test the supported migration behavior

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_fallthrough.zig tests/rules/no_fallthrough.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`