### PR TITLE
Add no-shadow function type parameter option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -286,7 +286,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
-| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, and `ignoreTypeValueShadow` configuration |
+| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1667,6 +1667,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow_builtin_globals: bool = false,
     typescript_eslint_no_shadow_hoist: NoShadowHoist = .functions_and_types,
     typescript_eslint_no_shadow_ignore_type_value_shadow: bool = false,
+    typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
@@ -2212,7 +2213,8 @@ pub const Options = struct {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
             self.typescript_eslint_no_shadow_hoist = try noShadowHoistFromConfig(value, .functions_and_types);
-            self.typescript_eslint_no_shadow_ignore_type_value_shadow = try noShadowIgnoreTypeValueShadowFromConfig(value);
+            self.typescript_eslint_no_shadow_ignore_type_value_shadow = try noShadowBoolOptionFromConfig(value, "ignoreTypeValueShadow", false);
+            self.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow = try noShadowBoolOptionFromConfig(value, "ignoreFunctionTypeParameterNameValueShadow", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/method-signature-style")) {
             self.typescript_eslint_method_signature_style_style = try typescriptEslintMethodSignatureStyleFromConfig(value);
@@ -3872,18 +3874,18 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
-    fn noShadowIgnoreTypeValueShadowFromConfig(value: std.json.Value) RuleConfigError!bool {
+    fn noShadowBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return false,
+            else => return default,
         };
-        if (items.len < 2) return false;
+        if (items.len < 2) return default;
 
         const config = switch (items[1]) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("ignoreTypeValueShadow") orelse return false) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6988,7 +6990,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\",\"ignoreTypeValueShadow\":true}]",
+        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\",\"ignoreTypeValueShadow\":true,\"ignoreFunctionTypeParameterNameValueShadow\":false}]",
         .{},
     );
     defer typescript_no_shadow_config.deinit();
@@ -6999,6 +7001,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_shadow_builtin_globals);
     try std.testing.expectEqual(NoShadowHoist.never, options.typescript_eslint_no_shadow_hoist);
     try std.testing.expect(options.typescript_eslint_no_shadow_ignore_type_value_shadow);
