### PR TITLE
Support prefer-const read-before-assign option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -164,7 +164,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
-| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Implemented for optional `destructuring: any` and `destructuring: all` behavior; `ignoreReadBeforeAssign: true` |
+| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1512,6 +1512,7 @@ pub const Options = struct {
     no_undef_typeof: bool = false,
     prefer_const: bool = true,
     prefer_const_destructuring: PreferConstDestructuring = .any,
+    prefer_const_ignore_read_before_assign: bool = true,
     prefer_exponentiation_operator: bool = true,
     prefer_numeric_literals: bool = true,
     prefer_object_has_own: bool = true,
@@ -2041,6 +2042,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "prefer-const")) {
             self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
+            self.prefer_const_ignore_read_before_assign = try preferConstBoolOptionFromConfig(value, "ignoreReadBeforeAssign", true);
         }
         if (std.mem.eql(u8, cli_name, "prefer-destructuring")) {
             self.prefer_destructuring_variable_declarator_array = try preferDestructuringOptionFromConfig(value, "VariableDeclarator", "array", true);
@@ -4008,6 +4010,24 @@ pub const Options = struct {
         if (std.mem.eql(u8, destructuring, "any")) return .any;
         if (std.mem.eql(u8, destructuring, "all")) return .all;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn preferConstBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const option = config.get(key) orelse return default;
+        return switch (option) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn preferDestructuringOptionFromConfig(
@@ -7067,13 +7087,14 @@ test "Options can apply ESLint-style rule config values" {
     var prefer_const_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"destructuring\":\"all\"}]",
+        "[\"error\",{\"destructuring\":\"all\",\"ignoreReadBeforeAssign\":false}]",
         .{},
     );
     defer prefer_const_config.deinit();
     try options.setByRuleConfigValue("prefer-const", prefer_const_config.value);
     try std.testing.expect(options.prefer_const);
     try std.testing.expectEqual(PreferConstDestructuring.all, options.prefer_const_destructuring);
+    try std.testing.expect(!options.prefer_const_ignore_read_before_assign);
 
     var prefer_destructuring_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/prefer_const.zig
+++ b/src/rules/prefer_const.zig
@@ -20,12 +20,18 @@ pub const Destructuring = enum {
 
 pub const Options = struct {
     destructuring: Destructuring = .any,
+    ignore_read_before_assign: bool = true,
 };
 
 const Candidate = struct {
     node: ast.NodeIndex,
     name: []const u8,
+    initialized: bool = true,
     reassigned: bool = false,
+    assignment_count: usize = 0,
+    first_assignment_node: ast.NodeIndex = .null,
+    first_assignment_end: u32 = 0,
+    read_before_assignment: bool = false,
     destructuring_group: ?usize = null,
 };
 
@@ -96,6 +102,11 @@ pub fn runWithOptions(
     while (candidate_iter.next()) |entry| {
         const candidate = entry.value_ptr.*;
         if (candidate.reassigned) continue;
+        const report_node = if (candidate.initialized) candidate.node else report_node: {
+            if (candidate.assignment_count != 1) continue;
+            if (options.ignore_read_before_assign and candidate.read_before_assignment) continue;
+            break :report_node candidate.first_assignment_node;
+        };
         if (candidate.destructuring_group) |group_id| {
             if (options.destructuring == .all and (destructuring_groups.get(group_id) orelse false)) continue;
         }
@@ -105,7 +116,7 @@ pub fn runWithOptions(
             diagnostics,
             .warning,
             id,
-            tree.span(candidate.node),
+            tree.span(report_node),
             "'{s}' is never reassigned. Use 'const' instead.",
             .{candidate.name},
         );
@@ -134,7 +145,6 @@ const Visitor = struct {
                 .variable_declarator => |declarator| declarator,
                 else => continue,
             };
-            if (declarator.init == .null) continue;
 
             const group = if (self.options.destructuring == .all and isDestructuringPattern(ctx.tree, declarator.id)) group: {
                 const group_id = self.next_destructuring_group;
@@ -143,7 +153,7 @@ const Visitor = struct {
                 break :group group_id;
             } else null;
 
-            try self.collectCandidate(ctx.tree, declarator.id, group);
+            try self.collectCandidate(ctx.tree, declarator.id, group, declarator.init != .null);
         }
 
         return .proceed;
@@ -152,10 +162,10 @@ const Visitor = struct {
     pub fn enter_assignment_expression(
         self: *Visitor,
         expression: ast.AssignmentExpression,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        try self.markReassigned(ctx.tree, expression.left);
+        try self.markAssignment(ctx.tree, expression.left, expression.operator == .assign, ctx.tree.span(index).end);
         return .proceed;
     }
 
@@ -182,10 +192,10 @@ const Visitor = struct {
     pub fn enter_update_expression(
         self: *Visitor,
         expression: ast.UpdateExpression,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        try self.markReassigned(ctx.tree, expression.argument);
+        try self.markAssignment(ctx.tree, expression.argument, false, ctx.tree.span(index).end);
         return .proceed;
     }
 
@@ -209,29 +219,59 @@ const Visitor = struct {
                 break :group group_id;
             } else null;
 
-            try self.collectCandidate(tree, declarator.id, group);
+            try self.collectCandidate(tree, declarator.id, group, true);
         }
     }
 
-    fn collectCandidate(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex, group: ?usize) Allocator.Error!void {
+    pub fn enter_identifier_reference(
+        self: *Visitor,
+        _: ast.IdentifierReference,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (isAssignmentWrite(ctx.tree, index, ctx)) return .proceed;
+
+        const symbol_id = self.reference_lookup.get(index) orelse return .proceed;
+        if (self.candidates.getPtr(symbol_id)) |candidate| {
+            if (!candidate.initialized and isReadBeforeFirstAssignment(ctx.tree, index, candidate.*)) {
+                candidate.read_before_assignment = true;
+            }
+        }
+
+        return .proceed;
+    }
+
+    fn collectCandidate(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        group: ?usize,
+        initialized: bool,
+    ) Allocator.Error!void {
         if (index == .null) return;
 
         switch (tree.data(index)) {
             .binding_identifier => |identifier| {
                 const symbol_id = self.decl_symbols.get(index) orelse return;
+                if (!initialized) {
+                    if (self.candidates.get(symbol_id)) |existing| {
+                        if (existing.initialized) return;
+                    }
+                }
                 try self.candidates.put(symbol_id, .{
                     .node = index,
                     .name = tree.string(identifier.name),
+                    .initialized = initialized,
                     .destructuring_group = group,
                 });
             },
-            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left, group),
-            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument, group),
+            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left, group, initialized),
+            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument, group, initialized),
             .array_pattern => |pattern| {
                 for (tree.extra(pattern.elements)) |element| {
-                    try self.collectCandidate(tree, element, group);
+                    try self.collectCandidate(tree, element, group, initialized);
                 }
-                try self.collectCandidate(tree, pattern.rest, group);
+                try self.collectCandidate(tree, pattern.rest, group, initialized);
             },
             .object_pattern => |pattern| {
                 for (tree.extra(pattern.properties)) |property_index| {
@@ -239,15 +279,21 @@ const Visitor = struct {
                         .binding_property => |property| property,
                         else => continue,
                     };
-                    try self.collectCandidate(tree, property.value, group);
+                    try self.collectCandidate(tree, property.value, group, initialized);
                 }
-                try self.collectCandidate(tree, pattern.rest, group);
+                try self.collectCandidate(tree, pattern.rest, group, initialized);
             },
             else => {},
         }
     }
 
-    fn markReassigned(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+    fn markAssignment(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        simple_assign: bool,
+        assignment_end: u32,
+    ) Allocator.Error!void {
         if (index == .null) return;
 
         const unwrapped = unwrapTransparent(tree, index);
@@ -255,18 +301,30 @@ const Visitor = struct {
             .identifier_reference => {
                 const symbol_id = self.reference_lookup.get(unwrapped) orelse return;
                 if (self.candidates.getPtr(symbol_id)) |candidate| {
-                    candidate.reassigned = true;
+                    if (candidate.initialized) {
+                        candidate.reassigned = true;
+                    } else if (simple_assign) {
+                        candidate.assignment_count += 1;
+                        if (candidate.assignment_count == 1) {
+                            candidate.first_assignment_node = unwrapped;
+                            candidate.first_assignment_end = assignment_end;
+                        } else {
+                            candidate.reassigned = true;
+                        }
+                    } else {
+                        candidate.reassigned = true;
+                    }
                     if (candidate.destructuring_group) |group_id| {
                         try self.destructuring_groups.put(group_id, true);
                     }
                 }
             },
-            .assignment_pattern => |pattern| try self.markReassigned(tree, pattern.left),
+            .assignment_pattern => |pattern| try self.markAssignment(tree, pattern.left, simple_assign, assignment_end),
             .array_pattern => |pattern| {
                 for (tree.extra(pattern.elements)) |element| {
-                    try self.markReassigned(tree, element);
+                    try self.markAssignment(tree, element, simple_assign, assignment_end);
                 }
-                try self.markReassigned(tree, pattern.rest);
+                try self.markAssignment(tree, pattern.rest, simple_assign, assignment_end);
             },
             .object_pattern => |pattern| {
                 for (tree.extra(pattern.properties)) |property_index| {
@@ -274,14 +332,30 @@ const Visitor = struct {
                         .binding_property => |property| property,
                         else => continue,
                     };
-                    try self.markReassigned(tree, property.value);
+                    try self.markAssignment(tree, property.value, simple_assign, assignment_end);
                 }
-                try self.markReassigned(tree, pattern.rest);
+                try self.markAssignment(tree, pattern.rest, simple_assign, assignment_end);
             },
             else => {},
         }
     }
 };
+
+fn isReadBeforeFirstAssignment(tree: *const ast.Tree, index: ast.NodeIndex, candidate: Candidate) bool {
+    if (candidate.assignment_count == 0) return true;
+    if (candidate.assignment_count > 1 or candidate.first_assignment_end == 0) return false;
+    return tree.span(index).start <= candidate.first_assignment_end;
+}
+
+fn isAssignmentWrite(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.parent() orelse return false;
+
+    return switch (tree.data(parent)) {
+        .assignment_expression => |expression| unwrapTransparent(tree, expression.left) == index,
+        .update_expression => |expression| unwrapTransparent(tree, expression.argument) == index,
+        else => false,
+    };
+}
 
 fn isDestructuringPattern(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     if (index == .null) return false;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1051,6 +1051,7 @@ pub fn runSemantic(
                 .any => .any,
                 .all => .all,
             },
+            .ignore_read_before_assign = options.prefer_const_ignore_read_before_assign,
         });
     }
 }

