### PR TITLE
Support require-atomic-updates allowProperties

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -177,7 +177,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) | Implemented |
 | [`radix`](https://eslint.org/docs/latest/rules/radix) | Implemented |
 | [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
-| [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Implemented |
+| [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Supports `allowProperties` configuration |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1611,6 +1611,7 @@ pub const Options = struct {
     radix_style: RadixStyle = .always,
     require_await: bool = true,
     require_atomic_updates: bool = true,
+    require_atomic_updates_allow_properties: bool = false,
     require_yield: bool = true,
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
@@ -2059,6 +2060,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "radix")) {
             self.radix_style = try radixStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "require-atomic-updates")) {
+            self.require_atomic_updates_allow_properties = try requireAtomicUpdatesBoolOptionFromConfig(value, "allowProperties", false);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
@@ -4025,6 +4029,23 @@ pub const Options = struct {
         };
         const option = config.get(key) orelse return default;
         return switch (option) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn requireAtomicUpdatesBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -7168,6 +7189,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("radix", radix_config.value);
     try std.testing.expect(options.radix);
     try std.testing.expectEqual(RadixStyle.as_needed, options.radix_style);
+
+    var require_atomic_updates_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowProperties\":true}]",
+        .{},
+    );
+    defer require_atomic_updates_config.deinit();
+    try options.setByRuleConfigValue("require-atomic-updates", require_atomic_updates_config.value);
+    try std.testing.expect(options.require_atomic_updates);
+    try std.testing.expect(options.require_atomic_updates_allow_properties);
 
     var no_useless_rename_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/require_atomic_updates.zig
+++ b/src/rules/require_atomic_updates.zig
@@ -8,6 +8,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "require-atomic-updates";
 
+pub const Options = struct {
+    allow_properties: bool = false,
+};
+
 const SymbolId = traverser.semantic.SymbolId;
 const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
 const SymbolSet = std.AutoHashMap(SymbolId, void);
@@ -31,6 +35,7 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 ) Allocator.Error!void {
     var reference_lookup = ReferenceLookup.init(allocator);
     defer reference_lookup.deinit();
@@ -46,6 +51,7 @@ pub fn run(
         .diagnostics = diagnostics,
         .symbol_table = symbol_table,
         .reference_lookup = &reference_lookup,
+        .options = options,
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
 }
@@ -55,6 +61,7 @@ const Visitor = struct {
     diagnostics: *core.DiagnosticList,
     symbol_table: traverser.semantic.SymbolTable,
     reference_lookup: *const ReferenceLookup,
+    options: Options,
 
     pub fn enter_function(
         self: *Visitor,
@@ -91,6 +98,7 @@ const Visitor = struct {
             .symbol_table = self.symbol_table,
             .reference_lookup = self.reference_lookup,
             .function_span = function_span,
+            .options = self.options,
             .read_symbols = SymbolSet.init(self.allocator),
             .stale_symbols = SymbolSet.init(self.allocator),
             .read_objects = SymbolSet.init(self.allocator),
@@ -109,6 +117,7 @@ const Analyzer = struct {
     symbol_table: traverser.semantic.SymbolTable,
     reference_lookup: *const ReferenceLookup,
     function_span: ast.Span,
+    options: Options,
     read_symbols: SymbolSet,
     stale_symbols: SymbolSet,
     read_objects: SymbolSet,
@@ -375,6 +384,8 @@ const Analyzer = struct {
                 try self.addVariableDiagnostic(diagnostic_node, name);
             },
             .member_expression => |member| {
+                if (self.options.allow_properties) return;
+
                 const symbol_id = rootObjectSymbol(self.tree, self.reference_lookup, member.object);
                 if (symbol_id == .none or !self.stale_objects.contains(symbol_id)) return;
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -969,7 +969,9 @@ pub fn runSemantic(
     }
 
     if (options.require_atomic_updates) {
-        try require_atomic_updates.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try require_atomic_updates.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .allow_properties = options.require_atomic_updates_allow_properties,
+        });
     }
 
     if (options.no_unused_vars and !options.typescript_eslint_no_unused_vars) {

--- a/tests/rules/require_atomic_updates.zig
+++ b/tests/rules/require_atomic_updates.zig
@@ -39,6 +39,35 @@ test "reports require-atomic-updates for stale property writes after await" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.require_atomic_updates.id));
 }
 
+test "supports configured require-atomic-updates allowProperties" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowProperties\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("require-atomic-updates", config.value);
+
+    const source =
+        \\let total = 0;
+        \\async function update(obj, value) {
+        \\  total += await value;
+        \\  obj.count += await value;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.require_atomic_updates.id));
+}
+
 test "reports require-atomic-updates across yield in generators" {
     const source =
         \\let total = 0;


### PR DESCRIPTION
## Summary
- add require-atomic-updates allowProperties config parsing
- skip stale property diagnostics when allowProperties is enabled while keeping variable diagnostics
- document the supported option in rule status

## Validation
- zig fmt --check src/rules/require_atomic_updates.zig src/rules/root.zig src/core.zig tests/rules/require_atomic_updates.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check