### PR TITLE
Support anchor-has-content components

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -210,6 +210,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`jsx-a11y/anchor-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md) | Supports `components` configuration |
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
 | [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1459,6 +1459,7 @@ pub const Options = struct {
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_anchor_has_content: bool = true,
+    jsx_a11y_anchor_has_content_components: JsxA11yImgRedundantAltNames = .{},
     jsx_a11y_aria_props: bool = true,
     jsx_a11y_aria_proptypes: bool = true,
     jsx_a11y_aria_role: bool = true,
@@ -2035,9 +2036,12 @@ pub const Options = struct {
             self.import_newline_after_import_exact_count = try importNewlineAfterImportExactCountFromConfig(value);
             self.import_newline_after_import_consider_comments = try importNewlineAfterImportConsiderCommentsFromConfig(value);
         }
+        if (std.mem.eql(u8, cli_name, "jsx-a11y/anchor-has-content")) {
+            self.jsx_a11y_anchor_has_content_components = try jsxA11yNamesFromConfig(value, "components");
+        }
         if (std.mem.eql(u8, cli_name, "jsx-a11y/img-redundant-alt")) {
-            self.jsx_a11y_img_redundant_alt_components = try jsxA11yImgRedundantAltNamesFromConfig(value, "components");
-            self.jsx_a11y_img_redundant_alt_words = try jsxA11yImgRedundantAltNamesFromConfig(value, "words");
+            self.jsx_a11y_img_redundant_alt_components = try jsxA11yNamesFromConfig(value, "components");
+            self.jsx_a11y_img_redundant_alt_words = try jsxA11yNamesFromConfig(value, "words");
         }
         if (std.mem.eql(u8, cli_name, "jsx-a11y/no-distracting-elements")) {
             const elements = try jsxA11yNoDistractingElementsFromConfig(value);
@@ -3010,7 +3014,7 @@ pub const Options = struct {
         return names;
     }
 
-    fn jsxA11yImgRedundantAltNamesFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!JsxA11yImgRedundantAltNames {
+    fn jsxA11yNamesFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!JsxA11yImgRedundantAltNames {
         const items = switch (value) {
             .array => |array| array.items,
             else => return .{},
@@ -6614,6 +6618,18 @@ test "Options can apply ESLint-style rule config values" {
     try array.append(.{ .string = "warn" });
     try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
     try std.testing.expect(options.jsx_a11y_aria_props);
+
+    var jsx_a11y_anchor_has_content_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"components\":[\"Anchor\"]}]",
+        .{},
+    );
+    defer jsx_a11y_anchor_has_content_config.deinit();
+    try options.setByRuleConfigValue("jsx-a11y/anchor-has-content", jsx_a11y_anchor_has_content_config.value);
+    try std.testing.expect(options.jsx_a11y_anchor_has_content);
+    try std.testing.expect(options.jsx_a11y_anchor_has_content_components.contains("Anchor"));
+    try std.testing.expect(!options.jsx_a11y_anchor_has_content_components.contains("Link"));
 
     var jsx_a11y_img_redundant_alt_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/jsx_a11y_anchor_has_content.zig
+++ b/src/rules/jsx_a11y_anchor_has_content.zig
@@ -9,19 +9,24 @@ pub const id = "jsx-a11y/anchor-has-content";
 
 const message = "Anchors must have content and the content must be accessible by a screen reader.";
 
+pub const Options = struct {
+    components: core.JsxA11yImgRedundantAltNames = .{},
+};
+
 pub fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     element: ast.JSXElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const opening = switch (tree.data(element.opening_element)) {
         .jsx_opening_element => |opening| opening,
         else => return,
     };
     const tag_name = elementName(tree, opening.name) orelse return;
-    if (!std.mem.eql(u8, tag_name, "a")) return;
+    if (!isCheckedElement(tag_name, options.components)) return;
 
     if (hasAccessibleChild(tree, element) or hasAnyAttribute(tree, opening, &.{ "title", "aria-label" })) return;
 
@@ -33,6 +38,10 @@ pub fn check(
         message,
         tree.span(index),
     );
+}
+
+fn isCheckedElement(tag_name: []const u8, components: core.JsxA11yImgRedundantAltNames) bool {
+    return std.mem.eql(u8, tag_name, "a") or components.contains(tag_name);
 }
 
 fn hasAccessibleChild(tree: *const ast.Tree, element: ast.JSXElement) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3116,7 +3116,9 @@ const BasicVisitor = struct {
             try jsx_a11y_alt_text.checkElement(self.allocator, self.diagnostics, ctx.tree, element, index);
         }
         if (self.options.jsx_a11y_anchor_has_content) {
-            try jsx_a11y_anchor_has_content.check(self.allocator, self.diagnostics, ctx.tree, element, index);
+            try jsx_a11y_anchor_has_content.check(self.allocator, self.diagnostics, ctx.tree, element, index, .{
+                .components = self.options.jsx_a11y_anchor_has_content_components,
+            });
         }
         if (self.options.react_void_dom_elements_no_children) {
             try react_void_dom_elements_no_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);

--- a/tests/rules/jsx_a11y_anchor_has_content.zig
+++ b/tests/rules/jsx_a11y_anchor_has_content.zig
@@ -50,6 +50,44 @@ test "allows jsx-a11y/anchor-has-content accessible content and labels" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_anchor_has_content.id));
 }
 
+test "supports configured jsx-a11y/anchor-has-content components" {
+    const source =
+        \\const one = <Anchor />;
+        \\const two = <Anchor>text</Anchor>;
+        \\const three = <Link />;
+        \\const four = <a />;
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.jsx_a11y_anchor_has_content.id));
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"components\":[\"Anchor\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("jsx-a11y/anchor-has-content", config.value);
+
+    var configured_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer configured_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(configured_result, lint.rules.jsx_a11y_anchor_has_content.id));
+}
+
 test "can disable jsx-a11y/anchor-has-content" {
     const source =
         \\const node = <a />;


### PR DESCRIPTION
## Summary
- add `components` config parsing for `jsx-a11y/anchor-has-content`
- check configured anchor wrapper components while always keeping native `<a>` covered
- cover default and configured component behavior in tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
