### PR TITLE
Support TS no-redeclare builtin globals

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -284,7 +284,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
-| [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `ignoreDeclarationMerge` configuration |
+| [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, and `ignoreTypeValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1659,6 +1659,7 @@ pub const Options = struct {
     typescript_eslint_no_namespace_allow_declarations: bool = true,
     typescript_eslint_no_namespace_allow_definition_files: bool = true,
     typescript_eslint_no_redeclare: bool = true,
+    typescript_eslint_no_redeclare_builtin_globals: bool = false,
     typescript_eslint_no_redeclare_ignore_declaration_merge: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_shadow: bool = true,
@@ -2221,6 +2222,7 @@ pub const Options = struct {
             self.typescript_eslint_no_namespace_allow_definition_files = try typescriptEslintNoNamespaceBoolOptionFromConfig(value, "allowDefinitionFiles", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-redeclare")) {
+            self.typescript_eslint_no_redeclare_builtin_globals = try typescriptEslintNoRedeclareBuiltinGlobalsFromConfig(value);
             self.typescript_eslint_no_redeclare_ignore_declaration_merge = try typescriptEslintNoRedeclareIgnoreDeclarationMergeFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
@@ -5540,6 +5542,10 @@ pub const Options = struct {
         return typescriptEslintNoNamespaceBoolOptionFromConfig(value, "ignoreDeclarationMerge", true);
     }
 
+    fn typescriptEslintNoRedeclareBuiltinGlobalsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return noShadowBuiltinGlobalsFromConfig(value);
+    }
+
     fn typescriptEslintNoThisAliasAllowedNamesFromConfig(value: std.json.Value) RuleConfigError!NoThisAliasAllowedNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6910,12 +6916,13 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_redeclare_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"ignoreDeclarationMerge\":false}]",
+        "[\"error\",{\"builtinGlobals\":true,\"ignoreDeclarationMerge\":false}]",
         .{},
     );
     defer typescript_no_redeclare_config.deinit();
     try options.setByRuleConfigValue("@typescript-eslint/no-redeclare", typescript_no_redeclare_config.value);
     try std.testing.expect(options.typescript_eslint_no_redeclare);
+    try std.testing.expect(options.typescript_eslint_no_redeclare_builtin_globals);
     try std.testing.expect(!options.typescript_eslint_no_redeclare_ignore_declaration_merge);
 
     var no_irregular_whitespace_config = try std.json.parseFromSlice(

--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -109,8 +109,7 @@ fn isBuiltinGlobalRedeclaration(
     name: []const u8,
     options: Options,
 ) bool {
-    return options.mode == .javascript and
-        options.builtin_globals and
+    return options.builtin_globals and
         tree.source_type == .script and
         symbol.scope == .root and
         core.isKnownGlobal(name);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -796,6 +796,7 @@ pub fn runSemantic(
             diagnostics,
             tree,
             semantic_result.symbol_table,
+            options.typescript_eslint_no_redeclare_builtin_globals,
             options.typescript_eslint_no_redeclare_ignore_declaration_merge,
         );
     }

--- a/src/rules/typescript_eslint_no_redeclare.zig
+++ b/src/rules/typescript_eslint_no_redeclare.zig
@@ -12,12 +12,14 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const parser.ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    builtin_globals: bool,
     ignore_declaration_merge: bool,
 ) Allocator.Error!void {
     try no_redeclare.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
         .rule_id = id,
         .severity = .@"error",
         .mode = .typescript,
+        .builtin_globals = builtin_globals,
         .ignore_declaration_merge = ignore_declaration_merge,
     });
 }

--- a/tests/rules/typescript_eslint_no_redeclare.zig
+++ b/tests/rules/typescript_eslint_no_redeclare.zig
@@ -111,6 +111,35 @@ test "supports configured @typescript-eslint/no-redeclare ignoreDeclarationMerge
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
 }
 
+test "supports configured @typescript-eslint/no-redeclare builtinGlobals" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"builtinGlobals\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-redeclare", config.value);
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\var Object = 1;
+        \\let undefinedValue = undefined;
+        \\let undefined = 1;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_redeclare.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_redeclare.id));
+}
+
 test "can disable @typescript-eslint/no-redeclare and fall back to no-redeclare" {
     const source =
         \\let value = 1;


### PR DESCRIPTION
## Summary
- parse `builtinGlobals` for `@typescript-eslint/no-redeclare`
- pass the option through the TypeScript wrapper to the shared no-redeclare implementation
- cover TypeScript script built-in global redeclarations with regression tests

## Validation
- `zig fmt --check src/rules/no_redeclare.zig src/rules/typescript_eslint_no_redeclare.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_redeclare.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`