### PR TITLE
Support func-name-matching property descriptors

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -19,7 +19,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
-| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, and `includeCommonJSModuleExports` configuration |
+| [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, `includeCommonJSModuleExports`, and `considerPropertyDescriptor` configuration |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Supports `always`, `as-needed`, `never`, and `generators` configuration |
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1255,6 +1255,7 @@ pub const Options = struct {
     func_name_matching: bool = true,
     func_name_matching_style: FuncNameMatchingStyle = .always,
     func_name_matching_include_commonjs_module_exports: bool = false,
+    func_name_matching_consider_property_descriptor: bool = false,
     func_names: bool = true,
     func_names_style: FuncNamesStyle = .always,
     func_names_has_generator_style: bool = false,
@@ -1940,7 +1941,8 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
-            self.func_name_matching_include_commonjs_module_exports = try funcNameMatchingIncludeCommonJSModuleExportsFromConfig(value);
+            self.func_name_matching_include_commonjs_module_exports = try funcNameMatchingBoolOptionFromConfig(value, "includeCommonJSModuleExports");
+            self.func_name_matching_consider_property_descriptor = try funcNameMatchingBoolOptionFromConfig(value, "considerPropertyDescriptor");
         }
         if (std.mem.eql(u8, cli_name, "func-names")) {
             self.func_names_style = try funcNamesStyleFromConfig(value);
@@ -2766,7 +2768,7 @@ pub const Options = struct {
         return error.UnsupportedRuleConfigValue;
     }
 
-    fn funcNameMatchingIncludeCommonJSModuleExportsFromConfig(value: std.json.Value) RuleConfigError!bool {
+    fn funcNameMatchingBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return false,
@@ -2782,7 +2784,7 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("includeCommonJSModuleExports") orelse return false) {
+        return switch (config.get(key) orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6769,7 +6771,7 @@ test "Options can apply ESLint-style rule config values" {
     var func_name_matching_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",\"never\",{\"includeCommonJSModuleExports\":true}]",
+        "[\"error\",\"never\",{\"includeCommonJSModuleExports\":true,\"considerPropertyDescriptor\":true}]",
         .{},
     );
     defer func_name_matching_config.deinit();
@@ -6777,6 +6779,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.func_name_matching);
     try std.testing.expectEqual(FuncNameMatchingStyle.never, options.func_name_matching_style);
     try std.testing.expect(options.func_name_matching_include_commonjs_module_exports);
+    try std.testing.expect(options.func_name_matching_consider_property_descriptor);
 
     var func_names_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/func_name_matching.zig
+++ b/src/rules/func_name_matching.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "func-name-matching";
@@ -15,6 +16,7 @@ pub const Style = enum {
 pub const Options = struct {
     style: Style = .always,
     include_commonjs_module_exports: bool = false,
+    consider_property_descriptor: bool = false,
 };
 
 pub fn checkVariableDeclarator(
@@ -67,6 +69,33 @@ pub fn checkAssignmentExpressionWithOptions(
     try checkFunctionName(allocator, diagnostics, tree, expression.right, target, options);
 }
 
+pub fn checkCallExpressionWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.consider_property_descriptor) return;
+
+    const arguments = tree.extra(call.arguments);
+    if (isStaticMemberCall(tree, call.callee, "Object", "defineProperty") or
+        isStaticMemberCall(tree, call.callee, "Reflect", "defineProperty"))
+    {
+        if (arguments.len < 3) return;
+        const target = propertyNameFromArgument(tree, arguments[1]) orelse return;
+        try checkPropertyDescriptor(allocator, diagnostics, tree, arguments[2], target, options);
+        return;
+    }
+
+    if (isStaticMemberCall(tree, call.callee, "Object", "defineProperties") or
+        isStaticMemberCall(tree, call.callee, "Object", "create"))
+    {
+        if (arguments.len < 2) return;
+        try checkNestedPropertyDescriptors(allocator, diagnostics, tree, arguments[1], options);
+    }
+}
+
 pub fn checkObjectProperty(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
@@ -90,6 +119,19 @@ pub fn checkObjectPropertyWithOptions(
 
     const target = propertyName(tree, property.key, property.computed) orelse return;
     try checkFunctionName(allocator, diagnostics, tree, property.value, target, options);
+}
+
+pub fn checkObjectPropertyWithContextOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (isPropertyDescriptorValueProperty(tree, property, index, ctx)) return;
+    try checkObjectPropertyWithOptions(allocator, diagnostics, tree, property, options);
 }
 
 pub fn checkPropertyDefinition(
@@ -157,6 +199,53 @@ fn checkFunctionName(
     }
 }
 
+fn checkNestedPropertyDescriptors(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    descriptors_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    const descriptors = switch (tree.data(descriptors_index)) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(descriptors.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        if (property.value == .null) continue;
+
+        const target = propertyName(tree, property.key, property.computed) orelse continue;
+        try checkPropertyDescriptor(allocator, diagnostics, tree, property.value, target, options);
+    }
+}
+
+fn checkPropertyDescriptor(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    descriptor_index: ast.NodeIndex,
+    target: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    const descriptor = switch (tree.data(descriptor_index)) {
+        .object_expression => |object| object,
+        else => return,
+    };
+
+    for (tree.extra(descriptor.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => continue,
+        };
+        if (property.value == .null or !propertyKeyEquals(tree, property, "value")) continue;
+        try checkFunctionName(allocator, diagnostics, tree, property.value, target, options);
+    }
+}
+
 fn assignmentTargetName(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) ?[]const u8 {
     if (index == .null) return null;
 
@@ -191,6 +280,117 @@ fn propertyName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?[]co
         .identifier_name => |identifier| tree.string(identifier.name),
         .string_literal => |literal| tree.string(literal.value),
         .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn propertyNameFromArgument(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn propertyKeyEquals(tree: *const ast.Tree, property: ast.ObjectProperty, name: []const u8) bool {
+    if (property.computed) return false;
+    if (property.key == .null) return false;
+
+    return switch (tree.data(property.key)) {
+        .identifier_name => |identifier| std.mem.eql(u8, tree.string(identifier.name), name),
+        .string_literal => |literal| std.mem.eql(u8, tree.string(literal.value), name),
+        else => false,
+    };
+}
+
+fn isPropertyDescriptorValueProperty(
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+) bool {
+    if (index == .null or property.value == .null or !propertyKeyEquals(tree, property, "value")) return false;
+
+    const descriptor_object = ctx.path.ancestor(1) orelse return false;
+    return isDefinePropertyDescriptorObject(tree, ctx, descriptor_object) or
+        isNestedPropertyDescriptorObject(tree, ctx, descriptor_object);
+}
+
+fn isDefinePropertyDescriptorObject(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    descriptor_object: ast.NodeIndex,
+) bool {
+    const call_index = ctx.path.ancestor(2) orelse return false;
+    const call = switch (tree.data(call_index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 3 or arguments[2] != descriptor_object) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "defineProperty") or
+        isStaticMemberCall(tree, call.callee, "Reflect", "defineProperty");
+}
+
+fn isNestedPropertyDescriptorObject(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    descriptor_object: ast.NodeIndex,
+) bool {
+    const property_index = ctx.path.ancestor(2) orelse return false;
+    const property = switch (tree.data(property_index)) {
+        .object_property => |property| property,
+        else => return false,
+    };
+    if (property.value != descriptor_object) return false;
+
+    const descriptors_object = ctx.path.ancestor(3) orelse return false;
+    const call_index = ctx.path.ancestor(4) orelse return false;
+    const call = switch (tree.data(call_index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2 or arguments[1] != descriptors_object) return false;
+    return isStaticMemberCall(tree, call.callee, "Object", "defineProperties") or
+        isStaticMemberCall(tree, call.callee, "Object", "create");
+}
+
+fn isStaticMemberCall(tree: *const ast.Tree, callee: ast.NodeIndex, object_name: []const u8, property_name: []const u8) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = staticMemberPropertyName(tree, member) orelse return false;
+    return isIdentifierReferenceNamed(tree, member.object, object_name) and
+        std.mem.eql(u8, property, property_name);
+}
+
+fn staticMemberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -355,6 +355,7 @@ fn funcNameMatchingOptions(options: *const core.Options) func_name_matching.Opti
     return .{
         .style = funcNameMatchingStyle(options.func_name_matching_style),
         .include_commonjs_module_exports = options.func_name_matching_include_commonjs_module_exports,
+        .consider_property_descriptor = options.func_name_matching_consider_property_descriptor,
     };
 }
 
@@ -2741,6 +2742,9 @@ const BasicVisitor = struct {
                 .set_without_get = self.options.accessor_pairs_set_without_get == .yes,
             });
         }
+        if (self.options.func_name_matching) {
+            try func_name_matching.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, funcNameMatchingOptions(&self.options));
+        }
         if (self.options.import_no_amd) {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
@@ -3276,7 +3280,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkObjectPropertyWithContextOptions(self.allocator, self.diagnostics, ctx.tree, property, index, ctx, funcNameMatchingOptions(&self.options));
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{

--- a/tests/rules/func_name_matching.zig
+++ b/tests/rules/func_name_matching.zig
@@ -163,6 +163,59 @@ test "supports configured func-name-matching includeCommonJSModuleExports" {
     );
 }
 
+test "supports configured func-name-matching considerPropertyDescriptor" {
+    const source =
+        \\Object.defineProperty(target, "defined", { value: function otherDefined() {} });
+        \\Reflect.defineProperty(target, "reflected", { value: function otherReflected() {} });
+        \\Object.defineProperties(target, {
+        \\  nested: { value: function otherNested() {} },
+        \\});
+        \\Object.create(proto, {
+        \\  created: { value: function otherCreated() {} },
+        \\});
+        \\const ordinary = { value: function otherValue() {} };
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.func_name_matching.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"considerPropertyDescriptor\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .func_names = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("func-name-matching", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.func_name_matching.id));
+    try std.testing.expectEqualStrings(
+        "Function name `otherDefined` should match target name `defined`.",
+        result.diagnostics[0].message,
+    );
+}
+
 test "can disable func-name-matching" {
     const source =
         \\const first = function second() {};


### PR DESCRIPTION
## Summary
- add func-name-matching support for considerPropertyDescriptor
- check Object.defineProperty, Reflect.defineProperty, Object.defineProperties, and Object.create descriptors when configured
- avoid treating descriptor value fields as ordinary object-property targets

## Validation
- zig fmt src/core.zig src/rules/root.zig src/rules/func_name_matching.zig tests/rules/func_name_matching.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check