### PR TITLE
Support jsx-no-target-blank forms

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -237,7 +237,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
-| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, and `warnOnSpreadAttributes` configuration |
+| [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, `warnOnSpreadAttributes`, `links`, and `forms` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, `allowNamespace`, and `ignore` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1711,6 +1711,8 @@ pub const Options = struct {
     react_jsx_no_target_blank_allow_referrer: bool = false,
     react_jsx_no_target_blank_enforce_dynamic_links: bool = true,
     react_jsx_no_target_blank_warn_on_spread_attributes: bool = false,
+    react_jsx_no_target_blank_links: bool = true,
+    react_jsx_no_target_blank_forms: bool = false,
     react_jsx_no_undef: bool = true,
     react_jsx_pascal_case: bool = true,
     react_jsx_pascal_case_allow_all_caps: bool = true,
@@ -2360,6 +2362,8 @@ pub const Options = struct {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
             self.react_jsx_no_target_blank_enforce_dynamic_links = try reactJsxNoTargetBlankEnforceDynamicLinksFromConfig(value);
             self.react_jsx_no_target_blank_warn_on_spread_attributes = try reactJsxNoTargetBlankWarnOnSpreadAttributesFromConfig(value);
+            self.react_jsx_no_target_blank_links = try reactJsxNoTargetBlankBoolOptionFromConfig(value, "links", true);
+            self.react_jsx_no_target_blank_forms = try reactJsxNoTargetBlankBoolOptionFromConfig(value, "forms", false);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-pascal-case")) {
             self.react_jsx_pascal_case_allow_all_caps = try reactJsxPascalCaseAllowAllCapsFromConfig(value);
@@ -3211,17 +3215,21 @@ pub const Options = struct {
     }
 
     fn reactJsxNoTargetBlankWarnOnSpreadAttributesFromConfig(value: std.json.Value) RuleConfigError!bool {
+        return reactJsxNoTargetBlankBoolOptionFromConfig(value, "warnOnSpreadAttributes", false);
+    }
+
+    fn reactJsxNoTargetBlankBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return false,
+            else => return default,
         };
-        if (items.len < 2) return false;
+        if (items.len < 2) return default;
 
         const config = switch (items[1]) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("warnOnSpreadAttributes") orelse return false) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
@@ -6541,6 +6549,8 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.react_jsx_no_target_blank);
     try std.testing.expect(!options.react_jsx_no_target_blank_allow_referrer);
     try std.testing.expect(options.react_jsx_no_target_blank_enforce_dynamic_links);
+    try std.testing.expect(options.react_jsx_no_target_blank_links);
+    try std.testing.expect(!options.react_jsx_no_target_blank_forms);
 
     try std.testing.expect(!options.import_no_duplicates);
     try std.testing.expect(options.setByCliName("import/no-duplicates", true));
@@ -6908,7 +6918,7 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowReferrer\":true,\"enforceDynamicLinks\":\"never\",\"warnOnSpreadAttributes\":true}]",
+        "[\"error\",{\"allowReferrer\":true,\"enforceDynamicLinks\":\"never\",\"warnOnSpreadAttributes\":true,\"links\":false,\"forms\":true}]",
         .{},
     );
     defer react_jsx_no_target_blank_config.deinit();
@@ -6917,6 +6927,8 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_no_target_blank_allow_referrer);
     try std.testing.expect(!options.react_jsx_no_target_blank_enforce_dynamic_links);
     try std.testing.expect(options.react_jsx_no_target_blank_warn_on_spread_attributes);
+    try std.testing.expect(!options.react_jsx_no_target_blank_links);
+    try std.testing.expect(options.react_jsx_no_target_blank_forms);
 
     var react_jsx_pascal_case_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_no_target_blank.zig
