### PR TITLE
align ts no-shadow type value option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -286,7 +286,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Implemented |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
-| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, and `hoist` configuration |
+| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, and `ignoreTypeValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1645,6 +1645,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
     typescript_eslint_no_shadow_hoist: NoShadowHoist = .functions_and_types,
+    typescript_eslint_no_shadow_ignore_type_value_shadow: bool = false,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
@@ -2187,6 +2188,7 @@ pub const Options = struct {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
             self.typescript_eslint_no_shadow_hoist = try noShadowHoistFromConfig(value, .functions_and_types);
+            self.typescript_eslint_no_shadow_ignore_type_value_shadow = try noShadowIgnoreTypeValueShadowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/method-signature-style")) {
             self.typescript_eslint_method_signature_style_style = try typescriptEslintMethodSignatureStyleFromConfig(value);
@@ -3811,6 +3813,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, hoist, "never")) return .never;
         if (std.mem.eql(u8, hoist, "types")) return .types;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noShadowIgnoreTypeValueShadowFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("ignoreTypeValueShadow") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noUnderscoreDangleBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -6871,7 +6890,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\"}]",
+        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\",\"ignoreTypeValueShadow\":true}]",
         .{},
     );
     defer typescript_no_shadow_config.deinit();
@@ -6881,6 +6900,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.typescript_eslint_no_shadow_allow.contains("other"));
     try std.testing.expect(options.typescript_eslint_no_shadow_builtin_globals);
     try std.testing.expectEqual(NoShadowHoist.never, options.typescript_eslint_no_shadow_hoist);
+    try std.testing.expect(options.typescript_eslint_no_shadow_ignore_type_value_shadow);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -15,6 +15,7 @@ pub const Options = struct {
     allow: core.NoShadowAllowNames = .{},
     builtin_globals: bool = false,
     hoist: core.NoShadowHoist = .functions,
+    ignore_type_value_shadow: bool = false,
 };
 
 pub const Mode = enum {
@@ -129,8 +130,22 @@ fn isAllowedTypescriptShadow(
     options: Options,
 ) bool {
     if (options.mode != .typescript) return false;
+    if (options.ignore_type_value_shadow and isTypeValueShadow(self_flags, candidate_flags)) return true;
     return (self_flags.interface and candidate_flags.class) or
         (self_flags.class and candidate_flags.interface);
+}
+
+fn isTypeValueShadow(self_flags: traverser.semantic.Symbol.Flags, candidate_flags: traverser.semantic.Symbol.Flags) bool {
+    return (isTypeOnlySymbol(self_flags) and isValueOnlySymbol(candidate_flags)) or
+        (isValueOnlySymbol(self_flags) and isTypeOnlySymbol(candidate_flags));
+}
+
+fn isTypeOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    return flags.inTypeSpace() and !flags.inValueSpace();
+}
+
+fn isValueOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    return flags.inValueSpace() and !flags.inTypeSpace();
 }
 
 fn isAllowedByHoist(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -813,6 +813,7 @@ pub fn runSemantic(
             .allow = options.typescript_eslint_no_shadow_allow,
             .builtin_globals = options.typescript_eslint_no_shadow_builtin_globals,
             .hoist = options.typescript_eslint_no_shadow_hoist,
+            .ignore_type_value_shadow = options.typescript_eslint_no_shadow_ignore_type_value_shadow,
         });
     }
 

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -32,5 +32,6 @@ pub fn runWithOptions(
         .allow = options.allow,
         .builtin_globals = options.builtin_globals,
         .hoist = options.hoist,
+        .ignore_type_value_shadow = options.ignore_type_value_shadow,
     });
 }

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -154,6 +154,44 @@ test "supports configured @typescript-eslint/no-shadow hoist option" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow ignoreTypeValueShadow" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTypeValueShadow\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\type TypeName = string;
+        \\const valueName = 1;
+        \\const other = 2;
+        \\function f(TypeName: string) {
+        \\  return TypeName;
+        \\}
+        \\function g() {
+        \\  type valueName = string;
+        \\  return null as valueName;
+        \\}
+        \\function h(other: string) {
+        \\  return other;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
+}
+
 test "can disable @typescript-eslint/no-shadow and fall back to no-shadow" {
     const source =
         \\const value = 1;


### PR DESCRIPTION
## Summary
- parse `ignoreTypeValueShadow` for `@typescript-eslint/no-shadow` configs
- skip configured TypeScript type-only/value-only shadow pairs while preserving value/value diagnostics
- document and test the supported migration behavior

## Validation
- `zig fmt --check src/core.zig src/rules/no_shadow.zig src/rules/root.zig src/rules/typescript_eslint_no_shadow.zig tests/rules/typescript_eslint_no_shadow.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`