### PR TITLE
Support curly multi-or-nest

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -11,7 +11,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
-| [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, and `multi` configuration |
+| [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, `multi`, and `multi-or-nest` configuration |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -26,6 +26,7 @@ pub const CurlyStyle = enum {
     all,
     multi_line,
     multi,
+    multi_or_nest,
 };
 
 pub const ObjectShorthandStyle = enum {
@@ -2487,6 +2488,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "all")) return .all;
         if (std.mem.eql(u8, style, "multi-line")) return .multi_line;
         if (std.mem.eql(u8, style, "multi")) return .multi;
+        if (std.mem.eql(u8, style, "multi-or-nest")) return .multi_or_nest;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -6723,6 +6725,16 @@ test "Options can apply ESLint-style rule config values" {
     defer curly_multi_config.deinit();
     try options.setByRuleConfigValue("curly", curly_multi_config.value);
     try std.testing.expectEqual(CurlyStyle.multi, options.curly_style);
+
+    var curly_multi_or_nest_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-or-nest\"]",
+        .{},
+    );
+    defer curly_multi_or_nest_config.deinit();
+    try options.setByRuleConfigValue("curly", curly_multi_or_nest_config.value);
+    try std.testing.expectEqual(CurlyStyle.multi_or_nest, options.curly_style);
 
     var eqeqeq_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/curly.zig
+++ b/src/rules/curly.zig
@@ -54,8 +54,8 @@ pub fn checkBodyWithOptions(
     if (body == .null) return;
     switch (tree.data(body)) {
         .block_statement => |block| {
-            if (options.style != .multi) return;
-            if (!isUnnecessaryMultiBlock(tree, block)) return;
+            if (options.style != .multi and options.style != .multi_or_nest) return;
+            if (!isUnnecessaryBlock(tree, block, options.style)) return;
 
             try core.addDiagnostic(
                 allocator,
@@ -70,8 +70,14 @@ pub fn checkBodyWithOptions(
         else => {},
     }
 
-    if (options.style == .multi_line or options.style == .multi) {
-        if (!isMultiLineBody(tree, body)) return;
+    switch (options.style) {
+        .all => {},
+        .multi_line, .multi => {
+            if (!isMultiLineBody(tree, body)) return;
+        },
+        .multi_or_nest => {
+            if (!isMultiLineBody(tree, body) and !isControlStatement(tree, body)) return;
+        },
     }
 
     try addExpectedBlockDiagnostic(
@@ -98,10 +104,25 @@ fn addExpectedBlockDiagnostic(
     );
 }
 
-fn isUnnecessaryMultiBlock(tree: *const ast.Tree, block: ast.BlockStatement) bool {
+fn isUnnecessaryBlock(tree: *const ast.Tree, block: ast.BlockStatement, style: core.CurlyStyle) bool {
     if (block.body.len != 1) return false;
     const statements = tree.extra(block.body);
+    if (style == .multi_or_nest and isControlStatement(tree, statements[0])) return false;
     return !hasBlockScopedDeclaration(tree, statements[0]);
+}
+
+fn isControlStatement(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .if_statement,
+        .while_statement,
+        .do_while_statement,
+        .for_statement,
+        .for_in_statement,
+        .for_of_statement,
+        => true,
+        else => false,
+    };
 }
 
 fn hasBlockScopedDeclaration(tree: *const ast.Tree, statement: ast.NodeIndex) bool {

--- a/tests/rules/curly.zig
+++ b/tests/rules/curly.zig
@@ -124,6 +124,41 @@ test "supports configured curly multi style" {
     try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.curly.id));
 }
 
+test "supports configured curly multi-or-nest style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-or-nest\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_for_in = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (ready) run();
+        \\if (ready)
+        \\  run();
+        \\if (ready) if (nested) run();
+        \\while (ready) for (let i = 0; i < 3; i++) run();
+        \\if (ready) { run(); }
+        \\if (ready) { if (nested) run(); }
+        \\if (ready) { let scoped = value; }
+        \\while (ready) { run(); step(); }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.curly.id));
+}
+
 test "can disable curly" {
     const source =
         \\if (ready) run();


### PR DESCRIPTION
## Summary
- add curly support for the multi-or-nest mode
- require blocks for multiline or nested-control bodies in that mode
- keep single nested-control blocks while reporting unnecessary simple single-statement blocks

## Validation
- zig fmt src/core.zig src/rules/curly.zig tests/rules/curly.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check