+++ b/src/rules/react_jsx_no_target_blank.zig
@@ -11,6 +11,13 @@ pub const Options = struct {
     allow_referrer: bool = false,
     enforce_dynamic_links: bool = true,
     warn_on_spread_attributes: bool = false,
+    links: bool = true,
+    forms: bool = false,
+};
+
+const CheckedElement = enum {
+    link,
+    form,
 };
 
 pub fn check(
@@ -21,16 +28,20 @@ pub fn check(
     index: ast.NodeIndex,
     options: Options,
 ) Allocator.Error!void {
-    if (!isAnchorElement(tree, opening.name)) return;
+    const element = checkedElement(tree, opening.name, options) orelse return;
+    const url_attribute = switch (element) {
+        .link => "href",
+        .form => "action",
+    };
 
-    if (options.warn_on_spread_attributes and hasUnsafeSpreadAttribute(tree, opening, options.allow_referrer)) {
+    if (options.warn_on_spread_attributes and hasUnsafeSpreadAttribute(tree, opening, options.allow_referrer, url_attribute)) {
         try addDiagnostic(allocator, diagnostics, tree, index);
         return;
     }
 
     const target = lastAttributeNamed(tree, opening, "target") orelse return;
     if (!attributeValuePossiblyBlank(tree, target.attribute)) return;
-    if (!hasDangerousHref(tree, opening, options.enforce_dynamic_links)) return;
+    if (!hasDangerousUrl(tree, opening, url_attribute, options.enforce_dynamic_links)) return;
     if (hasSecureRel(tree, opening, target.attribute.value, options.allow_referrer)) return;
 
     try addDiagnostic(allocator, diagnostics, tree, index);
@@ -56,11 +67,14 @@ const AttributeMatch = struct {
     attribute: ast.JSXAttribute,
 };
 
-fn isAnchorElement(tree: *const ast.Tree, name_index: ast.NodeIndex) bool {
-    return switch (tree.data(name_index)) {
-        .jsx_identifier => |identifier| std.mem.eql(u8, tree.string(identifier.name), "a"),
-        else => false,
+fn checkedElement(tree: *const ast.Tree, name_index: ast.NodeIndex, options: Options) ?CheckedElement {
+    const name = switch (tree.data(name_index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => return null,
     };
+    if (options.links and std.mem.eql(u8, name, "a")) return .link;
+    if (options.forms and std.mem.eql(u8, name, "form")) return .form;
+    return null;
 }
 
 fn lastAttributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, name: []const u8) ?AttributeMatch {
@@ -79,7 +93,7 @@ fn lastAttributeNamed(tree: *const ast.Tree, opening: ast.JSXOpeningElement, nam
     return null;
 }
 
-fn hasUnsafeSpreadAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement, allow_referrer: bool) bool {
+fn hasUnsafeSpreadAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElement, allow_referrer: bool, url_attribute: []const u8) bool {
     const attributes = tree.extra(opening.attributes);
     var last_spread: ?usize = null;
     for (attributes, 0..) |attribute_index, index| {
@@ -99,7 +113,7 @@ fn hasUnsafeSpreadAttribute(tree: *const ast.Tree, opening: ast.JSXOpeningElemen
 
         if (std.mem.eql(u8, name, "rel") and attributeRelValueIsSecure(tree, attribute, allow_referrer)) return false;
         if (std.mem.eql(u8, name, "target") and !attributeValuePossiblyBlank(tree, attribute)) return false;
-        if (std.mem.eql(u8, name, "href") and attributeValueIsSafeHref(tree, attribute)) return false;
+        if (std.mem.eql(u8, name, url_attribute) and attributeValueIsSafeUrl(tree, attribute)) return false;
     }
     return true;
 }
@@ -127,11 +141,11 @@ fn attributeValuePossiblyBlank(tree: *const ast.Tree, attribute: ast.JSXAttribut
         isStringLiteralIgnoreCase(tree, conditional.alternate, "_blank");
 }
 
-fn hasDangerousHref(tree: *const ast.Tree, opening: ast.JSXOpeningElement, enforce_dynamic_links: bool) bool {
-    const href = lastAttributeNamed(tree, opening, "href") orelse return false;
-    if (href.attribute.value == .null) return false;
-    if (stringValue(tree, href.attribute.value)) |value| return isExternalHref(value);
-    return enforce_dynamic_links and tree.data(href.attribute.value) == .jsx_expression_container;
+fn hasDangerousUrl(tree: *const ast.Tree, opening: ast.JSXOpeningElement, url_attribute: []const u8, enforce_dynamic_links: bool) bool {
+    const url = lastAttributeNamed(tree, opening, url_attribute) orelse return false;
+    if (url.attribute.value == .null) return false;
+    if (stringValue(tree, url.attribute.value)) |value| return isExternalHref(value);
+    return enforce_dynamic_links and tree.data(url.attribute.value) == .jsx_expression_container;
 }
 
 fn hasSecureRel(tree: *const ast.Tree, opening: ast.JSXOpeningElement, target_value: ast.NodeIndex, allow_referrer: bool) bool {
@@ -154,7 +168,7 @@ fn attributeRelValueIsSecure(tree: *const ast.Tree, attribute: ast.JSXAttribute,
     return valueIsSecureRel(value, allow_referrer);
 }
 
-fn attributeValueIsSafeHref(tree: *const ast.Tree, attribute: ast.JSXAttribute) bool {
+fn attributeValueIsSafeUrl(tree: *const ast.Tree, attribute: ast.JSXAttribute) bool {
     if (attribute.value == .null) return false;
     const value = stringValue(tree, attribute.value) orelse return false;
     return !isExternalHref(value);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3217,6 +3217,8 @@ const BasicVisitor = struct {
                 .allow_referrer = self.options.react_jsx_no_target_blank_allow_referrer,
                 .enforce_dynamic_links = self.options.react_jsx_no_target_blank_enforce_dynamic_links,
                 .warn_on_spread_attributes = self.options.react_jsx_no_target_blank_warn_on_spread_attributes,
+                .links = self.options.react_jsx_no_target_blank_links,
+                .forms = self.options.react_jsx_no_target_blank_forms,
             });
         }
         if (self.options.react_jsx_pascal_case) {

--- a/tests/rules/react_jsx_no_target_blank.zig
+++ b/tests/rules/react_jsx_no_target_blank.zig
@@ -131,6 +131,39 @@ test "supports configured react/jsx-no-target-blank enforceDynamicLinks never" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
 }
 
+test "supports configured react/jsx-no-target-blank links and forms" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"links\":false,\"forms\":true,\"warnOnSpreadAttributes\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("react/jsx-no-target-blank", config.value);
+    options.eol_last = false;
+    options.jsx_a11y_anchor_has_content = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\const link = <a href="https://example.com" target="_blank" />;
+        \\const form = <form action="https://example.com" target="_blank" />;
+        \\const dynamicForm = <form action={url} target="_blank" />;
+        \\const relativeForm = <form action="/submit" target="_blank" />;
+        \\const safeForm = <form action="https://example.com" target="_blank" rel="noreferrer" />;
+        \\const spreadForm = <form {...props} />;
+        \\const safeSpreadForm = <form {...props} action="/submit" />;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_jsx_no_target_blank.id));
+}
+
 test "can disable react/jsx-no-target-blank" {
     const source =
         \\const link = <a href="https://example.com" target="_blank" />;


### PR DESCRIPTION
## Summary
- add `links` and `forms` parsing for `react/jsx-no-target-blank`
- let the rule disable link checks or enable form `action` checks from config
- cover configured form checks and spread handling in tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
