### PR TITLE
Support import/no-unresolved ignore patterns

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -203,7 +203,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
-| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions and `smallfish:`/`minifish:` ignores |
+| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, and common `ignore` pattern behavior |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -388,6 +388,30 @@ pub const NoParamReassignProps = enum {
     no,
 };
 
+pub const max_import_no_unresolved_ignore_patterns = 32;
+pub const max_import_no_unresolved_ignore_pattern_len = 256;
+
+pub const ImportNoUnresolvedIgnorePatterns = struct {
+    count: usize = 0,
+    lengths: [max_import_no_unresolved_ignore_patterns]usize = undefined,
+    storage: [max_import_no_unresolved_ignore_patterns][max_import_no_unresolved_ignore_pattern_len]u8 = undefined,
+
+    pub fn at(self: *const ImportNoUnresolvedIgnorePatterns, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ImportNoUnresolvedIgnorePatterns, pattern: []const u8) bool {
+        if (pattern.len == 0) return false;
+        if (self.count >= max_import_no_unresolved_ignore_patterns) return false;
+        if (pattern.len > max_import_no_unresolved_ignore_pattern_len) return false;
+
+        @memcpy(self.storage[self.count][0..pattern.len], pattern);
+        self.lengths[self.count] = pattern.len;
+        self.count += 1;
+        return true;
+    }
+};
+
 pub const max_no_param_reassign_ignored_names = 32;
 pub const max_no_param_reassign_ignored_name_len = 128;
 pub const max_no_param_reassign_ignored_name_patterns = 32;
@@ -1456,6 +1480,7 @@ pub const Options = struct {
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
     import_no_unresolved: bool = true,
+    import_no_unresolved_ignore: ImportNoUnresolvedIgnorePatterns = .{},
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_alt_text_img: bool = true,
@@ -2012,6 +2037,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "eslint-comments/no-restricted-disable")) {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
+        }
+        if (std.mem.eql(u8, cli_name, "import/no-unresolved")) {
+            self.import_no_unresolved_ignore = try importNoUnresolvedIgnorePatternsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
@@ -2863,6 +2891,33 @@ pub const Options = struct {
             if (std.mem.eql(u8, rule, "no-nested-ternary")) return true;
         }
         return false;
+    }
+
+    fn importNoUnresolvedIgnorePatternsFromConfig(value: std.json.Value) RuleConfigError!ImportNoUnresolvedIgnorePatterns {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignores = switch (config.get("ignore") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var patterns = ImportNoUnresolvedIgnorePatterns{};
+        for (ignores) |ignore| {
+            const pattern = switch (ignore) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!patterns.append(pattern)) return error.UnsupportedRuleConfigValue;
+        }
+        return patterns;
     }
 
     fn funcNameMatchingStyleFromConfig(value: std.json.Value) RuleConfigError!FuncNameMatchingStyle {
@@ -6604,6 +6659,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_unresolved);
     try std.testing.expect(options.setByCliName("import/no-unresolved", true));
     try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expectEqual(@as(usize, 0), options.import_no_unresolved_ignore.count);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
     try std.testing.expect(options.setByCliName("react/default-props-match-prop-types", true));
@@ -7093,6 +7149,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("consistent-return", consistent_return_config.value);
     try std.testing.expect(options.consistent_return);
     try std.testing.expect(options.consistent_return_treat_undefined_as_unspecified);
+
+    var import_no_unresolved_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
+        .{},
+    );
+    defer import_no_unresolved_config.deinit();
+    try options.setByRuleConfigValue("import/no-unresolved", import_no_unresolved_config.value);
+    try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expectEqual(@as(usize, 2), options.import_no_unresolved_ignore.count);
+    try std.testing.expectEqualStrings("\\.img$", options.import_no_unresolved_ignore.at(0));
+    try std.testing.expectEqualStrings("^virtual:", options.import_no_unresolved_ignore.at(1));
 
     var dot_notation_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/import_no_unresolved.zig
+++ b/src/rules/import_no_unresolved.zig
@@ -25,12 +25,17 @@ const resolve_extensions = [_][]const u8{
     ".cts",
 };
 
+pub const Options = struct {
+    ignore: core.ImportNoUnresolvedIgnorePatterns = .{},
+};
+
 pub fn run(
     allocator: Allocator,
     io: std.Io,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     file_path: []const u8,
+    options: Options,
 ) Allocator.Error!void {
     const program = switch (tree.data(tree.root)) {
         .program => |program| program,
@@ -41,15 +46,15 @@ pub fn run(
         switch (tree.data(statement_index)) {
             .import_declaration => |declaration| {
                 if (declaration.import_kind == .type) continue;
-                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source, options);
             },
             .export_named_declaration => |declaration| {
                 if (declaration.export_kind == .type or declaration.source == .null) continue;
-                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source, options);
             },
             .export_all_declaration => |declaration| {
                 if (declaration.export_kind == .type) continue;
-                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source);
+                try checkSourceNode(allocator, io, diagnostics, tree, file_path, declaration.source, options);
             },
             else => {},
         }
@@ -60,6 +65,7 @@ pub fn run(
         .io = io,
         .diagnostics = diagnostics,
         .file_path = file_path,
+        .options = options,
     };
     try traverser.basic.traverse(DynamicImportVisitor, tree, &visitor);
 }
@@ -69,6 +75,7 @@ const DynamicImportVisitor = struct {
     io: std.Io,
     diagnostics: *core.DiagnosticList,
     file_path: []const u8,
+    options: Options,
 
     pub fn enter_import_expression(
         self: *DynamicImportVisitor,
@@ -76,7 +83,7 @@ const DynamicImportVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, expression.source);
+        try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, expression.source, self.options);
         return .proceed;
     }
 };
