### PR TITLE
Add TS no-use-before-define enums

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -298,7 +298,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-useless-empty-export`](https://typescript-eslint.io/rules/no-useless-empty-export/) | Implemented |
 | [`@typescript-eslint/no-unused-expressions`](https://typescript-eslint.io/rules/no-unused-expressions/) | Supports `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` configuration |
 | [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
-| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, `typedefs`, `allowNamedExports`, and `ignoreTypeReferences` configuration |
+| [`@typescript-eslint/no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) | Supports `functions`, `classes`, `variables`, `typedefs`, `enums`, `allowNamedExports`, and `ignoreTypeReferences` configuration |
 | [`@typescript-eslint/no-var-requires`](https://typescript-eslint.io/rules/no-var-requires/) | Implemented |
 | [`@typescript-eslint/no-wrapper-object-types`](https://typescript-eslint.io/rules/no-wrapper-object-types/) | Implemented |
 | [`@typescript-eslint/prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1706,6 +1706,7 @@ pub const Options = struct {
     typescript_eslint_no_use_before_define_check_classes: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_check_variables: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_check_typedefs: NoUseBeforeDefineCheck = .yes,
+    typescript_eslint_no_use_before_define_check_enums: NoUseBeforeDefineCheck = .yes,
     typescript_eslint_no_use_before_define_allow_named_exports: bool = false,
     typescript_eslint_no_use_before_define_ignore_type_references: bool = true,
     typescript_eslint_no_var_requires: bool = true,
@@ -2279,6 +2280,7 @@ pub const Options = struct {
             self.typescript_eslint_no_use_before_define_check_classes = try noUseBeforeDefineCheckFromConfig(value, "classes", true);
             self.typescript_eslint_no_use_before_define_check_variables = try noUseBeforeDefineCheckFromConfig(value, "variables", true);
             self.typescript_eslint_no_use_before_define_check_typedefs = try noUseBeforeDefineCheckFromConfig(value, "typedefs", true);
+            self.typescript_eslint_no_use_before_define_check_enums = try noUseBeforeDefineCheckFromConfig(value, "enums", true);
             self.typescript_eslint_no_use_before_define_allow_named_exports = try noUseBeforeDefineAllowNamedExportsFromConfig(value);
             self.typescript_eslint_no_use_before_define_ignore_type_references = try noUseBeforeDefineBoolOptionFromConfig(value, "ignoreTypeReferences", true);
         }
@@ -7459,7 +7461,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_use_before_define_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false,\"typedefs\":false,\"allowNamedExports\":true,\"ignoreTypeReferences\":false}]",
+        "[\"error\",{\"functions\":true,\"classes\":false,\"variables\":false,\"typedefs\":false,\"enums\":false,\"allowNamedExports\":true,\"ignoreTypeReferences\":false}]",
         .{},
     );
     defer typescript_no_use_before_define_config.deinit();
@@ -7469,6 +7471,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_classes);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_variables);
     try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_typedefs);
+    try std.testing.expectEqual(NoUseBeforeDefineCheck.no, options.typescript_eslint_no_use_before_define_check_enums);
     try std.testing.expect(options.typescript_eslint_no_use_before_define_allow_named_exports);
     try std.testing.expect(!options.typescript_eslint_no_use_before_define_ignore_type_references);
 

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -20,6 +20,7 @@ pub const Options = struct {
     check_variables: bool = true,
     check_type_references: bool = false,
     check_typedefs: bool = true,
+    check_enums: bool = true,
     allow_named_exports: bool = false,
 };
 
@@ -285,10 +286,15 @@ fn isLintableValueSymbol(flags: traverser.semantic.Symbol.Flags, options: Option
 fn isLintableTypeSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bool {
     if (flags.ambient) return false;
     if (!options.check_typedefs and isTypedefSymbol(flags)) return false;
+    if (!options.check_enums and isEnumSymbol(flags)) return false;
     if (!options.check_classes and flags.class) return false;
     return flags.inTypeSpace() or flags.type_import;
 }
 
 fn isTypedefSymbol(flags: traverser.semantic.Symbol.Flags) bool {
     return flags.interface or flags.type_alias or flags.type_import;
+}
+
+fn isEnumSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    return flags.regular_enum or flags.const_enum;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1026,6 +1026,7 @@ pub fn runSemantic(
             .check_variables = options.typescript_eslint_no_use_before_define_check_variables == .yes,
             .check_type_references = !options.typescript_eslint_no_use_before_define_ignore_type_references,
             .check_typedefs = options.typescript_eslint_no_use_before_define_check_typedefs == .yes,
+            .check_enums = options.typescript_eslint_no_use_before_define_check_enums == .yes,
             .allow_named_exports = options.typescript_eslint_no_use_before_define_allow_named_exports,
         });
     }

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -36,6 +36,7 @@ pub fn runWithOptions(
         .check_variables = options.check_variables,
         .check_type_references = options.check_type_references,
         .check_typedefs = options.check_typedefs,
+        .check_enums = options.check_enums,
         .allow_named_exports = options.allow_named_exports,
     });
 }

--- a/tests/rules/typescript_eslint_no_use_before_define.zig
+++ b/tests/rules/typescript_eslint_no_use_before_define.zig
@@ -108,6 +108,55 @@ test "supports configured @typescript-eslint/no-use-before-define typedefs false
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_use_before_define.id));
 }
 
+test "supports configured @typescript-eslint/no-use-before-define enums false" {
+    const source =
+        \\type EnumUser = LaterEnum;
+        \\enum LaterEnum {
+        \\  A,
+        \\}
+    ;
+
+    var report_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTypeReferences\":false}]",
+        .{},
+    );
+    defer report_config.deinit();
+
+    var report_options = lint.Options{};
+    try report_options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", report_config.value);
+    report_options.no_unused_vars = false;
+    report_options.typescript_eslint_no_unused_vars = false;
+    report_options.parser_semantic_errors = false;
+
+    var report_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", report_options);
+    defer report_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(report_result, lint.rules.typescript_eslint_no_use_before_define.id));
+    try std.testing.expect(!helpers.hasRule(report_result, lint.rules.no_use_before_define.id));
+
+    var ignore_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreTypeReferences\":false,\"enums\":false}]",
+        .{},
+    );
+    defer ignore_config.deinit();
+
+    var ignore_options = lint.Options{};
+    try ignore_options.setByRuleConfigValue("@typescript-eslint/no-use-before-define", ignore_config.value);
+    ignore_options.no_unused_vars = false;
+    ignore_options.typescript_eslint_no_unused_vars = false;
+    ignore_options.parser_semantic_errors = false;
+
+    var ignore_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", ignore_options);
+    defer ignore_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(ignore_result, lint.rules.typescript_eslint_no_use_before_define.id));
+    try std.testing.expect(!helpers.hasRule(ignore_result, lint.rules.no_use_before_define.id));
+}
+
 test "uses configured @typescript-eslint/no-use-before-define function and class checks" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-use-before-define` `enums` config
- skip enum type-reference checks when `enums` is disabled
- document and test the supported option

## Validation
- `zig fmt --check src/rules/no_use_before_define.zig src/rules/typescript_eslint_no_use_before_define.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_use_before_define.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`