### PR TITLE
Support no-unused-prop-types ignore option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -243,7 +243,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
-| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` configuration |
+| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` and `ignore` configuration |
 | [`react/prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) | Supports `always` and `never` configurations |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` and `ignore` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1673,6 +1673,7 @@ pub const Options = struct {
     react_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
     react_no_unused_prop_types: bool = true,
     react_no_unused_prop_types_skip_shape_props: bool = true,
+    react_no_unused_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_string_refs_no_template_literals: bool = false,
@@ -2255,6 +2256,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
+            self.react_no_unused_prop_types_ignore = try reactPropTypesIgnoreFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-string-refs")) {
             self.react_no_string_refs_no_template_literals = try reactNoStringRefsNoTemplateLiteralsFromConfig(value);
@@ -6517,13 +6519,16 @@ test "Options can apply ESLint-style rule config values" {
     var react_no_unused_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"skipShapeProps\":false}]",
+        "[\"error\",{\"skipShapeProps\":false,\"ignore\":[\"age\",\"user\"]}]",
         .{},
     );
     defer react_no_unused_prop_types_config.deinit();
     try options.setByRuleConfigValue("react/no-unused-prop-types", react_no_unused_prop_types_config.value);
     try std.testing.expect(options.react_no_unused_prop_types);
     try std.testing.expect(!options.react_no_unused_prop_types_skip_shape_props);
+    try std.testing.expect(options.react_no_unused_prop_types_ignore.contains("age"));
+    try std.testing.expect(options.react_no_unused_prop_types_ignore.ignoresPath("user.id"));
+    try std.testing.expect(!options.react_no_unused_prop_types_ignore.contains("role"));
 
     var array_callback_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_unused_prop_types.zig
+++ b/src/rules/react_no_unused_prop_types.zig
@@ -13,13 +13,14 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     skip_shape_props: bool,
+    ignore: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     var state = try react_prop_types.collect(allocator, tree);
     defer state.deinit(allocator);
 
     for (state.components.items) |component| {
         if (!component.detected) continue;
-        try reportUnusedProps(allocator, diagnostics, tree, component, component.declared_props.items, "", skip_shape_props);
+        try reportUnusedProps(allocator, diagnostics, tree, component, component.declared_props.items, "", skip_shape_props, ignore);
     }
 }
 
@@ -31,6 +32,7 @@ fn reportUnusedProps(
     props: []const react_prop_types.DeclaredProp,
     prefix: []const u8,
     skip_shape_props: bool,
+    ignore: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     for (props) |prop| {
         const full_name = if (prefix.len == 0)
@@ -38,6 +40,8 @@ fn reportUnusedProps(
         else
             try std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, prop.name });
         defer allocator.free(full_name);
+
+        if (ignore.ignoresPath(full_name)) continue;
 
         if (skip_shape_props and (prop.kind == .shape or prop.kind == .exact)) {
             continue;
@@ -55,7 +59,7 @@ fn reportUnusedProps(
             );
         }
 
-        try reportUnusedProps(allocator, diagnostics, tree, component, prop.children.items, full_name, skip_shape_props);
+        try reportUnusedProps(allocator, diagnostics, tree, component, prop.children.items, full_name, skip_shape_props, ignore);
     }
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -576,7 +576,7 @@ pub fn runBasic(
         try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared, &options.react_prop_types_ignore);
     }
     if (options.react_no_unused_prop_types) {
-        try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props);
+        try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props, &options.react_no_unused_prop_types_ignore);
     }
 
     var visitor = BasicVisitor{

--- a/tests/rules/react_no_unused_prop_types.zig
+++ b/tests/rules/react_no_unused_prop_types.zig
@@ -92,6 +92,40 @@ test "reports react/no-unused-prop-types object props" {
     try std.testing.expect(std.mem.eql(u8, result.diagnostics[0].message, "'user' PropType is defined but prop is never used"));
 }
 
+test "supports configured react/no-unused-prop-types ignore" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"age\",\"user\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = noUnusedPropTypesOnly();
+    try options.setByRuleConfigValue("react/no-unused-prop-types", config.value);
+
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.name}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  name: PropTypes.string,
+        \\  age: PropTypes.number,
+        \\  user: PropTypes.shape({
+        \\    id: PropTypes.number,
+        \\  }),
+        \\  role: PropTypes.string,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(hasMessage(result, "'role' PropType is defined but prop is never used"));
+}
+
 test "reports react/no-unused-prop-types for class components" {
     const source =
         \\import React from 'react';


### PR DESCRIPTION
## Summary
- parse `ignore` for `react/no-unused-prop-types`
- skip unused prop type diagnostics for ignored prop names and their nested paths
- document the expanded `react/no-unused-prop-types` option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_no_unused_prop_types.zig tests/rules/react_no_unused_prop_types.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`