### PR TITLE
Support no-param-reassign regex ignores

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -112,7 +112,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-object-constructor`](https://eslint.org/docs/latest/rules/no-object-constructor) | Implemented |
 | [`no-octal`](https://eslint.org/docs/latest/rules/no-octal) | Implemented |
 | [`no-octal-escape`](https://eslint.org/docs/latest/rules/no-octal-escape) | Implemented |
-| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented with optional `props` and `ignorePropertyModificationsFor` behavior |
+| [`no-param-reassign`](https://eslint.org/docs/latest/rules/no-param-reassign) | Implemented with optional `props`, `ignorePropertyModificationsFor`, and common `ignorePropertyModificationsForRegex` behavior |
 | [`no-path-concat`](https://eslint.org/docs/latest/rules/no-path-concat) | Implemented |
 | [`no-plusplus`](https://eslint.org/docs/latest/rules/no-plusplus) | Implemented with optional `allowForLoopAfterthoughts` behavior |
 | [`no-process-env`](https://eslint.org/docs/latest/rules/no-process-env) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -384,6 +384,8 @@ pub const NoParamReassignProps = enum {
 
 pub const max_no_param_reassign_ignored_names = 32;
 pub const max_no_param_reassign_ignored_name_len = 128;
+pub const max_no_param_reassign_ignored_name_patterns = 32;
+pub const max_no_param_reassign_ignored_name_pattern_len = 256;
 
 pub const NoParamReassignIgnoredNamesError = error{
     EmptyNoParamReassignIgnoredName,
@@ -414,6 +416,32 @@ pub const NoParamReassignIgnoredNames = struct {
 
         @memcpy(self.storage[self.count][0..name.len], name);
         self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
+pub const NoParamReassignIgnoredNamePatternsError = error{
+    EmptyNoParamReassignIgnoredNamePattern,
+    TooManyNoParamReassignIgnoredNamePatterns,
+    NoParamReassignIgnoredNamePatternTooLong,
+};
+
+pub const NoParamReassignIgnoredNamePatterns = struct {
+    count: usize = 0,
+    lengths: [max_no_param_reassign_ignored_name_patterns]usize = undefined,
+    storage: [max_no_param_reassign_ignored_name_patterns][max_no_param_reassign_ignored_name_pattern_len]u8 = undefined,
+
+    pub fn at(self: *const NoParamReassignIgnoredNamePatterns, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoParamReassignIgnoredNamePatterns, pattern: []const u8) NoParamReassignIgnoredNamePatternsError!void {
+        if (pattern.len == 0) return error.EmptyNoParamReassignIgnoredNamePattern;
+        if (self.count >= max_no_param_reassign_ignored_name_patterns) return error.TooManyNoParamReassignIgnoredNamePatterns;
+        if (pattern.len > max_no_param_reassign_ignored_name_pattern_len) return error.NoParamReassignIgnoredNamePatternTooLong;
+
+        @memcpy(self.storage[self.count][0..pattern.len], pattern);
+        self.lengths[self.count] = pattern.len;
         self.count += 1;
     }
 };
@@ -1358,6 +1386,7 @@ pub const Options = struct {
     no_param_reassign: bool = true,
     no_param_reassign_props: NoParamReassignProps = .no,
     no_param_reassign_ignore_property_modifications_for: NoParamReassignIgnoredNames = .{},
+    no_param_reassign_ignore_property_modifications_for_regex: NoParamReassignIgnoredNamePatterns = .{},
     no_path_concat: bool = true,
     no_plusplus: bool = true,
     no_plusplus_allow_for_loop_afterthoughts: NoPlusplusAllowForLoopAfterthoughts = .no,
@@ -1949,6 +1978,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-param-reassign")) {
             self.no_param_reassign_props = try noParamReassignPropsFromConfig(value);
             self.no_param_reassign_ignore_property_modifications_for = try noParamReassignIgnoredNamesFromConfig(value);
+            self.no_param_reassign_ignore_property_modifications_for_regex = try noParamReassignIgnoredNamePatternsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
@@ -3735,6 +3765,34 @@ pub const Options = struct {
                 else => return error.UnsupportedRuleConfigValue,
             };
             ignored.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return ignored;
+    }
+
+    fn noParamReassignIgnoredNamePatternsFromConfig(value: std.json.Value) RuleConfigError!NoParamReassignIgnoredNamePatterns {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignored_value = config.get("ignorePropertyModificationsForRegex") orelse return .{};
+        const ignored_items = switch (ignored_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignored = NoParamReassignIgnoredNamePatterns{};
+        for (ignored_items) |item| {
+            const pattern = switch (item) {
+                .string => |pattern| pattern,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            ignored.append(pattern) catch return error.UnsupportedRuleConfigValue;
         }
         return ignored;
     }
@@ -6816,7 +6874,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_param_reassign_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"props\":true,\"ignorePropertyModificationsFor\":[\"req\",\"res\"]}]",
+        "[\"error\",{\"props\":true,\"ignorePropertyModificationsFor\":[\"req\",\"res\"],\"ignorePropertyModificationsForRegex\":[\"^ctx\",\"Response$\"]}]",
         .{},
     );
     defer no_param_reassign_config.deinit();
@@ -6826,6 +6884,9 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("req"));
     try std.testing.expect(options.no_param_reassign_ignore_property_modifications_for.contains("res"));
     try std.testing.expect(!options.no_param_reassign_ignore_property_modifications_for.contains("ctx"));
+    try std.testing.expectEqual(@as(usize, 2), options.no_param_reassign_ignore_property_modifications_for_regex.count);
+    try std.testing.expectEqualStrings("^ctx", options.no_param_reassign_ignore_property_modifications_for_regex.at(0));
+    try std.testing.expectEqualStrings("Response$", options.no_param_reassign_ignore_property_modifications_for_regex.at(1));
 
     var no_redeclare_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_param_reassign.zig
+++ b/src/rules/no_param_reassign.zig
@@ -12,6 +12,7 @@ const ParamSet = std.StringHashMapUnmanaged(void);
 pub const Options = struct {
     props: bool = false,
     ignore_property_modifications_for: core.NoParamReassignIgnoredNames = .{},
+    ignore_property_modifications_for_regex: core.NoParamReassignIgnoredNamePatterns = .{},
 };
 
 pub fn checkFunction(
@@ -320,7 +321,7 @@ fn checkTarget(
             if (!options.props) return;
             const name = rootIdentifierReferenceName(tree, member.object) orelse return;
             if (!params.contains(name)) return;
-            if (options.ignore_property_modifications_for.contains(name)) return;
+            if (isIgnoredPropertyModificationName(name, options)) return;
 
             try core.addDiagnosticFmt(
                 allocator,
@@ -352,6 +353,88 @@ fn checkTarget(
         .binding_rest_element => |element| try checkTarget(allocator, diagnostics, tree, params, element.argument, options),
         else => {},
     }
+}
+
+fn isIgnoredPropertyModificationName(name: []const u8, options: Options) bool {
+    if (options.ignore_property_modifications_for.contains(name)) return true;
+
+    for (0..options.ignore_property_modifications_for_regex.count) |index| {
+        if (matchesPattern(name, options.ignore_property_modifications_for_regex.at(index))) return true;
+    }
+
+    return false;
+}
+
+fn matchesPattern(value: []const u8, pattern: []const u8) bool {
+    var start: usize = 0;
+    while (start <= pattern.len) {
+        const remainder = pattern[start..];
+        const separator = std.mem.indexOfScalar(u8, remainder, '|');
+        const end = if (separator) |offset| start + offset else pattern.len;
+        if (matchesAlternative(value, pattern[start..end])) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn matchesAlternative(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = std.mem.startsWith(u8, pattern, "^");
+    const anchored_end = std.mem.endsWith(u8, pattern, "$");
+    const body_start: usize = if (anchored_start) 1 else 0;
+    const body_end = if (anchored_end and pattern.len > body_start) pattern.len - 1 else pattern.len;
+    const body = pattern[body_start..body_end];
+
+    if (std.mem.indexOf(u8, body, ".*") != null) {
+        return matchesWildcardSequence(value, body, anchored_start, anchored_end);
+    }
+    if (anchored_start and anchored_end) return std.mem.eql(u8, value, body);
+    if (anchored_start) return std.mem.startsWith(u8, value, body);
+    if (anchored_end) return std.mem.endsWith(u8, value, body);
+    return std.mem.indexOf(u8, value, body) != null;
+}
+
+fn matchesWildcardSequence(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    var value_offset: usize = 0;
+    var pattern_offset: usize = 0;
+    var part_index: usize = 0;
+
+    while (pattern_offset <= pattern.len) : (part_index += 1) {
+        const remainder = pattern[pattern_offset..];
+        const wildcard = std.mem.indexOf(u8, remainder, ".*");
+        const part_end = if (wildcard) |offset| pattern_offset + offset else pattern.len;
+        const part = pattern[pattern_offset..part_end];
+
+        if (part.len > 0) {
+            if (part_index == 0 and anchored_start) {
+                if (!std.mem.startsWith(u8, value[value_offset..], part)) return false;
+                value_offset += part.len;
+            } else {
+                const found = std.mem.indexOf(u8, value[value_offset..], part) orelse return false;
+                value_offset += found + part.len;
+            }
+        }
+
+        if (wildcard == null) break;
+        pattern_offset = part_end + 2;
+    }
+
+    if (!anchored_end) return true;
+    const suffix_start = lastWildcardPartStart(pattern);
+    return std.mem.endsWith(u8, value, pattern[suffix_start..]);
+}
+
+fn lastWildcardPartStart(pattern: []const u8) usize {
+    var offset: usize = 0;
+    var start: usize = 0;
+    while (offset < pattern.len) {
+        const wildcard = std.mem.indexOf(u8, pattern[offset..], ".*") orelse break;
+        start = offset + wildcard + 2;
+        offset = start;
+    }
+    return start;
 }
 
 fn rootIdentifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1261,6 +1261,7 @@ const BasicVisitor = struct {
             try no_param_reassign.checkFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, function, .{
                 .props = self.options.no_param_reassign_props == .yes,
                 .ignore_property_modifications_for = self.options.no_param_reassign_ignore_property_modifications_for,
+                .ignore_property_modifications_for_regex = self.options.no_param_reassign_ignore_property_modifications_for_regex,
             });
         }
         if (self.options.no_inner_declarations) {
@@ -2451,6 +2452,7 @@ const BasicVisitor = struct {
             try no_param_reassign.checkArrowFunctionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .props = self.options.no_param_reassign_props == .yes,
                 .ignore_property_modifications_for = self.options.no_param_reassign_ignore_property_modifications_for,
+                .ignore_property_modifications_for_regex = self.options.no_param_reassign_ignore_property_modifications_for_regex,
             });
         }
         if (self.options.react_display_name) {

--- a/tests/rules/no_param_reassign.zig
+++ b/tests/rules/no_param_reassign.zig
@@ -141,6 +141,37 @@ test "allows configured parameter property modification names" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_param_reassign.id));
 }
 
+test "allows configured parameter property modification name patterns" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"props\":true,\"ignorePropertyModificationsFor\":[\"exact\"],\"ignorePropertyModificationsForRegex\":[\"^req\",\"Response$\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-param-reassign", config.value);
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\function middleware(req, apiResponse, exact, ctx) {
+        \\  req.body = next;
+        \\  apiResponse.statusCode = next;
+        \\  exact.value = next;
+        \\  ctx.value = next;
+        \\  req = next;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_param_reassign.id));
+}
+
 test "can disable no-param-reassign" {
     const source =
         \\function run(value) {


### PR DESCRIPTION
## Summary
- parse `ignorePropertyModificationsForRegex` for `no-param-reassign`
- ignore configured parameter property writes by common regex-like name patterns
- add config parsing and rule regression coverage, and update rule status

## Validation
- `zig fmt --check src/core.zig src/rules/no_param_reassign.zig src/rules/root.zig tests/rules/no_param_reassign.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`