### PR TITLE
Support invalid void generic allowlist

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -279,7 +279,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
-| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports boolean `allowAsThisParameter` and `allowInGenericTypeArguments` configuration |
+| [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports `allowAsThisParameter` and boolean/string-list `allowInGenericTypeArguments` configuration |
 | [`@typescript-eslint/no-loss-of-precision`](https://typescript-eslint.io/rules/no-loss-of-precision/) | Implemented |
 | [`@typescript-eslint/no-misused-new`](https://typescript-eslint.io/rules/no-misused-new/) | Implemented |
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |

--- a/src/core.zig
+++ b/src/core.zig
@@ -610,6 +610,42 @@ pub const NoThisAliasAllowedNames = struct {
     }
 };
 
+pub const max_typescript_eslint_no_invalid_void_type_allowed_generic_type_names = 32;
+pub const max_typescript_eslint_no_invalid_void_type_allowed_generic_type_name_len = 128;
+
+pub const TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNamesError = error{
+    EmptyAllowedGenericTypeName,
+    TooManyAllowedGenericTypeNames,
+    AllowedGenericTypeNameTooLong,
+};
+
+pub const TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames = struct {
+    count: usize = 0,
+    lengths: [max_typescript_eslint_no_invalid_void_type_allowed_generic_type_names]usize = undefined,
+    storage: [max_typescript_eslint_no_invalid_void_type_allowed_generic_type_names][max_typescript_eslint_no_invalid_void_type_allowed_generic_type_name_len]u8 = undefined,
+
+    pub fn contains(self: *const TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames, name: []const u8) TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNamesError!void {
+        if (name.len == 0) return error.EmptyAllowedGenericTypeName;
+        if (self.count >= max_typescript_eslint_no_invalid_void_type_allowed_generic_type_names) return error.TooManyAllowedGenericTypeNames;
+        if (name.len > max_typescript_eslint_no_invalid_void_type_allowed_generic_type_name_len) return error.AllowedGenericTypeNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_react_jsx_pascal_case_ignore_names = 32;
 pub const max_react_jsx_pascal_case_ignore_name_len = 128;
 
@@ -1658,6 +1694,7 @@ pub const Options = struct {
     typescript_eslint_no_invalid_void_type: bool = true,
     typescript_eslint_no_invalid_void_type_allow_as_this_parameter: bool = false,
     typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments: bool = true,
+    typescript_eslint_no_invalid_void_type_allowed_generic_type_names: TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames = .{},
     typescript_eslint_no_loss_of_precision: bool = true,
     typescript_eslint_no_loop_func: bool = true,
     typescript_eslint_no_misused_new: bool = true,
@@ -2231,7 +2268,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-invalid-void-type")) {
             self.typescript_eslint_no_invalid_void_type_allow_as_this_parameter = try typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value, "allowAsThisParameter", false);
-            self.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments = try typescriptEslintNoInvalidVoidTypeBoolOptionFromConfig(value, "allowInGenericTypeArguments", true);
+            const allow_in_generic_type_arguments = try typescriptEslintNoInvalidVoidTypeGenericTypeArgumentsFromConfig(value);
+            self.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments = allow_in_generic_type_arguments.allow_any;
+            self.typescript_eslint_no_invalid_void_type_allowed_generic_type_names = allow_in_generic_type_arguments.allowed_names;
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-shadow")) {
             self.typescript_eslint_no_shadow_allow = try noShadowAllowFromConfig(value);
@@ -5670,6 +5709,43 @@ pub const Options = struct {
         };
     }
 
+    const TypescriptEslintNoInvalidVoidTypeGenericTypeArguments = struct {
+        allow_any: bool = true,
+        allowed_names: TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames = .{},
+    };
+
+    fn typescriptEslintNoInvalidVoidTypeGenericTypeArgumentsFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintNoInvalidVoidTypeGenericTypeArguments {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        return switch (config.get("allowInGenericTypeArguments") orelse return .{}) {
+            .bool => |enabled| .{ .allow_any = enabled },
+            .array => |array| blk: {
+                var names = TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames{};
+                for (array.items) |item| {
+                    const name = switch (item) {
+                        .string => |name| name,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    names.append(name) catch return error.UnsupportedRuleConfigValue;
+                }
+                break :blk .{
+                    .allow_any = false,
+                    .allowed_names = names,
+                };
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintNoEmptyInterfaceAllowSingleExtendsFromConfig(value: std.json.Value) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -7459,7 +7535,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_invalid_void_type_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowAsThisParameter\":true,\"allowInGenericTypeArguments\":false}]",
+        "[\"error\",{\"allowAsThisParameter\":true,\"allowInGenericTypeArguments\":[\"Promise\",\"React.VoidFunctionComponent\"]}]",
         .{},
     );
     defer typescript_no_invalid_void_type_config.deinit();
@@ -7467,6 +7543,9 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_invalid_void_type);
     try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allow_as_this_parameter);
     try std.testing.expect(!options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments);
+    try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("Promise"));
+    try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("React.VoidFunctionComponent"));
+    try std.testing.expect(!options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("Map"));
 
     var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1964,6 +1964,7 @@ const BasicVisitor = struct {
             try typescript_eslint_no_invalid_void_type.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
                 .allow_as_this_parameter = self.options.typescript_eslint_no_invalid_void_type_allow_as_this_parameter,
                 .allow_in_generic_type_arguments = self.options.typescript_eslint_no_invalid_void_type_allow_in_generic_type_arguments,
+                .allowed_generic_type_names = self.options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names,
             });
         }
         return .proceed;

