### PR TITLE
Support react prop-types ignore option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -245,7 +245,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
 | [`react/prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) | Supports `always` and `never` configurations |
-| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` configuration |
+| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` and `ignore` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |
 
 ## React Hooks rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -769,6 +769,51 @@ pub const ReactNoUnknownPropertyIgnoreNames = struct {
     }
 };
 
+pub const max_react_prop_types_ignore_names = 32;
+pub const max_react_prop_types_ignore_name_len = 128;
+
+pub const ReactPropTypesIgnoreNamesError = error{
+    EmptyReactPropTypesIgnoreName,
+    TooManyReactPropTypesIgnoreNames,
+    ReactPropTypesIgnoreNameTooLong,
+};
+
+pub const ReactPropTypesIgnoreNames = struct {
+    count: usize = 0,
+    lengths: [max_react_prop_types_ignore_names]usize = undefined,
+    storage: [max_react_prop_types_ignore_names][max_react_prop_types_ignore_name_len]u8 = undefined,
+
+    pub fn contains(self: *const ReactPropTypesIgnoreNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn ignoresPath(self: *const ReactPropTypesIgnoreNames, path: []const u8) bool {
+        for (0..self.count) |index| {
+            const name = self.at(index);
+            if (std.mem.eql(u8, path, name)) return true;
+            if (path.len > name.len and path[name.len] == '.' and std.mem.eql(u8, path[0..name.len], name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const ReactPropTypesIgnoreNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ReactPropTypesIgnoreNames, name: []const u8) ReactPropTypesIgnoreNamesError!void {
+        if (name.len == 0) return error.EmptyReactPropTypesIgnoreName;
+        if (self.count >= max_react_prop_types_ignore_names) return error.TooManyReactPropTypesIgnoreNames;
+        if (name.len > max_react_prop_types_ignore_name_len) return error.ReactPropTypesIgnoreNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_typescript_eslint_ban_type_entries = 32;
 pub const max_typescript_eslint_ban_type_name_len = 128;
 pub const max_typescript_eslint_ban_type_message_len = 512;
@@ -1625,6 +1670,7 @@ pub const Options = struct {
     react_no_unknown_property_require_data_lowercase: bool = false,
     react_prop_types: bool = true,
     react_prop_types_skip_undeclared: bool = false,
+    react_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
     react_no_unused_prop_types: bool = true,
     react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_state: bool = true,
@@ -2205,6 +2251,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/prop-types")) {
             self.react_prop_types_skip_undeclared = try reactPropTypesSkipUndeclaredFromConfig(value);
+            self.react_prop_types_ignore = try reactPropTypesIgnoreFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
@@ -2793,6 +2840,33 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn reactPropTypesIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactPropTypesIgnoreNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore_items = switch (config.get("ignore") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignore = ReactPropTypesIgnoreNames{};
+        for (ignore_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            ignore.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return ignore;
     }
 
     fn reactJsxNoTargetBlankAllowReferrerFromConfig(value: std.json.Value) RuleConfigError!bool {
@@ -6356,13 +6430,16 @@ test "Options can apply ESLint-style rule config values" {
     var react_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"skipUndeclared\":true}]",
+        "[\"error\",{\"skipUndeclared\":true,\"ignore\":[\"name\",\"user\"]}]",
         .{},
     );
     defer react_prop_types_config.deinit();
     try options.setByRuleConfigValue("react/prop-types", react_prop_types_config.value);
     try std.testing.expect(options.react_prop_types);
     try std.testing.expect(options.react_prop_types_skip_undeclared);
+    try std.testing.expect(options.react_prop_types_ignore.contains("name"));
+    try std.testing.expect(options.react_prop_types_ignore.ignoresPath("user.name"));
+    try std.testing.expect(!options.react_prop_types_ignore.contains("age"));
 
     var react_no_string_refs_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -120,11 +120,12 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     skip_undeclared: bool,
+    ignore: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     var state = try collect(allocator, tree);
     defer state.deinit(allocator);
 
-    try finish(allocator, diagnostics, tree, &state, skip_undeclared);
+    try finish(allocator, diagnostics, tree, &state, skip_undeclared, ignore);
 }
 
 pub fn collect(
@@ -607,12 +608,14 @@ fn finish(
     tree: *const ast.Tree,
     state: *State,
     skip_undeclared: bool,
+    ignore: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     if (skip_undeclared) return;
 
     for (state.components.items) |component| {
         if (!component.detected) continue;
         for (component.used_props.items) |used| {
+            if (ignore.ignoresPath(used.name)) continue;
             if (isDeclared(component.declared_props.items, used.name)) continue;
             try core.addDiagnosticFmt(
                 allocator,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -573,7 +573,7 @@ pub fn runBasic(
         try require_await.run(allocator, diagnostics, tree);
     }
     if (options.react_prop_types) {
-        try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared);
+        try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared, &options.react_prop_types_ignore);
     }
     if (options.react_no_unused_prop_types) {
         try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props);

--- a/tests/rules/react_prop_types.zig
+++ b/tests/rules/react_prop_types.zig
@@ -54,6 +54,39 @@ test "supports configured react/prop-types skipUndeclared" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_prop_types.id));
 }
 
+test "supports configured react/prop-types ignore" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"name\",\"user\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/prop-types", config.value);
+
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}{props.user.name}{props.age}</div>;
+        \\}
+        \\Foo.propTypes = {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_prop_types.id));
+    var saw_age = false;
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_prop_types.id)) {
+            saw_age = std.mem.eql(u8, diagnostic.message, "'age' is missing in props validation");
+        }
+    }
+    try std.testing.expect(saw_age);
+}
+
 test "allows react/prop-types declared object children" {
     const source =
         \\import React from 'react';


### PR DESCRIPTION
## Summary
- parse `ignore` for `react/prop-types`
- skip missing prop validation diagnostics for ignored prop names and their nested paths
- document the expanded `react/prop-types` option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_prop_types.zig tests/rules/react_prop_types.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`