### PR TITLE
Support alt-text options

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -210,6 +210,7 @@ Each rule links to the corresponding ESLint rule reference.
 
 | Rule | Status |
 | --- | --- |
+| [`jsx-a11y/alt-text`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md) | Supports `elements` and element component mapping configuration |
 | [`jsx-a11y/anchor-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md) | Supports `components` configuration |
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
 | [`jsx-a11y/aria-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md) | Supports `allowedInvalidRoles` and `ignoreNonDOM` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1458,6 +1458,14 @@ pub const Options = struct {
     import_no_unresolved: bool = true,
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
+    jsx_a11y_alt_text_img: bool = true,
+    jsx_a11y_alt_text_object: bool = true,
+    jsx_a11y_alt_text_area: bool = true,
+    jsx_a11y_alt_text_input_image: bool = true,
+    jsx_a11y_alt_text_img_components: JsxA11yImgRedundantAltNames = .{},
+    jsx_a11y_alt_text_object_components: JsxA11yImgRedundantAltNames = .{},
+    jsx_a11y_alt_text_area_components: JsxA11yImgRedundantAltNames = .{},
+    jsx_a11y_alt_text_input_image_components: JsxA11yImgRedundantAltNames = .{},
     jsx_a11y_anchor_has_content: bool = true,
     jsx_a11y_anchor_has_content_components: JsxA11yImgRedundantAltNames = .{},
     jsx_a11y_aria_props: bool = true,
@@ -2044,6 +2052,17 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "jsx-a11y/aria-role")) {
             self.jsx_a11y_aria_role_allowed_invalid_roles = try jsxA11yNamesFromConfig(value, "allowedInvalidRoles");
             self.jsx_a11y_aria_role_ignore_non_dom = try jsxA11yBoolOptionFromConfig(value, "ignoreNonDOM", true);
+        }
+        if (std.mem.eql(u8, cli_name, "jsx-a11y/alt-text")) {
+            const elements = try jsxA11yAltTextElementsFromConfig(value);
+            self.jsx_a11y_alt_text_img = elements.img;
+            self.jsx_a11y_alt_text_object = elements.object;
+            self.jsx_a11y_alt_text_area = elements.area;
+            self.jsx_a11y_alt_text_input_image = elements.input_image;
+            self.jsx_a11y_alt_text_img_components = try jsxA11yNamesFromConfig(value, "img");
+            self.jsx_a11y_alt_text_object_components = try jsxA11yNamesFromConfig(value, "object");
+            self.jsx_a11y_alt_text_area_components = try jsxA11yNamesFromConfig(value, "area");
+            self.jsx_a11y_alt_text_input_image_components = try jsxA11yNamesFromConfig(value, "input[type=\"image\"]");
         }
         if (std.mem.eql(u8, cli_name, "jsx-a11y/img-redundant-alt")) {
             self.jsx_a11y_img_redundant_alt_components = try jsxA11yNamesFromConfig(value, "components");
@@ -3062,6 +3081,55 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    const JsxA11yAltTextElementsConfig = struct {
+        img: bool = true,
+        object: bool = true,
+        area: bool = true,
+        input_image: bool = true,
+    };
+
+    fn jsxA11yAltTextElementsFromConfig(value: std.json.Value) RuleConfigError!JsxA11yAltTextElementsConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const element_items = switch (config.get("elements") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = JsxA11yAltTextElementsConfig{
+            .img = false,
+            .object = false,
+            .area = false,
+            .input_image = false,
+        };
+        for (element_items) |item| {
+            const element = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, element, "img")) {
+                result.img = true;
+            } else if (std.mem.eql(u8, element, "object")) {
+                result.object = true;
+            } else if (std.mem.eql(u8, element, "area")) {
+                result.area = true;
+            } else if (std.mem.eql(u8, element, "input[type=\"image\"]")) {
+                result.input_image = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        return result;
     }
 
     const JsxA11yNoDistractingElementsConfig = struct {
@@ -6641,6 +6709,24 @@ test "Options can apply ESLint-style rule config values" {
     try array.append(.{ .string = "warn" });
     try options.setByRuleConfigValue("jsx-a11y/aria-props", .{ .array = array });
     try std.testing.expect(options.jsx_a11y_aria_props);
+
+    var jsx_a11y_alt_text_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"elements\":[\"img\",\"input[type=\\\"image\\\"]\"],\"img\":[\"Image\"],\"object\":[\"Object\"],\"area\":[\"Area\"],\"input[type=\\\"image\\\"]\":[\"InputImage\"]}]",
+        .{},
+    );
+    defer jsx_a11y_alt_text_config.deinit();
+    try options.setByRuleConfigValue("jsx-a11y/alt-text", jsx_a11y_alt_text_config.value);
+    try std.testing.expect(options.jsx_a11y_alt_text);
+    try std.testing.expect(options.jsx_a11y_alt_text_img);
+    try std.testing.expect(!options.jsx_a11y_alt_text_object);
+    try std.testing.expect(!options.jsx_a11y_alt_text_area);
+    try std.testing.expect(options.jsx_a11y_alt_text_input_image);
+    try std.testing.expect(options.jsx_a11y_alt_text_img_components.contains("Image"));
+    try std.testing.expect(options.jsx_a11y_alt_text_object_components.contains("Object"));
+    try std.testing.expect(options.jsx_a11y_alt_text_area_components.contains("Area"));
+    try std.testing.expect(options.jsx_a11y_alt_text_input_image_components.contains("InputImage"));
 
     var jsx_a11y_anchor_has_content_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/jsx_a11y_alt_text.zig
+++ b/src/rules/jsx_a11y_alt_text.zig
@@ -7,20 +7,38 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "jsx-a11y/alt-text";
 
+pub const Options = struct {
+    img: bool = true,
+    object: bool = true,
+    area: bool = true,
+    input_image: bool = true,
+    img_components: core.JsxA11yImgRedundantAltNames = .{},
+    object_components: core.JsxA11yImgRedundantAltNames = .{},
+    area_components: core.JsxA11yImgRedundantAltNames = .{},
+    input_image_components: core.JsxA11yImgRedundantAltNames = .{},
+};
+
+const CheckedElement = enum {
+    img,
+    object,
+    area,
+    input_image,
+};
+
 pub fn checkOpeningElement(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     opening: ast.JSXOpeningElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const tag_name = elementName(tree, opening.name) orelse return;
-    if (std.mem.eql(u8, tag_name, "img")) {
-        try checkImg(allocator, diagnostics, tree, opening, index, tag_name);
-    } else if (std.mem.eql(u8, tag_name, "area")) {
-        try checkArea(allocator, diagnostics, tree, opening, index);
-    } else if (std.mem.eql(u8, tag_name, "input")) {
-        try checkInputImage(allocator, diagnostics, tree, opening, index);
+    switch (checkedElement(tag_name, options) orelse return) {
+        .img => try checkImg(allocator, diagnostics, tree, opening, index, tag_name),
+        .object => {},
+        .area => try checkArea(allocator, diagnostics, tree, opening, index),
+        .input_image => try checkInputImage(allocator, diagnostics, tree, opening, index, std.mem.eql(u8, tag_name, "input")),
     }
 }
 
@@ -30,13 +48,14 @@ pub fn checkElement(
     tree: *const ast.Tree,
     element: ast.JSXElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const opening = switch (tree.data(element.opening_element)) {
         .jsx_opening_element => |opening| opening,
         else => return,
     };
     const tag_name = elementName(tree, opening.name) orelse return;
-    if (!std.mem.eql(u8, tag_name, "object")) return;
+    if (checkedElement(tag_name, options) != .object) return;
 
     if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
         ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")) or
@@ -52,6 +71,82 @@ pub fn checkElement(
         .warning,
         id,
         "Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.",
+        tree.span(index),
+    );
+}
+
+fn checkedElement(tag_name: []const u8, options: Options) ?CheckedElement {
+    if (options.img and (std.mem.eql(u8, tag_name, "img") or options.img_components.contains(tag_name))) {
+        return .img;
+    }
+    if (options.object and (std.mem.eql(u8, tag_name, "object") or options.object_components.contains(tag_name))) {
+        return .object;
+    }
+    if (options.area and (std.mem.eql(u8, tag_name, "area") or options.area_components.contains(tag_name))) {
+        return .area;
+    }
+    if (options.input_image and (std.mem.eql(u8, tag_name, "input") or options.input_image_components.contains(tag_name))) {
+        return .input_image;
+    }
+    return null;
+}
+
+fn checkArea(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
+        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
+    {
+        return;
+    }
+
+    const alt = attributeNamed(tree, opening, "alt");
+    if (alt != null and altValueIsValid(tree, alt.?)) return;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
+        tree.span(index),
+    );
+}
+
+fn checkInputImage(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    opening: ast.JSXOpeningElement,
+    index: ast.NodeIndex,
+    require_image_type: bool,
+) Allocator.Error!void {
+    if (require_image_type) {
+        const typ = attributeNamed(tree, opening, "type") orelse return;
+        const type_value = propValue(tree, typ.value) orelse return;
+        switch (type_value) {
+            .string => |string| if (!std.mem.eql(u8, string, "image")) return,
+            else => return,
+        }
+    }
+
+    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
+        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
+    {
+        return;
+    }
+
+    const alt = attributeNamed(tree, opening, "alt");
+    if (alt != null and altValueIsValid(tree, alt.?)) return;
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
         tree.span(index),
     );
 }
@@ -124,63 +219,6 @@ fn checkImg(
         tree.span(index),
         "Invalid alt value for {s}. Use alt=\"\" for presentational images.",
         .{tag_name},
-    );
-}
-
-fn checkArea(
-    allocator: Allocator,
-    diagnostics: *core.DiagnosticList,
-    tree: *const ast.Tree,
-    opening: ast.JSXOpeningElement,
-    index: ast.NodeIndex,
-) Allocator.Error!void {
-    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
-        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
-    {
-        return;
-    }
-
-    const alt = attributeNamed(tree, opening, "alt");
-    if (alt != null and altValueIsValid(tree, alt.?)) return;
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
-        tree.span(index),
-    );
-}
-
-fn checkInputImage(
-    allocator: Allocator,
-    diagnostics: *core.DiagnosticList,
-    tree: *const ast.Tree,
-    opening: ast.JSXOpeningElement,
-    index: ast.NodeIndex,
-) Allocator.Error!void {
-    const typ = attributeNamed(tree, opening, "type") orelse return;
-    const type_value = propValue(tree, typ.value) orelse return;
-    switch (type_value) {
-        .string => |string| if (!std.mem.eql(u8, string, "image")) return,
-        else => return,
-    }
-
-    if (ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-label")) or
-        ariaLabelHasValue(tree, attributeNamed(tree, opening, "aria-labelledby")))
-    {
-        return;
-    }
-
-    const alt = attributeNamed(tree, opening, "alt");
-    if (alt != null and altValueIsValid(tree, alt.?)) return;
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.",
-        tree.span(index),
     );
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3113,7 +3113,16 @@ const BasicVisitor = struct {
             try react_no_danger_with_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, &self.react_no_danger_with_children_bindings);
         }
         if (self.options.jsx_a11y_alt_text) {
-            try jsx_a11y_alt_text.checkElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+            try jsx_a11y_alt_text.checkElement(self.allocator, self.diagnostics, ctx.tree, element, index, .{
+                .img = self.options.jsx_a11y_alt_text_img,
+                .object = self.options.jsx_a11y_alt_text_object,
+                .area = self.options.jsx_a11y_alt_text_area,
+                .input_image = self.options.jsx_a11y_alt_text_input_image,
+                .img_components = self.options.jsx_a11y_alt_text_img_components,
+                .object_components = self.options.jsx_a11y_alt_text_object_components,
+                .area_components = self.options.jsx_a11y_alt_text_area_components,
+                .input_image_components = self.options.jsx_a11y_alt_text_input_image_components,
+            });
         }
         if (self.options.jsx_a11y_anchor_has_content) {
             try jsx_a11y_anchor_has_content.check(self.allocator, self.diagnostics, ctx.tree, element, index, .{
@@ -3153,7 +3162,16 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.jsx_a11y_alt_text) {
-            try jsx_a11y_alt_text.checkOpeningElement(self.allocator, self.diagnostics, ctx.tree, opening, index);
+            try jsx_a11y_alt_text.checkOpeningElement(self.allocator, self.diagnostics, ctx.tree, opening, index, .{
+                .img = self.options.jsx_a11y_alt_text_img,
+                .object = self.options.jsx_a11y_alt_text_object,
+                .area = self.options.jsx_a11y_alt_text_area,
+                .input_image = self.options.jsx_a11y_alt_text_input_image,
+                .img_components = self.options.jsx_a11y_alt_text_img_components,
+                .object_components = self.options.jsx_a11y_alt_text_object_components,
+                .area_components = self.options.jsx_a11y_alt_text_area_components,
+                .input_image_components = self.options.jsx_a11y_alt_text_input_image_components,
+            });
         }
         if (self.options.jsx_a11y_no_access_key) {
             try jsx_a11y_no_access_key.check(self.allocator, self.diagnostics, ctx.tree, opening, index);

--- a/tests/rules/jsx_a11y_alt_text.zig
+++ b/tests/rules/jsx_a11y_alt_text.zig
@@ -60,6 +60,58 @@ test "allows jsx-a11y/alt-text valid alternatives and non matching elements" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jsx_a11y_alt_text.id));
 }
 
