### PR TITLE
Support no-unused-vars reportUsedIgnorePattern

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -148,7 +148,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
@@ -297,7 +297,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor/) | Implemented |
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
-| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1469,6 +1469,7 @@ pub const Options = struct {
     no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_destructured_array_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
+    no_unused_vars_report_used_ignore_pattern: bool = false,
     no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_use_before_define: bool = true,
     no_use_before_define_check_functions: NoUseBeforeDefineCheck = .yes,
@@ -1664,6 +1665,7 @@ pub const Options = struct {
     typescript_eslint_no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_unused_vars_destructured_array_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
+    typescript_eslint_no_unused_vars_report_used_ignore_pattern: bool = false,
     typescript_eslint_no_unused_vars_vars_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     typescript_eslint_no_use_before_define: bool = true,
     typescript_eslint_no_use_before_define_check_functions: NoUseBeforeDefineCheck = .no,
@@ -2040,6 +2042,7 @@ pub const Options = struct {
             self.no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
             self.no_unused_vars_destructured_array_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "destructuredArrayIgnorePattern");
+            self.no_unused_vars_report_used_ignore_pattern = try noUnusedVarsReportUsedIgnorePatternFromConfig(value, false);
             self.no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "no-use-before-define")) {
@@ -2197,6 +2200,7 @@ pub const Options = struct {
             self.typescript_eslint_no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
             self.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "destructuredArrayIgnorePattern");
+            self.typescript_eslint_no_unused_vars_report_used_ignore_pattern = try noUnusedVarsReportUsedIgnorePatternFromConfig(value, false);
             self.typescript_eslint_no_unused_vars_vars_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "varsIgnorePattern");
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/triple-slash-reference")) {
@@ -4217,6 +4221,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("ignoreRestSiblings") orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn noUnusedVarsReportUsedIgnorePatternFromConfig(value: std.json.Value, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("reportUsedIgnorePattern") orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -7134,7 +7155,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -7144,6 +7165,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
+    try std.testing.expect(options.no_unused_vars_report_used_ignore_pattern);
     try std.testing.expectEqualStrings("^_", options.no_unused_vars_args_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("^ignoredError", options.no_unused_vars_caught_errors_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("^ignoredItem", options.no_unused_vars_destructured_array_ignore_pattern.pattern().?);
@@ -7152,7 +7174,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"argsIgnorePattern\":\"^unused\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"Error$\",\"destructuredArrayIgnorePattern\":\"Item$\",\"ignoreRestSiblings\":false,\"varsIgnorePattern\":\"Ignored$\"}]",
+        "[\"error\",{\"vars\":\"local\",\"args\":\"none\",\"argsIgnorePattern\":\"^unused\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"Error$\",\"destructuredArrayIgnorePattern\":\"Item$\",\"ignoreRestSiblings\":false,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"Ignored$\"}]",
         .{},
     );
     defer typescript_no_unused_vars_config.deinit();
@@ -7162,6 +7184,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.none, options.typescript_eslint_no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.typescript_eslint_no_unused_vars_caught_errors);
     try std.testing.expect(!options.typescript_eslint_no_unused_vars_ignore_rest_siblings);
+    try std.testing.expect(options.typescript_eslint_no_unused_vars_report_used_ignore_pattern);
     try std.testing.expectEqualStrings("^unused", options.typescript_eslint_no_unused_vars_args_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("Error$", options.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("Item$", options.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern.pattern().?);

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -25,6 +25,7 @@ pub const Options = struct {
     args_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
     caught_errors_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
     destructured_array_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
+    report_used_ignore_pattern: bool = false,
     vars_ignore_pattern: core.NoUnusedVarsIgnorePattern = .{},
 };
 
@@ -100,6 +101,9 @@ pub fn runWithOptions(
     var ignored_decls = IgnoredDecls.init(allocator);
     defer ignored_decls.deinit();
 
+    var destructured_array_ignored_decls = IgnoredDecls.init(allocator);
+    defer destructured_array_ignored_decls.deinit();
+
     if (options.ignore_rest_siblings) {
         var visitor = RestSiblingVisitor{ .ignored_decls = &ignored_decls };
         try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
@@ -108,6 +112,7 @@ pub fn runWithOptions(
     if (options.destructured_array_ignore_pattern.pattern() != null) {
         var visitor = DestructuredArrayVisitor{
             .ignored_decls = &ignored_decls,
+            .destructured_array_ignored_decls = &destructured_array_ignored_decls,
             .pattern = options.destructured_array_ignore_pattern,
         };
         try traverser.basic.traverse(DestructuredArrayVisitor, tree, &visitor);
@@ -129,15 +134,29 @@ pub fn runWithOptions(
             if (!options.check_parameters) continue;
             if (options.args_after_used and !shouldCheckParameter(entry.id, symbol.scope, parameters.items)) continue;
         }
-        if (isReferenced(tree, symbol_table, entry.id, options)) continue;
 
         const name = tree.string(symbol.name);
+        const decls = symbol_table.symbolDecls(entry.id);
+        if (decls.len == 0) continue;
+
+        if (isReferenced(tree, symbol_table, entry.id, options)) {
+            if (options.report_used_ignore_pattern and isReportedUsedIgnoredName(name, flags, decls, &destructured_array_ignored_decls, options)) {
+                try core.addDiagnosticFmt(
+                    allocator,
+                    diagnostics,
+                    options.severity,
+                    options.rule_id,
+                    tree.span(decls[0]),
+                    "'{s}' is marked as ignored but is used.",
+                    .{name},
+                );
+            }
+            continue;
+        }
+
         if (std.mem.startsWith(u8, name, "_")) continue;
         if (isIgnoredVariableName(name, flags, options)) continue;
         if (isUsedByReactJSX(name, jsx_react_usage)) continue;
-
-        const decls = symbol_table.symbolDecls(entry.id);
-        if (decls.len == 0) continue;
         if (ignored_decls.contains(decls[0])) continue;
 
         try core.addDiagnosticFmt(
@@ -150,6 +169,19 @@ pub fn runWithOptions(
             .{name},
         );
     }
+}
+
+fn isReportedUsedIgnoredName(
+    name: []const u8,
+    flags: traverser.semantic.Symbol.Flags,
+    decls: []const ast.NodeIndex,
+    destructured_array_ignored_decls: *IgnoredDecls,
+    options: Options,
+) bool {
+    if (flags.parameter) return matchesPatternOption(name, options.args_ignore_pattern);
+    if (flags.catch_var) return matchesPatternOption(name, options.caught_errors_ignore_pattern);
+    if (decls.len > 0 and destructured_array_ignored_decls.contains(decls[0])) return true;
+    return matchesPatternOption(name, options.vars_ignore_pattern);
 }
 
 fn isIgnoredVariableName(name: []const u8, flags: traverser.semantic.Symbol.Flags, options: Options) bool {
@@ -372,6 +404,7 @@ const RestSiblingVisitor = struct {
 
 const DestructuredArrayVisitor = struct {
     ignored_decls: *IgnoredDecls,
+    destructured_array_ignored_decls: *IgnoredDecls,
     pattern: core.NoUnusedVarsIgnorePattern,
 
     pub fn enter_array_pattern(
@@ -398,7 +431,10 @@ const DestructuredArrayVisitor = struct {
         switch (ctx.tree.data(index)) {
             .binding_identifier => |identifier| {
                 const name = ctx.tree.string(identifier.name);
-                if (matchesPatternOption(name, self.pattern)) try self.ignored_decls.put(index, {});
+                if (matchesPatternOption(name, self.pattern)) {
+                    try self.ignored_decls.put(index, {});
+                    try self.destructured_array_ignored_decls.put(index, {});
+                }
             },
             .assignment_pattern => |assignment| try self.collectBinding(assignment.left, ctx),
             .binding_rest_element => |rest| try self.collectBinding(rest.argument, ctx),

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -974,6 +974,7 @@ pub fn runSemantic(
             .args_ignore_pattern = options.no_unused_vars_args_ignore_pattern,
             .caught_errors_ignore_pattern = options.no_unused_vars_caught_errors_ignore_pattern,
             .destructured_array_ignore_pattern = options.no_unused_vars_destructured_array_ignore_pattern,
+            .report_used_ignore_pattern = options.no_unused_vars_report_used_ignore_pattern,
             .vars_ignore_pattern = options.no_unused_vars_vars_ignore_pattern,
         });
     }
@@ -994,6 +995,7 @@ pub fn runSemantic(
             options.typescript_eslint_no_unused_vars_args_ignore_pattern,
             options.typescript_eslint_no_unused_vars_caught_errors_ignore_pattern,
             options.typescript_eslint_no_unused_vars_destructured_array_ignore_pattern,
+            options.typescript_eslint_no_unused_vars_report_used_ignore_pattern,
             options.typescript_eslint_no_unused_vars_vars_ignore_pattern,
         );
     }

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -22,6 +22,7 @@ pub fn run(
     args_ignore_pattern: core.NoUnusedVarsIgnorePattern,
     caught_errors_ignore_pattern: core.NoUnusedVarsIgnorePattern,
     destructured_array_ignore_pattern: core.NoUnusedVarsIgnorePattern,
+    report_used_ignore_pattern: bool,
     vars_ignore_pattern: core.NoUnusedVarsIgnorePattern,
 ) Allocator.Error!void {
     try no_unused_vars.runWithOptions(allocator, diagnostics, tree, scope_tree, symbol_table, .{
@@ -38,6 +39,7 @@ pub fn run(
         .args_ignore_pattern = args_ignore_pattern,
         .caught_errors_ignore_pattern = caught_errors_ignore_pattern,
         .destructured_array_ignore_pattern = destructured_array_ignore_pattern,
+        .report_used_ignore_pattern = report_used_ignore_pattern,
         .vars_ignore_pattern = vars_ignore_pattern,
     });
 }

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -275,3 +275,39 @@ test "supports configured no-unused-vars destructuredArrayIgnorePattern" {
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_vars.id));
 }
+
+test "supports configured no-unused-vars reportUsedIgnorePattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^ignored\",\"caughtErrors\":\"all\",\"caughtErrorsIgnorePattern\":\"^ignored\",\"destructuredArrayIgnorePattern\":\"^ignored\",\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const ignoredValue = 1;
+        \\function demo(ignoredParam) {
+        \\  console.log(ignoredValue, ignoredParam);
+        \\  try {
+        \\    run();
+        \\  } catch (ignoredError) {
+        \\    console.log(ignoredError);
+        \\  }
+        \\  const [ignoredItem] = items;
+        \\  console.log(ignoredItem);
+        \\}
+        \\demo(1);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unused_vars.id));
+}

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -245,6 +245,41 @@ test "supports configured @typescript-eslint/no-unused-vars destructuredArrayIgn
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "supports configured @typescript-eslint/no-unused-vars reportUsedIgnorePattern" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^ignored\",\"caughtErrors\":\"all\",\"caughtErrorsIgnorePattern\":\"^ignored\",\"destructuredArrayIgnorePattern\":\"^ignored\",\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", config.value);
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const ignoredValue = 1;
+        \\function demo(ignoredParam: string) {
+        \\  console.log(ignoredValue, ignoredParam);
+        \\  try {
+        \\    run();
+        \\  } catch (ignoredError) {
+        \\    console.log(ignoredError);
+        \\  }
+        \\  const [ignoredItem]: string[] = items;
+        \\  console.log(ignoredItem);
+        \\}
+        \\demo("ignored");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
 test "can disable @typescript-eslint/no-unused-vars and fall back to core rule" {
     const source =
         \\const unused = 1;


### PR DESCRIPTION
## Summary
- add `reportUsedIgnorePattern` config parsing for `no-unused-vars` and `@typescript-eslint/no-unused-vars`
- report used declarations that match configured ignore patterns, including array destructuring patterns
- document rule status and add JS/TS regression coverage

## Validation
- `zig fmt --check src/rules/no_unused_vars.zig src/rules/typescript_eslint_no_unused_vars.zig src/rules/root.zig src/core.zig tests/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`