### PR TITLE
Support jsx filename as-needed mode

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -228,7 +228,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/display-name`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) | Supports `checkContextObjects` and `ignoreTranspilerName` configuration |
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
-| [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` configuration |
+| [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` and `allow` configuration |
 | [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` and `checkFragmentShorthand` configuration |
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -56,6 +56,11 @@ pub const UnicodeBomStyle = enum {
     always,
 };
 
+pub const ReactJsxFilenameExtensionAllow = enum {
+    always,
+    as_needed,
+};
+
 pub const NoCondAssignStyle = enum {
     except_parens,
     always,
@@ -1626,6 +1631,7 @@ pub const Options = struct {
     react_jsx_boolean_value_style: ReactJsxBooleanValueStyle = .never,
     react_jsx_filename_extension: bool = true,
     react_jsx_filename_extension_extensions: ReactJsxFilenameExtensions = .{},
+    react_jsx_filename_extension_allow: ReactJsxFilenameExtensionAllow = .always,
     react_jsx_no_duplicate_props: bool = true,
     react_jsx_no_duplicate_props_ignore_case: bool = true,
     react_jsx_no_comment_textnodes: bool = true,
@@ -2240,6 +2246,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-filename-extension")) {
             self.react_jsx_filename_extension_extensions = try reactJsxFilenameExtensionsFromConfig(value);
+            self.react_jsx_filename_extension_allow = try reactJsxFilenameExtensionAllowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-boolean-value")) {
             self.react_jsx_boolean_value_style = try reactJsxBooleanValueStyleFromConfig(value);
@@ -5315,6 +5322,26 @@ pub const Options = struct {
         return extensions;
     }
 
+    fn reactJsxFilenameExtensionAllowFromConfig(value: std.json.Value) RuleConfigError!ReactJsxFilenameExtensionAllow {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .always,
+        };
+        if (items.len < 2) return .always;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allow") orelse return .always) {
+            .string => |string| string,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, allow, "always")) return .always;
+        if (std.mem.eql(u8, allow, "as-needed")) return .as_needed;
+        return error.UnsupportedRuleConfigValue;
+    }
+
     fn reactJsxBooleanValueStyleFromConfig(value: std.json.Value) RuleConfigError!ReactJsxBooleanValueStyle {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6503,6 +6530,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_filename_extension);
     try std.testing.expectEqual(@as(usize, 1), options.react_jsx_filename_extension_extensions.len());
     try std.testing.expectEqualStrings(".tsx", options.react_jsx_filename_extension_extensions.at(0));
+    try std.testing.expectEqual(ReactJsxFilenameExtensionAllow.always, options.react_jsx_filename_extension_allow);
+
+    var react_jsx_filename_extension_allow_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":\"as-needed\"}]",
+        .{},
+    );
+    defer react_jsx_filename_extension_allow_config.deinit();
+    try options.setByRuleConfigValue("react/jsx-filename-extension", react_jsx_filename_extension_allow_config.value);
+    try std.testing.expect(options.react_jsx_filename_extension);
+    try std.testing.expectEqual(ReactJsxFilenameExtensionAllow.as_needed, options.react_jsx_filename_extension_allow);
 
     var react_jsx_no_bind_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_filename_extension.zig
+++ b/src/rules/react_jsx_filename_extension.zig
@@ -9,10 +9,12 @@ pub const id = "react/jsx-filename-extension";
 
 pub const Options = struct {
     extensions: core.ReactJsxFilenameExtensions = .{},
+    allow: core.ReactJsxFilenameExtensionAllow = .always,
 };
 
 pub const State = struct {
     reported: bool = false,
+    has_jsx: bool = false,
 };
 
 pub fn check(
@@ -24,6 +26,7 @@ pub fn check(
     state: *State,
     options: Options,
 ) Allocator.Error!void {
+    state.has_jsx = true;
     if (state.reported or options.extensions.containsFilePath(file_path)) return;
 
     state.reported = true;
@@ -34,6 +37,30 @@ pub fn check(
         id,
         tree.span(index),
         "JSX not allowed in files with extension '{s}'",
+        .{extension(file_path)},
+    );
+}
+
+pub fn finish(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    index: ast.NodeIndex,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (options.allow != .as_needed or state.reported or state.has_jsx) return;
+    if (!options.extensions.containsFilePath(file_path)) return;
+
+    state.reported = true;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        tree.span(index),
+        "Only files containing JSX may use the extension '{s}'",
         .{extension(file_path)},
     );
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1245,7 +1245,7 @@ const BasicVisitor = struct {
     pub fn exit_program(
         self: *BasicVisitor,
         _: ast.Program,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) void {
         if (self.options.react_display_name) {
@@ -1254,6 +1254,12 @@ const BasicVisitor = struct {
         if (self.options.react_default_props_match_prop_types) {
             react_default_props_match_prop_types.finish(self.allocator, self.diagnostics, ctx.tree, &self.react_default_props_match_prop_types_state, .{
                 .allow_required_defaults = self.options.react_default_props_match_prop_types_allow_required_defaults,
+            }) catch {};
+        }
+        if (self.options.react_jsx_filename_extension) {
+            react_jsx_filename_extension.finish(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
+                .extensions = self.options.react_jsx_filename_extension_extensions,
+                .allow = self.options.react_jsx_filename_extension_allow,
             }) catch {};
         }
     }
@@ -3087,6 +3093,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_filename_extension) {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
                 .extensions = self.options.react_jsx_filename_extension_extensions,
+                .allow = self.options.react_jsx_filename_extension_allow,
             });
         }
         if (self.options.react_button_has_type) {
@@ -3120,6 +3127,7 @@ const BasicVisitor = struct {
         if (self.options.react_jsx_filename_extension) {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
                 .extensions = self.options.react_jsx_filename_extension_extensions,
+                .allow = self.options.react_jsx_filename_extension_allow,
             });
         }
         return .proceed;

--- a/tests/rules/react_jsx_filename_extension.zig
+++ b/tests/rules/react_jsx_filename_extension.zig
@@ -95,6 +95,47 @@ test "supports configured react/jsx-filename-extension extensions" {
     try std.testing.expect(!helpers.hasRule(tsx_result, "parse"));
 }
 
+test "allows configured react/jsx-filename-extension files without JSX by default" {
+    const source =
+        \\const view = null;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+}
+
+test "supports react/jsx-filename-extension as-needed allow mode" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":\"as-needed\",\"extensions\":[\".jsx\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/jsx-filename-extension", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, "const view = null;", "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(hasMessage(result, "Only files containing JSX may use the extension '.jsx'"));
+    try std.testing.expect(!helpers.hasRule(result, "parse"));
+
+    var jsx_result = try lint.lintSource(std.testing.allocator, "const view = <div />;", "fixture.jsx", options);
+    defer jsx_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(jsx_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(jsx_result, "parse"));
+
+    var js_result = try lint.lintSource(std.testing.allocator, "const view = null;", "fixture.js", options);
+    defer js_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(js_result, lint.rules.react_jsx_filename_extension.id));
+    try std.testing.expect(!helpers.hasRule(js_result, "parse"));
+}
+
 test "preserves parser diagnostics when JSX fallback still fails" {
     const source =
         \\const view = <div;


### PR DESCRIPTION
## Summary
- add `allow` config parsing for `react/jsx-filename-extension`
- support `allow: "as-needed"` by reporting allowed extension files that contain no JSX
- cover default `always` behavior and as-needed behavior in rule tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