@@ -88,9 +95,10 @@ fn checkSourceNode(
     tree: *const ast.Tree,
     file_path: []const u8,
     source_node: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const source = stringLiteralValue(tree, source_node) orelse return;
-    if (shouldIgnore(source)) return;
+    if (shouldIgnore(source, options.ignore)) return;
     if (try resolves(allocator, io, file_path, source)) return;
 
     try core.addDiagnosticFmt(
@@ -294,9 +302,100 @@ fn packageName(source: []const u8) ?[]const u8 {
     return source[0..second_slash];
 }
 
-fn shouldIgnore(source: []const u8) bool {
-    return std.mem.startsWith(u8, source, "smallfish:") or
-        std.mem.startsWith(u8, source, "minifish:");
+fn shouldIgnore(source: []const u8, ignore: core.ImportNoUnresolvedIgnorePatterns) bool {
+    if (std.mem.startsWith(u8, source, "smallfish:") or
+        std.mem.startsWith(u8, source, "minifish:")) return true;
+
+    for (0..ignore.count) |index| {
+        if (matchesIgnorePattern(ignore.at(index), source)) return true;
+    }
+    return false;
+}
+
+fn matchesIgnorePattern(pattern: []const u8, source: []const u8) bool {
+    if (pattern.len == 0) return false;
+    const anchored_start = pattern[0] == '^';
+    const anchored_end = hasUnescapedTrailingDollar(pattern);
+    const start: usize = if (anchored_start) 1 else 0;
+    const end: usize = if (anchored_end) pattern.len - 1 else pattern.len;
+    const body = pattern[start..end];
+
+    if (anchored_start) {
+        return matchPatternAt(body, 0, source, 0, anchored_end);
+    }
+
+    for (0..source.len + 1) |source_index| {
+        if (matchPatternAt(body, 0, source, source_index, anchored_end)) return true;
+    }
+    return false;
+}
+
+fn hasUnescapedTrailingDollar(pattern: []const u8) bool {
+    if (pattern.len == 0 or pattern[pattern.len - 1] != '$') return false;
+    var slash_count: usize = 0;
+    var index = pattern.len - 1;
+    while (index > 0) {
+        index -= 1;
+        if (pattern[index] != '\\') break;
+        slash_count += 1;
+    }
+    return slash_count % 2 == 0;
+}
+
+fn matchPatternAt(pattern: []const u8, pattern_index: usize, source: []const u8, source_index: usize, anchored_end: bool) bool {
+    if (pattern_index >= pattern.len) return !anchored_end or source_index == source.len;
+
+    const token = readPatternToken(pattern, pattern_index);
+    const next_index = token.next_index;
+    if (next_index < pattern.len and pattern[next_index] == '*') {
+        var end_index = source_index;
+        while (end_index < source.len and token.matches(source[end_index])) {
+            end_index += 1;
+        }
+        while (true) {
+            if (matchPatternAt(pattern, next_index + 1, source, end_index, anchored_end)) return true;
+            if (end_index == source_index) break;
+            end_index -= 1;
+        }
+        return false;
+    }
+
+    if (source_index >= source.len or !token.matches(source[source_index])) return false;
+    return matchPatternAt(pattern, next_index, source, source_index + 1, anchored_end);
+}
+
+const PatternToken = struct {
+    kind: enum { any, literal },
+    literal: u8 = 0,
+    next_index: usize,
+
+    fn matches(self: PatternToken, value: u8) bool {
+        return switch (self.kind) {
+            .any => true,
+            .literal => self.literal == value,
+        };
+    }
+};
+
+fn readPatternToken(pattern: []const u8, index: usize) PatternToken {
+    if (pattern[index] == '\\' and index + 1 < pattern.len) {
+        return .{
+            .kind = .literal,
+            .literal = pattern[index + 1],
+            .next_index = index + 2,
+        };
+    }
+    if (pattern[index] == '.') {
+        return .{
+            .kind = .any,
+            .next_index = index + 1,
+        };
+    }
+    return .{
+        .kind = .literal,
+        .literal = pattern[index],
+        .next_index = index + 1,
+    };
 }
 
 fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -738,6 +738,9 @@ pub fn runSemantic(
                 diagnostics,
                 tree,
                 file_path,
+                .{
+                    .ignore = options.import_no_unresolved_ignore,
+                },
             );
         }
     }

--- a/tests/rules/import_no_unresolved.zig
+++ b/tests/rules/import_no_unresolved.zig
@@ -106,6 +106,39 @@ test "reports import/no-unresolved for missing packages" {
     try std.testing.expectEqualStrings("Unable to resolve path to module 'definitely-missing-package'.", ruleDiagnostic(result, 0).message);
 }
 
+test "supports configured import/no-unresolved ignore patterns" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source =
+        \\import img from './missing.img';
+        \\import virtual from 'virtual:module';
+        \\import missing from './missing.js';
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = optionsOnly();
+    try options.setByRuleConfigValue("import/no-unresolved", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_no_unresolved.id));
+    try std.testing.expectEqualStrings("Unable to resolve path to module './missing.js'.", ruleDiagnostic(result, 0).message);
+}
+
 test "can disable import/no-unresolved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
- parse `import/no-unresolved` `ignore` option from ESLint-style config
- skip unresolved diagnostics for configured ignore patterns, including common `\.ext$` and `^prefix` patterns
- document the newly supported behavior in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`