### PR TITLE
Add TS no-use-before-define ignoreTypeReferences

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -298,7 +298,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
-| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
+| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, `allowNamedExports`, and `ignoreTypeReferences` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1706,6 +1706,7 @@ pub const Options = struct {
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_allow_named_exports: bool = false,
+    typescript_eslint_no_use_before_define_ignore_type_references: bool = true,
     typescript_eslint_no_var_requires: bool = true,
     typescript_eslint_no_wrapper_object_types: bool = true,
     typescript_eslint_prefer_as_const: bool = true,
@@ -2277,6 +2278,7 @@ pub const Options = struct {
             self.typescript_eslint_no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
             self.typescript_eslint_no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
             self.typescript_eslint_no_use_before_define_allow_named_exports = try noUseBeforeDefineAllowNamedExportsFromConfig(value);
+            self.typescript_eslint_no_use_before_define_ignore_type_references = try noUseBeforeDefineBoolOptionFromConfig(value, "ignoreTypeReferences", true);
         }
         if (std.mem.eql(u8, cli_name, "no-void")) {
             self.no_void_allow_as_statement = try noVoidAllowAsStatementFromConfig(value);
@@ -4360,18 +4362,22 @@ pub const Options = struct {
     }
 
     fn noUseBeforeDefineAllowNamedExportsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return noUseBeforeDefineBoolOptionFromConfig(value, "allowNamedExports", false);
+    }
+
+    fn noUseBeforeDefineBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return false,
+            else => return default,
         };
-        if (items.len < 2) return false;
+        if (items.len < 2) return default;
 
         const config = switch (items[1]) {
             .object => |object| object,
-            .string => return false,
+            .string => return default,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("allowNamedExports") orelse return false) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -7451,7 +7457,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false,\"allowNamedExports\":true}]",
+        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false,\"allowNamedExports\":true,\"ignoreTypeReferences\":false}]",
         .{},
     );
     defer typescript_no_use_before_define_config.deinit();
@@ -7461,6 +7467,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_classes);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_variables);
     try std.testing.expect(options.typescript_eslint_no_use_before_define_allow_named_exports);
+    try std.testing.expect(!options.typescript_eslint_no_use_before_define_ignore_type_references);
 
     var no_void_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -18,6 +18,7 @@ pub const Options = struct {
     check_functions: bool = true,
     check_classes: bool = true,
     check_variables: bool = true,
+    check_type_references: bool = false,
     allow_named_exports: bool = false,
 };
 
@@ -79,15 +80,15 @@ pub fn runWithOptions(
     var reference_iter = symbol_table.iterReferences();
     while (reference_iter.next()) |entry| {
         const reference = entry.reference;
-        if (reference.kind != .value) continue;
+        if (reference.kind == .type and !options.check_type_references) continue;
         if (options.allow_named_exports and named_export_refs.contains(reference.node)) continue;
 
         const symbol_id = symbol_table.referenceSymbol(entry.id);
         if (symbol_id == .none) continue;
 
         const symbol = symbol_table.getSymbol(symbol_id);
-        if (!isLintableSymbol(symbol.flags, options)) continue;
-        if (shouldIgnoreVariableReference(scope_tree, reference.scope, symbol.scope, symbol.flags, options)) continue;
+        if (!isLintableReferenceSymbol(symbol.flags, reference.kind, options)) continue;
+        if (reference.kind == .value and shouldIgnoreVariableReference(scope_tree, reference.scope, symbol.scope, symbol.flags, options)) continue;
 
         const decls = symbol_table.symbolDecls(symbol_id);
         if (decls.len == 0) continue;
@@ -258,9 +259,30 @@ fn crossesFunctionScope(
 }
 
 fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
+    return isLintableValueSymbol(flags, options);
+}
+
+fn isLintableReferenceSymbol(
+    flags: traverser.semantic.Symbol.Flags,
+    kind: traverser.semantic.Reference.Kind,
+    options: Options,
+) bool {
+    return switch (kind) {
+        .value => isLintableValueSymbol(flags, options),
+        .type => isLintableTypeSymbol(flags, options),
+    };
+}
+
+fn isLintableValueSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
     if (flags.ambient) return false;
     if (flags.type_import or flags.interface or flags.type_alias or flags.type_parameter) return false;
     if (!options.check_functions and flags.function) return false;
     if (!options.check_classes and flags.class) return false;
     return flags.inValueSpace() or flags.import;
+}
+
+fn isLintableTypeSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
+    if (flags.ambient) return false;
+    if (!options.check_classes and flags.class) return false;
+    return flags.inTypeSpace() or flags.type_import;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1024,6 +1024,7 @@ pub fn runSemantic(
             .check_functions = options.typescript_eslint_no_use_before_define_check_functions == .yes,
             .check_classes = options.typescript_eslint_no_use_before_define_check_classes == .yes,
             .check_variables = options.typescript_eslint_no_use_before_define_check_variables == .yes,
+            .check_type_references = !options.typescript_eslint_no_use_before_define_ignore_type_references,
             .allow_named_exports = options.typescript_eslint_no_use_before_define_allow_named_exports,
         });
     }

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -34,6 +34,7 @@ pub fn runWithOptions(
         .check_functions = options.check_functions,
         .check_classes = options.check_classes,
         .check_variables = options.check_variables,
+        .check_type_references = options.check_type_references,
         .allow_named_exports = options.allow_named_exports,
     });
 }

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -46,6 +46,37 @@ test "does not report @typescript-eslint/no-use-before-define for type reference
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
 }
 
+test "supports configured @typescript-eslint/no-use-before-define ignoreTypeReferences false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTypeReferences\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", config.value);
+    options.no_unused_vars = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\type AliasUser = LaterAlias;
+        \\type InterfaceUser = LaterInterface;
+        \\type LaterAlias = string;
+        \\interface LaterInterface {
+        \\  value: string;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_use_before_define.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_use_before_define.id));
+}
+
 test "uses configured @typescript-eslint/no-use-before-define function and class checks" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-use-before-define` `ignoreTypeReferences` config
- check type-position references when the option is explicitly disabled
- document and test the supported option

## Validation
- `zig fmt --check src/rules/no_use_before_define.zig src/rules/typescript_eslint_no_use_before_define.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_use_before_define.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`