### PR TITLE
Add no-shadow ignoreOnInitialization

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -128,7 +128,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-self-compare`](https://eslint.org/docs/latest/rules/no-self-compare) | Implemented |
 | [`no-sequences`](https://eslint.org/docs/latest/rules/no-sequences) | Implemented with optional `allowInParentheses` behavior |
 | [`no-setter-return`](https://eslint.org/docs/latest/rules/no-setter-return) | Implemented |
-| [`no-shadow`](https://eslint.org/docs/latest/rules/no-shadow) | Supports `allow`, `builtinGlobals`, and `hoist` configuration |
+| [`no-shadow`](https://eslint.org/docs/latest/rules/no-shadow) | Supports `allow`, `builtinGlobals`, `hoist`, and `ignoreOnInitialization` configuration |
 | [`no-shadow-restricted-names`](https://eslint.org/docs/latest/rules/no-shadow-restricted-names) | Implemented |
 | [`no-sparse-arrays`](https://eslint.org/docs/latest/rules/no-sparse-arrays) | Implemented |
 | [`no-tabs`](https://eslint.org/docs/latest/rules/no-tabs) | Supports `allowIndentationTabs` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1412,6 +1412,7 @@ pub const Options = struct {
     no_shadow_allow: NoShadowAllowNames = .{},
     no_shadow_builtin_globals: bool = false,
     no_shadow_hoist: NoShadowHoist = .functions,
+    no_shadow_ignore_on_initialization: bool = false,
     no_shadow_restricted_names: bool = true,
     no_sequences: bool = true,
     no_sequences_allow_in_parentheses: NoSequencesAllowInParentheses = .yes,
@@ -2011,6 +2012,7 @@ pub const Options = struct {
             self.no_shadow_allow = try noShadowAllowFromConfig(value);
             self.no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
             self.no_shadow_hoist = try noShadowHoistFromConfig(value, .functions);
+            self.no_shadow_ignore_on_initialization = try noShadowBoolOptionFromConfig(value, "ignoreOnInitialization", false);
         }
         if (std.mem.eql(u8, cli_name, "no-underscore-dangle")) {
             self.no_underscore_dangle_allow_after_this = try noUnderscoreDangleBoolOptionFromConfig(value, "allowAfterThis", false);
@@ -6956,7 +6958,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"done\"],\"builtinGlobals\":true,\"hoist\":\"all\"}]",
+        "[\"error\",{\"allow\":[\"done\"],\"builtinGlobals\":true,\"hoist\":\"all\",\"ignoreOnInitialization\":true}]",
         .{},
     );
     defer no_shadow_config.deinit();
@@ -6966,6 +6968,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.no_shadow_allow.contains("other"));
     try std.testing.expect(options.no_shadow_builtin_globals);
     try std.testing.expectEqual(NoShadowHoist.all, options.no_shadow_hoist);
+    try std.testing.expect(options.no_shadow_ignore_on_initialization);
 
     var no_underscore_dangle_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -15,6 +15,7 @@ pub const Options = struct {
     allow: core.NoShadowAllowNames = .{},
     builtin_globals: bool = false,
     hoist: core.NoShadowHoist = .functions,
+    ignore_on_initialization: bool = false,
     ignore_type_value_shadow: bool = false,
     ignore_function_type_parameter_name_value_shadow: bool = true,
 };
@@ -73,6 +74,7 @@ pub fn runWithOptions(
         if (shadowed_decls.len == 0) continue;
         const shadowed_flags = symbol_table.getSymbol(shadowed_id).flags;
         if (isAllowedByHoist(tree, decls[0], shadowed_decls[0], shadowed_flags, options)) continue;
+        if (options.ignore_on_initialization and isAllowedOnInitialization(tree, decls[0], shadowed_decls[0])) continue;
 
         const shadowed_position = offsetToLineColumn(tree.source, tree.span(shadowed_decls[0]).start);
         try core.addDiagnosticFmt(
@@ -151,6 +153,82 @@ fn isTypeOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
 
 fn isValueOnlySymbol(flags: traverser.semantic.Symbol.Flags) bool {
     return flags.inValueSpace() and !flags.inTypeSpace();
+}
+
+fn isAllowedOnInitialization(tree: *const ast.Tree, self_decl: ast.NodeIndex, shadowed_decl: ast.NodeIndex) bool {
+    const init = initializerForBinding(tree, shadowed_decl) orelse return false;
+    if (!containsNode(tree, init, self_decl)) return false;
+
+    const function_node = initializationFunctionContaining(tree, init, self_decl) orelse return false;
+    return functionIsCalledDuringInitialization(tree, init, function_node);
+}
+
+fn initializerForBinding(tree: *const ast.Tree, binding: ast.NodeIndex) ?ast.NodeIndex {
+    for (tree.nodes.items(.data)) |data| {
+        const declarator = switch (data) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+        if (declarator.init != .null and containsNode(tree, declarator.id, binding)) return declarator.init;
+    }
+    return null;
+}
+
+fn initializationFunctionContaining(tree: *const ast.Tree, init: ast.NodeIndex, target: ast.NodeIndex) ?ast.NodeIndex {
+    var result: ?ast.NodeIndex = null;
+
+    for (tree.nodes.items(.data), 0..) |data, raw_index| {
+        const index: ast.NodeIndex = @enumFromInt(@as(u32, @intCast(raw_index)));
+        if (!containsNode(tree, init, index) or !containsNode(tree, index, target)) continue;
+
+        switch (data) {
+            .function, .arrow_function_expression => result = index,
+            else => {},
+        }
+    }
+
+    return result;
+}
+
+fn functionIsCalledDuringInitialization(tree: *const ast.Tree, init: ast.NodeIndex, function_node: ast.NodeIndex) bool {
+    for (tree.nodes.items(.data), 0..) |data, raw_index| {
+        const call = switch (data) {
+            .call_expression => |call| call,
+            else => continue,
+        };
+        const call_index: ast.NodeIndex = @enumFromInt(@as(u32, @intCast(raw_index)));
+        if (!containsNode(tree, init, call_index)) continue;
+
+        if (unwrapCallTarget(tree, call.callee) == function_node) return true;
+
+        for (tree.extra(call.arguments)) |argument| {
+            if (unwrapCallTarget(tree, argument) == function_node) return true;
+        }
+    }
+
+    return false;
+}
+
+fn unwrapCallTarget(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    if (index == .null) return index;
+
+    var current = index;
+    while (true) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |expression| current = expression.expression,
+            .chain_expression => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+}
+
+fn containsNode(tree: *const ast.Tree, container: ast.NodeIndex, node: ast.NodeIndex) bool {
+    if (container == .null or node == .null) return false;
+    if (container == node) return true;
+
+    const container_span = tree.span(container);
+    const node_span = tree.span(node);
+    return container_span.start <= node_span.start and node_span.end <= container_span.end;
 }
 
 fn checkFunctionTypeParameterNameValueShadows(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -812,6 +812,7 @@ pub fn runSemantic(
             .allow = options.no_shadow_allow,
             .builtin_globals = options.no_shadow_builtin_globals,
             .hoist = options.no_shadow_hoist,
+            .ignore_on_initialization = options.no_shadow_ignore_on_initialization,
         });
     }
 

--- a/tests/rules/no_shadow.zig
+++ b/tests/rules/no_shadow.zig
@@ -159,6 +159,45 @@ test "supports configured no-shadow hoist option" {
     try std.testing.expect(!helpers.hasRule(never_result, lint.rules.no_shadow.id));
 }
 
+test "supports configured no-shadow ignoreOnInitialization" {
+    const source =
+        \\function wrapper(fn) {
+        \\  return fn;
+        \\}
+        \\const callback = wrapper(function(callback) {
+        \\  return callback;
+        \\});
+        \\const immediate = (function(immediate) {
+        \\  return immediate;
+        \\})();
+        \\const direct = direct => direct;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(default_result, lint.rules.no_shadow.id));
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreOnInitialization\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("no-shadow", config.value);
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer ignored_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(ignored_result, lint.rules.no_shadow.id));
+}
+
 test "can disable no-shadow" {
     const source =
         \\let a = 1;


### PR DESCRIPTION
## Summary
- parse the ESLint `no-shadow` `ignoreOnInitialization` option
- skip initializer callback/IIFE shadows when the option is enabled
- document and test the supported option

## Validation
- `zig fmt --check src/rules/no_shadow.zig src/rules/root.zig src/core.zig tests/rules/no_shadow.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`