### PR TITLE
Support aria-role options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -212,6 +212,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`jsx-a11y/anchor-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md) | Supports `components` configuration |
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
+| [`jsx-a11y/aria-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md) | Supports `allowedInvalidRoles` and `ignoreNonDOM` configuration |
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
 | [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |
 | [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1463,6 +1463,8 @@ pub const Options = struct {
     jsx_a11y_aria_props: bool = true,
     jsx_a11y_aria_proptypes: bool = true,
     jsx_a11y_aria_role: bool = true,
+    jsx_a11y_aria_role_allowed_invalid_roles: JsxA11yImgRedundantAltNames = .{},
+    jsx_a11y_aria_role_ignore_non_dom: bool = true,
     jsx_a11y_aria_unsupported_elements: bool = true,
     jsx_a11y_iframe_has_title: bool = true,
     jsx_a11y_img_redundant_alt: bool = true,
@@ -2038,6 +2040,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "jsx-a11y/anchor-has-content")) {
             self.jsx_a11y_anchor_has_content_components = try jsxA11yNamesFromConfig(value, "components");
+        }
+        if (std.mem.eql(u8, cli_name, "jsx-a11y/aria-role")) {
+            self.jsx_a11y_aria_role_allowed_invalid_roles = try jsxA11yNamesFromConfig(value, "allowedInvalidRoles");
+            self.jsx_a11y_aria_role_ignore_non_dom = try jsxA11yBoolOptionFromConfig(value, "ignoreNonDOM", true);
         }
         if (std.mem.eql(u8, cli_name, "jsx-a11y/img-redundant-alt")) {
             self.jsx_a11y_img_redundant_alt_components = try jsxA11yNamesFromConfig(value, "components");
@@ -3039,6 +3045,23 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    fn jsxA11yBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     const JsxA11yNoDistractingElementsConfig = struct {
@@ -6630,6 +6653,19 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.jsx_a11y_anchor_has_content);
     try std.testing.expect(options.jsx_a11y_anchor_has_content_components.contains("Anchor"));
     try std.testing.expect(!options.jsx_a11y_anchor_has_content_components.contains("Link"));
+
+    var jsx_a11y_aria_role_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowedInvalidRoles\":[\"text\"],\"ignoreNonDOM\":false}]",
+        .{},
+    );
+    defer jsx_a11y_aria_role_config.deinit();
+    try options.setByRuleConfigValue("jsx-a11y/aria-role", jsx_a11y_aria_role_config.value);
+    try std.testing.expect(options.jsx_a11y_aria_role);
+    try std.testing.expect(options.jsx_a11y_aria_role_allowed_invalid_roles.contains("text"));
+    try std.testing.expect(!options.jsx_a11y_aria_role_allowed_invalid_roles.contains("datepicker"));
+    try std.testing.expect(!options.jsx_a11y_aria_role_ignore_non_dom);
 
     var jsx_a11y_img_redundant_alt_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/jsx_a11y_aria_role.zig
+++ b/src/rules/jsx_a11y_aria_role.zig
@@ -9,6 +9,11 @@ pub const id = "jsx-a11y/aria-role";
 
 const message = "Elements with ARIA roles must use a valid, non-abstract ARIA role.";
 
+pub const Options = struct {
+    allowed_invalid_roles: core.JsxA11yImgRedundantAltNames = .{},
+    ignore_non_dom: bool = true,
+};
+
 const RoleValueStatus = enum {
     valid,
     invalid,
@@ -20,9 +25,10 @@ pub fn check(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
+    options: Options,
 ) Allocator.Error!void {
     const tag_name = elementName(tree, opening.name) orelse return;
-    if (!isDomElement(tag_name)) return;
+    if (options.ignore_non_dom and !isDomElement(tag_name)) return;
 
     for (tree.extra(opening.attributes)) |attribute_index| {
         const attribute = switch (tree.data(attribute_index)) {
@@ -32,7 +38,7 @@ pub fn check(
         const name = attributeName(tree, attribute.name) orelse continue;
         if (!std.ascii.eqlIgnoreCase(name, "role")) continue;
 
-        switch (roleValueStatus(tree, attribute.value)) {
+        switch (roleValueStatus(tree, attribute.value, options.allowed_invalid_roles)) {
             .valid, .ignored => {},
             .invalid => try core.addDiagnostic(
                 allocator,
@@ -46,20 +52,20 @@ pub fn check(
     }
 }
 
-fn roleValueStatus(tree: *const ast.Tree, value_index: ast.NodeIndex) RoleValueStatus {
+fn roleValueStatus(tree: *const ast.Tree, value_index: ast.NodeIndex, allowed_invalid_roles: core.JsxA11yImgRedundantAltNames) RoleValueStatus {
     if (value_index == .null) return .invalid;
 
     return switch (tree.data(value_index)) {
-        .string_literal => |literal| validateRoleList(tree.string(literal.value)),
-        .jsx_expression_container => |container| roleExpressionStatus(tree, container.expression),
+        .string_literal => |literal| validateRoleList(tree.string(literal.value), allowed_invalid_roles),
+        .jsx_expression_container => |container| roleExpressionStatus(tree, container.expression, allowed_invalid_roles),
         else => .ignored,
     };
 }
 
-fn roleExpressionStatus(tree: *const ast.Tree, expression_index: ast.NodeIndex) RoleValueStatus {
+fn roleExpressionStatus(tree: *const ast.Tree, expression_index: ast.NodeIndex, allowed_invalid_roles: core.JsxA11yImgRedundantAltNames) RoleValueStatus {
     return switch (tree.data(expression_index)) {
-        .string_literal => |literal| validateRoleList(tree.string(literal.value)),
-        .template_literal => |literal| templateRoleStatus(tree, literal),
+        .string_literal => |literal| validateRoleList(tree.string(literal.value), allowed_invalid_roles),
+        .template_literal => |literal| templateRoleStatus(tree, literal, allowed_invalid_roles),
         .identifier_reference => |identifier| identifierRoleStatus(tree.string(identifier.name)),
         .boolean_literal,
         .null_literal,
@@ -69,14 +75,14 @@ fn roleExpressionStatus(tree: *const ast.Tree, expression_index: ast.NodeIndex) 
     };
 }
 
-fn templateRoleStatus(tree: *const ast.Tree, literal: ast.TemplateLiteral) RoleValueStatus {
+fn templateRoleStatus(tree: *const ast.Tree, literal: ast.TemplateLiteral, allowed_invalid_roles: core.JsxA11yImgRedundantAltNames) RoleValueStatus {
     if (literal.expressions.len != 0) return .invalid;
 
     const quasis = tree.extra(literal.quasis);
-    if (quasis.len == 0) return validateRoleList("");
+    if (quasis.len == 0) return validateRoleList("", allowed_invalid_roles);
 
     return switch (tree.data(quasis[0])) {
-        .template_element => |element| validateRoleList(tree.string(element.cooked)),
+        .template_element => |element| validateRoleList(tree.string(element.cooked), allowed_invalid_roles),
         else => .ignored,
     };
 }
@@ -96,10 +102,10 @@ fn identifierRoleStatus(name: []const u8) RoleValueStatus {
     return .ignored;
 }
 
-fn validateRoleList(value: []const u8) RoleValueStatus {
+fn validateRoleList(value: []const u8, allowed_invalid_roles: core.JsxA11yImgRedundantAltNames) RoleValueStatus {
     var values = std.mem.splitScalar(u8, value, ' ');
     while (values.next()) |role| {
-        if (!isValidRole(role)) return .invalid;
+        if (!isValidRole(role) and !allowed_invalid_roles.contains(role)) return .invalid;
     }
     return .valid;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3180,7 +3180,10 @@ const BasicVisitor = struct {
             try jsx_a11y_aria_unsupported_elements.check(self.allocator, self.diagnostics, ctx.tree, opening, index);
         }
         if (self.options.jsx_a11y_aria_role) {
-            try jsx_a11y_aria_role.check(self.allocator, self.diagnostics, ctx.tree, opening);
+            try jsx_a11y_aria_role.check(self.allocator, self.diagnostics, ctx.tree, opening, .{
+                .allowed_invalid_roles = self.options.jsx_a11y_aria_role_allowed_invalid_roles,
+                .ignore_non_dom = self.options.jsx_a11y_aria_role_ignore_non_dom,
+            });
         }
         if (self.options.jsx_a11y_role_has_required_aria_props) {
             try jsx_a11y_role_has_required_aria_props.check(self.allocator, self.diagnostics, ctx.tree, opening);

--- a/tests/rules/jsx_a11y_aria_role.zig
+++ b/tests/rules/jsx_a11y_aria_role.zig
@@ -52,6 +52,54 @@ test "allows jsx-a11y/aria-role valid roles and non-dom elements" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_aria_role.id));
 }
 
+test "supports configured jsx-a11y/aria-role allowed invalid roles and non-dom checks" {
+    var allowed_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowedInvalidRoles\":[\"text\"]}]",
+        .{},
+    );
+    defer allowed_config.deinit();
+
+    var allowed_options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try allowed_options.setByRuleConfigValue("jsx-a11y/aria-role", allowed_config.value);
+
+    var allowed_result = try lint.lintSource(std.testing.allocator,
+        \\const one = <div role="text" />;
+        \\const two = <div role="text button" />;
+        \\const three = <div role="datepicker" />;
+    , "fixture.tsx", allowed_options);
+    defer allowed_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(allowed_result, lint.rules.jsx_a11y_aria_role.id));
+
+    var non_dom_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreNonDOM\":false}]",
+        .{},
+    );
+    defer non_dom_config.deinit();
+
+    var non_dom_options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try non_dom_options.setByRuleConfigValue("jsx-a11y/aria-role", non_dom_config.value);
+
+    var non_dom_result = try lint.lintSource(std.testing.allocator,
+        \\const one = <Foo role="datepicker" />;
+        \\const two = <foo role="datepicker" />;
+        \\const three = <Foo role="button" />;
+    , "fixture.tsx", non_dom_options);
+    defer non_dom_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(non_dom_result, lint.rules.jsx_a11y_aria_role.id));
+}
+
 test "can disable jsx-a11y/aria-role" {
     const source =
         \\const node = <div role="foo" />;


### PR DESCRIPTION
## Summary
- add `allowedInvalidRoles` and `ignoreNonDOM` parsing for `jsx-a11y/aria-role`
- allow configured invalid role names while preserving existing default non-DOM behavior
- support explicitly checking non-DOM JSX elements when `ignoreNonDOM` is false

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
