### PR TITLE
Support react/jsx-key duplicate key warnings

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -233,7 +233,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/forbid-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) | Supports `forbid`, `checkContextTypes`, and `checkChildContextTypes` configuration |
 | [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | Implemented for `never` and `always` configurations |
 | [`react/jsx-filename-extension`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md) | Supports `extensions` and `allow` configuration |
-| [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread` and `checkFragmentShorthand` configuration |
+| [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) | Supports `checkKeyMustBeforeSpread`, `checkFragmentShorthand`, and `warnOnDuplicates` configuration |
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1702,6 +1702,7 @@ pub const Options = struct {
     react_jsx_key: bool = true,
     react_jsx_key_check_key_must_before_spread: bool = false,
     react_jsx_key_check_fragment_shorthand: bool = false,
+    react_jsx_key_warn_on_duplicates: bool = false,
     react_button_has_type: bool = true,
     react_button_has_type_button: bool = true,
     react_button_has_type_submit: bool = true,
@@ -2355,8 +2356,9 @@ pub const Options = struct {
             self.react_jsx_no_duplicate_props_ignore_case = try reactJsxNoDuplicatePropsIgnoreCaseFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-key")) {
-            self.react_jsx_key_check_key_must_before_spread = try reactJsxKeyCheckKeyMustBeforeSpreadFromConfig(value);
-            self.react_jsx_key_check_fragment_shorthand = try reactJsxKeyCheckFragmentShorthandFromConfig(value);
+            self.react_jsx_key_check_key_must_before_spread = try reactJsxKeyBoolOptionFromConfig(value, "checkKeyMustBeforeSpread", false);
+            self.react_jsx_key_check_fragment_shorthand = try reactJsxKeyBoolOptionFromConfig(value, "checkFragmentShorthand", false);
+            self.react_jsx_key_warn_on_duplicates = try reactJsxKeyBoolOptionFromConfig(value, "warnOnDuplicates", false);
         }
         if (std.mem.eql(u8, cli_name, "react/jsx-no-target-blank")) {
             self.react_jsx_no_target_blank_allow_referrer = try reactJsxNoTargetBlankAllowReferrerFromConfig(value);
@@ -5702,35 +5704,18 @@ pub const Options = struct {
         };
     }
 
-    fn reactJsxKeyCheckKeyMustBeforeSpreadFromConfig(value: std.json.Value) RuleConfigError!bool {
+    fn reactJsxKeyBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return false,
+            else => return default,
         };
-        if (items.len < 2) return false;
+        if (items.len < 2) return default;
 
         const config = switch (items[1]) {
             .object => |object| object,
             else => return error.UnsupportedRuleConfigValue,
         };
-        return switch (config.get("checkKeyMustBeforeSpread") orelse return false) {
-            .bool => |enabled| enabled,
-            else => error.UnsupportedRuleConfigValue,
-        };
-    }
-
-    fn reactJsxKeyCheckFragmentShorthandFromConfig(value: std.json.Value) RuleConfigError!bool {
-        const items = switch (value) {
-            .array => |array| array.items,
-            else => return false,
-        };
-        if (items.len < 2) return false;
-
-        const config = switch (items[1]) {
-            .object => |object| object,
-            else => return error.UnsupportedRuleConfigValue,
-        };
-        return switch (config.get("checkFragmentShorthand") orelse return false) {
+        return switch (config.get(key) orelse return default) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
@@ -6656,6 +6641,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("react/jsx-key", true));
     try std.testing.expect(options.react_jsx_key);
     try std.testing.expect(!options.react_jsx_key_check_key_must_before_spread);
+    try std.testing.expect(!options.react_jsx_key_warn_on_duplicates);
 
     try std.testing.expect(!options.react_prop_types);
     try std.testing.expect(options.setByCliName("react/prop-types", true));
@@ -6906,7 +6892,7 @@ test "Options can apply ESLint-style rule config values" {
     var react_jsx_key_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"checkKeyMustBeforeSpread\":true,\"checkFragmentShorthand\":true}]",
+        "[\"error\",{\"checkKeyMustBeforeSpread\":true,\"checkFragmentShorthand\":true,\"warnOnDuplicates\":true}]",
         .{},
     );
     defer react_jsx_key_config.deinit();
@@ -6914,6 +6900,7 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.react_jsx_key);
     try std.testing.expect(options.react_jsx_key_check_key_must_before_spread);
     try std.testing.expect(options.react_jsx_key_check_fragment_shorthand);
+    try std.testing.expect(options.react_jsx_key_warn_on_duplicates);
 
     var react_jsx_no_target_blank_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_jsx_key.zig
+++ b/src/rules/react_jsx_key.zig
@@ -9,6 +9,7 @@ pub const id = "react/jsx-key";
 
 const missing_array_key_message = "Missing \"key\" prop for element in array";
 const missing_iter_key_message = "Missing \"key\" prop for element in iterator";
+const non_unique_key_message = "`key` prop must be unique";
 
 pub const State = struct {
     pragma: []const u8 = "React",
@@ -18,6 +19,12 @@ pub const State = struct {
 pub const Options = struct {
     check_key_must_before_spread: bool = false,
     check_fragment_shorthand: bool = false,
+    warn_on_duplicates: bool = false,
+};
+
+const KeyProp = struct {
+    value: []const u8,
+    node: ast.NodeIndex,
 };
 
 pub fn collectProgram(tree: *const ast.Tree, state: *State) void {
@@ -56,6 +63,9 @@ pub fn checkArrayExpression(
     expression: ast.ArrayExpression,
     options: Options,
 ) Allocator.Error!void {
+    var keys: std.ArrayList(KeyProp) = .empty;
+    defer keys.deinit(allocator);
+
     for (tree.extra(expression.elements)) |element_index| {
         if (element_index == .null) continue;
         const element = switch (tree.data(unwrapTransparent(tree, element_index))) {
@@ -68,9 +78,39 @@ pub fn checkArrayExpression(
             },
             else => continue,
         };
+        if (options.warn_on_duplicates) {
+            try collectKeyProps(allocator, tree, element, &keys);
+        }
         if (hasKeyProp(tree, element, options)) continue;
         try report(allocator, diagnostics, tree, element_index, missing_array_key_message);
     }
+
+    if (options.warn_on_duplicates) {
+        try reportDuplicateKeys(allocator, diagnostics, tree, keys.items);
+    }
+}
+
+pub fn checkJSXElementChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.warn_on_duplicates) return;
+
+    var keys: std.ArrayList(KeyProp) = .empty;
+    defer keys.deinit(allocator);
+
+    for (tree.extra(element.children)) |child_index| {
+        const child = switch (tree.data(unwrapTransparent(tree, child_index))) {
+            .jsx_element => |child| child,
+            else => continue,
+        };
+        try collectKeyProps(allocator, tree, child, &keys);
+    }
+
+    try reportDuplicateKeys(allocator, diagnostics, tree, keys.items);
 }
 
 fn checkIteratorCallback(
@@ -222,6 +262,60 @@ fn hasKeyProp(tree: *const ast.Tree, element: ast.JSXElement, options: Options) 
         }
     }
     return false;
+}
+
+fn collectKeyProps(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    keys: *std.ArrayList(KeyProp),
+) Allocator.Error!void {
+    const opening = switch (tree.data(element.opening_element)) {
+        .jsx_opening_element => |opening| opening,
+        else => return,
+    };
+
+    for (tree.extra(opening.attributes)) |attribute_index| {
+        const attribute = switch (tree.data(attribute_index)) {
+            .jsx_attribute => |attribute| attribute,
+            else => continue,
+        };
+        const name = jsxIdentifierName(tree, attribute.name) orelse continue;
+        if (!std.mem.eql(u8, name, "key")) continue;
+        const value = if (attribute.value == .null) "" else sourceForNode(tree, attribute.value);
+        try keys.append(allocator, .{
+            .value = value,
+            .node = attribute_index,
+        });
+    }
+}
+
+fn reportDuplicateKeys(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    keys: []const KeyProp,
+) Allocator.Error!void {
+    for (keys, 0..) |key, index| {
+        if (!hasDuplicateKeyValue(keys, index, key.value)) continue;
+        try report(allocator, diagnostics, tree, key.node, non_unique_key_message);
+    }
+}
+
+fn hasDuplicateKeyValue(keys: []const KeyProp, current_index: usize, value: []const u8) bool {
+    for (keys, 0..) |key, index| {
+        if (index == current_index) continue;
+        if (std.mem.eql(u8, key.value, value)) return true;
+    }
+    return false;
+}
+
+fn sourceForNode(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= end or end > tree.source.len) return "";
+    return tree.source[start..end];
 }
 
 fn isChildrenToArrayCall(tree: *const ast.Tree, call: ast.CallExpression, state: State) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2851,6 +2851,7 @@ const BasicVisitor = struct {
             try react_jsx_key.enterCallExpression(self.allocator, self.diagnostics, ctx.tree, call, &self.react_jsx_key_state, .{
                 .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
                 .check_fragment_shorthand = self.options.react_jsx_key_check_fragment_shorthand,
+                .warn_on_duplicates = self.options.react_jsx_key_warn_on_duplicates,
             });
         }
         if (self.options.new_cap) {
@@ -3022,6 +3023,7 @@ const BasicVisitor = struct {
             try react_jsx_key.checkArrayExpression(self.allocator, self.diagnostics, ctx.tree, expression, .{
                 .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
                 .check_fragment_shorthand = self.options.react_jsx_key_check_fragment_shorthand,
+                .warn_on_duplicates = self.options.react_jsx_key_warn_on_duplicates,
             });
         }
         return .proceed;
@@ -3131,6 +3133,13 @@ const BasicVisitor = struct {
         }
         if (self.options.react_void_dom_elements_no_children) {
             try react_void_dom_elements_no_children.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+        }
+        if (self.options.react_jsx_key and self.react_jsx_key_state.children_to_array_depth == 0) {
+            try react_jsx_key.checkJSXElementChildren(self.allocator, self.diagnostics, ctx.tree, element, .{
+                .check_key_must_before_spread = self.options.react_jsx_key_check_key_must_before_spread,
+                .check_fragment_shorthand = self.options.react_jsx_key_check_fragment_shorthand,
+                .warn_on_duplicates = self.options.react_jsx_key_warn_on_duplicates,
+            });
         }
         return .proceed;
     }

--- a/tests/rules/react_jsx_key.zig
+++ b/tests/rules/react_jsx_key.zig
@@ -91,6 +91,74 @@ test "supports configured react jsx key fragment shorthand" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
 }
 
+test "supports configured react jsx key duplicate warnings" {
+    const source =
+        \\const nodes = [
+        \\  <Item key="same" />,
+        \\  <Item key="same" />,
+        \\  <Item key={id} />,
+        \\  <Item key={id} />,
+        \\  <Item key="other" />,
+        \\];
+        \\const unique = [
+        \\  <Item key="first" />,
+        \\  <Item key="second" />,
+        \\];
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"warnOnDuplicates\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-key", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.react_jsx_key.id));
+    try std.testing.expect(hasMessage(result, "`key` prop must be unique"));
+}
+
+test "supports configured react jsx key duplicate warnings for children" {
+    const source =
+        \\const view = (
+        \\  <List>
+        \\    <Item key="same" />
+        \\    <Item key="same" />
+        \\    <Item key="other" />
+        \\  </List>
+        \\);
+        \\const unique = (
+        \\  <List>
+        \\    <Item key="first" />
+        \\    <Item key="second" />
+        \\  </List>
+        \\);
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"warnOnDuplicates\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = test_options;
+    try options.setByRuleConfigValue("react/jsx-key", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_jsx_key.id));
+    try std.testing.expect(hasMessage(result, "`key` prop must be unique"));
+}
+
 test "allows react jsx key fragment shorthand by default" {
     const source =
         \\const nodes = [
@@ -103,6 +171,17 @@ test "allows react jsx key fragment shorthand by default" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_jsx_key.id));
+}
+
+fn hasMessage(result: lint.Result, expected: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_jsx_key.id) and
+            std.mem.eql(u8, diagnostic.message, expected))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 test "reports JSX elements without keys in block callback returns" {


### PR DESCRIPTION
## Summary
- add `react/jsx-key` support for the `warnOnDuplicates` option
- report duplicate static key values in array literals and JSX child collections
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
