### PR TITLE
Support import/no-unresolved commonjs

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -203,7 +203,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
-| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, and common `ignore` pattern behavior |
+| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, `commonjs`, and common `ignore` pattern behavior |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -1481,6 +1481,7 @@ pub const Options = struct {
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
     import_no_unresolved: bool = true,
+    import_no_unresolved_commonjs: bool = false,
     import_no_unresolved_ignore: ImportNoUnresolvedIgnorePatterns = .{},
     import_no_self_import: bool = true,
     jsx_a11y_alt_text: bool = true,
@@ -2040,6 +2041,7 @@ pub const Options = struct {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-unresolved")) {
+            self.import_no_unresolved_commonjs = try importNoUnresolvedBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_unresolved_ignore = try importNoUnresolvedIgnorePatternsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
@@ -2922,6 +2924,23 @@ pub const Options = struct {
             if (!patterns.append(pattern)) return error.UnsupportedRuleConfigValue;
         }
         return patterns;
+    }
+
+    fn importNoUnresolvedBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn funcNameMatchingStyleFromConfig(value: std.json.Value) RuleConfigError!FuncNameMatchingStyle {
@@ -6683,6 +6702,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_unresolved);
     try std.testing.expect(options.setByCliName("import/no-unresolved", true));
     try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expect(!options.import_no_unresolved_commonjs);
     try std.testing.expectEqual(@as(usize, 0), options.import_no_unresolved_ignore.count);
 
     try std.testing.expect(!options.react_default_props_match_prop_types);
@@ -7188,12 +7208,13 @@ test "Options can apply ESLint-style rule config values" {
     var import_no_unresolved_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
+        "[\"error\",{\"commonjs\":true,\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
         .{},
     );
     defer import_no_unresolved_config.deinit();
     try options.setByRuleConfigValue("import/no-unresolved", import_no_unresolved_config.value);
     try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expect(options.import_no_unresolved_commonjs);
     try std.testing.expectEqual(@as(usize, 2), options.import_no_unresolved_ignore.count);
     try std.testing.expectEqualStrings("\\.img$", options.import_no_unresolved_ignore.at(0));
     try std.testing.expectEqualStrings("^virtual:", options.import_no_unresolved_ignore.at(1));

--- a/src/rules/import_no_unresolved.zig
+++ b/src/rules/import_no_unresolved.zig
@@ -26,6 +26,7 @@ const resolve_extensions = [_][]const u8{
 };
 
 pub const Options = struct {
+    commonjs: bool = false,
     ignore: core.ImportNoUnresolvedIgnorePatterns = .{},
 };
 
@@ -84,6 +85,20 @@ const DynamicImportVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, expression.source, self.options);
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *DynamicImportVisitor,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.options.commonjs) return .proceed;
+        if (!isRequireCall(ctx.tree, call)) return .proceed;
+        const arguments = ctx.tree.extra(call.arguments);
+        if (arguments.len != 1) return .proceed;
+        try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, arguments[0], self.options);
         return .proceed;
     }
 };
@@ -396,6 +411,30 @@ fn readPatternToken(pattern: []const u8, index: usize) PatternToken {
         .literal = pattern[index],
         .next_index = index + 1,
     };
+}
+
+fn isRequireCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    return isIdentifierReferenceNamed(tree, unwrapTransparent(tree, call.callee), "require");
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, expected);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
 }
 
 fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -742,6 +742,7 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 .{
+                    .commonjs = options.import_no_unresolved_commonjs,
                     .ignore = options.import_no_unresolved_ignore,
                 },
             );

--- a/tests/rules/import_no_unresolved.zig
+++ b/tests/rules/import_no_unresolved.zig
@@ -139,6 +139,58 @@ test "supports configured import/no-unresolved ignore patterns" {
     try std.testing.expectEqualStrings("Unable to resolve path to module './missing.js'.", ruleDiagnostic(result, 0).message);
 }
 
+test "supports configured import/no-unresolved commonjs requires" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/resolved.js", .data = "module.exports = 1;\n" });
+    const source =
+        \\const resolved = require('./resolved');
+        \\const missing = require('./missing');
+        \\require(0);
+        \\require(['./amd-missing'], function () {});
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"commonjs\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = optionsOnly();
+    try options.setByRuleConfigValue("import/no-unresolved", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.import_no_unresolved.id));
+    try std.testing.expectEqualStrings("Unable to resolve path to module './missing'.", ruleDiagnostic(result, 0).message);
+}
+
+test "allows import/no-unresolved commonjs requires by default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source = "const missing = require('./missing');\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
+}
+
 test "can disable import/no-unresolved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
- parse `import/no-unresolved` `commonjs` from ESLint-style config
- check single-string `require()` calls when the option is enabled
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`