--- a/src/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/src/rules/typescript_eslint_no_invalid_void_type.zig
@@ -1,15 +1,17 @@
 const parser = @import("parser");
 const core = @import("../core.zig");
+const std = @import("std");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-invalid-void-type";
 
 pub const Options = struct {
     allow_as_this_parameter: bool = false,
     allow_in_generic_type_arguments: bool = true,
+    allowed_generic_type_names: core.TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames = .{},
 };
 
 const Ancestor = struct {
@@ -49,7 +51,10 @@ pub fn checkWithOptions(
             );
             return;
         },
-        .ts_type_parameter_instantiation => if (options.allow_in_generic_type_arguments) return,
+        .ts_type_parameter_instantiation => {
+            if (options.allow_in_generic_type_arguments) return;
+            if (allowedGenericTypeArgument(tree, parent.index, ctx.path.ancestor(parent.depth + 1), &options.allowed_generic_type_names)) return;
+        },
         .ts_type_annotation => {
             if (isReturnTypeAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
             if (options.allow_as_this_parameter and isThisParameterAnnotation(tree, parent.index, ctx.path.ancestor(parent.depth + 1))) return;
@@ -100,4 +105,38 @@ fn isThisParameterAnnotation(tree: *const ast.Tree, annotation_index: ast.NodeIn
         .ts_this_parameter => |parameter| parameter.type_annotation == annotation_index,
         else => false,
     };
+}
+
+fn allowedGenericTypeArgument(
+    tree: *const ast.Tree,
+    type_arguments_index: ast.NodeIndex,
+    owner_index: ?ast.NodeIndex,
+    allowed_names: *const core.TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames,
+) bool {
+    const owner = owner_index orelse return false;
+
+    return switch (tree.data(owner)) {
+        .ts_type_reference => |reference| reference.type_arguments == type_arguments_index and allowedGenericTypeName(tree, reference.type_name, allowed_names),
+        else => false,
+    };
+}
+
+fn allowedGenericTypeName(
+    tree: *const ast.Tree,
+    type_name_index: ast.NodeIndex,
+    allowed_names: *const core.TypescriptEslintNoInvalidVoidTypeAllowedGenericTypeNames,
+) bool {
+    const name = switch (tree.data(type_name_index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .ts_qualified_name => sourceText(tree, type_name_index),
+        else => return false,
+    };
+
+    return allowed_names.contains(std.mem.trim(u8, name, " \t\r\n"));
+}
+
+fn sourceText(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    return tree.source[span.start..span.end];
 }

--- a/tests/rules/typescript_eslint_no_invalid_void_type.zig
+++ b/tests/rules/typescript_eslint_no_invalid_void_type.zig
@@ -96,6 +96,35 @@ test "supports configured @typescript-eslint/no-invalid-void-type generic type a
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
 }
 
+test "supports configured @typescript-eslint/no-invalid-void-type generic type argument allowlist" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowInGenericTypeArguments\":[\"Promise\",\"React.VoidFunctionComponent\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-invalid-void-type", config.value);
+
+    const source =
+        \\type PromiseVoid = Promise<void>;
+        \\type ReactVoid = React.VoidFunctionComponent<void>;
+        \\type ArrayVoid = Array<void>;
+        \\function returnsVoid(): void {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_invalid_void_type.id));
+}
+
 test "supports configured @typescript-eslint/no-invalid-void-type this parameters" {
     var config = try std.json.parseFromSlice(
         std.json.Value,


### PR DESCRIPTION
## Summary
- support string-list `allowInGenericTypeArguments` for `@typescript-eslint/no-invalid-void-type`
- allow listed `TSTypeReference` names such as `Promise` and `React.VoidFunctionComponent` while still reporting other generic void arguments
- document the expanded rule option support

## Validation
- `zig fmt --check src/core.zig src/rules/typescript_eslint_no_invalid_void_type.zig src/rules/root.zig tests/rules/typescript_eslint_no_invalid_void_type.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`