### PR TITLE
Preserve migrated rule options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ directory or its ancestors. Use `--config=path/to/utoo.json` for an explicit fil
 ```
 
 Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an
-ESLint-style array whose first item is the severity.
+ESLint-style array whose first item is the severity and later items are native
+rule options.
 
 To migrate an existing ESLint config into the native utoo format:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ The template includes a `$schema` entry for editor validation and a focused set 
 }
 ```
 
-`utoo-lint` currently treats config severities as ESLint-compatible rule toggles. `off`, `0`, and `false` disable a rule. `warn`, `error`, `on`, `1`, `2`, and `true` enable a rule. ESLint-style arrays are accepted, but only the first item is interpreted today; rule-specific options are reserved for future support.
+`utoo-lint` treats config severities as ESLint-compatible rule toggles. `off`, `0`, and `false` disable a rule. `warn`, `error`, `on`, `1`, `2`, and `true` enable a rule. ESLint-style arrays are accepted; the first item controls severity, and supported option objects are passed to the native rule implementation.
 
 ## Rule Names
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -27,9 +27,9 @@ npx utoo-lint migrate eslint --from eslint.config.js --output utoo.json
 
 The generated config is a native `utoo-lint` config, not an ESLint config
 executed through a compatibility layer. The migrator copies supported rule
-severities, keeps `files` and `ignores` patterns, skips formatter-only rules
-such as `prettier/prettier`, and reports unsupported rules that still need a
-native utoo rule or a deliberate replacement.
+configs, keeps `files` and `ignores` patterns, skips formatter-only rules such
+as `prettier/prettier`, and reports unsupported rules that still need a native
+utoo rule or a deliberate replacement.
 
 For a preview without writing a file:
 
@@ -37,9 +37,9 @@ For a preview without writing a file:
 npx utoo-lint migrate eslint --print --report=json
 ```
 
-Rule-specific ESLint options are not interpreted by `utoo-lint` yet. When a rule
-uses an array config, the migrator keeps the severity and reports that the rule
-options were dropped.
+Rule values are preserved in the generated native config, including arrays such
+as `["error", { ...options }]`. Native utoo rules consume the options they
+support; unsupported rules are reported instead of being copied.
 
 ## Add a Config File
 
@@ -73,7 +73,7 @@ Rule values support the common ESLint forms:
 
 - `"off"`, `0`, or `false` disable a rule.
 - `"warn"`, `"error"`, `1`, `2`, or `true` enable a rule.
-- Arrays such as `["error", { ...options }]` use the first item as severity. Rule-specific options are not interpreted yet.
+- Arrays such as `["error", { ...options }]` use the first item as severity and pass supported options to the native rule implementation.
 
 CLI flags are applied after config files, so command-line toggles override config:
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -129,7 +129,7 @@ utoo-lint migrate eslint --from eslint.config.js --output utoo.json
 
 The migrator writes a utoo config, reports unsupported rules, skips
 formatter-only rules such as `prettier/prettier`, and keeps supported rule
-severities without treating ESLint as the long-term runtime API.
+configs without treating ESLint as the long-term runtime API.
 The package ships TypeScript declarations for the main entrypoint and
 compatibility subpaths, so typed ESLint integrations do not need a separate
 `@types` package.

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -183,7 +183,6 @@ function migrateEslintConfig(options) {
   const supportedRules = [];
   const unsupportedRules = [];
   const ignoredRules = [];
-  const optionDroppedRules = [];
 
   for (const entry of entries) {
     addPatterns(files, entry.files);
@@ -200,11 +199,8 @@ function migrateEslintConfig(options) {
         unsupportedRules.push(ruleId);
         continue;
       }
-      rules[ruleId] = severityOnly(ruleConfig);
+      rules[ruleId] = migratableRuleConfig(ruleConfig);
       supportedRules.push(ruleId);
-      if (Array.isArray(ruleConfig) && ruleConfig.length > 1) {
-        optionDroppedRules.push(ruleId);
-      }
     }
   }
 
@@ -227,7 +223,7 @@ function migrateEslintConfig(options) {
       supportedRules: uniqueSorted(supportedRules),
       unsupportedRules: uniqueSorted(unsupportedRules),
       ignoredRules: uniqueByRuleId(ignoredRules),
-      optionDroppedRules: uniqueSorted(optionDroppedRules)
+      optionDroppedRules: []
     }
   };
 }
@@ -295,8 +291,8 @@ function addPatterns(target, value) {
   }
 }
 
-function severityOnly(ruleConfig) {
-  return Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
+function migratableRuleConfig(ruleConfig) {
+  return Array.isArray(ruleConfig) ? [...ruleConfig] : ruleConfig;
 }
 
 function sortObjectByKey(object) {
@@ -326,9 +322,6 @@ function writeReport(report, options, stream) {
     stream.write(`utoo-lint migrate eslint: wrote ${report.output}\n`);
   }
   stream.write(`utoo-lint migrate eslint: migrated ${report.supportedRules.length} supported rule(s)\n`);
-  if (report.optionDroppedRules.length > 0) {
-    stream.write(`utoo-lint migrate eslint: dropped options for ${report.optionDroppedRules.length} rule(s): ${report.optionDroppedRules.join(", ")}\n`);
-  }
   if (report.ignoredRules.length > 0) {
     stream.write(`utoo-lint migrate eslint: ignored ${report.ignoredRules.length} rule(s): ${report.ignoredRules.map((rule) => rule.ruleId).join(", ")}\n`);
   }


### PR DESCRIPTION
## Summary
- preserve ESLint-style rule arrays when migrating supported rules into native utoo config
- stop reporting dropped options for supported rules while keeping unsupported and ignored rule reporting
- update migration/config docs to describe native rule option handling

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- node --check npm/utoo-lint/bin/migrate.js
- git diff --check
- manual node migration sample preserving no-console and @typescript-eslint/no-unused-vars options