### PR TITLE
Add no-unused-vars static block ignore option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -148,7 +148,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
-| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreClassWithStaticInitBlock`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1496,6 +1496,7 @@ pub const Options = struct {
     no_unused_vars_args: NoUnusedVarsArgs = .none,
     no_unused_vars_caught_errors: NoUnusedVarsCaughtErrors = .all,
     no_unused_vars_ignore_rest_siblings: bool = false,
+    no_unused_vars_ignore_class_with_static_init_block: bool = false,
     no_unused_vars_ignore_using_declarations: bool = false,
     no_unused_vars_args_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
     no_unused_vars_caught_errors_ignore_pattern: NoUnusedVarsIgnorePattern = .{},
@@ -2080,6 +2081,7 @@ pub const Options = struct {
             self.no_unused_vars_args = try noUnusedVarsArgsFromConfig(value, .none);
             self.no_unused_vars_caught_errors = try noUnusedVarsCaughtErrorsFromConfig(value, .all);
             self.no_unused_vars_ignore_rest_siblings = try noUnusedVarsIgnoreRestSiblingsFromConfig(value, false);
+            self.no_unused_vars_ignore_class_with_static_init_block = try noUnusedVarsBoolOptionFromConfig(value, "ignoreClassWithStaticInitBlock", false);
             self.no_unused_vars_ignore_using_declarations = try noUnusedVarsBoolOptionFromConfig(value, "ignoreUsingDeclarations", false);
             self.no_unused_vars_args_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "argsIgnorePattern");
             self.no_unused_vars_caught_errors_ignore_pattern = try noUnusedVarsIgnorePatternFromConfig(value, "caughtErrorsIgnorePattern");
@@ -7256,7 +7258,7 @@ test "Options can apply ESLint-style rule config values" {
     var no_unused_vars_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreRestSiblings\":true,\"ignoreUsingDeclarations\":true,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
+        "[\"error\",{\"args\":\"all\",\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"caughtErrorsIgnorePattern\":\"^ignoredError\",\"destructuredArrayIgnorePattern\":\"^ignoredItem\",\"ignoreClassWithStaticInitBlock\":true,\"ignoreRestSiblings\":true,\"ignoreUsingDeclarations\":true,\"reportUsedIgnorePattern\":true,\"varsIgnorePattern\":\"^ignored\"}]",
         .{},
     );
     defer no_unused_vars_config.deinit();
@@ -7266,6 +7268,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(NoUnusedVarsArgs.all, options.no_unused_vars_args);
     try std.testing.expectEqual(NoUnusedVarsCaughtErrors.none, options.no_unused_vars_caught_errors);
     try std.testing.expect(options.no_unused_vars_ignore_rest_siblings);
+    try std.testing.expect(options.no_unused_vars_ignore_class_with_static_init_block);
     try std.testing.expect(options.no_unused_vars_ignore_using_declarations);
     try std.testing.expect(options.no_unused_vars_report_used_ignore_pattern);
     try std.testing.expectEqualStrings("^_", options.no_unused_vars_args_ignore_pattern.pattern().?);

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -19,6 +19,7 @@ pub const Options = struct {
     vars: core.NoUnusedVarsVars = .all,
     check_caught_errors: bool = true,
     ignore_rest_siblings: bool = false,
+    ignore_class_with_static_init_block: bool = false,
     ignore_using_declarations: bool = false,
     check_type_parameters: bool = false,
     react_jsx_uses_react: bool = false,
@@ -108,6 +109,11 @@ pub fn runWithOptions(
     if (options.ignore_rest_siblings) {
         var visitor = RestSiblingVisitor{ .ignored_decls = &ignored_decls };
         try traverser.basic.traverse(RestSiblingVisitor, tree, &visitor);
+    }
+
+    if (options.ignore_class_with_static_init_block) {
+        var visitor = ClassWithStaticBlockVisitor{ .ignored_decls = &ignored_decls };
+        try traverser.basic.traverse(ClassWithStaticBlockVisitor, tree, &visitor);
     }
 
     if (options.ignore_using_declarations) {
@@ -458,6 +464,37 @@ const UsingDeclarationVisitor = struct {
         }
     }
 };
+
+const ClassWithStaticBlockVisitor = struct {
+    ignored_decls: *IgnoredDecls,
+
+    pub fn enter_class(
+        self: *ClassWithStaticBlockVisitor,
+        class: ast.Class,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (class.type != .class_declaration or class.id == .null) return .proceed;
+        if (!hasStaticBlock(ctx.tree, class.body)) return .proceed;
+
+        try self.ignored_decls.put(class.id, {});
+        return .proceed;
+    }
+};
+
+fn hasStaticBlock(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    if (body_index == .null) return false;
+
+    const body = switch (tree.data(body_index)) {
+        .class_body => |body| body,
+        else => return false,
+    };
+
+    for (tree.extra(body.body)) |element_index| {
+        if (tree.data(element_index) == .static_block) return true;
+    }
+    return false;
+}
 
 const DestructuredArrayVisitor = struct {
     ignored_decls: *IgnoredDecls,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -979,6 +979,7 @@ pub fn runSemantic(
             .args_after_used = options.no_unused_vars_args == .after_used,
             .check_caught_errors = options.no_unused_vars_caught_errors == .all,
             .ignore_rest_siblings = options.no_unused_vars_ignore_rest_siblings,
+            .ignore_class_with_static_init_block = options.no_unused_vars_ignore_class_with_static_init_block,
             .ignore_using_declarations = options.no_unused_vars_ignore_using_declarations,
             .react_jsx_uses_react = options.react_jsx_uses_react,
             .react_jsx_uses_vars = options.react_jsx_uses_vars,

--- a/tests/rules/no_unused_vars.zig
+++ b/tests/rules/no_unused_vars.zig
@@ -190,6 +190,51 @@ test "supports configured no-unused-vars ignoreUsingDeclarations" {
     try std.testing.expect(!helpers.hasRule(ignored_result, lint.rules.no_unused_vars.id));
 }
 
+test "supports configured no-unused-vars ignoreClassWithStaticInitBlock" {
+    const source =
+        \\class IgnoredWithStatic {
+        \\  static {
+        \\    const stillReported = 1;
+        \\    setup();
+        \\  }
+        \\}
+        \\const reportedExpression = class {
+        \\  static {
+        \\    setup();
+        \\  }
+        \\};
+        \\class ReportedPlain {}
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_undef = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(default_result, lint.rules.no_unused_vars.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreClassWithStaticInitBlock\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unused-vars", config.value);
+    options.no_undef = false;
+    options.typescript_eslint_no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer ignored_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(ignored_result, lint.rules.no_unused_vars.id));
+}
+
 test "supports configured no-unused-vars varsIgnorePattern" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- Add core no-unused-vars parsing for `ignoreClassWithStaticInitBlock`.
- Ignore unused class declarations that contain static initialization blocks while still reporting unused variables inside static blocks and class-expression assignments.
- Cover the option in rule tests and rule-status docs.

## Validation
- `zig fmt --check src/rules/no_unused_vars.zig src/core.zig src/rules/root.zig tests/rules/no_unused_vars.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`