### PR TITLE
Support prop-types custom validators

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -245,7 +245,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` and `ignore` configuration |
 | [`react/prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) | Supports `always` and `never` configurations |
-| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared` and `ignore` configuration |
+| [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared`, `ignore`, and `customValidators` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |
 
 ## React Hooks rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -1688,6 +1688,7 @@ pub const Options = struct {
     react_prop_types: bool = true,
     react_prop_types_skip_undeclared: bool = false,
     react_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
+    react_prop_types_custom_validators: ReactPropTypesIgnoreNames = .{},
     react_no_unused_prop_types: bool = true,
     react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
@@ -2283,6 +2284,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "react/prop-types")) {
             self.react_prop_types_skip_undeclared = try reactPropTypesSkipUndeclaredFromConfig(value);
             self.react_prop_types_ignore = try reactPropTypesIgnoreFromConfig(value);
+            self.react_prop_types_custom_validators = try reactPropTypesCustomValidatorsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
@@ -2916,6 +2918,14 @@ pub const Options = struct {
     }
 
     fn reactPropTypesIgnoreFromConfig(value: std.json.Value) RuleConfigError!ReactPropTypesIgnoreNames {
+        return reactPropTypesNamesFromConfig(value, "ignore");
+    }
+
+    fn reactPropTypesCustomValidatorsFromConfig(value: std.json.Value) RuleConfigError!ReactPropTypesIgnoreNames {
+        return reactPropTypesNamesFromConfig(value, "customValidators");
+    }
+
+    fn reactPropTypesNamesFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!ReactPropTypesIgnoreNames {
         const items = switch (value) {
             .array => |array| array.items,
             else => return .{},
@@ -2926,20 +2936,20 @@ pub const Options = struct {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        const ignore_items = switch (config.get("ignore") orelse return .{}) {
+        const name_items = switch (config.get(key) orelse return .{}) {
             .array => |array| array.items,
             else => return error.UnsupportedRuleConfigValue,
         };
 
-        var ignore = ReactPropTypesIgnoreNames{};
-        for (ignore_items) |item| {
+        var names = ReactPropTypesIgnoreNames{};
+        for (name_items) |item| {
             const name = switch (item) {
                 .string => |string| string,
                 else => return error.UnsupportedRuleConfigValue,
             };
-            ignore.append(name) catch return error.UnsupportedRuleConfigValue;
+            names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
-        return ignore;
+        return names;
     }
 
     fn reactJsxNoTargetBlankAllowReferrerFromConfig(value: std.json.Value) RuleConfigError!bool {
@@ -6647,6 +6657,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_prop_types_ignore.contains("name"));
     try std.testing.expect(options.react_prop_types_ignore.ignoresPath("user.name"));
     try std.testing.expect(!options.react_prop_types_ignore.contains("age"));
+
+    var react_prop_types_custom_validators_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"customValidators\":[\"CustomValidator\"]}]",
+        .{},
+    );
+    defer react_prop_types_custom_validators_config.deinit();
+    try options.setByRuleConfigValue("react/prop-types", react_prop_types_custom_validators_config.value);
+    try std.testing.expect(options.react_prop_types_custom_validators.contains("CustomValidator"));
+    try std.testing.expect(!options.react_prop_types_custom_validators.contains("OtherValidator"));
 
     var react_no_string_refs_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -121,8 +121,9 @@ pub fn run(
     tree: *const ast.Tree,
     skip_undeclared: bool,
     ignore: *const core.ReactPropTypesIgnoreNames,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
-    var state = try collect(allocator, tree);
+    var state = try collectWithCustomValidators(allocator, tree, custom_validators);
     defer state.deinit(allocator);
 
     try finish(allocator, diagnostics, tree, &state, skip_undeclared, ignore);
@@ -132,10 +133,19 @@ pub fn collect(
     allocator: Allocator,
     tree: *const ast.Tree,
 ) Allocator.Error!State {
+    const custom_validators = core.ReactPropTypesIgnoreNames{};
+    return collectWithCustomValidators(allocator, tree, &custom_validators);
+}
+
+fn collectWithCustomValidators(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
+) Allocator.Error!State {
     var state = State{};
     errdefer state.deinit(allocator);
 
-    try collectComponents(allocator, tree, &state);
+    try collectComponents(allocator, tree, &state, custom_validators);
 
     var visitor = UsageVisitor{
         .allocator = allocator,
@@ -152,6 +162,7 @@ fn collectComponents(
     allocator: Allocator,
     tree: *const ast.Tree,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const program = switch (tree.data(tree.root)) {
         .program => |program| program,
@@ -159,7 +170,7 @@ fn collectComponents(
     };
 
     for (tree.extra(program.body)) |statement_index| {
-        try collectTopLevelDeclaration(allocator, tree, statement_index, state);
+        try collectTopLevelDeclaration(allocator, tree, statement_index, state, custom_validators);
     }
 }
 
@@ -168,25 +179,26 @@ fn collectTopLevelDeclaration(
     tree: *const ast.Tree,
     statement_index: ast.NodeIndex,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     switch (tree.data(statement_index)) {
         .function => |function| try collectFunctionDeclaration(allocator, tree, function, statement_index, state),
-        .class => |class| try collectClassDeclaration(allocator, tree, class, statement_index, state),
+        .class => |class| try collectClassDeclaration(allocator, tree, class, statement_index, state, custom_validators),
         .variable_declaration => |declaration| {
             for (tree.extra(declaration.declarators)) |declarator_index| {
                 const declarator = switch (tree.data(declarator_index)) {
                     .variable_declarator => |declarator| declarator,
                     else => continue,
                 };
-                try collectVariableDeclarator(allocator, tree, declarator, declarator_index, state);
+                try collectVariableDeclarator(allocator, tree, declarator, declarator_index, state, custom_validators);
             }
         },
-        .expression_statement => |statement| try collectExpressionStatement(allocator, tree, statement.expression, state),
+        .expression_statement => |statement| try collectExpressionStatement(allocator, tree, statement.expression, state, custom_validators),
         .export_named_declaration => |declaration| {
-            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state);
+            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state, custom_validators);
         },
         .export_default_declaration => |declaration| {
-            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state);
+            if (declaration.declaration != .null) try collectTopLevelDeclaration(allocator, tree, declaration.declaration, state, custom_validators);
         },
         else => {},
     }
@@ -212,12 +224,13 @@ fn collectClassDeclaration(
     class: ast.Class,
     index: ast.NodeIndex,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     if (!isComponentClass(tree, class)) return;
     const name = bindingIdentifierName(tree, class.id) orelse return;
     const component_index = try state.ensureComponent(allocator, name, index, true);
     try appendNode(allocator, &state.components.items[component_index].class_nodes, index);
-    try collectClassPropTypes(allocator, tree, class, component_index, state);
+    try collectClassPropTypes(allocator, tree, class, component_index, state, custom_validators);
 }
 
 fn collectVariableDeclarator(
@@ -226,6 +239,7 @@ fn collectVariableDeclarator(
     declarator: ast.VariableDeclarator,
     index: ast.NodeIndex,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const name = bindingIdentifierName(tree, declarator.id) orelse return;
     if (!startsUppercase(name) or declarator.init == .null) return;
@@ -241,7 +255,7 @@ fn collectVariableDeclarator(
             if (isCreateReactClassCall(tree, call)) {
                 const object = createClassObject(tree, call) orelse return;
                 const component_index = try state.ensureComponent(allocator, name, index, true);
-                try collectCreateClassPropTypes(allocator, tree, object, component_index, state);
+                try collectCreateClassPropTypes(allocator, tree, object, component_index, state, custom_validators);
                 return;
             }
 
@@ -259,6 +273,7 @@ fn collectExpressionStatement(
     tree: *const ast.Tree,
     expression_index: ast.NodeIndex,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const assignment = switch (tree.data(unwrapTransparent(tree, expression_index))) {
         .assignment_expression => |assignment| assignment,
@@ -269,9 +284,9 @@ fn collectExpressionStatement(
     const target = propTypesAssignmentTarget(tree, assignment.left) orelse return;
     const component_index = try state.ensureComponent(allocator, target.component, assignment.left, false);
     if (target.prop) |prop| {
-        try addDeclaredPropValue(allocator, tree, &state.components.items[component_index].declared_props, prop, assignment.left, assignment.right);
+        try addDeclaredPropValue(allocator, tree, &state.components.items[component_index].declared_props, prop, assignment.left, assignment.right, custom_validators);
     } else {
-        try collectPropTypesObject(allocator, tree, assignment.right, component_index, state);
+        try collectPropTypesObject(allocator, tree, assignment.right, component_index, state, custom_validators);
     }
 }
 
@@ -281,6 +296,7 @@ fn collectClassPropTypes(
     class: ast.Class,
     component_index: usize,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const body = switch (tree.data(class.body)) {
         .class_body => |body| body,
@@ -295,7 +311,7 @@ fn collectClassPropTypes(
         if (!property.static) continue;
         const key = propertyName(tree, property.key, property.computed) orelse continue;
         if (!std.mem.eql(u8, key, "propTypes")) continue;
-        try collectPropTypesObject(allocator, tree, property.value, component_index, state);
+        try collectPropTypesObject(allocator, tree, property.value, component_index, state, custom_validators);
     }
 }
 
@@ -305,6 +321,7 @@ fn collectCreateClassPropTypes(
     object: ast.ObjectExpression,
     component_index: usize,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     for (tree.extra(object.properties)) |property_index| {
         const property = switch (tree.data(property_index)) {
@@ -313,7 +330,7 @@ fn collectCreateClassPropTypes(
         };
         const key = propertyName(tree, property.key, property.computed) orelse continue;
         if (!std.mem.eql(u8, key, "propTypes")) continue;
-        try collectPropTypesObject(allocator, tree, property.value, component_index, state);
+        try collectPropTypesObject(allocator, tree, property.value, component_index, state, custom_validators);
     }
 }
 
@@ -323,6 +340,7 @@ fn collectPropTypesObject(
     value: ast.NodeIndex,
     component_index: usize,
     state: *State,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const object = switch (tree.data(unwrapTransparent(tree, value))) {
         .object_expression => |object| object,
@@ -340,6 +358,7 @@ fn collectPropTypesObject(
                     name,
                     property_index,
                     property.value,
+                    custom_validators,
                 );
             },
             else => {},
@@ -354,6 +373,7 @@ fn addDeclaredPropValue(
     name: []const u8,
     node: ast.NodeIndex,
     value: ast.NodeIndex,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     var prop = try ensureDeclaredProp(allocator, props, name, node);
     const target = stripIsRequired(tree, value);
@@ -365,6 +385,11 @@ fn addDeclaredPropValue(
     }
 
     if (propTypeCall(tree, target)) |call| {
+        if (isCustomValidatorCall(tree, call, custom_validators)) {
+            prop.accepts_any_children = true;
+            return;
+        }
+
         const callee_name = propTypeTargetName(tree, call.callee) orelse return;
         if (acceptsAnyChildren(callee_name)) {
             prop.accepts_any_children = true;
@@ -374,15 +399,19 @@ fn addDeclaredPropValue(
             prop.kind = if (std.mem.eql(u8, callee_name, "shape")) .shape else .exact;
             const arguments = tree.extra(call.arguments);
             if (arguments.len == 0) return;
-            try collectShapeChildren(allocator, tree, arguments[0], prop);
+            try collectShapeChildren(allocator, tree, arguments[0], prop, custom_validators);
         } else if (std.mem.eql(u8, callee_name, "arrayOf") or std.mem.eql(u8, callee_name, "objectOf")) {
             const arguments = tree.extra(call.arguments);
             if (arguments.len == 0) return;
             const child_call = propTypeCall(tree, stripIsRequired(tree, arguments[0])) orelse return;
+            if (isCustomValidatorCall(tree, child_call, custom_validators)) {
+                prop.accepts_any_children = true;
+                return;
+            }
             const child_name = propTypeTargetName(tree, child_call.callee) orelse return;
             if (std.mem.eql(u8, child_name, "shape") or std.mem.eql(u8, child_name, "exact")) {
                 const child_arguments = tree.extra(child_call.arguments);
-                if (child_arguments.len > 0) try collectShapeChildren(allocator, tree, child_arguments[0], prop);
+                if (child_arguments.len > 0) try collectShapeChildren(allocator, tree, child_arguments[0], prop, custom_validators);
             } else if (acceptsAnyChildren(child_name)) {
                 prop.accepts_any_children = true;
             }
@@ -395,6 +424,7 @@ fn collectShapeChildren(
     tree: *const ast.Tree,
     value: ast.NodeIndex,
     parent: *DeclaredProp,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
     const object = switch (tree.data(unwrapTransparent(tree, value))) {
         .object_expression => |object| object,
@@ -407,8 +437,17 @@ fn collectShapeChildren(
             else => continue,
         };
         const name = propertyName(tree, property.key, property.computed) orelse continue;
-        try addDeclaredPropValue(allocator, tree, &parent.children, name, property_index, property.value);
+        try addDeclaredPropValue(allocator, tree, &parent.children, name, property_index, property.value, custom_validators);
     }
+}
+
+fn isCustomValidatorCall(tree: *const ast.Tree, call: ast.CallExpression, custom_validators: *const core.ReactPropTypesIgnoreNames) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const object_name = identifierReferenceName(tree, member.object) orelse return false;
+    return custom_validators.contains(object_name);
 }
 
 fn ensureDeclaredProp(

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -581,7 +581,7 @@ pub fn runBasic(
         try require_await.run(allocator, diagnostics, tree);
     }
     if (options.react_prop_types) {
-        try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared, &options.react_prop_types_ignore);
+        try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared, &options.react_prop_types_ignore, &options.react_prop_types_custom_validators);
     }
     if (options.react_no_unused_prop_types) {
         try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props, &options.react_no_unused_prop_types_ignore);

--- a/tests/rules/react_prop_types.zig
+++ b/tests/rules/react_prop_types.zig
@@ -87,6 +87,38 @@ test "supports configured react/prop-types ignore" {
     try std.testing.expect(saw_age);
 }
 
+test "supports configured react/prop-types customValidators" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.outer.inner}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  outer: CustomValidator.shape({}),
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", propTypesOnly());
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.react_prop_types.id));
+    try std.testing.expect(std.mem.eql(u8, default_result.diagnostics[0].message, "'outer.inner' is missing in props validation"));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"customValidators\":[\"CustomValidator\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = propTypesOnly();
+    try options.setByRuleConfigValue("react/prop-types", config.value);
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer configured_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(configured_result, lint.rules.react_prop_types.id));
+}
+
 test "allows react/prop-types declared object children" {
     const source =
         \\import React from 'react';


### PR DESCRIPTION
## Summary
- add `customValidators` config parsing for `react/prop-types`
- pass configured validators into propTypes collection
- treat custom validator calls as declarations that cover nested prop usage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