+    try std.testing.expect(!options.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -16,6 +16,7 @@ pub const Options = struct {
     builtin_globals: bool = false,
     hoist: core.NoShadowHoist = .functions,
     ignore_type_value_shadow: bool = false,
+    ignore_function_type_parameter_name_value_shadow: bool = true,
 };
 
 pub const Mode = enum {
@@ -84,6 +85,10 @@ pub fn runWithOptions(
             .{ name, shadowed_position.line, shadowed_position.column },
         );
     }
+
+    if (options.mode == .typescript and !options.ignore_function_type_parameter_name_value_shadow) {
+        try checkFunctionTypeParameterNameValueShadows(allocator, diagnostics, tree, scope_tree, symbol_table, options);
+    }
 }
 
 fn findShadowedSymbol(
@@ -146,6 +151,250 @@ fn isTypeOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
 
 fn isValueOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
     return flags.inValueSpace() and !flags.inTypeSpace();
+}
+
+fn checkFunctionTypeParameterNameValueShadows(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
+    for (tree.nodes.items(.data), 0..) |data, raw_index| {
+        const function_type = switch (data) {
+            .ts_function_type => |function_type| function_type,
+            else => continue,
+        };
+
+        const scope_id = scopeIdForNode(scope_tree, @enumFromInt(@as(u32, @intCast(raw_index)))) orelse continue;
+        try checkFunctionTypeParameters(
+            allocator,
+            diagnostics,
+            tree,
+            scope_tree,
+            symbol_table,
+            function_type.params,
+            scope_id,
+            options,
+        );
+    }
+}
+
+fn checkFunctionTypeParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    params_index: ast.NodeIndex,
+    scope_id: traverser.semantic.ScopeId,
+    options: Options,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkFunctionTypeParameterBinding(
+                allocator,
+                diagnostics,
+                tree,
+                scope_tree,
+                symbol_table,
+                parameter.pattern,
+                scope_id,
+                options,
+            ),
+            else => {},
+        }
+    }
+
+    try checkFunctionTypeParameterBinding(
+        allocator,
+        diagnostics,
+        tree,
+        scope_tree,
+        symbol_table,
+        params.rest,
+        scope_id,
+        options,
+    );
+}
+
+fn checkFunctionTypeParameterBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    scope_id: traverser.semantic.ScopeId,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| try checkFunctionTypeParameterIdentifier(
+            allocator,
+            diagnostics,
+            tree,
+            scope_tree,
+            symbol_table,
+            index,
+            tree.string(identifier.name),
+            scope_id,
+            options,
+        ),
+        .assignment_pattern => |pattern| try checkFunctionTypeParameterBinding(
+            allocator,
+            diagnostics,
+            tree,
+            scope_tree,
+            symbol_table,
+            pattern.left,
+            scope_id,
+            options,
+        ),
+        .binding_rest_element => |element| try checkFunctionTypeParameterBinding(
+            allocator,
+            diagnostics,
+            tree,
+            scope_tree,
+            symbol_table,
+            element.argument,
+            scope_id,
+            options,
+        ),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkFunctionTypeParameterBinding(
+                    allocator,
+                    diagnostics,
+                    tree,
+                    scope_tree,
+                    symbol_table,
+                    element,
+                    scope_id,
+                    options,
+                );
+            }
+            try checkFunctionTypeParameterBinding(
+                allocator,
+                diagnostics,
+                tree,
+                scope_tree,
+                symbol_table,
+                pattern.rest,
+                scope_id,
+                options,
+            );
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkFunctionTypeParameterBinding(
+                    allocator,
+                    diagnostics,
+                    tree,
+                    scope_tree,
+                    symbol_table,
+                    property.value,
+                    scope_id,
+                    options,
+                );
+            }
+            try checkFunctionTypeParameterBinding(
+                allocator,
+                diagnostics,
+                tree,
+                scope_tree,
+                symbol_table,
+                pattern.rest,
+                scope_id,
+                options,
+            );
+        },
+        else => {},
+    }
+}
+
+fn checkFunctionTypeParameterIdentifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    name: []const u8,
+    scope_id: traverser.semantic.ScopeId,
+    options: Options,
+) Allocator.Error!void {
+    if (options.allow.contains(name)) return;
+
+    if (options.builtin_globals and core.isKnownGlobal(name)) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            options.severity,
+            options.rule_id,
+            tree.span(index),
+            "'{s}' is already a global variable.",
+            .{name},
+        );
+        return;
+    }
+
+    const shadowed_id = findShadowedValueSymbol(scope_tree, symbol_table, scope_id, name) orelse return;
+    const shadowed_decls = symbol_table.symbolDecls(shadowed_id);
+    if (shadowed_decls.len == 0) return;
+
+    const shadowed_flags = symbol_table.getSymbol(shadowed_id).flags;
+    if (isAllowedByHoist(tree, index, shadowed_decls[0], shadowed_flags, options)) return;
+
+    const shadowed_position = offsetToLineColumn(tree.source, tree.span(shadowed_decls[0]).start);
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        options.severity,
+        options.rule_id,
+        tree.span(index),
+        "'{s}' is already declared in the upper scope on line {d} column {d}.",
+        .{ name, shadowed_position.line, shadowed_position.column },
+    );
+}
+
+fn findShadowedValueSymbol(
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    scope: traverser.semantic.ScopeId,
+    name: []const u8,
+) ?traverser.semantic.SymbolId {
+    var current = scope_tree.getScope(scope).parent;
+    while (current != .none) {
+        if (symbol_table.findInScope(current, name)) |candidate_id| {
+            const candidate_flags = symbol_table.getSymbol(candidate_id).flags;
+            if (candidate_flags.inValueSpace() or candidate_flags.import or candidate_flags.namespace_module) {
+                return candidate_id;
+            }
+        }
+        current = scope_tree.getScope(current).parent;
+    }
+    return null;
+}
+
+fn scopeIdForNode(scope_tree: traverser.semantic.ScopeTree, node: ast.NodeIndex) ?traverser.semantic.ScopeId {
+    for (scope_tree.scopes, 0..) |scope, index| {
+        if (scope.node == node) return @enumFromInt(@as(u32, @intCast(index)));
+    }
+    return null;
 }
 
 fn isAllowedByHoist(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -821,6 +821,7 @@ pub fn runSemantic(
             .builtin_globals = options.typescript_eslint_no_shadow_builtin_globals,
             .hoist = options.typescript_eslint_no_shadow_hoist,
             .ignore_type_value_shadow = options.typescript_eslint_no_shadow_ignore_type_value_shadow,
+            .ignore_function_type_parameter_name_value_shadow = options.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow,
         });
     }
 

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -33,5 +33,6 @@ pub fn runWithOptions(
         .builtin_globals = options.builtin_globals,
         .hoist = options.hoist,
         .ignore_type_value_shadow = options.ignore_type_value_shadow,
+        .ignore_function_type_parameter_name_value_shadow = options.ignore_function_type_parameter_name_value_shadow,
     });
 }

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -192,6 +192,44 @@ test "supports configured @typescript-eslint/no-shadow ignoreTypeValueShadow" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow ignoreFunctionTypeParameterNameValueShadow" {
+    const source =
+        \\const value = 1;
+        \\type Fn = (value: string) => typeof value;
+    ;
+
+    var default_options = lint.Options{};
+    default_options.no_unused_vars = false;
+    default_options.typescript_eslint_no_unused_vars = false;
+    default_options.parser_semantic_errors = false;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", default_options);
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.no_shadow.id));
+
+    var report_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreFunctionTypeParameterNameValueShadow\":false}]",
+        .{},
+    );
+    defer report_config.deinit();
+
+    var report_options = lint.Options{};
+    try report_options.setByRuleConfigValue("@typescript-eslint/no-shadow", report_config.value);
+    report_options.no_unused_vars = false;
+    report_options.typescript_eslint_no_unused_vars = false;
+    report_options.parser_semantic_errors = false;
+
+    var report_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", report_options);
+    defer report_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(report_result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(report_result, lint.rules.no_shadow.id));
+}
+
 test "can disable @typescript-eslint/no-shadow and fall back to no-shadow" {
     const source =
         \\const value = 1;


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-shadow` `ignoreFunctionTypeParameterNameValueShadow` config
- report function type parameter name/value shadows only when the option is explicitly disabled
- document and test the supported option

## Validation
- `zig fmt --check src/rules/no_shadow.zig src/rules/typescript_eslint_no_shadow.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_shadow.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`