### PR TITLE
Add no-unused-vars ignoreUsingDeclarations

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -148,7 +148,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1496,6 +1496,7 @@ pub const Options = struct {
     no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     no_unused_vars_ignore_rest_siblings: bool = false,
+    no_unused_vars_ignore_using_declarations: bool = false,
     no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_destructured_array_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
@@ -2078,6 +2079,7 @@ pub const Options = struct {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
             self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
+            self.no_unused_vars_ignore_using_declarations = try noUnusedVarsBoolOptionFromConfig(value, "ignoreUsingDeclarations", false);
             self.no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
             self.no_unused_vars_destructured_array_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "destructuredArrayIgnorePattern");
@@ -4286,23 +4288,14 @@ pub const Options = struct {
     }
 
     fn noUnusedVarsIgnoreRestSiblingsFromConfig(value: std.json.Value, default: bool) RuleConfigError!bool {
-        const items = switch (value) {
-            .array => |array| array.items,
-            else => return default,
-        };
-        if (items.len < 2) return default;
-
-        const config = switch (items[1]) {
-            .object => |object| object,
-            else => return error.UnsupportedRuleConfigValue,
-        };
-        return switch (config.get("ignoreRestSiblings") orelse return default) {
-            .bool => |enabled| enabled,
-            else => return error.UnsupportedRuleConfigValue,
-        };
+        return noUnusedVarsBoolOptionFromConfig(value, "ignoreRestSiblings", default);
     }
 
     fn noUnusedVarsReportUsedIgnorePatternFromConfig(value: std.json.Value, default: bool) RuleConfigError!bool {
+        return noUnusedVarsBoolOptionFromConfig(value, "reportUsedIgnorePattern", default);
+    }
+
+    fn noUnusedVarsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return default,
@@ -4313,7 +4306,7 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("reportUsedIgnorePattern") orelse return default) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -7261,7 +7254,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"ignoreUsingDeclarations\":true,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -7271,6 +7264,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
+    try std.testing.expect(options.no_unused_vars_ignore_using_declarations);
     try std.testing.expect(options.no_unused_vars_report_used_ignore_pattern);
     try std.testing.expectEqualStrings("^_", options.no_unused_vars_args_ignore_pattern.pattern().?);
     try std.testing.expectEqualStrings("^ignoredError", options.no_unused_vars_caught_errors_ignore_pattern.pattern().?);

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -19,6 +19,7 @@ pub const Options = struct {
     vars: core.NoUnusedVarsVars = .all,
     check_caught_errors: bool = true,
     ignore_rest_siblings: bool = false,
+    ignore_using_declarations: bool = false,
     check_type_parameters: bool = false,
     react_jsx_uses_react: bool = false,
     react_jsx_uses_vars: bool = true,
@@ -107,6 +108,11 @@ pub fn runWithOptions(
     if (options.ignore_rest_siblings) {
         var visitor = RestSiblingVisitor{ .ignored_decls = &ignored_decls };
         try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
+    }
+
+    if (options.ignore_using_declarations) {
+        var visitor = UsingDeclarationVisitor{ .ignored_decls = &ignored_decls };
+        try traverser.basic.traverse(UsingDeclarationVisitor, tree, &visitor);
     }
 
     if (options.destructured_array_ignore_pattern.pattern() != null) {
@@ -375,6 +381,57 @@ const RestSiblingVisitor = struct {
 
     fn collectBinding(
         self: *RestSiblingVisitor,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!void {
+        if (index == .null) return;
+
+        switch (ctx.tree.data(index)) {
+            .binding_identifier => try self.ignored_decls.put(index, {}),
+            .assignment_pattern => |assignment| try self.collectBinding(assignment.left, ctx),
+            .binding_rest_element => |rest| try self.collectBinding(rest.argument, ctx),
+            .array_pattern => |array| {
+                for (ctx.tree.extra(array.elements)) |element| {
+                    try self.collectBinding(element, ctx);
+                }
+                try self.collectBinding(array.rest, ctx);
+            },
+            .object_pattern => |object| {
+                for (ctx.tree.extra(object.properties)) |property_index| {
+                    const property = ctx.tree.data(property_index).binding_property;
+                    try self.collectBinding(property.value, ctx);
+                }
+                try self.collectBinding(object.rest, ctx);
+            },
+            else => {},
+        }
+    }
+};
+
+const UsingDeclarationVisitor = struct {
+    ignored_decls: *IgnoredDecls,
+
+    pub fn enter_variable_declaration(
+        self: *UsingDeclarationVisitor,
+        declaration: ast.VariableDeclaration,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (declaration.kind != .using and declaration.kind != .await_using) return .proceed;
+
+        for (ctx.tree.extra(declaration.declarators)) |declarator_index| {
+            const declarator = switch (ctx.tree.data(declarator_index)) {
+                .variable_declarator => |declarator| declarator,
+                else => continue,
+            };
+            try self.collectBinding(declarator.id, ctx);
+        }
+
+        return .proceed;
+    }
+
+    fn collectBinding(
+        self: *UsingDeclarationVisitor,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!void {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -979,6 +979,7 @@ pub fn runSemantic(
             .args_after_used = options.no_unused_vars_args == .after_used,
             .check_caught_errors = options.no_unused_vars_caught_errors == .all,
             .ignore_rest_siblings = options.no_unused_vars_ignore_rest_siblings,
+            .ignore_using_declarations = options.no_unused_vars_ignore_using_declarations,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,
             .args_ignore_pattern = options.no_unused_vars_args_ignore_pattern,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -156,6 +156,40 @@ test "supports configured no-unused-vars ignoreRestSiblings" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_vars.id));
 }
 
+test "supports configured no-unused-vars ignoreUsingDeclarations" {
+    const source =
+        \\using resource = acquire();
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.no_unused_vars.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreUsingDeclarations\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer ignored_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(ignored_result, lint.rules.no_unused_vars.id));
+}
+
 test "supports configured no-unused-vars varsIgnorePattern" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- parse `no-unused-vars` `ignoreUsingDeclarations` config
- skip unused diagnostics for `using` and `await using` declarations when enabled
- document and test the supported option

## Validation
- `zig fmt --check src/rules/no_unused_vars.zig src/rules/root.zig src/core.zig tests/rules/no_unused_vars.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`