### PR TITLE
Support func-name-matching CommonJS option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -19,7 +19,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
-| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Implemented for `always` and optional `never` behavior |
+| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, and `includeCommonJSModuleExports` configuration |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Supports `always`, `as-needed`, `never`, and `generators` configuration |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1254,6 +1254,7 @@ pub const Options = struct {
     for_direction: bool = true,
     func_name_matching: bool = true,
     func_name_matching_style: FuncNameMatchingStyle = .always,
+    func_name_matching_include_commonjs_module_exports: bool = false,
     func_names: bool = true,
     func_names_style: FuncNamesStyle = .always,
     func_names_has_generator_style: bool = false,
@@ -1939,6 +1940,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
+            self.func_name_matching_include_commonjs_module_exports = try funcNameMatchingIncludeCommonJSModuleExportsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "func-names")) {
             self.func_names_style = try funcNamesStyleFromConfig(value);
@@ -2756,11 +2758,34 @@ pub const Options = struct {
 
         const style = switch (items[1]) {
             .string => |style| style,
+            .object => return .always,
             else => return error.UnsupportedRuleConfigValue,
         };
         if (std.mem.eql(u8, style, "always")) return .always;
         if (std.mem.eql(u8, style, "never")) return .never;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn funcNameMatchingIncludeCommonJSModuleExportsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config_value = switch (items[1]) {
+            .object => items[1],
+            .string => if (items.len >= 3) items[2] else return false,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const config = switch (config_value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("includeCommonJSModuleExports") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn funcNamesStyleFromConfig(value: std.json.Value) RuleConfigError!FuncNamesStyle {
@@ -6744,13 +6769,14 @@ test "Options can apply ESLint-style rule config values" {
     var func_name_matching_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\"]",
+        "[\"error\",\"never\",{\"includeCommonJSModuleExports\":true}]",
         .{},
     );
     defer func_name_matching_config.deinit();
     try options.setByRuleConfigValue("func-name-matching", func_name_matching_config.value);
     try std.testing.expect(options.func_name_matching);
     try std.testing.expectEqual(FuncNameMatchingStyle.never, options.func_name_matching_style);
+    try std.testing.expect(options.func_name_matching_include_commonjs_module_exports);
 
     var func_names_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -14,6 +14,7 @@ pub const Style = enum {
 
 pub const Options = struct {
     style: Style = .always,
+    include_commonjs_module_exports: bool = false,
 };
 
 pub fn checkVariableDeclarator(
@@ -62,7 +63,7 @@ pub fn checkAssignmentExpressionWithOptions(
 ) Allocator.Error!void {
     if (expression.operator != .assign) return;
 
-    const target = assignmentTargetName(tree, expression.left) orelse return;
+    const target = assignmentTargetName(tree, expression.left, options) orelse return;
     try checkFunctionName(allocator, diagnostics, tree, expression.right, target, options);
 }
 
@@ -156,18 +157,18 @@ fn checkFunctionName(
     }
 }
 
-fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) ?[]const u8 {
     if (index == .null) return null;
 
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .identifier_reference => |identifier| tree.string(identifier.name),
-        .member_expression => |member| memberTargetName(tree, member),
+        .member_expression => |member| memberTargetName(tree, member, options),
         else => null,
     };
 }
 
-fn memberTargetName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
-    if (isModuleExportsTarget(tree, member)) return null;
+fn memberTargetName(tree: *const ast.Tree, member: ast.MemberExpression, options: Options) ?[]const u8 {
+    if (isModuleExportsTarget(tree, member) and !options.include_commonjs_module_exports) return null;
     return propertyName(tree, member.property, member.computed);
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -351,6 +351,13 @@ fn funcNameMatchingStyle(style: core.FuncNameMatchingStyle) func_name_matching.S
     };
 }
 
+fn funcNameMatchingOptions(options: *const core.Options) func_name_matching.Options {
+    return .{
+        .style = funcNameMatchingStyle(options.func_name_matching_style),
+        .include_commonjs_module_exports = options.func_name_matching_include_commonjs_module_exports,
+    };
+}
+
 fn reactPreferEs6ClassStyle(style: core.ReactPreferEs6ClassStyle) react_prefer_es6_class.Style {
     return switch (style) {
         .always => .always,
@@ -1675,9 +1682,7 @@ const BasicVisitor = struct {
             try no_multi_assign.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, .{
-                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
-            });
+            try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, funcNameMatchingOptions(&self.options));
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
@@ -2515,9 +2520,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
-                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
-            });
+            try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, funcNameMatchingOptions(&self.options));
         }
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
@@ -3273,9 +3276,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
-                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
-            });
+            try func_name_matching.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, funcNameMatchingOptions(&self.options));
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
@@ -3476,9 +3477,7 @@ const BasicVisitor = struct {
             );
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
-                .style = funcNameMatchingStyle(self.options.func_name_matching_style),
-            });
+            try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, funcNameMatchingOptions(&self.options));
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -118,6 +118,51 @@ test "reports func-name-matching for matching names in never mode" {
     );
 }
 
+test "supports configured func-name-matching includeCommonJSModuleExports" {
+    const source =
+        \\module.exports = function exported() {};
+        \\module["exports"] = function computedExported() {};
+        \\exports.value = function exportedValue() {};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.func_name_matching.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"includeCommonJSModuleExports\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("func-name-matching", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.func_name_matching.id));
+    try std.testing.expectEqualStrings(
+        "Function name `exported` should match target name `exports`.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable func-name-matching" {
     const source =
         \\const first = function second() {};


### PR DESCRIPTION
## Summary
- parse `includeCommonJSModuleExports` for `func-name-matching` ESLint-style config
- check direct `module.exports` assignments when that option is enabled
- document the expanded rule option support

## Validation
- `zig fmt --check src/core.zig src/rules/root.zig src/rules/func_name_matching.zig tests/rules/func_name_matching.zig`
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`