### PR TITLE
Support getter-return allowImplicit

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -21,7 +21,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, `includeCommonJSModuleExports`, and `considerPropertyDescriptor` configuration |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Supports `always`, `as-needed`, `never`, and `generators` configuration |
-| [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Implemented |
+| [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Supports optional `allowImplicit` behavior |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1261,6 +1261,7 @@ pub const Options = struct {
     func_names_has_generator_style: bool = false,
     func_names_generator_style: FuncNamesStyle = .always,
     getter_return: bool = true,
+    getter_return_allow_implicit: bool = false,
     grouped_accessor_pairs: bool = true,
     grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,
     guard_for_in: bool = true,
@@ -1949,6 +1950,9 @@ pub const Options = struct {
             const generator_style = try funcNamesGeneratorStyleFromConfig(value);
             self.func_names_has_generator_style = generator_style != null;
             self.func_names_generator_style = generator_style orelse self.func_names_style;
+        }
+        if (std.mem.eql(u8, cli_name, "getter-return")) {
+            self.getter_return_allow_implicit = try getterReturnAllowImplicitFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "grouped-accessor-pairs")) {
             self.grouped_accessor_pairs_style = try groupedAccessorPairsStyleFromConfig(value);
@@ -2785,6 +2789,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get(key) orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn getterReturnAllowImplicitFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowImplicit") orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6780,6 +6801,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(FuncNameMatchingStyle.never, options.func_name_matching_style);
     try std.testing.expect(options.func_name_matching_include_commonjs_module_exports);
     try std.testing.expect(options.func_name_matching_consider_property_descriptor);
+
+    var getter_return_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowImplicit\":true}]",
+        .{},
+    );
+    defer getter_return_config.deinit();
+    try options.setByRuleConfigValue("getter-return", getter_return_config.value);
+    try std.testing.expect(options.getter_return);
+    try std.testing.expect(options.getter_return_allow_implicit);
 
     var func_names_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/getter_return.zig
+++ b/src/rules/getter_return.zig
@@ -8,6 +8,10 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "getter-return";
 
+pub const Options = struct {
+    allow_implicit: bool = false,
+};
+
 const Completion = enum {
     continues,
     valid_terminal,
@@ -22,8 +26,20 @@ pub fn check(
     index: ast.NodeIndex,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, body, index, ctx, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.FunctionBody,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
     if (!isGetterBody(tree, ctx)) return;
-    if (rangeAlwaysReturnsValue(tree, body.body)) return;
+    if (rangeAlwaysReturnsValue(tree, body.body, options)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -112,13 +128,13 @@ fn isNestedDescriptorObject(
         isStaticMemberCall(tree, call.callee, "Object", "defineProperties");
 }
 
-fn rangeAlwaysReturnsValue(tree: *const ast.Tree, range: ast.IndexRange) bool {
-    return rangeCompletion(tree, range) == .valid_terminal;
+fn rangeAlwaysReturnsValue(tree: *const ast.Tree, range: ast.IndexRange, options: Options) bool {
+    return rangeCompletion(tree, range, options) == .valid_terminal;
 }
 
-fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
+fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange, options: Options) Completion {
     for (tree.extra(range)) |statement| {
-        switch (statementCompletion(tree, statement)) {
+        switch (statementCompletion(tree, statement, options)) {
             .continues => {},
             .valid_terminal => return .valid_terminal,
             .invalid_return => return .invalid_return,
@@ -128,38 +144,38 @@ fn rangeCompletion(tree: *const ast.Tree, range: ast.IndexRange) Completion {
     return .continues;
 }
 
-fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex) Completion {
+fn statementCompletion(tree: *const ast.Tree, index: ast.NodeIndex, options: Options) Completion {
     if (index == .null) return .continues;
 
     return switch (tree.data(index)) {
-        .return_statement => |statement| if (statement.argument != .null) .valid_terminal else .invalid_return,
+        .return_statement => |statement| if (statement.argument != .null or options.allow_implicit) .valid_terminal else .invalid_return,
         .throw_statement => .valid_terminal,
-        .block_statement => |block| rangeCompletion(tree, block.body),
-        .if_statement => |statement| ifCompletion(tree, statement),
-        .try_statement => |statement| tryCompletion(tree, statement),
+        .block_statement => |block| rangeCompletion(tree, block.body, options),
+        .if_statement => |statement| ifCompletion(tree, statement, options),
+        .try_statement => |statement| tryCompletion(tree, statement, options),
         else => .continues,
     };
 }
 
-fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement) Completion {
-    const consequent = statementCompletion(tree, statement.consequent);
+fn ifCompletion(tree: *const ast.Tree, statement: ast.IfStatement, options: Options) Completion {
+    const consequent = statementCompletion(tree, statement.consequent, options);
     if (consequent == .invalid_return) return .invalid_return;
 
     if (statement.alternate == .null) return .continues;
-    const alternate = statementCompletion(tree, statement.alternate);
+    const alternate = statementCompletion(tree, statement.alternate, options);
     if (alternate == .invalid_return) return .invalid_return;
 
     if (consequent == .valid_terminal and alternate == .valid_terminal) return .valid_terminal;
     return .continues;
 }
 
-fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion {
+fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement, options: Options) Completion {
     if (statement.finalizer != .null) {
-        const finalizer = statementCompletion(tree, statement.finalizer);
+        const finalizer = statementCompletion(tree, statement.finalizer, options);
         if (finalizer != .continues) return finalizer;
     }
 
-    const block = statementCompletion(tree, statement.block);
+    const block = statementCompletion(tree, statement.block, options);
     if (block == .invalid_return) return .invalid_return;
     if (statement.handler == .null) return block;
 
@@ -167,7 +183,7 @@ fn tryCompletion(tree: *const ast.Tree, statement: ast.TryStatement) Completion 
         .catch_clause => |handler| handler.body,
         else => return .continues,
     };
-    const handler = statementCompletion(tree, handler_node);
+    const handler = statementCompletion(tree, handler_node, options);
     if (handler == .invalid_return) return .invalid_return;
 
     if (block == .valid_terminal and handler == .valid_terminal) return .valid_terminal;

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2266,7 +2266,9 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.getter_return) {
-            try getter_return.check(self.allocator, self.diagnostics, ctx.tree, body, index, ctx);
+            try getter_return.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, body, index, ctx, .{
+                .allow_implicit = self.options.getter_return_allow_implicit,
+            });
         }
         if (self.options.no_unreachable) {
             try no_unreachable.checkRange(self.allocator, self.diagnostics, ctx.tree, body.body);

--- a/tests/rules/getter_return.zig
+++ b/tests/rules/getter_return.zig
@@ -154,6 +154,48 @@ test "does not report getter-return when all getter paths return or throw" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.getter_return.id));
 }
 
+test "supports configured getter-return allowImplicit" {
+    const source =
+        \\class Example {
+        \\  get bare() {
+        \\    return;
+        \\  }
+        \\  get partial() {
+        \\    if (ready) {
+        \\      return;
+        \\    }
+        \\  }
+        \\  get missing() {}
+        \\}
+        \\Object.defineProperty(target, "x", {
+        \\  get: function () {
+        \\    return;
+        \\  }
+        \\});
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowImplicit\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("getter-return", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.getter_return.id));
+}
+
 test "can disable getter-return" {
     const source =
         \\class Example {


### PR DESCRIPTION
## Summary
- add getter-return support for the allowImplicit option
- treat bare return statements as valid getter returns only when configured
- add config parsing, rule coverage, and rule-status documentation

## Validation
- zig fmt src/core.zig src/rules/root.zig src/rules/getter_return.zig tests/rules/getter_return.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check