### PR TITLE
Support forbid-prop-types context options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -226,7 +226,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) | Supports `button`, `submit`, and `reset` configuration |
 | [`react/default-props-match-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md) | Supports `allowRequiredDefaults` configuration |
 | [`react/display-name`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) | Supports `checkContextObjects` and `ignoreTranspilerName` configuration |
-| [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid` configuration |
+| [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid`, `checkContextTypes`, and `checkChildContextTypes` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` and `allow` configuration |
 | [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` and `checkFragmentShorthand` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1669,6 +1669,8 @@ pub const Options = struct {
     react_forbid_prop_types_forbid_any: bool = true,
     react_forbid_prop_types_forbid_array: bool = true,
     react_forbid_prop_types_forbid_object: bool = true,
+    react_forbid_prop_types_check_context_types: bool = false,
+    react_forbid_prop_types_check_child_context_types: bool = false,
     react_no_array_index_key: bool = true,
     react_no_children_prop: bool = true,
     react_no_find_dom_node: bool = true,
@@ -2243,6 +2245,8 @@ pub const Options = struct {
             self.react_forbid_prop_types_forbid_any = forbid.any;
             self.react_forbid_prop_types_forbid_array = forbid.array;
             self.react_forbid_prop_types_forbid_object = forbid.object;
+            self.react_forbid_prop_types_check_context_types = try reactForbidPropTypesBoolOptionFromConfig(value, "checkContextTypes", false);
+            self.react_forbid_prop_types_check_child_context_types = try reactForbidPropTypesBoolOptionFromConfig(value, "checkChildContextTypes", false);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-filename-extension")) {
             self.react_jsx_filename_extension_extensions = try reactJsxFilenameExtensionsFromConfig(value);
@@ -5295,6 +5299,23 @@ pub const Options = struct {
         return forbid;
     }
 
+    fn reactForbidPropTypesBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn reactJsxFilenameExtensionsFromConfig(value: std.json.Value) RuleConfigError!ReactJsxFilenameExtensions {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6485,6 +6506,20 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.react_forbid_prop_types_forbid_any);
     try std.testing.expect(options.react_forbid_prop_types_forbid_array);
     try std.testing.expect(!options.react_forbid_prop_types_forbid_object);
+    try std.testing.expect(!options.react_forbid_prop_types_check_context_types);
+    try std.testing.expect(!options.react_forbid_prop_types_check_child_context_types);
+
+    var react_forbid_prop_types_context_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkContextTypes\":true,\"checkChildContextTypes\":true}]",
+        .{},
+    );
+    defer react_forbid_prop_types_context_config.deinit();
+    try options.setByRuleConfigValue("react/forbid-prop-types", react_forbid_prop_types_context_config.value);
+    try std.testing.expect(options.react_forbid_prop_types);
+    try std.testing.expect(options.react_forbid_prop_types_check_context_types);
+    try std.testing.expect(options.react_forbid_prop_types_check_child_context_types);
 
     var react_default_props_match_prop_types_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_forbid_prop_types.zig
+++ b/src/rules/react_forbid_prop_types.zig
@@ -16,6 +16,8 @@ pub const Options = struct {
     forbid_any: bool = true,
     forbid_array: bool = true,
     forbid_object: bool = true,
+    check_context_types: bool = false,
+    check_child_context_types: bool = false,
 };
 
 pub const State = struct {
@@ -74,7 +76,7 @@ pub fn checkPropertyDefinition(
     state: State,
     options: Options,
 ) Allocator.Error!void {
-    if (!isPropTypesKey(tree, property.key, property.computed)) return;
+    if (!isCheckedTypesKey(tree, property.key, property.computed, options)) return;
     try checkNode(allocator, diagnostics, tree, property.value, state, options);
 }
 
@@ -90,7 +92,7 @@ pub fn checkAssignmentExpression(
         .member_expression => |member| member,
         else => return,
     };
-    if (!isPropTypesKey(tree, member.property, member.computed)) return;
+    if (!isCheckedTypesKey(tree, member.property, member.computed, options)) return;
     try checkNode(allocator, diagnostics, tree, expression.right, state, options);
 }
 
@@ -107,7 +109,7 @@ pub fn checkObjectExpression(
             .object_property => |property| property,
             else => continue,
         };
-        if (!isPropTypesKey(tree, property.key, property.computed)) continue;
+        if (!isCheckedTypesKey(tree, property.key, property.computed, options)) continue;
         try checkNode(allocator, diagnostics, tree, property.value, state, options);
     }
 }
@@ -120,7 +122,7 @@ pub fn checkMethodDefinition(
     state: State,
     options: Options,
 ) Allocator.Error!void {
-    if (!isPropTypesKey(tree, method.key, method.computed)) return;
+    if (!isCheckedTypesKey(tree, method.key, method.computed, options)) return;
     const argument = returnArgument(tree, method.value) orelse return;
     try checkNode(allocator, diagnostics, tree, argument, state, options);
 }
@@ -377,9 +379,11 @@ fn returnArgumentFromStatement(tree: *const ast.Tree, statement: ast.NodeIndex) 
     }
 }
 
-fn isPropTypesKey(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) bool {
+fn isCheckedTypesKey(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool, options: Options) bool {
     const name = propertyName(tree, key, computed) orelse return false;
-    return std.mem.eql(u8, name, "propTypes");
+    return std.mem.eql(u8, name, "propTypes") or
+        (options.check_context_types and std.mem.eql(u8, name, "contextTypes")) or
+        (options.check_child_context_types and std.mem.eql(u8, name, "childContextTypes"));
 }
 
 fn callExpression(tree: *const ast.Tree, node: ast.NodeIndex) ?ast.CallExpression {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1130,6 +1130,16 @@ const BasicVisitor = struct {
         };
     }
 
+    fn reactForbidPropTypesOptions(self: *const BasicVisitor) react_forbid_prop_types.Options {
+        return .{
+            .forbid_any = self.options.react_forbid_prop_types_forbid_any,
+            .forbid_array = self.options.react_forbid_prop_types_forbid_array,
+            .forbid_object = self.options.react_forbid_prop_types_forbid_object,
+            .check_context_types = self.options.react_forbid_prop_types_check_context_types,
+            .check_child_context_types = self.options.react_forbid_prop_types_check_child_context_types,
+        };
+    }
+
     fn funcNamesStyle(self: *const BasicVisitor, function: ast.Function) func_names.Style {
         const style = if (function.generator and self.options.func_names_has_generator_style)
             self.options.func_names_generator_style
@@ -2572,11 +2582,7 @@ const BasicVisitor = struct {
             try react_no_unused_state.checkAssignmentExpression(self.allocator, ctx.tree, expression, ctx, &self.react_no_unused_state_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, .{
-                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
-                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
-                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
-            });
+            try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
         return .proceed;
     }
@@ -3256,11 +3262,7 @@ const BasicVisitor = struct {
             try react_no_unused_state.enterObjectExpression(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, .{
-                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
-                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
-                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
-            });
+            try react_forbid_prop_types.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
         return .proceed;
     }
@@ -3418,11 +3420,7 @@ const BasicVisitor = struct {
             try react_no_typos.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, index, ctx);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, self.react_forbid_prop_types_state, .{
-                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
-                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
-                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
-            });
+            try react_forbid_prop_types.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterMethodDefinition(self.allocator, ctx.tree, method, &self.react_no_unused_state_state);
@@ -3498,11 +3496,7 @@ const BasicVisitor = struct {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);
         }
         if (self.options.react_forbid_prop_types) {
-            try react_forbid_prop_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, self.react_forbid_prop_types_state, .{
-                .forbid_any = self.options.react_forbid_prop_types_forbid_any,
-                .forbid_array = self.options.react_forbid_prop_types_forbid_array,
-                .forbid_object = self.options.react_forbid_prop_types_forbid_object,
-            });
+            try react_forbid_prop_types.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterPropertyDefinition(self.allocator, ctx.tree, property, &self.react_no_unused_state_state);

--- a/tests/rules/react_forbid_prop_types.zig
+++ b/tests/rules/react_forbid_prop_types.zig
@@ -62,6 +62,50 @@ test "supports configured react/forbid-prop-types forbid list" {
     try std.testing.expect(hasMessage(result, "Prop type \"array\" is forbidden"));
 }
 
+test "supports configured react/forbid-prop-types context type checks" {
+    const source =
+        \\class View extends React.Component {
+        \\  static contextTypes = {
+        \\    anyValue: PropTypes.any,
+        \\  };
+        \\}
+        \\View.childContextTypes = {
+        \\  objectValue: PropTypes.object,
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.react_forbid_prop_types.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"checkContextTypes\":true,\"checkChildContextTypes\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("react/forbid-prop-types", config.value);
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer configured_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(configured_result, lint.rules.react_forbid_prop_types.id));
+    try std.testing.expect(hasMessage(configured_result, "Prop type \"any\" is forbidden"));
+    try std.testing.expect(hasMessage(configured_result, "Prop type \"object\" is forbidden"));
+}
+
 test "reports react/forbid-prop-types in assignments and variable references" {
     const source =
         \\const declaredTypes = {


### PR DESCRIPTION
## Summary
- add `checkContextTypes` and `checkChildContextTypes` config parsing for `react/forbid-prop-types`
- include `contextTypes` and `childContextTypes` in checked keys only when configured
- cover default ignored context types and configured reporting in rule tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
