### PR TITLE
Support no-duplicate-imports includeExports

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -55,7 +55,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-dupe-else-if`](https://eslint.org/docs/latest/rules/no-dupe-else-if) | Implemented |
 | [`no-dupe-keys`](https://eslint.org/docs/latest/rules/no-dupe-keys) | Implemented |
 | [`no-duplicate-case`](https://eslint.org/docs/latest/rules/no-duplicate-case) | Implemented |
-| [`no-duplicate-imports`](https://eslint.org/docs/latest/rules/no-duplicate-imports) | Supports `allowSeparateTypeImports` configuration |
+| [`no-duplicate-imports`](https://eslint.org/docs/latest/rules/no-duplicate-imports) | Supports `allowSeparateTypeImports` and `includeExports` configuration |
 | [`no-else-return`](https://eslint.org/docs/latest/rules/no-else-return) | Implemented |
 | [`no-empty`](https://eslint.org/docs/latest/rules/no-empty) | Implemented with optional `allowEmptyCatch` behavior |
 | [`no-empty-block-statements`](https://eslint.org/docs/latest/rules/no-empty-block-statements) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1316,6 +1316,7 @@ pub const Options = struct {
     no_dupe_keys: bool = true,
     no_duplicate_imports: bool = true,
     no_duplicate_imports_allow_separate_type_imports: bool = false,
+    no_duplicate_imports_include_exports: bool = false,
     no_delete_var: bool = true,
     no_div_regex: bool = true,
     no_empty: bool = true,
@@ -1990,6 +1991,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-duplicate-imports")) {
             self.no_duplicate_imports_allow_separate_type_imports = try noDuplicateImportsBoolOptionFromConfig(value, "allowSeparateTypeImports", false);
+            self.no_duplicate_imports_include_exports = try noDuplicateImportsBoolOptionFromConfig(value, "includeExports", false);
         }
         if (std.mem.eql(u8, cli_name, "no-cond-assign")) {
             self.no_cond_assign_style = try noCondAssignStyleFromConfig(value);
@@ -6846,13 +6848,14 @@ test "Options can apply ESLint-style rule config values" {
     var no_duplicate_imports_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowSeparateTypeImports\":true}]",
+        "[\"error\",{\"allowSeparateTypeImports\":true,\"includeExports\":true}]",
         .{},
     );
     defer no_duplicate_imports_config.deinit();
     try options.setByRuleConfigValue("no-duplicate-imports", no_duplicate_imports_config.value);
     try std.testing.expect(options.no_duplicate_imports);
     try std.testing.expect(options.no_duplicate_imports_allow_separate_type_imports);
+    try std.testing.expect(options.no_duplicate_imports_include_exports);
 
     var no_multi_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/no_duplicate_imports.zig
+++ b/src/rules/no_duplicate_imports.zig
@@ -9,6 +9,7 @@ pub const id = "no-duplicate-imports";
 
 pub const Options = struct {
     allow_separate_type_imports: bool = false,
+    include_exports: bool = false,
 };
 
 const ImportKind = enum {
@@ -44,13 +45,23 @@ pub fn checkWithOptions(
 
     for (tree.extra(program.body)) |statement_index| {
         const declaration = switch (tree.data(statement_index)) {
-            .import_declaration => |declaration| declaration,
+            .import_declaration => |declaration| ImportOrExportDeclaration{
+                .source = importSource(tree, declaration) orelse continue,
+                .kind = importKind(tree, declaration),
+                .import_kind = declaration.import_kind,
+            },
+            .export_named_declaration => |declaration| blk: {
+                if (!options.include_exports) continue;
+                break :blk ImportOrExportDeclaration{
+                    .source = exportNamedSource(tree, declaration) orelse continue,
+                    .kind = .named_only,
+                    .import_kind = declaration.export_kind,
+                };
+            },
             else => continue,
         };
-        const source = importSource(tree, declaration) orelse continue;
-        const kind = importKind(tree, declaration);
 
-        if (hasDuplicate(seen.items, source, kind, declaration.import_kind, options)) {
+        if (hasDuplicate(seen.items, declaration.source, declaration.kind, declaration.import_kind, options)) {
             try core.addDiagnosticFmt(
                 allocator,
                 diagnostics,
@@ -58,18 +69,24 @@ pub fn checkWithOptions(
                 id,
                 tree.span(statement_index),
                 "Duplicate import from \"{s}\".",
-                .{source},
+                .{declaration.source},
             );
             continue;
         }
 
         try seen.append(allocator, .{
-            .source = source,
-            .kind = kind,
+            .source = declaration.source,
+            .kind = declaration.kind,
             .import_kind = declaration.import_kind,
         });
     }
 }
+
+const ImportOrExportDeclaration = struct {
+    source: []const u8,
+    kind: ImportKind,
+    import_kind: ast.ImportOrExportKind,
+};
 
 fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]const u8 {
     return switch (tree.data(declaration.source)) {
@@ -87,6 +104,14 @@ fn importKind(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ImportK
         if (tree.data(specifier) != .import_specifier) return .other;
     }
     return .named_only;
+}
+
+fn exportNamedSource(tree: *const ast.Tree, declaration: ast.ExportNamedDeclaration) ?[]const u8 {
+    if (declaration.source == .null) return null;
+    return switch (tree.data(declaration.source)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
 }
 
 fn hasDuplicate(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1218,6 +1218,7 @@ const BasicVisitor = struct {
         if (self.options.no_duplicate_imports and !self.options.import_no_duplicates) {
             try no_duplicate_imports.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, program, .{
                 .allow_separate_type_imports = self.options.no_duplicate_imports_allow_separate_type_imports,
+                .include_exports = self.options.no_duplicate_imports_include_exports,
             });
         }
         if (self.options.typescript_eslint_adjacent_overload_signatures) {

--- a/tests/rules/no_duplicate_imports.zig
+++ b/tests/rules/no_duplicate_imports.zig
@@ -127,6 +127,56 @@ test "supports configured no-duplicate-imports allowSeparateTypeImports" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
 }
 
+test "ignores re-exports by default" {
+    const source =
+        \\import { foo } from "alpha";
+        \\export { bar } from "alpha";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .import_no_duplicates = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_duplicate_imports.id));
+}
+
+test "supports configured no-duplicate-imports includeExports" {
+    const source =
+        \\import { foo } from "alpha";
+        \\export { bar } from "alpha";
+        \\export { baz } from "beta";
+        \\export { qux } from "beta";
+        \\export * from "gamma";
+        \\export * as gamma from "gamma";
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"includeExports\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .import_no_duplicates = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-duplicate-imports", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_duplicate_imports.id));
+}
+
 test "can disable no-duplicate-imports" {
     const source =
         \\import foo from "alpha";


### PR DESCRIPTION
## Summary
- parse `includeExports` for `no-duplicate-imports` ESLint-style config
- include named re-exports in duplicate source checks when enabled
- keep re-exports ignored by default and leave star re-exports outside the duplicate import check

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/no_duplicate_imports.zig tests/rules/no_duplicate_imports.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`