### PR TITLE
Support img redundant alt options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -212,7 +212,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
-| [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Implemented |
+| [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |
 | [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |
 
 ## Parser diagnostics

--- a/src/core.zig
+++ b/src/core.zig
@@ -820,6 +820,49 @@ pub const ReactPropTypesIgnoreNames = struct {
     }
 };
 
+pub const max_jsx_a11y_img_redundant_alt_names = 32;
+pub const max_jsx_a11y_img_redundant_alt_name_len = 128;
+
+pub const JsxA11yImgRedundantAltNamesError = error{
+    EmptyJsxA11yImgRedundantAltName,
+    TooManyJsxA11yImgRedundantAltNames,
+    JsxA11yImgRedundantAltNameTooLong,
+};
+
+pub const JsxA11yImgRedundantAltNames = struct {
+    count: usize = 0,
+    lengths: [max_jsx_a11y_img_redundant_alt_names]usize = undefined,
+    storage: [max_jsx_a11y_img_redundant_alt_names][max_jsx_a11y_img_redundant_alt_name_len]u8 = undefined,
+
+    pub fn contains(self: *const JsxA11yImgRedundantAltNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn containsIgnoreCase(self: *const JsxA11yImgRedundantAltNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.ascii.eqlIgnoreCase(self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const JsxA11yImgRedundantAltNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *JsxA11yImgRedundantAltNames, name: []const u8) JsxA11yImgRedundantAltNamesError!void {
+        if (name.len == 0) return error.EmptyJsxA11yImgRedundantAltName;
+        if (self.count >= max_jsx_a11y_img_redundant_alt_names) return error.TooManyJsxA11yImgRedundantAltNames;
+        if (name.len > max_jsx_a11y_img_redundant_alt_name_len) return error.JsxA11yImgRedundantAltNameTooLong;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const max_typescript_eslint_ban_type_entries = 32;
 pub const max_typescript_eslint_ban_type_name_len = 128;
 pub const max_typescript_eslint_ban_type_message_len = 512;
@@ -1422,6 +1465,8 @@ pub const Options = struct {
     jsx_a11y_aria_unsupported_elements: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,
+    jsx_a11y_img_redundant_alt_components: JsxA11yImgRedundantAltNames = .{},
+    jsx_a11y_img_redundant_alt_words: JsxA11yImgRedundantAltNames = .{},
     jsx_a11y_no_access_key: bool = true,
     jsx_a11y_no_distracting_elements: bool = true,
     jsx_a11y_role_has_required_aria_props: bool = true,
@@ -1987,6 +2032,10 @@ pub const Options = struct {
             self.import_newline_after_import_count = try importNewlineAfterImportCountFromConfig(value);
             self.import_newline_after_import_exact_count = try importNewlineAfterImportExactCountFromConfig(value);
             self.import_newline_after_import_consider_comments = try importNewlineAfterImportConsiderCommentsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "jsx-a11y/img-redundant-alt")) {
+            self.jsx_a11y_img_redundant_alt_components = try jsxA11yImgRedundantAltNamesFromConfig(value, "components");
+            self.jsx_a11y_img_redundant_alt_words = try jsxA11yImgRedundantAltNamesFromConfig(value, "words");
         }
         if (std.mem.eql(u8, cli_name, "new-cap")) {
             self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
@@ -2944,6 +2993,33 @@ pub const Options = struct {
         };
 
         var names = ReactPropTypesIgnoreNames{};
+        for (name_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            names.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return names;
+    }
+
+    fn jsxA11yImgRedundantAltNamesFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!JsxA11yImgRedundantAltNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const name_items = switch (config.get(key) orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var names = JsxA11yImgRedundantAltNames{};
         for (name_items) |item| {
             const name = switch (item) {
                 .string => |string| string,
@@ -6490,6 +6566,20 @@ test "Options can apply ESLint-style rule config values" {
     try array.append(.{ .string = "warn" });
     try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
     try std.testing.expect(options.jsx_a11y_aria_props);
+
+    var jsx_a11y_img_redundant_alt_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"components\":[\"Image\"],\"words\":[\"Bild\"]}]",
+        .{},
+    );
+    defer jsx_a11y_img_redundant_alt_config.deinit();
+    try options.setByRuleConfigValue("jsx-a11y/img-redundant-alt", jsx_a11y_img_redundant_alt_config.value);
+    try std.testing.expect(options.jsx_a11y_img_redundant_alt);
+    try std.testing.expect(options.jsx_a11y_img_redundant_alt_components.contains("Image"));
+    try std.testing.expect(!options.jsx_a11y_img_redundant_alt_components.contains("Picture"));
+    try std.testing.expect(options.jsx_a11y_img_redundant_alt_words.containsIgnoreCase("bild"));
+    try std.testing.expect(!options.jsx_a11y_img_redundant_alt_words.containsIgnoreCase("foto"));
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
 

--- a/src/rules/jsx_a11y_img_redundant_alt.zig
+++ b/src/rules/jsx_a11y_img_redundant_alt.zig
@@ -9,19 +9,25 @@ pub const id = "jsx-a11y/img-redundant-alt";
 
 const message = "Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.";
 
+pub const Options = struct {
+    components: core.JsxA11yImgRedundantAltNames = .{},
+    words: core.JsxA11yImgRedundantAltNames = .{},
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
-    if (!isImgElement(tree, opening.name)) return;
+    if (!isCheckedElement(tree, opening.name, options.components)) return;
     if (isAriaHidden(tree, opening)) return;
 
     const alt = attributeNamed(tree, opening, "alt") orelse return;
     const value = stringValue(tree, alt.value) orelse return;
-    if (!containsRedundantWord(value)) return;
+    if (!containsRedundantWord(value, options.words)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -33,11 +39,12 @@ pub fn check(
     );
 }
 
-fn isImgElement(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
-    return switch (tree.data(name_index)) {
-        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "img"),
-        else => false,
+fn isCheckedElement(tree: *const ast.Tree, name_index: ast.NodeIndex, components: core.JsxA11yImgRedundantAltNames) bool {
+    const name = switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => return false,
     };
+    return std.mem.eql(u8, name, "img") or components.contains(name);
 }
 
 fn attributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, name: []const u8) ?ast.JSXAttribute {
@@ -95,10 +102,10 @@ fn firstTemplateQuasi(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]co
     };
 }
 
-fn containsRedundantWord(value: []const u8) bool {
-    var words = std.mem.tokenizeAny(u8, value, " \t\r\n");
-    while (words.next()) |word| {
-        if (equalsRedundantWord(word)) return true;
+fn containsRedundantWord(value: []const u8, words: core.JsxA11yImgRedundantAltNames) bool {
+    var tokens = std.mem.tokenizeAny(u8, value, " \t\r\n");
+    while (tokens.next()) |word| {
+        if (equalsRedundantWord(word) or words.containsIgnoreCase(word)) return true;
     }
     return false;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3160,7 +3160,10 @@ const BasicVisitor = struct {
             try jsx_a11y_iframe_has_title.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.jsx_a11y_img_redundant_alt) {
-            try jsx_a11y_img_redundant_alt.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+            try jsx_a11y_img_redundant_alt.check(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
+                .components = self.options.jsx_a11y_img_redundant_alt_components,
+                .words = self.options.jsx_a11y_img_redundant_alt_words,
+            });
         }
         if (self.options.alipay_ant_prefer_safe_image_renderer) {
             try alipay_ant_prefer_safe_image_renderer.check(self.allocator, self.diagnostics, ctx.tree, opening);

--- a/tests/rules/jsx_a11y_img_redundant_alt.zig
+++ b/tests/rules/jsx_a11y_img_redundant_alt.zig
@@ -47,6 +47,43 @@ test "allows jsx-a11y/img-redundant-alt non-redundant hidden or dynamic alt text
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_img_redundant_alt.id));
 }
 
+test "supports configured jsx-a11y/img-redundant-alt components and words" {
+    const source =
+        \\const one = <Image alt="Bild von profile" />;
+        \\const two = <img alt="Bild von profile" />;
+        \\const three = <Avatar alt="Bild von profile" />;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(default_result, lint.rules.jsx_a11y_img_redundant_alt.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"components\":[\"Image\"],\"words\":[\"Bild\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("jsx-a11y/img-redundant-alt", config.value);
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer configured_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(configured_result, lint.rules.jsx_a11y_img_redundant_alt.id));
+}
+
 test "can disable jsx-a11y/img-redundant-alt" {
     const source =
         \\const node = <img alt="image" />;


### PR DESCRIPTION
## Summary
- add `components` and `words` config parsing for `jsx-a11y/img-redundant-alt`
- check configured image wrapper components in addition to `<img>`
- check configured redundant alt words in addition to the default English words

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