+test "supports configured jsx-a11y/alt-text elements and components" {
+    var elements_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"elements\":[\"img\"]}]",
+        .{},
+    );
+    defer elements_config.deinit();
+
+    var elements_options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try elements_options.setByRuleConfigValue("jsx-a11y/alt-text", elements_config.value);
+
+    var elements_result = try lint.lintSource(std.testing.allocator,
+        \\const one = <img />;
+        \\const two = <area />;
+        \\const three = <object />;
+        \\const four = <input type="image" />;
+    , "fixture.tsx", elements_options);
+    defer elements_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(elements_result, lint.rules.jsx_a11y_alt_text.id));
+
+    var components_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"img\":[\"Image\"],\"object\":[\"ObjectEmbed\"],\"area\":[\"MapArea\"],\"input[type=\\\"image\\\"]\":[\"InputImage\"]}]",
+        .{},
+    );
+    defer components_config.deinit();
+
+    var components_options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try components_options.setByRuleConfigValue("jsx-a11y/alt-text", components_config.value);
+
+    var components_result = try lint.lintSource(std.testing.allocator,
+        \\const one = <Image />;
+        \\const two = <ObjectEmbed />;
+        \\const three = <MapArea />;
+        \\const four = <InputImage />;
+        \\const five = <Avatar />;
+    , "fixture.tsx", components_options);
+    defer components_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(components_result, lint.rules.jsx_a11y_alt_text.id));
+    try std.testing.expect(hasMessage(components_result, "Image elements must have an alt prop, either with meaningful text, or an empty string for decorative images."));
+}
+
 test "can disable jsx-a11y/alt-text" {
     const source =
         \\const node = <img />;


### PR DESCRIPTION
## Summary
- add `elements` parsing for `jsx-a11y/alt-text`
- support custom component mappings for `img`, `object`, `area`, and `input[type="image"]`
- keep native behavior as the default and cover configured whitelist/component behavior in tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
