### PR TITLE
Support import/no-cycle maxDepth

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -199,7 +199,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count`, `exactCount`, and `considerComments` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
-| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions |
+| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth` configuration |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1476,6 +1476,7 @@ pub const Options = struct {
     import_newline_after_import_consider_comments: bool = false,
     import_no_amd: bool = true,
     import_no_cycle: bool = true,
+    import_no_cycle_max_depth: usize = 1024,
     import_no_duplicates: bool = true,
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
@@ -2071,6 +2072,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "import/no-cycle")) {
+            self.import_no_cycle_max_depth = try importNoCycleMaxDepthFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/newline-after-import")) {
             self.import_newline_after_import_count = try importNewlineAfterImportCountFromConfig(value);
@@ -3956,6 +3960,25 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn importNoCycleMaxDepthFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 1024,
+        };
+        if (items.len < 2) return 1024;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const max_depth = switch (config.get("maxDepth") orelse return 1024) {
+            .integer => |max_depth| max_depth,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (max_depth < 1) return error.UnsupportedRuleConfigValue;
+        return @intCast(max_depth);
     }
 
     fn importNewlineAfterImportCountFromConfig(value: std.json.Value) RuleConfigError!usize {
@@ -6647,6 +6670,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_cycle);
     try std.testing.expect(options.setByCliName("import/no-cycle", true));
     try std.testing.expect(options.import_no_cycle);
+    try std.testing.expectEqual(@as(usize, 1024), options.import_no_cycle_max_depth);
 
     try std.testing.expect(!options.import_no_named_as_default);
     try std.testing.expect(options.setByCliName("import/no-named-as-default", true));
@@ -7149,6 +7173,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("consistent-return", consistent_return_config.value);
     try std.testing.expect(options.consistent_return);
     try std.testing.expect(options.consistent_return_treat_undefined_as_unspecified);
+
+    var import_no_cycle_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"maxDepth\":1}]",
+        .{},
+    );
+    defer import_no_cycle_config.deinit();
+    try options.setByRuleConfigValue("import/no-cycle", import_no_cycle_config.value);
+    try std.testing.expect(options.import_no_cycle);
+    try std.testing.expectEqual(@as(usize, 1), options.import_no_cycle_max_depth);
 
     var import_no_unresolved_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/import_no_cycle.zig
+++ b/src/rules/import_no_cycle.zig
@@ -9,7 +9,10 @@ const Allocator = std.mem.Allocator;
 pub const id = "import/no-cycle";
 
 const max_source_size = 1024 * 1024;
-const max_depth = 1024;
+
+pub const Options = struct {
+    max_depth: usize = 1024,
+};
 
 const Dependency = struct {
     source: []const u8,
@@ -37,6 +40,7 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     file_path: []const u8,
+    options: Options,
 ) Allocator.Error!void {
     const normalized_file_path = try std.fs.path.resolve(allocator, &.{file_path});
     defer allocator.free(normalized_file_path);
@@ -53,7 +57,7 @@ pub fn run(
         var route: std.ArrayList(RouteStep) = .empty;
         defer deinitRoute(allocator, &route);
 
-        if (try hasCycle(allocator, io, dependency.resolved, normalized_file_path, &visited, &route, 0)) {
+        if (try hasCycle(allocator, io, dependency.resolved, normalized_file_path, &visited, &route, 0, options.max_depth)) {
             try reportCycle(allocator, diagnostics, tree, dependency.line, dependency.source, &route);
         }
     }
@@ -67,6 +71,7 @@ fn hasCycle(
     visited: *std.StringHashMap(void),
     route: *std.ArrayList(RouteStep),
     depth: usize,
+    max_depth: usize,
 ) Allocator.Error!bool {
     if (depth >= max_depth) return false;
     if (visited.contains(path)) return false;
@@ -92,7 +97,7 @@ fn hasCycle(
             .line = dependency.line,
         });
 
-        if (try hasCycle(allocator, io, dependency.resolved, target, visited, route, depth + 1)) {
+        if (try hasCycle(allocator, io, dependency.resolved, target, visited, route, depth + 1, max_depth)) {
             return true;
         }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -705,6 +705,9 @@ pub fn runSemantic(
                 diagnostics,
                 tree,
                 file_path,
+                .{
+                    .max_depth = options.import_no_cycle_max_depth,
+                },
             );
         }
     }

--- a/tests/rules/import_no_cycle.zig
+++ b/tests/rules/import_no_cycle.zig
@@ -51,6 +51,54 @@ test "reports import/no-cycle for direct and indirect relative import cycles" {
     try std.testing.expectEqual(.@"error", ruleDiagnostic(result, 0).severity);
 }
 
+test "supports configured import/no-cycle maxDepth option" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.ts",
+        .data = "import { entry } from './entry';\nexport const direct = entry;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/middle.ts",
+        .data = "import { leaf } from './leaf';\nexport const middle = leaf;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/leaf.ts",
+        .data = "import { entry } from './entry';\nexport const leaf = entry;\n",
+    });
+
+    const source =
+        \\import { direct } from './direct';
+        \\import { middle } from './middle';
+        \\export const entry = direct + middle;
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.ts",
+        .data = source,
+    });
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"maxDepth\":1}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("import/no-cycle", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_no_cycle.id));
+    try std.testing.expectEqualStrings("Dependency cycle detected.", ruleDiagnostic(result, 0).message);
+}
+
 test "ignores import/no-cycle type imports unresolved modules and self imports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -124,6 +172,24 @@ test "can disable import/no-cycle" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn entryPath(tmp: *std.testing.TmpDir) ![]u8 {
+    return std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "src",
+        "entry.ts",
+    });
 }
 
 fn ruleDiagnostic(result: lint.Result, index: usize) lint.Diagnostic {


### PR DESCRIPTION
## Summary
- parse `import/no-cycle` `maxDepth` from ESLint-style config
- use the configured depth limit during cycle traversal
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`