### PR TITLE
Support jsx-pascal-case leading underscore

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -234,7 +234,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, and `warnOnSpreadAttributes` configuration |
-| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps` and `ignore` configuration |
+| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1644,6 +1644,7 @@ pub const Options = struct {
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
+    react_jsx_pascal_case_allow_leading_underscore: bool = false,
     react_jsx_pascal_case_ignore: ReactJsxPascalCaseIgnoreNames = .{},
     react_jsx_uses_react: bool = true,
     react_jsx_uses_vars: bool = true,
@@ -2250,6 +2251,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
+            self.react_jsx_pascal_case_allow_leading_underscore = try reactJsxPascalCaseAllowLeadingUnderscoreFromConfig(value);
             self.react_jsx_pascal_case_ignore = try reactJsxPascalCaseIgnoreFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/prop-types")) {
@@ -5486,6 +5488,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactJsxPascalCaseAllowLeadingUnderscoreFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowLeadingUnderscore") orelse return false) {
+            .bool => |allow_leading_underscore| allow_leading_underscore,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxPascalCaseIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactJsxPascalCaseIgnoreNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6438,13 +6457,14 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_pascal_case_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowAllCaps\":false,\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
+        "[\"error\",{\"allowAllCaps\":false,\"allowLeadingUnderscore\":true,\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
         .{},
     );
     defer react_jsx_pascal_case_config.deinit();
     try options.setByRuleConfigValue("react/jsx-pascal-case", react_jsx_pascal_case_config.value);
     try std.testing.expect(options.react_jsx_pascal_case);
     try std.testing.expect(!options.react_jsx_pascal_case_allow_all_caps);
+    try std.testing.expect(options.react_jsx_pascal_case_allow_leading_underscore);
     try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("bar"));
     try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("Legacy_widget"));
     try std.testing.expect(!options.react_jsx_pascal_case_ignore.contains("other"));

--- a/src/rules/react_jsx_pascal_case.zig
+++ b/src/rules/react_jsx_pascal_case.zig
@@ -9,6 +9,7 @@ pub const id = "react/jsx-pascal-case";
 
 pub const Options = struct {
     allow_all_caps: bool = true,
+    allow_leading_underscore: bool = false,
     ignore: core.ReactJsxPascalCaseIgnoreNames = .{},
 };
 
@@ -64,7 +65,8 @@ fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Op
             const name = tree.string(identifier.name);
             if (name.len == 1) return null;
             if (options.ignore.contains(name)) return null;
-            return if (isPascalCase(name) or (options.allow_all_caps and isAllCaps(name))) null else name;
+            const check_name = if (options.allow_leading_underscore and std.mem.startsWith(u8, name, "_")) name[1..] else name;
+            return if (isPascalCase(check_name) or (options.allow_all_caps and isAllCaps(check_name))) null else name;
         },
         .jsx_namespaced_name => |name| {
             if (invalidNamePart(tree, name.namespace, options)) |invalid| return invalid;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3168,6 +3168,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_pascal_case) {
             try react_jsx_pascal_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
                 .allow_all_caps = self.options.react_jsx_pascal_case_allow_all_caps,
+                .allow_leading_underscore = self.options.react_jsx_pascal_case_allow_leading_underscore,
                 .ignore = self.options.react_jsx_pascal_case_ignore,
             });
         }

--- a/tests/rules/react_jsx_pascal_case.zig
+++ b/tests/rules/react_jsx_pascal_case.zig
@@ -96,6 +96,36 @@ test "supports configured react/jsx-pascal-case ignore list" {
     try std.testing.expectEqualStrings("Imported JSX component baz must be in PascalCase or SCREAMING_SNAKE_CASE", result.diagnostics[0].message);
 }
 
+test "supports configured react/jsx-pascal-case allowLeadingUnderscore" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowLeadingUnderscore\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-pascal-case", config.value);
+
+    const source =
+        \\const allowedRoot = <_AllowedComponent />;
+        \\const allowedMember = <Foo._Bar />;
+        \\const reportedRoot = <_bad />;
+        \\const reportedMember = <Foo._bad />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
+}
+
 test "can disable react/jsx-pascal-case" {
     const source =
         \\const node = <Foo.bar />;


### PR DESCRIPTION
## Summary
- parse `allowLeadingUnderscore` for `react/jsx-pascal-case` ESLint-style config
- allow leading-underscore JSX component name parts by validating the remaining name
- document the expanded rule option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_pascal_case.zig tests/rules/react_jsx_pascal_case.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`