--- a/tests/rules/prefer_const.zig
+++ b/tests/rules/prefer_const.zig
@@ -24,13 +24,14 @@ test "reports prefer-const for initialized let declarations that are never reass
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_const.id));
 }
 
-test "does not report prefer-const for reassigned let bindings or uninitialized declarations" {
+test "does not report prefer-const for reassigned let bindings or read-before-assign declarations by default" {
     const source =
         \\let a = 1;
         \\a = 2;
         \\let b = 1;
         \\b++;
         \\let c;
+        \\console.log(c);
         \\c = 1;
         \\for (let key in obj) {
         \\  key = "other";
@@ -44,6 +45,46 @@ test "does not report prefer-const for reassigned let bindings or uninitialized 
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_const.id));
+}
+
+test "supports configured prefer-const ignoreReadBeforeAssign false" {
+    const source =
+        \\let assignedOnce;
+        \\assignedOnce = 1;
+        \\console.log(assignedOnce);
+        \\let readBefore;
+        \\console.log(readBefore);
+        \\readBefore = 1;
+        \\let reassigned;
+        \\reassigned = 1;
+        \\reassigned = 2;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.prefer_const.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreReadBeforeAssign\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("prefer-const", config.value);
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer configured_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(configured_result, lint.rules.prefer_const.id));
 }
 
 test "reports prefer-const for destructuring any by default" {


### PR DESCRIPTION
## Summary
- Add `ignoreReadBeforeAssign` parsing for `prefer-const` while keeping the project default at `true`.
- Report uninitialized `let` bindings that are assigned exactly once, matching the ordinary `prefer-const` case.
- Respect read-before-assign suppression by default and allow ESLint configs to set it to `false`.

## Validation
- `zig fmt --check src/rules/prefer_const.zig src/core.zig src/rules/root.zig tests/rules/prefer_const.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`