### PR TITLE
align no-console custom allow methods

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -41,7 +41,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-comma-operator`](https://eslint.org/docs/latest/rules/no-comma-operator) | Implemented |
 | [`no-compare-neg-zero`](https://eslint.org/docs/latest/rules/no-compare-neg-zero) | Implemented |
 | [`no-cond-assign`](https://eslint.org/docs/latest/rules/no-cond-assign) | Implemented |
-| [`no-console`](https://eslint.org/docs/latest/rules/no-console) | Implemented with `allow` support for known console methods |
+| [`no-console`](https://eslint.org/docs/latest/rules/no-console) | Implemented with `allow` support for configured console methods |
 | [`no-const-assign`](https://eslint.org/docs/latest/rules/no-const-assign) | Implemented |
 | [`no-constant-condition`](https://eslint.org/docs/latest/rules/no-constant-condition) | Implemented |
 | [`no-constructor-return`](https://eslint.org/docs/latest/rules/no-constructor-return) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -75,45 +75,34 @@ pub const NoConfusingArrowAllowParens = enum {
     no,
 };
 
+pub const max_no_console_allow_methods = 32;
+pub const max_no_console_allow_method_len = 128;
+
 pub const NoConsoleAllow = struct {
-    assert: bool = false,
-    clear: bool = false,
-    count: bool = false,
-    countReset: bool = false,
-    debug: bool = false,
-    dir: bool = false,
-    dirxml: bool = false,
-    @"error": bool = false,
-    group: bool = false,
-    groupCollapsed: bool = false,
-    groupEnd: bool = false,
-    info: bool = false,
-    log: bool = false,
-    profile: bool = false,
-    profileEnd: bool = false,
-    table: bool = false,
-    time: bool = false,
-    timeEnd: bool = false,
-    timeLog: bool = false,
-    timeStamp: bool = false,
-    trace: bool = false,
-    warn: bool = false,
+    count: usize = 0,
+    lengths: [max_no_console_allow_methods]usize = undefined,
+    storage: [max_no_console_allow_methods][max_no_console_allow_method_len]u8 = undefined,
 
     pub fn contains(self: NoConsoleAllow, name: []const u8) bool {
-        inline for (@typeInfo(NoConsoleAllow).@"struct".fields) |field| {
-            if (std.mem.eql(u8, field.name, name)) return @field(self, field.name);
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
         }
         return false;
     }
 
+    pub fn at(self: *const NoConsoleAllow, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
     pub fn enable(self: *NoConsoleAllow, name: []const u8) bool {
-        inline for (@typeInfo(NoConsoleAllow).@"struct".fields) |field| {
-            if (std.mem.eql(u8, field.name, name)) {
-                @field(self, field.name) = true;
-                return true;
-            }
-        }
-        return false;
+        if (name.len == 0 or name.len > max_no_console_allow_method_len) return false;
+        if (self.contains(name)) return true;
+        if (self.count >= max_no_console_allow_methods) return false;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
     }
 };
 
@@ -6434,7 +6423,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_console_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"warn\",\"error\"]}]",
+        "[\"error\",{\"allow\":[\"warn\",\"error\",\"todo\"]}]",
         .{},
     );
     defer no_console_config.deinit();
@@ -6442,6 +6431,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_console);
     try std.testing.expect(options.no_console_allow.contains("warn"));
     try std.testing.expect(options.no_console_allow.contains("error"));
+    try std.testing.expect(options.no_console_allow.contains("todo"));
     try std.testing.expect(!options.no_console_allow.contains("log"));
 
     var no_duplicate_imports_config = try std.json.parseFromSlice(

--- a/src/main.zig
+++ b/src/main.zig
@@ -1079,7 +1079,7 @@ fn parseNoConsoleAllow(value: []const u8, options: *lint.Options) void {
             std.process.exit(2);
         }
         if (!allow.enable(method)) {
-            std.debug.print("utoo-lint: unsupported --no-console-allow method: {s}\n", .{method});
+            std.debug.print("utoo-lint: --no-console-allow method is too long or too many methods were provided: {s}\n", .{method});
             std.process.exit(2);
         }
     }

--- a/tests/rules/no_console.zig
+++ b/tests/rules/no_console.zig
@@ -56,6 +56,33 @@ test "allows configured no-console methods" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_console.id));
 }
 
+test "supports configured no-console custom method names" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"todo\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-console", config.value);
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\console.todo(value);
+        \\console["todo"](value);
+        \\console.log(value);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_console.id));
+}
+
 test "does not report no-console for shadowed console" {
     const source =
         \\function local(console) {


### PR DESCRIPTION
## Summary
- allow arbitrary `no-console` `allow` method names instead of only known console methods
- keep the existing `contains`/`enable` API for rule and CLI callers
- document and test custom console method migration behavior

## Validation
- `zig fmt --check src/core.zig src/main.zig tests/rules/no_console.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`