### PR TITLE
align no-unused-vars array ignore pattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -148,7 +148,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
@@ -297,7 +297,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
-| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`varsIgnorePattern` configuration |
+| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1479,6 +1479,7 @@ pub const Options = struct {
     no_unused_vars_ignore_rest_siblings: bool = false,
     no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
+    no_unused_vars_destructured_array_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
@@ -1672,6 +1673,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_vars_ignore_rest_siblings: bool = true,
     typescript_eslint_no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
+    typescript_eslint_no_unused_vars_destructured_array_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
@@ -2047,6 +2049,7 @@ pub const Options = struct {
             self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
             self.no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
+            self.no_unused_vars_destructured_array_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "destructuredArrayIgnorePattern");
             self.no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
@@ -2202,6 +2205,7 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, true);
             self.typescript_eslint_no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
+            self.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "destructuredArrayIgnorePattern");
             self.typescript_eslint_no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/triple-slash-reference")) {
@@ -7120,7 +7124,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"ignoreRestSiblings\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"varsIgnorePattern\":\"^ignored\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -7132,12 +7136,13 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
     try std.testing.expectEqualStrings("^_", options.no_unused_vars_args_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("^ignoredError", options.no_unused_vars_caught_errors_ignore_pattern.pattern().?);
+    try std.testing.expectEqualStrings("^ignoredItem", options.no_unused_vars_destructured_array_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("^ignored", options.no_unused_vars_vars_ignore_pattern.pattern().?);
 
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"argsIgnorePattern\":\"^unused\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"Error$\",\"ignoreRestSiblings\":false,\"varsIgnorePattern\":\"Ignored$\"}]",
+        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"argsIgnorePattern\":\"^unused\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"Error$\",\"destructuredArrayIgnorePattern\":\"Item$\",\"ignoreRestSiblings\":false,\"varsIgnorePattern\":\"Ignored$\"}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
@@ -7149,6 +7154,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
     try std.testing.expectEqualStrings("^unused", options.typescript_eslint_no_unused_vars_args_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("Error$", options.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern.pattern().?);
+    try std.testing.expectEqualStrings("Item$", options.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("Ignored$", options.typescript_eslint_no_unused_vars_vars_ignore_pattern.pattern().?);
 
     var typescript_ban_types_config = try std.json.parseFromSlice(

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -24,6 +24,7 @@ pub const Options = struct {
     react_jsx_uses_vars: bool = true,
     args_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
     caught_errors_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
+    destructured_array_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
     vars_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
 };
 
@@ -102,6 +103,14 @@ pub fn runWithOptions(
     if (options.ignore_rest_siblings) {
         var visitor = RestSiblingVisitor{ .ignored_decls = &ignored_decls };
         try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
+    }
+
+    if (options.destructured_array_ignore_pattern.pattern() != null) {
+        var visitor = DestructuredArrayVisitor{
+            .ignored_decls = &ignored_decls,
+            .pattern = options.destructured_array_ignore_pattern,
+        };
+        try traverser.basic.traverse(DestructuredArrayVisitor, tree, &visitor);
     }
 
     const jsx_react_usage = if (options.react_jsx_uses_react) collectJSXReactUsage(tree) else JSXReactUsage{};
@@ -341,6 +350,56 @@ const RestSiblingVisitor = struct {
 
         switch (ctx.tree.data(index)) {
             .binding_identifier => try self.ignored_decls.put(index, {}),
+            .assignment_pattern => |assignment| try self.collectBinding(assignment.left, ctx),
+            .binding_rest_element => |rest| try self.collectBinding(rest.argument, ctx),
+            .array_pattern => |array| {
+                for (ctx.tree.extra(array.elements)) |element| {
+                    try self.collectBinding(element, ctx);
+                }
+                try self.collectBinding(array.rest, ctx);
+            },
+            .object_pattern => |object| {
+                for (ctx.tree.extra(object.properties)) |property_index| {
+                    const property = ctx.tree.data(property_index).binding_property;
+                    try self.collectBinding(property.value, ctx);
+                }
+                try self.collectBinding(object.rest, ctx);
+            },
+            else => {},
+        }
+    }
+};
+
+const DestructuredArrayVisitor = struct {
+    ignored_decls: *IgnoredDecls,
+    pattern: core.NoUnusedVarsIgnorePattern,
+
+    pub fn enter_array_pattern(
+        self: *DestructuredArrayVisitor,
+        pattern: ast.ArrayPattern,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        for (ctx.tree.extra(pattern.elements)) |element| {
+            try self.collectBinding(element, ctx);
+        }
+        try self.collectBinding(pattern.rest, ctx);
+
+        return .proceed;
+    }
+
+    fn collectBinding(
+        self: *DestructuredArrayVisitor,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!void {
+        if (index == .null) return;
+
+        switch (ctx.tree.data(index)) {
+            .binding_identifier => |identifier| {
+                const name = ctx.tree.string(identifier.name);
+                if (matchesPatternOption(name, self.pattern)) try self.ignored_decls.put(index, {});
+            },
             .assignment_pattern => |assignment| try self.collectBinding(assignment.left, ctx),
             .binding_rest_element => |rest| try self.collectBinding(rest.argument, ctx),
             .array_pattern => |array| {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -972,6 +972,7 @@ pub fn runSemantic(
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
             .args_ignore_pattern = options.no_unused_vars_args_ignore_pattern,
             .caught_errors_ignore_pattern = options.no_unused_vars_caught_errors_ignore_pattern,
+            .destructured_array_ignore_pattern = options.no_unused_vars_destructured_array_ignore_pattern,
             .vars_ignore_pattern = options.no_unused_vars_vars_ignore_pattern,
         });
     }
@@ -991,6 +992,7 @@ pub fn runSemantic(
             options.typescript_eslint_no_unused_vars_ignore_rest_siblings,
             options.typescript_eslint_no_unused_vars_args_ignore_pattern,
             options.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern,
+            options.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern,
             options.typescript_eslint_no_unused_vars_vars_ignore_pattern,
         );
     }

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -21,6 +21,7 @@ pub fn run(
     ignore_rest_siblings: bool,
     args_ignore_pattern: core.NoUnusedVarsIgnorePattern,
     caught_errors_ignore_pattern: core.NoUnusedVarsIgnorePattern,
+    destructured_array_ignore_pattern: core.NoUnusedVarsIgnorePattern,
     vars_ignore_pattern: core.NoUnusedVarsIgnorePattern,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
@@ -36,6 +37,7 @@ pub fn run(
         .react_jsx_uses_vars = react_jsx_uses_vars,
         .args_ignore_pattern = args_ignore_pattern,
         .caught_errors_ignore_pattern = caught_errors_ignore_pattern,
+        .destructured_array_ignore_pattern = destructured_array_ignore_pattern,
         .vars_ignore_pattern = vars_ignore_pattern,
     });
 }

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -249,3 +249,29 @@ test "supports configured no-unused-vars caughtErrorsIgnorePattern" {
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars destructuredArrayIgnorePattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"destructuredArrayIgnorePattern\":\"^ignored\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const [ignoredItem, unusedItem, usedItem] = items;
+        \\console.log(usedItem);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -220,6 +220,31 @@ test "supports configured @typescript-eslint/no-unused-vars caughtErrorsIgnorePa
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars destructuredArrayIgnorePattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"destructuredArrayIgnorePattern\":\"^ignored\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const [ignoredItem, unusedItem, usedItem]: string[] = items;
+        \\console.log(usedItem);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "can disable @typescript-eslint/no-unused-vars and fall back to core rule" {
     const source =
         \\const unused = 1;


### PR DESCRIPTION
## Summary
- parse `destructuredArrayIgnorePattern` for core `no-unused-vars` and `@typescript-eslint/no-unused-vars` configs
- collect array destructuring bindings that match the configured pattern and skip their unused diagnostics
- document and test the supported migration behavior

## Validation
- `zig fmt --check src/core.zig src/rules/no_unused_vars.zig src/rules/root.zig src/rules/typescript_eslint_no_unused_vars.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`