### PR TITLE
Support invalid void generic option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -279,7 +279,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
-| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Implemented |
+| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports boolean `allowInGenericTypeArguments` configuration |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1656,6 +1656,7 @@ pub const Options = struct {
     typescript_eslint_no_inferrable_types_ignore_parameters: bool = false,
     typescript_eslint_no_inferrable_types_ignore_properties: bool = false,
     typescript_eslint_no_invalid_void_type: bool = true,
+    typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_loop_func: bool = true,
     typescript_eslint_no_misused_new: bool = true,
@@ -2226,6 +2227,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-inferrable-types")) {
             self.typescript_eslint_no_inferrable_types_ignore_parameters = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreParameters", false);
             self.typescript_eslint_no_inferrable_types_ignore_properties = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreProperties", false);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-invalid-void-type")) {
+            self.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments = try typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value, "allowInGenericTypeArguments", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -5647,6 +5651,23 @@ pub const Options = struct {
         };
     }
 
+    fn typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintNoEmptyInterfaceAllowSingleExtendsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -7432,6 +7453,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_inferrable_types);
     try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_parameters);
     try std.testing.expect(options.typescript_eslint_no_inferrable_types_ignore_properties);
+
+    var typescript_no_invalid_void_type_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowInGenericTypeArguments\":false}]",
+        .{},
+    );
+    defer typescript_no_invalid_void_type_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-invalid-void-type", typescript_no_invalid_void_type_config.value);
+    try std.testing.expect(options.typescript_eslint_no_invalid_void_type);
+    try std.testing.expect(!options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments);
 
     var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1961,7 +1961,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_invalid_void_type) {
-            try typescript_eslint_no_invalid_void_type.check(self.allocator, self.diagnostics, ctx.tree, index, ctx);
+            try typescript_eslint_no_invalid_void_type.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .allow_in_generic_type_arguments = self.options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments,
+            });
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/src/rules/typescript_eslint_no_invalid_void_type.zig
@@ -7,6 +7,10 @@ const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-invalid-void-type";
 
+pub const Options = struct {
+    allow_in_generic_type_arguments: bool = true,
+};
+
 const Ancestor = struct {
     index: ast.NodeIndex,
     depth: usize,
@@ -18,6 +22,17 @@ pub fn check(
     tree: *const ast.Tree,
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    return checkWithOptions(allocator, diagnostics, tree, index, ctx, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
 ) Allocator.Error!void {
     const parent = nearestNonParenthesizedAncestor(tree, ctx, 1) orelse return;
 
@@ -33,7 +48,7 @@ pub fn check(
             );
             return;
         },
-        .ts_type_parameter_instantiation => return,
+        .ts_type_parameter_instantiation => if (options.allow_in_generic_type_arguments) return,
         .ts_type_annotation => {
             if (isReturnTypeAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
         },

--- a/tests/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/tests/rules/typescript_eslint_no_invalid_void_type.zig
@@ -68,6 +68,34 @@ test "reports @typescript-eslint/no-invalid-void-type for void in unions inside 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
 }
 
+test "supports configured @typescript-eslint/no-invalid-void-type generic type arguments" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowInGenericTypeArguments\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-invalid-void-type", config.value);
+
+    const source =
+        \\type PromiseVoid = Promise<void>;
+        \\type Callback = Map<string, void>;
+        \\function returnsVoid(): void {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}
+
 test "can disable @typescript-eslint/no-invalid-void-type" {
     const source =
         \\type Alias = void;


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-invalid-void-type parsing for boolean allowInGenericTypeArguments
- report bare void generic type arguments when that option is false
- document the supported option in rule status

## Validation
- zig fmt --check src/rules/typescript_eslint_no_invalid_void_type.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_invalid_void_type.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check