### PR TITLE
Add TS no-shadow ignoreOnInitialization

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -286,7 +286,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
-| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
+| [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreOnInitialization`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1667,6 +1667,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
     typescript_eslint_no_shadow_hoist: NoShadowHoist = .functions_and_types,
+    typescript_eslint_no_shadow_ignore_on_initialization: bool = false,
     typescript_eslint_no_shadow_ignore_type_value_shadow: bool = false,
     typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow: bool = true,
     typescript_eslint_no_this_alias: bool = true,
@@ -2215,6 +2216,7 @@ pub const Options = struct {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
             self.typescript_eslint_no_shadow_builtin_globals = try noShadowBuiltinGlobalsFromConfig(value);
             self.typescript_eslint_no_shadow_hoist = try noShadowHoistFromConfig(value, .functions_and_types);
+            self.typescript_eslint_no_shadow_ignore_on_initialization = try noShadowBoolOptionFromConfig(value, "ignoreOnInitialization", false);
             self.typescript_eslint_no_shadow_ignore_type_value_shadow = try noShadowBoolOptionFromConfig(value, "ignoreTypeValueShadow", false);
             self.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow = try noShadowBoolOptionFromConfig(value, "ignoreFunctionTypeParameterNameValueShadow", true);
         }
@@ -6993,7 +6995,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_shadow_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\",\"ignoreTypeValueShadow\":true,\"ignoreFunctionTypeParameterNameValueShadow\":false}]",
+        "[\"error\",{\"allow\":[\"value\"],\"builtinGlobals\":true,\"hoist\":\"never\",\"ignoreOnInitialization\":true,\"ignoreTypeValueShadow\":true,\"ignoreFunctionTypeParameterNameValueShadow\":false}]",
         .{},
     );
     defer typescript_no_shadow_config.deinit();
@@ -7003,6 +7005,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.typescript_eslint_no_shadow_allow.contains("other"));
     try std.testing.expect(options.typescript_eslint_no_shadow_builtin_globals);
     try std.testing.expectEqual(NoShadowHoist.never, options.typescript_eslint_no_shadow_hoist);
+    try std.testing.expect(options.typescript_eslint_no_shadow_ignore_on_initialization);
     try std.testing.expect(options.typescript_eslint_no_shadow_ignore_type_value_shadow);
     try std.testing.expect(!options.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow);
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -821,6 +821,7 @@ pub fn runSemantic(
             .allow = options.typescript_eslint_no_shadow_allow,
             .builtin_globals = options.typescript_eslint_no_shadow_builtin_globals,
             .hoist = options.typescript_eslint_no_shadow_hoist,
+            .ignore_on_initialization = options.typescript_eslint_no_shadow_ignore_on_initialization,
             .ignore_type_value_shadow = options.typescript_eslint_no_shadow_ignore_type_value_shadow,
             .ignore_function_type_parameter_name_value_shadow = options.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow,
         });

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -32,6 +32,7 @@ pub fn runWithOptions(
         .allow = options.allow,
         .builtin_globals = options.builtin_globals,
         .hoist = options.hoist,
+        .ignore_on_initialization = options.ignore_on_initialization,
         .ignore_type_value_shadow = options.ignore_type_value_shadow,
         .ignore_function_type_parameter_name_value_shadow = options.ignore_function_type_parameter_name_value_shadow,
     });

--- a/tests/rules/typescript_eslint_no_shadow.zig
+++ b/tests/rules/typescript_eslint_no_shadow.zig
@@ -154,6 +154,51 @@ test "supports configured @typescript-eslint/no-shadow hoist option" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_shadow.id));
 }
 
+test "supports configured @typescript-eslint/no-shadow ignoreOnInitialization" {
+    const source =
+        \\function wrapper(fn) {
+        \\  return fn;
+        \\}
+        \\const callback = wrapper(function(callback) {
+        \\  return callback;
+        \\});
+        \\const immediate = (function(immediate) {
+        \\  return immediate;
+        \\})();
+        \\const direct = direct => direct;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(default_result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.no_shadow.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreOnInitialization\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-shadow", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer ignored_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(ignored_result, lint.rules.typescript_eslint_no_shadow.id));
+    try std.testing.expect(!helpers.hasRule(ignored_result, lint.rules.no_shadow.id));
+}
+
 test "supports configured @typescript-eslint/no-shadow ignoreTypeValueShadow" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-shadow` `ignoreOnInitialization` config
- pass the option through the TypeScript no-shadow wrapper
- document and test the supported TS option

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/typescript_eslint_no_shadow.zig tests/rules/typescript_eslint_no_shadow.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`