### PR TITLE
Support no-this-alias destructuring option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -287,7 +287,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
 | [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreOnInitialization`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
-| [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Implemented for `allowedNames` configuration |
+| [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Supports `allowedNames` and `allowDestructuring` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |
 | [`@typescript-eslint/triple-slash-reference`](https://typescript-eslint.io/rules/triple-slash-reference/) | Implemented for `path`, `types`, and `lib` `always`/`never` configurations |
 | [`@typescript-eslint/typedef`](https://typescript-eslint.io/rules/typedef/) | Supports `propertyDeclaration`, `memberVariableDeclaration`, `parameter`, `arrowParameter`, `arrayDestructuring`, `objectDestructuring`, `variableDeclaration`, and `variableDeclarationIgnoreFunction` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1715,6 +1715,7 @@ pub const Options = struct {
     typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow: bool = true,
     typescript_eslint_no_this_alias: bool = true,
     typescript_eslint_no_this_alias_allowed_names: NoThisAliasAllowedNames = .{},
+    typescript_eslint_no_this_alias_allow_destructuring: bool = true,
     typescript_eslint_no_unsafe_declaration_merging: bool = true,
     typescript_eslint_triple_slash_reference: bool = true,
     typescript_eslint_triple_slash_reference_path: TypescriptEslintTripleSlashReferenceMode = .never,
@@ -2293,6 +2294,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
             self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
+            self.typescript_eslint_no_this_alias_allow_destructuring = try typescriptEslintNoThisAliasAllowDestructuringFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-unused-vars")) {
             self.typescript_eslint_no_unused_vars_vars = try noUnusedVarsVarsFromConfig(value, .all);
@@ -5675,6 +5677,23 @@ pub const Options = struct {
         return names;
     }
 
+    fn typescriptEslintNoThisAliasAllowDestructuringFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return true,
+        };
+        if (items.len < 2) return true;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowDestructuring") orelse return true) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintNoInferrableTypesBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -7157,6 +7176,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_shadow_ignore_on_initialization);
     try std.testing.expect(options.typescript_eslint_no_shadow_ignore_type_value_shadow);
     try std.testing.expect(!options.typescript_eslint_no_shadow_ignore_function_type_parameter_name_value_shadow);
+
+    var typescript_no_this_alias_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowedNames\":[\"that\"],\"allowDestructuring\":false}]",
+        .{},
+    );
+    defer typescript_no_this_alias_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-this-alias", typescript_no_this_alias_config.value);
+    try std.testing.expect(options.typescript_eslint_no_this_alias);
+    try std.testing.expect(options.typescript_eslint_no_this_alias_allowed_names.contains("that"));
+    try std.testing.expect(!options.typescript_eslint_no_this_alias_allowed_names.contains("self"));
+    try std.testing.expect(!options.typescript_eslint_no_this_alias_allow_destructuring);
 
     var no_plusplus_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1657,6 +1657,7 @@ const BasicVisitor = struct {
                 ctx.tree,
                 declarator,
                 &self.options.typescript_eslint_no_this_alias_allowed_names,
+                self.options.typescript_eslint_no_this_alias_allow_destructuring,
             );
         }
         if (self.options.typescript_eslint_no_inferrable_types) {
@@ -2547,6 +2548,7 @@ const BasicVisitor = struct {
                 ctx.tree,
                 expression,
                 &self.options.typescript_eslint_no_this_alias_allowed_names,
+                self.options.typescript_eslint_no_this_alias_allow_destructuring,
             );
         }
         if (self.options.react_no_typos) {

--- a/src/rules/typescript_eslint_no_this_alias.zig
+++ b/src/rules/typescript_eslint_no_this_alias.zig
@@ -13,15 +13,19 @@ pub fn checkVariableDeclarator(
     tree: *const ast.Tree,
     declarator: ast.VariableDeclarator,
     allowed_names: *const core.NoThisAliasAllowedNames,
+    allow_destructuring: bool,
 ) Allocator.Error!void {
     switch (tree.data(declarator.id)) {
-        .binding_identifier => {},
+        .binding_identifier => {
+            if (!isThisExpression(tree, declarator.init)) return;
+            try reportIfDisallowed(allocator, diagnostics, tree, declarator.id, allowed_names);
+        },
+        .array_pattern, .object_pattern => {
+            if (allow_destructuring or !isThisExpression(tree, declarator.init)) return;
+            try report(allocator, diagnostics, tree, declarator.id);
+        },
         else => return,
     }
-
-    if (!isThisExpression(tree, declarator.init)) return;
-
-    try reportIfDisallowed(allocator, diagnostics, tree, declarator.id, allowed_names);
 }
 
 pub fn checkAssignmentExpression(
@@ -30,17 +34,21 @@ pub fn checkAssignmentExpression(
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
     allowed_names: *const core.NoThisAliasAllowedNames,
+    allow_destructuring: bool,
 ) Allocator.Error!void {
     if (expression.operator != .assign) return;
 
     switch (tree.data(expression.left)) {
-        .identifier_reference => {},
+        .identifier_reference => {
+            if (!isThisExpression(tree, expression.right)) return;
+            try reportIfDisallowed(allocator, diagnostics, tree, expression.left, allowed_names);
+        },
+        .array_pattern, .object_pattern => {
+            if (allow_destructuring or !isThisExpression(tree, expression.right)) return;
+            try report(allocator, diagnostics, tree, expression.left);
+        },
         else => return,
     }
-
-    if (!isThisExpression(tree, expression.right)) return;
-
-    try reportIfDisallowed(allocator, diagnostics, tree, expression.left, allowed_names);
 }
 
 fn reportIfDisallowed(
@@ -52,6 +60,15 @@ fn reportIfDisallowed(
 ) Allocator.Error!void {
     if (isAllowedAlias(tree, target, allowed_names)) return;
 
+    try report(allocator, diagnostics, tree, target);
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    target: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,

--- a/tests/rules/typescript_eslint_no_this_alias.zig
+++ b/tests/rules/typescript_eslint_no_this_alias.zig
@@ -63,7 +63,7 @@ test "supports configured @typescript-eslint/no-this-alias allowedNames option" 
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        \\["error", {"allowedNames": ["that"]}]
+        \\["error", {"allowedNames": ["that"], "allowDestructuring": false}]
     ,
         .{},
     );
@@ -75,6 +75,37 @@ test "supports configured @typescript-eslint/no-this-alias allowedNames option" 
     try std.testing.expect(options.typescript_eslint_no_this_alias);
     try std.testing.expect(options.typescript_eslint_no_this_alias_allowed_names.contains("that"));
     try std.testing.expect(!options.typescript_eslint_no_this_alias_allowed_names.contains("self"));
+    try std.testing.expect(!options.typescript_eslint_no_this_alias_allow_destructuring);
+}
+
+test "supports configured @typescript-eslint/no-this-alias allowDestructuring false" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"allowDestructuring": false}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("@typescript-eslint/no-this-alias", config.value);
+
+    const source =
+        \\const { props } = this;
+        \\const [first] = this;
+        \\let state;
+        \\({ state } = this);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.typescript_eslint_no_this_alias.id));
 }
 
 test "can disable @typescript-eslint/no-this-alias" {


### PR DESCRIPTION
## Summary
- parse `allowDestructuring` for `@typescript-eslint/no-this-alias`
- report object and array destructuring from `this` when `allowDestructuring: false`
- keep the existing default behavior that allows destructuring and document the expanded option support

## Validation
- `zig fmt --check src/core.zig src/rules/typescript_eslint_no_this_alias.zig src/rules/root.zig tests/rules/typescript_eslint_no_this_alias.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`