### PR TITLE
Support no-distracting-elements options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -214,6 +214,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
 | [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |
 | [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |
+| [`jsx-a11y/no-distracting-elements`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-distracting-elements.md) | Supports `elements` configuration |
 
 ## Parser diagnostics
 

--- a/src/core.zig
+++ b/src/core.zig
@@ -1469,6 +1469,8 @@ pub const Options = struct {
     jsx_a11y_img_redundant_alt_words: JsxA11yImgRedundantAltNames = .{},
     jsx_a11y_no_access_key: bool = true,
     jsx_a11y_no_distracting_elements: bool = true,
+    jsx_a11y_no_distracting_elements_marquee: bool = true,
+    jsx_a11y_no_distracting_elements_blink: bool = true,
     jsx_a11y_role_has_required_aria_props: bool = true,
     jsx_a11y_role_supports_aria_props: bool = true,
     jsx_a11y_scope: bool = true,
@@ -2036,6 +2038,11 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "jsx-a11y/img-redundant-alt")) {
             self.jsx_a11y_img_redundant_alt_components = try jsxA11yImgRedundantAltNamesFromConfig(value, "components");
             self.jsx_a11y_img_redundant_alt_words = try jsxA11yImgRedundantAltNamesFromConfig(value, "words");
+        }
+        if (std.mem.eql(u8, cli_name, "jsx-a11y/no-distracting-elements")) {
+            const elements = try jsxA11yNoDistractingElementsFromConfig(value);
+            self.jsx_a11y_no_distracting_elements_marquee = elements.marquee;
+            self.jsx_a11y_no_distracting_elements_blink = elements.blink;
         }
         if (std.mem.eql(u8, cli_name, "new-cap")) {
             self.new_cap_new_is_cap = try newCapBoolOptionFromConfig(value, "newIsCap", true);
@@ -3028,6 +3035,47 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    const JsxA11yNoDistractingElementsConfig = struct {
+        marquee: bool = true,
+        blink: bool = true,
+    };
+
+    fn jsxA11yNoDistractingElementsFromConfig(value: std.json.Value) RuleConfigError!JsxA11yNoDistractingElementsConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const element_items = switch (config.get("elements") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = JsxA11yNoDistractingElementsConfig{
+            .marquee = false,
+            .blink = false,
+        };
+        for (element_items) |item| {
+            const element = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, element, "marquee")) {
+                result.marquee = true;
+            } else if (std.mem.eql(u8, element, "blink")) {
+                result.blink = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        return result;
     }
 
     fn reactJsxNoTargetBlankAllowReferrerFromConfig(value: std.json.Value) RuleConfigError!bool {
@@ -6580,6 +6628,18 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(!options.jsx_a11y_img_redundant_alt_components.contains("Picture"));
     try std.testing.expect(options.jsx_a11y_img_redundant_alt_words.containsIgnoreCase("bild"));
     try std.testing.expect(!options.jsx_a11y_img_redundant_alt_words.containsIgnoreCase("foto"));
+
+    var jsx_a11y_no_distracting_elements_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"elements\":[\"blink\"]}]",
+        .{},
+    );
+    defer jsx_a11y_no_distracting_elements_config.deinit();
+    try options.setByRuleConfigValue("jsx-a11y/no-distracting-elements", jsx_a11y_no_distracting_elements_config.value);
+    try std.testing.expect(options.jsx_a11y_no_distracting_elements);
+    try std.testing.expect(!options.jsx_a11y_no_distracting_elements_marquee);
+    try std.testing.expect(options.jsx_a11y_no_distracting_elements_blink);
 
     try options.setByRuleConfigValue("prettier/prettier", .{ .string = "error" });
 

--- a/src/rules/jsx_a11y_no_distracting_elements.zig
+++ b/src/rules/jsx_a11y_no_distracting_elements.zig
@@ -7,14 +7,20 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "jsx-a11y/no-distracting-elements";
 
+pub const Options = struct {
+    marquee: bool = true,
+    blink: bool = true,
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
-    const element = distractingElement(tree, opening.name) orelse return;
+    const element = distractingElement(tree, opening.name, options) orelse return;
 
     try core.addDiagnosticFmt(
         allocator,
@@ -27,12 +33,16 @@ pub fn check(
     );
 }
 
-fn distractingElement(tree: *const ast.Tree, name_index: ast.NodeIndex) ?[]const u8 {
+fn distractingElement(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Options) ?[]const u8 {
     const name = switch (tree.data(name_index)) {
         .jsx_identifier => |identifier| tree.string(identifier.name),
         else => return null,
     };
 
-    if (std.mem.eql(u8, name, "marquee") or std.mem.eql(u8, name, "blink")) return name;
+    if ((options.marquee and std.mem.eql(u8, name, "marquee")) or
+        (options.blink and std.mem.eql(u8, name, "blink")))
+    {
+        return name;
+    }
     return null;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3169,7 +3169,10 @@ const BasicVisitor = struct {
             try alipay_ant_prefer_safe_image_renderer.check(self.allocator, self.diagnostics, ctx.tree, opening);
         }
         if (self.options.jsx_a11y_no_distracting_elements) {
-            try jsx_a11y_no_distracting_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
+            try jsx_a11y_no_distracting_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
+                .marquee = self.options.jsx_a11y_no_distracting_elements_marquee,
+                .blink = self.options.jsx_a11y_no_distracting_elements_blink,
+            });
         }
         if (self.options.jsx_a11y_aria_unsupported_elements) {
             try jsx_a11y_aria_unsupported_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/rules/jsx_a11y_no_distracting_elements.zig
+++ b/tests/rules/jsx_a11y_no_distracting_elements.zig
@@ -39,6 +39,35 @@ test "allows jsx-a11y/no-distracting-elements non distracting and custom compone
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_no_distracting_elements.id));
 }
 
+test "supports configured jsx-a11y/no-distracting-elements elements" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"elements\":[\"blink\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("jsx-a11y/no-distracting-elements", config.value);
+
+    const source =
+        \\const one = <marquee />;
+        \\const two = <blink />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.jsx_a11y_no_distracting_elements.id));
+    try std.testing.expect(!hasMessage(result, "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated."));
+    try std.testing.expect(hasMessage(result, "Do not use <blink> elements as they can create visual accessibility issues and are deprecated."));
+}
+
 test "can disable jsx-a11y/no-distracting-elements" {
     const source =
         \\const node = <marquee />;


### PR DESCRIPTION
## Summary
- add `elements` config parsing for `jsx-a11y/no-distracting-elements`
- let configured `elements` choose whether `marquee`, `blink`, or both are checked
- cover the configured single-element behavior in tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
