### PR TITLE
Support no-unused-prop-types custom validators

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -243,7 +243,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
-| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps` and `ignore` configuration |
+| [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps`, `ignore`, and `customValidators` configuration |
 | [`react/prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) | Supports `always` and `never` configurations |
 | [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) | Supports `skipUndeclared`, `ignore`, and `customValidators` configuration |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1692,6 +1692,7 @@ pub const Options = struct {
     react_no_unused_prop_types: bool = true,
     react_no_unused_prop_types_skip_shape_props: bool = true,
     react_no_unused_prop_types_ignore: ReactPropTypesIgnoreNames = .{},
+    react_no_unused_prop_types_custom_validators: ReactPropTypesIgnoreNames = .{},
     react_no_unused_state: bool = true,
     react_no_string_refs: bool = true,
     react_no_string_refs_no_template_literals: bool = false,
@@ -2289,6 +2290,7 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "react/no-unused-prop-types")) {
             self.react_no_unused_prop_types_skip_shape_props = try reactNoUnusedPropTypesSkipShapePropsFromConfig(value);
             self.react_no_unused_prop_types_ignore = try reactPropTypesIgnoreFromConfig(value);
+            self.react_no_unused_prop_types_custom_validators = try reactPropTypesCustomValidatorsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-string-refs")) {
             self.react_no_string_refs_no_template_literals = try reactNoStringRefsNoTemplateLiteralsFromConfig(value);
@@ -6755,6 +6757,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_no_unused_prop_types_ignore.contains("age"));
     try std.testing.expect(options.react_no_unused_prop_types_ignore.ignoresPath("user.id"));
     try std.testing.expect(!options.react_no_unused_prop_types_ignore.contains("role"));
+    try std.testing.expect(!options.react_no_unused_prop_types_custom_validators.contains("CustomValidator"));
+
+    var react_no_unused_prop_types_custom_validators_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"customValidators\":[\"CustomValidator\"]}]",
+        .{},
+    );
+    defer react_no_unused_prop_types_custom_validators_config.deinit();
+    try options.setByRuleConfigValue("react/no-unused-prop-types", react_no_unused_prop_types_custom_validators_config.value);
+    try std.testing.expect(options.react_no_unused_prop_types_custom_validators.contains("CustomValidator"));
+    try std.testing.expect(!options.react_no_unused_prop_types_custom_validators.contains("OtherValidator"));
 
     var array_callback_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_unused_prop_types.zig
+++ b/src/rules/react_no_unused_prop_types.zig
@@ -14,8 +14,9 @@ pub fn run(
     tree: *const ast.Tree,
     skip_shape_props: bool,
     ignore: *const core.ReactPropTypesIgnoreNames,
+    custom_validators: *const core.ReactPropTypesIgnoreNames,
 ) Allocator.Error!void {
-    var state = try react_prop_types.collect(allocator, tree);
+    var state = try react_prop_types.collectWithCustomValidators(allocator, tree, custom_validators);
     defer state.deinit(allocator);
 
     for (state.components.items) |component| {

--- a/src/rules/react_prop_types.zig
+++ b/src/rules/react_prop_types.zig
@@ -137,7 +137,7 @@ pub fn collect(
     return collectWithCustomValidators(allocator, tree, &custom_validators);
 }
 
-fn collectWithCustomValidators(
+pub fn collectWithCustomValidators(
     allocator: Allocator,
     tree: *const ast.Tree,
     custom_validators: *const core.ReactPropTypesIgnoreNames,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -584,7 +584,7 @@ pub fn runBasic(
         try react_prop_types.run(allocator, diagnostics, tree, options.react_prop_types_skip_undeclared, &options.react_prop_types_ignore, &options.react_prop_types_custom_validators);
     }
     if (options.react_no_unused_prop_types) {
-        try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props, &options.react_no_unused_prop_types_ignore);
+        try react_no_unused_prop_types.run(allocator, diagnostics, tree, options.react_no_unused_prop_types_skip_shape_props, &options.react_no_unused_prop_types_ignore, &options.react_no_unused_prop_types_custom_validators);
     }
 
     var visitor = BasicVisitor{

--- a/tests/rules/react_no_unused_prop_types.zig
+++ b/tests/rules/react_no_unused_prop_types.zig
@@ -126,6 +126,42 @@ test "supports configured react/no-unused-prop-types ignore" {
     try std.testing.expect(hasMessage(result, "'role' PropType is defined but prop is never used"));
 }
 
+test "supports configured react/no-unused-prop-types customValidators" {
+    const source =
+        \\import React from 'react';
+        \\function Foo(props) {
+        \\  return <div>{props.outer}</div>;
+        \\}
+        \\Foo.propTypes = {
+        \\  outer: CustomValidator.shape({
+        \\    inner: CustomValidator.string,
+        \\  }),
+        \\};
+    ;
+
+    var default_options = noUnusedPropTypesOnly();
+    default_options.react_no_unused_prop_types_skip_shape_props = false;
+    var default_result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", default_options);
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.react_no_unused_prop_types.id));
+    try std.testing.expect(hasMessage(default_result, "'outer.inner' PropType is defined but prop is never used"));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"skipShapeProps\":false,\"customValidators\":[\"CustomValidator\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = noUnusedPropTypesOnly();
+    try options.setByRuleConfigValue("react/no-unused-prop-types", config.value);
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "sample.jsx", options);
+    defer configured_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(configured_result, lint.rules.react_no_unused_prop_types.id));
+}
+
 test "reports react/no-unused-prop-types for class components" {
     const source =
         \\import React from 'react';


### PR DESCRIPTION
## Summary
- add `customValidators` config parsing for `react/no-unused-prop-types`
- pass configured validators into shared propTypes collection
- cover custom validator behavior when shape prop reporting is enabled

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
