### PR TITLE
Support TS no-redeclare declaration merge option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -284,7 +284,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
-| [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Implemented |
+| [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `ignoreDeclarationMerge` configuration |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, and `ignoreTypeValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1659,6 +1659,7 @@ pub const Options = struct {
     typescript_eslint_no_namespace_allow_declarations: bool = true,
     typescript_eslint_no_namespace_allow_definition_files: bool = true,
     typescript_eslint_no_redeclare: bool = true,
+    typescript_eslint_no_redeclare_ignore_declaration_merge: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
@@ -2218,6 +2219,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-namespace")) {
             self.typescript_eslint_no_namespace_allow_declarations = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDeclarations", true);
             self.typescript_eslint_no_namespace_allow_definition_files = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDefinitionFiles", true);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-redeclare")) {
+            self.typescript_eslint_no_redeclare_ignore_declaration_merge = try typescriptEslintNoRedeclareIgnoreDeclarationMergeFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
             self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
@@ -5532,6 +5536,10 @@ pub const Options = struct {
         };
     }
 
+    fn typescriptEslintNoRedeclareIgnoreDeclarationMergeFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return typescriptEslintNoNamespaceBoolOptionFromConfig(value, "ignoreDeclarationMerge", true);
+    }
+
     fn typescriptEslintNoThisAliasAllowedNamesFromConfig(value: std.json.Value) RuleConfigError!NoThisAliasAllowedNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6898,6 +6906,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-redeclare", no_redeclare_config.value);
     try std.testing.expect(options.no_redeclare);
     try std.testing.expectEqual(NoRedeclareBuiltinGlobals.yes, options.no_redeclare_builtin_globals);
+
+    var typescript_no_redeclare_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreDeclarationMerge\":false}]",
+        .{},
+    );
+    defer typescript_no_redeclare_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-redeclare", typescript_no_redeclare_config.value);
+    try std.testing.expect(options.typescript_eslint_no_redeclare);
+    try std.testing.expect(!options.typescript_eslint_no_redeclare_ignore_declaration_merge);
 
     var no_irregular_whitespace_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -13,6 +13,7 @@ pub const Options = struct {
     severity: core.Severity = .warning,
     mode: Mode = .javascript,
     builtin_globals: bool = false,
+    ignore_declaration_merge: bool = true,
 };
 
 pub const Mode = enum {
@@ -129,7 +130,7 @@ fn checkTypescriptRedeclarations(
 
     for (decls) |decl| {
         const current = decl_info.get(decl) orelse DeclInfo{ .kind = .other };
-        if (isAllowedAfterSeen(current, seen.items)) {
+        if (isAllowedAfterSeen(current, seen.items, options)) {
             try seen.append(allocator, current);
             continue;
         }
@@ -139,16 +140,16 @@ fn checkTypescriptRedeclarations(
     }
 }
 
-fn isAllowedAfterSeen(current: DeclInfo, seen: []const DeclInfo) bool {
+fn isAllowedAfterSeen(current: DeclInfo, seen: []const DeclInfo, options: Options) bool {
     if (seen.len == 0) return true;
 
     for (seen) |previous| {
-        if (!isAllowedTypescriptMerge(previous, current, seen)) return false;
+        if (!isAllowedTypescriptMerge(previous, current, seen, options)) return false;
     }
     return true;
 }
 
-fn isAllowedTypescriptMerge(previous: DeclInfo, current: DeclInfo, seen: []const DeclInfo) bool {
+fn isAllowedTypescriptMerge(previous: DeclInfo, current: DeclInfo, seen: []const DeclInfo, options: Options) bool {
     if (previous.kind == .function and current.kind == .function) {
         return functionBodyCount(seen) + @intFromBool(current.function_has_body) <= 1;
     }
@@ -157,11 +158,12 @@ fn isAllowedTypescriptMerge(previous: DeclInfo, current: DeclInfo, seen: []const
         (previous.kind == .interface and current.kind == .class) or
         (previous.kind == .class and current.kind == .interface))
     {
-        return true;
+        return options.ignore_declaration_merge;
     }
 
     if (previous.kind == .namespace or current.kind == .namespace) {
         const other = if (previous.kind == .namespace) current.kind else previous.kind;
+        if (!options.ignore_declaration_merge) return false;
         return switch (other) {
             .class, .function, .@"enum", .namespace => true,
             else => false,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -791,7 +791,13 @@ pub fn runSemantic(
     }
 
     if (use_typescript_no_redeclare) {
-        try typescript_eslint_no_redeclare.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try typescript_eslint_no_redeclare.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.typescript_eslint_no_redeclare_ignore_declaration_merge,
+        );
     }
 
     if (options.typescript_eslint_no_unsafe_declaration_merging and tree.isTs()) {

--- a/src/rules/typescript_eslint_no_redeclare.zig
+++ b/src/rules/typescript_eslint_no_redeclare.zig
@@ -12,10 +12,12 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    ignore_declaration_merge: bool,
 ) Allocator.Error!void {
     try no_redeclare.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
         .mode = .typescript,
+        .ignore_declaration_merge = ignore_declaration_merge,
     });
 }

--- a/tests/rules/typescript_eslint_no_redeclare.zig
+++ b/tests/rules/typescript_eslint_no_redeclare.zig
@@ -71,6 +71,46 @@ test "allows @typescript-eslint/no-redeclare TypeScript declaration merging" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
 }
 
+test "supports configured @typescript-eslint/no-redeclare ignoreDeclarationMerge false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreDeclarationMerge\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-redeclare", config.value);
+    options.no_empty_block_statements = false;
+    options.typescript_eslint_no_empty_function = false;
+    options.typescript_eslint_no_empty_interface = false;
+    options.typescript_eslint_no_namespace = false;
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\interface Box {}
+        \\interface Box {}
+        \\class Model {}
+        \\interface Model {}
+        \\enum Direction {}
+        \\namespace Direction {}
+        \\function overload(value: string): void;
+        \\function overload(value: number): void;
+        \\function overload(value: string | number): void {
+        \\  value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_redeclare.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
+}
+
 test "can disable @typescript-eslint/no-redeclare and fall back to no-redeclare" {
     const source =
         \\let value = 1;


### PR DESCRIPTION
## Summary
- add `ignoreDeclarationMerge` config parsing for `@typescript-eslint/no-redeclare`
- keep declaration merge ignored by default while allowing config to report it
- preserve TypeScript overload allowance and add regression coverage

## Validation
- `zig fmt --check src/rules/no_redeclare.zig src/rules/typescript_eslint_no_redeclare.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_redeclare.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`