### PR TITLE
Support jsx-pascal-case namespace option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -234,7 +234,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, and `warnOnSpreadAttributes` configuration |
-| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, and `ignore` configuration |
+| [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, `allowNamespace`, and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1645,6 +1645,7 @@ pub const Options = struct {
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
     react_jsx_pascal_case_allow_leading_underscore: bool = false,
+    react_jsx_pascal_case_allow_namespace: bool = false,
     react_jsx_pascal_case_ignore: ReactJsxPascalCaseIgnoreNames = .{},
     react_jsx_uses_react: bool = true,
     react_jsx_uses_vars: bool = true,
@@ -2252,6 +2253,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
             self.react_jsx_pascal_case_allow_leading_underscore = try reactJsxPascalCaseAllowLeadingUnderscoreFromConfig(value);
+            self.react_jsx_pascal_case_allow_namespace = try reactJsxPascalCaseAllowNamespaceFromConfig(value);
             self.react_jsx_pascal_case_ignore = try reactJsxPascalCaseIgnoreFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/prop-types")) {
@@ -5505,6 +5507,23 @@ pub const Options = struct {
         };
     }
 
+    fn reactJsxPascalCaseAllowNamespaceFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowNamespace") orelse return false) {
+            .bool => |allow_namespace| allow_namespace,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxPascalCaseIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactJsxPascalCaseIgnoreNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6457,7 +6476,7 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_pascal_case_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowAllCaps\":false,\"allowLeadingUnderscore\":true,\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
+        "[\"error\",{\"allowAllCaps\":false,\"allowLeadingUnderscore\":true,\"allowNamespace\":true,\"ignore\":[\"bar\",\"Legacy_widget\"]}]",
         .{},
     );
     defer react_jsx_pascal_case_config.deinit();
@@ -6465,6 +6484,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_pascal_case);
     try std.testing.expect(!options.react_jsx_pascal_case_allow_all_caps);
     try std.testing.expect(options.react_jsx_pascal_case_allow_leading_underscore);
+    try std.testing.expect(options.react_jsx_pascal_case_allow_namespace);
     try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("bar"));
     try std.testing.expect(options.react_jsx_pascal_case_ignore.contains("Legacy_widget"));
     try std.testing.expect(!options.react_jsx_pascal_case_ignore.contains("other"));

--- a/src/rules/react_jsx_pascal_case.zig
+++ b/src/rules/react_jsx_pascal_case.zig
@@ -10,6 +10,7 @@ pub const id = "react/jsx-pascal-case";
 pub const Options = struct {
     allow_all_caps: bool = true,
     allow_leading_underscore: bool = false,
+    allow_namespace: bool = false,
     ignore: core.ReactJsxPascalCaseIgnoreNames = .{},
 };
 
@@ -70,10 +71,12 @@ fn invalidNamePart(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Op
         },
         .jsx_namespaced_name => |name| {
             if (invalidNamePart(tree, name.namespace, options)) |invalid| return invalid;
+            if (options.allow_namespace) return null;
             return invalidNamePart(tree, name.name, options);
         },
         .jsx_member_expression => |member| {
             if (invalidNamePart(tree, member.object, options)) |invalid| return invalid;
+            if (options.allow_namespace) return null;
             return invalidNamePart(tree, member.property, options);
         },
         else => return null,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3169,6 +3169,7 @@ const BasicVisitor = struct {
             try react_jsx_pascal_case.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
                 .allow_all_caps = self.options.react_jsx_pascal_case_allow_all_caps,
                 .allow_leading_underscore = self.options.react_jsx_pascal_case_allow_leading_underscore,
+                .allow_namespace = self.options.react_jsx_pascal_case_allow_namespace,
                 .ignore = self.options.react_jsx_pascal_case_ignore,
             });
         }

--- a/tests/rules/react_jsx_pascal_case.zig
+++ b/tests/rules/react_jsx_pascal_case.zig
@@ -126,6 +126,36 @@ test "supports configured react/jsx-pascal-case allowLeadingUnderscore" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
 }
 
+test "supports configured react/jsx-pascal-case allowNamespace" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowNamespace\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/jsx-pascal-case", config.value);
+
+    const source =
+        \\const allowedMember = <Foo.bar />;
+        \\const allowedNestedMember = <Foo.bar.baz />;
+        \\const reportedRoot = <Foo_bar.baz />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_pascal_case.id));
+    try std.testing.expectEqualStrings("Imported JSX component Foo_bar must be in PascalCase or SCREAMING_SNAKE_CASE", result.diagnostics[0].message);
+}
+
 test "can disable react/jsx-pascal-case" {
     const source =
         \\const node = <Foo.bar />;


### PR DESCRIPTION
## Summary
- parse `allowNamespace` for `react/jsx-pascal-case` ESLint-style config
- skip validation of JSX member/namespace suffixes once the namespace prefix is valid
- document the expanded rule option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/react_jsx_pascal_case.zig tests/rules/react_jsx_pascal_case.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`