### PR TITLE
Support newline-after-import comments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -197,7 +197,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/first`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md) | Implemented |
 | [`import/named`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
-| [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count` and `exactCount` configurations |
+| [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count`, `exactCount`, and `considerComments` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1401,6 +1401,7 @@ pub const Options = struct {
     import_newline_after_import: bool = true,
     import_newline_after_import_count: usize = 1,
     import_newline_after_import_exact_count: bool = false,
+    import_newline_after_import_consider_comments: bool = false,
     import_no_amd: bool = true,
     import_no_cycle: bool = true,
     import_no_duplicates: bool = true,
@@ -1975,6 +1976,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "import/newline-after-import")) {
             self.import_newline_after_import_count = try importNewlineAfterImportCountFromConfig(value);
             self.import_newline_after_import_exact_count = try importNewlineAfterImportExactCountFromConfig(value);
+            self.import_newline_after_import_consider_comments = try importNewlineAfterImportConsiderCommentsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "new-cap")) {
             self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
@@ -3680,6 +3682,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("exactCount") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn importNewlineAfterImportConsiderCommentsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("considerComments") orelse return false) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };

--- a/src/rules/import_newline_after_import.zig
+++ b/src/rules/import_newline_after_import.zig
@@ -13,6 +13,7 @@ pub fn check(
     program: ast.Program,
     count: usize,
     exact_count: bool,
+    consider_comments: bool,
 ) Allocator.Error!void {
     const body = tree.extra(program.body);
     for (body, 0..) |statement_index, i| {
@@ -23,7 +24,7 @@ pub fn check(
         if (tree.data(next_index) == .import_declaration) continue;
 
         const import_end = offsetToLine(tree.source, tree.span(statement_index).end);
-        const next_start = offsetToLine(tree.source, tree.span(next_index).start);
+        const next_start = nextLine(tree, statement_index, next_index, consider_comments);
         const blank_lines = if (next_start > import_end) next_start - import_end - 1 else 0;
         if (exact_count) {
             if (blank_lines == count) continue;
@@ -39,6 +40,25 @@ pub fn check(
             .{ count, if (count == 1) "" else "s" },
         );
     }
+}
+
+fn nextLine(tree: *const ast.Tree, import_index: ast.NodeIndex, next_index: ast.NodeIndex, consider_comments: bool) usize {
+    const next_start = tree.span(next_index).start;
+    if (consider_comments) {
+        const import_end = tree.span(import_index).end;
+        var first_comment_start: ?u32 = null;
+
+        for (tree.comments) |comment| {
+            if (comment.start < import_end or comment.start >= next_start) continue;
+            if (first_comment_start == null or comment.start < first_comment_start.?) {
+                first_comment_start = comment.start;
+            }
+        }
+
+        if (first_comment_start) |start| return offsetToLine(tree.source, start);
+    }
+
+    return offsetToLine(tree.source, next_start);
 }
 
 fn offsetToLine(source: []const u8, offset: u32) usize {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1179,6 +1179,7 @@ const BasicVisitor = struct {
                 program,
                 self.options.import_newline_after_import_count,
                 self.options.import_newline_after_import_exact_count,
+                self.options.import_newline_after_import_consider_comments,
             );
         }
         if (self.options.import_no_duplicates) {

--- a/tests/rules/import_newline_after_import.zig
+++ b/tests/rules/import_newline_after_import.zig
@@ -99,11 +99,64 @@ test "reports import/newline-after-import when exactCount rejects extra blank li
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_newline_after_import.id));
 }
 
+test "supports configured import/newline-after-import considerComments" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"considerComments": true}]
+    ,
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("import/newline-after-import", config.value);
+
+    const source =
+        \\import first from "./first";
+        \\// comment is considered adjacent to the import
+        \\const firstValue = first;
+        \\
+        \\import second from "./second";
+        \\
+        \\// comment has a blank line after the import
+        \\const secondValue = second;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_newline_after_import.id));
+}
+
+test "ignores comments after import by default" {
+    const source =
+        \\import thing from "./thing";
+        \\// comment is ignored by default
+        \\const value = thing;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_newline_after_import.id));
+}
+
 test "supports configured import/newline-after-import count options" {
     var config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        \\["error", {"count": 2, "exactCount": true}]
+        \\["error", {"count": 2, "exactCount": true, "considerComments": true}]
     ,
         .{},
     );
@@ -115,6 +168,7 @@ test "supports configured import/newline-after-import count options" {
     try std.testing.expect(options.import_newline_after_import);
     try std.testing.expectEqual(@as(usize, 2), options.import_newline_after_import_count);
     try std.testing.expect(options.import_newline_after_import_exact_count);
+    try std.testing.expect(options.import_newline_after_import_consider_comments);
 }
 
 test "can disable import/newline-after-import" {


### PR DESCRIPTION
## Summary
- add import/newline-after-import support for considerComments
- include comments between the final import and following statement in spacing checks when configured
- document and test the new configuration path

## Validation
- zig fmt src/core.zig src/rules/root.zig src/rules/import_newline_after_import.zig tests/rules/import_newline_after_import.zig
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check