### PR TITLE
Support invalid void this option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -279,7 +279,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
-| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports boolean `allowInGenericTypeArguments` configuration |
+| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports boolean `allowAsThisParameter` and `allowInGenericTypeArguments` configuration |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1656,6 +1656,7 @@ pub const Options = struct {
     typescript_eslint_no_inferrable_types_ignore_parameters: bool = false,
     typescript_eslint_no_inferrable_types_ignore_properties: bool = false,
     typescript_eslint_no_invalid_void_type: bool = true,
+    typescript_eslint_no_invalid_void_type_allow_as_this_parameter: bool = false,
     typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments: bool = true,
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_loop_func: bool = true,
@@ -2229,6 +2230,7 @@ pub const Options = struct {
             self.typescript_eslint_no_inferrable_types_ignore_properties = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreProperties", false);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-invalid-void-type")) {
+            self.typescript_eslint_no_invalid_void_type_allow_as_this_parameter = try typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value, "allowAsThisParameter", false);
             self.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments = try typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value, "allowInGenericTypeArguments", true);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
@@ -7457,12 +7459,13 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_invalid_void_type_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowInGenericTypeArguments\":false}]",
+        "[\"error\",{\"allowAsThisParameter\":true,\"allowInGenericTypeArguments\":false}]",
         .{},
     );
     defer typescript_no_invalid_void_type_config.deinit();
     try options.setByRuleConfigValue("@typescript-eslint/no-invalid-void-type", typescript_no_invalid_void_type_config.value);
     try std.testing.expect(options.typescript_eslint_no_invalid_void_type);
+    try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allow_as_this_parameter);
     try std.testing.expect(!options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments);
 
     var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1962,6 +1962,7 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_invalid_void_type) {
             try typescript_eslint_no_invalid_void_type.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .allow_as_this_parameter = self.options.typescript_eslint_no_invalid_void_type_allow_as_this_parameter,
                 .allow_in_generic_type_arguments = self.options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments,
             });
         }

--- a/src/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/src/rules/typescript_eslint_no_invalid_void_type.zig
@@ -8,6 +8,7 @@ const Allocator = @import("std").mem.Allocator;
 pub const id = "@typescript-eslint/no-invalid-void-type";
 
 pub const Options = struct {
+    allow_as_this_parameter: bool = false,
     allow_in_generic_type_arguments: bool = true,
 };
 
@@ -51,6 +52,7 @@ pub fn checkWithOptions(
         .ts_type_parameter_instantiation => if (options.allow_in_generic_type_arguments) return,
         .ts_type_annotation => {
             if (isReturnTypeAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
+            if (options.allow_as_this_parameter and isThisParameterAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
         },
         else => {},
     }
@@ -87,6 +89,15 @@ fn isReturnTypeAnnotation(tree: *const ast.Tree, annotation_index: ast.NodeIndex
         .ts_method_signature => |signature| signature.return_type == annotation_index,
         .ts_call_signature_declaration => |signature| signature.return_type == annotation_index,
         .ts_construct_signature_declaration => |signature| signature.return_type == annotation_index,
+        else => false,
+    };
+}
+
+fn isThisParameterAnnotation(tree: *const ast.Tree, annotation_index: ast.NodeIndex, owner_index: ?ast.NodeIndex) bool {
+    const owner = owner_index orelse return false;
+
+    return switch (tree.data(owner)) {
+        .ts_this_parameter => |parameter| parameter.type_annotation == annotation_index,
         else => false,
     };
 }

--- a/tests/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/tests/rules/typescript_eslint_no_invalid_void_type.zig
@@ -96,6 +96,35 @@ test "supports configured @typescript-eslint/no-invalid-void-type generic type a
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
 }
 
+test "supports configured @typescript-eslint/no-invalid-void-type this parameters" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAsThisParameter\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-invalid-void-type", config.value);
+
+    const source =
+        \\function detached(this: void) {}
+        \\function takesVoid(value: void) {}
+        \\type Callback = (this: void) => void;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}
+
 test "can disable @typescript-eslint/no-invalid-void-type" {
     const source =
         \\type Alias = void;


### PR DESCRIPTION
## Summary
- add @typescript-eslint/no-invalid-void-type parsing for allowAsThisParameter
- allow void in TypeScript this parameters only when that option is enabled
- document the supported option in rule status

## Validation
- zig fmt --check src/rules/typescript_eslint_no_invalid_void_type.zig src/rules/root.zig src/core.zig tests/rules/typescript_eslint_no_invalid_void_type.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check