### PR TITLE
Support jsx-no-target-blank spread option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -233,7 +233,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
-| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer` and `enforceDynamicLinks` configuration |
+| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, and `warnOnSpreadAttributes` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps` and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1640,6 +1640,7 @@ pub const Options = struct {
     react_jsx_no_target_blank: bool = true,
     react_jsx_no_target_blank_allow_referrer: bool = false,
     react_jsx_no_target_blank_enforce_dynamic_links: bool = true,
+    react_jsx_no_target_blank_warn_on_spread_attributes: bool = false,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
@@ -2245,6 +2246,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
             self.react_jsx_no_target_blank_enforce_dynamic_links = try reactJsxNoTargetBlankEnforceDynamicLinksFromConfig(value);
+            self.react_jsx_no_target_blank_warn_on_spread_attributes = try reactJsxNoTargetBlankWarnOnSpreadAttributesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
@@ -2906,6 +2908,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, mode, "always")) return true;
         if (std.mem.eql(u8, mode, "never")) return false;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn reactJsxNoTargetBlankWarnOnSpreadAttributesFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("warnOnSpreadAttributes") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     const ReactNoUnescapedEntitiesForbid = struct {
@@ -6406,7 +6425,7 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowReferrer\":true,\"enforceDynamicLinks\":\"never\"}]",
+        "[\"error\",{\"allowReferrer\":true,\"enforceDynamicLinks\":\"never\",\"warnOnSpreadAttributes\":true}]",
         .{},
     );
     defer react_jsx_no_target_blank_config.deinit();
@@ -6414,6 +6433,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_no_target_blank);
     try std.testing.expect(options.react_jsx_no_target_blank_allow_referrer);
     try std.testing.expect(!options.react_jsx_no_target_blank_enforce_dynamic_links);
+    try std.testing.expect(options.react_jsx_no_target_blank_warn_on_spread_attributes);
 
     var react_jsx_pascal_case_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_no_target_blank.zig
+++ b/src/rules/react_jsx_no_target_blank.zig
@@ -10,6 +10,7 @@ pub const id = "react/jsx-no-target-blank";
 pub const Options = struct {
     allow_referrer: bool = false,
     enforce_dynamic_links: bool = true,
+    warn_on_spread_attributes: bool = false,
 };
 
 pub fn check(
@@ -22,11 +23,25 @@ pub fn check(
 ) Allocator.Error!void {
     if (!isAnchorElement(tree, opening.name)) return;
 
+    if (options.warn_on_spread_attributes and hasUnsafeSpreadAttribute(tree, opening, options.allow_referrer)) {
+        try addDiagnostic(allocator, diagnostics, tree, index);
+        return;
+    }
+
     const target = lastAttributeNamed(tree, opening, "target") orelse return;
     if (!attributeValuePossiblyBlank(tree, target.attribute)) return;
     if (!hasDangerousHref(tree, opening, options.enforce_dynamic_links)) return;
     if (hasSecureRel(tree, opening, target.attribute.value, options.allow_referrer)) return;
 
+    try addDiagnostic(allocator, diagnostics, tree, index);
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -62,6 +77,31 @@ fn lastAttributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, nam
         }
     }
     return null;
+}
+
+fn hasUnsafeSpreadAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement, allow_referrer: bool) bool {
+    const attributes = tree.extra(opening.attributes);
+    var last_spread: ?usize = null;
+    for (attributes, 0..) |attribute_index, index| {
+        switch (tree.data(attribute_index)) {
+            .jsx_spread_attribute => last_spread = index,
+            else => {},
+        }
+    }
+
+    const spread_index = last_spread orelse return false;
+    for (attributes[spread_index + 1 ..]) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = attributeName(tree, attribute.name) orelse continue;
+
+        if (std.mem.eql(u8, name, "rel") and attributeRelValueIsSecure(tree, attribute, allow_referrer)) return false;
+        if (std.mem.eql(u8, name, "target") and !attributeValuePossiblyBlank(tree, attribute)) return false;
+        if (std.mem.eql(u8, name, "href") and attributeValueIsSafeHref(tree, attribute)) return false;
+    }
+    return true;
 }
 
 fn attributeName(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
@@ -106,6 +146,18 @@ fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_va
         if (!valueIsSecureRel(value orelse return false, allow_referrer)) return false;
     }
     return true;
+}
+
+fn attributeRelValueIsSecure(tree: *const ast.Tree, attribute: ast.JSXAttribute, allow_referrer: bool) bool {
+    if (attribute.value == .null) return false;
+    const value = stringValue(tree, attribute.value) orelse return false;
+    return valueIsSecureRel(value, allow_referrer);
+}
+
+fn attributeValueIsSafeHref(tree: *const ast.Tree, attribute: ast.JSXAttribute) bool {
+    if (attribute.value == .null) return false;
+    const value = stringValue(tree, attribute.value) orelse return false;
+    return !isExternalHref(value);
 }
 
 fn relValues(tree: *const ast.Tree, rel_value: ast.NodeIndex, target_value: ast.NodeIndex, values: *[2]?[]const u8) usize {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3162,6 +3162,7 @@ const BasicVisitor = struct {
             try react_jsx_no_target_blank.check(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
                 .allow_referrer = self.options.react_jsx_no_target_blank_allow_referrer,
                 .enforce_dynamic_links = self.options.react_jsx_no_target_blank_enforce_dynamic_links,
+                .warn_on_spread_attributes = self.options.react_jsx_no_target_blank_warn_on_spread_attributes,
             });
         }
         if (self.options.react_jsx_pascal_case) {

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -31,6 +31,7 @@ test "allows secure rel non-external links and non-anchor elements" {
         \\const relative = <a href="/docs" target="_blank" />;
         \\const button = <button href="https://example.com" target="_blank" />;
         \\const conditional = <a href={url} target={open ? "_blank" : "_self"} rel={open ? "noreferrer" : ""} />;
+        \\const spread = <a {...props} />;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
@@ -42,6 +43,36 @@ test "allows secure rel non-external links and non-anchor elements" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_no_target_blank.id));
+}
+
+test "supports configured react/jsx-no-target-blank warnOnSpreadAttributes" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"warnOnSpreadAttributes\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/jsx-no-target-blank", config.value);
+    options.eol_last = false;
+    options.jsx_a11y_anchor_has_content = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const unsafe = <a {...props} />;
+        \\const safeRel = <a {...props} rel="noreferrer" />;
+        \\const safeTarget = <a {...props} target="_self" />;
+        \\const safeHref = <a {...props} href="/docs" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
 }
 
 test "supports configured react/jsx-no-target-blank allowReferrer" {


### PR DESCRIPTION
## Summary
- parse `warnOnSpreadAttributes` for `react/jsx-no-target-blank` ESLint-style config
- report unsafe JSX spread attributes unless a later `rel`, `target`, or `href` prop safely overrides them
- document the expanded rule option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_no_target_blank.zig tests/rules/react_jsx_no_target_blank.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`