### PR TITLE
Support import/no-unresolved amd

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -203,7 +203,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
-| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, `commonjs`, and common `ignore` pattern behavior |
+| [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, `commonjs`, `amd`, and common `ignore` pattern behavior |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
 ## JSX a11y rules

--- a/src/core.zig
+++ b/src/core.zig
@@ -1481,6 +1481,7 @@ pub const Options = struct {
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
     import_no_unresolved: bool = true,
+    import_no_unresolved_amd: bool = false,
     import_no_unresolved_commonjs: bool = false,
     import_no_unresolved_ignore: ImportNoUnresolvedIgnorePatterns = .{},
     import_no_self_import: bool = true,
@@ -2041,6 +2042,7 @@ pub const Options = struct {
             self.eslint_comments_no_restricted_disable_no_nested_ternary = noRestrictedDisableRestrictsNoNestedTernary(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-unresolved")) {
+            self.import_no_unresolved_amd = try importNoUnresolvedBoolOptionFromConfig(value, "amd", false);
             self.import_no_unresolved_commonjs = try importNoUnresolvedBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_unresolved_ignore = try importNoUnresolvedIgnorePatternsFromConfig(value);
         }
@@ -6702,6 +6704,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_unresolved);
     try std.testing.expect(options.setByCliName("import/no-unresolved", true));
     try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expect(!options.import_no_unresolved_amd);
     try std.testing.expect(!options.import_no_unresolved_commonjs);
     try std.testing.expectEqual(@as(usize, 0), options.import_no_unresolved_ignore.count);
 
@@ -7208,12 +7211,13 @@ test "Options can apply ESLint-style rule config values" {
     var import_no_unresolved_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"commonjs\":true,\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
+        "[\"error\",{\"amd\":true,\"commonjs\":true,\"ignore\":[\"\\\\.img$\",\"^virtual:\"]}]",
         .{},
     );
     defer import_no_unresolved_config.deinit();
     try options.setByRuleConfigValue("import/no-unresolved", import_no_unresolved_config.value);
     try std.testing.expect(options.import_no_unresolved);
+    try std.testing.expect(options.import_no_unresolved_amd);
     try std.testing.expect(options.import_no_unresolved_commonjs);
     try std.testing.expectEqual(@as(usize, 2), options.import_no_unresolved_ignore.count);
     try std.testing.expectEqualStrings("\\.img$", options.import_no_unresolved_ignore.at(0));

--- a/src/rules/import_no_unresolved.zig
+++ b/src/rules/import_no_unresolved.zig
@@ -26,6 +26,7 @@ const resolve_extensions = [_][]const u8{
 };
 
 pub const Options = struct {
+    amd: bool = false,
     commonjs: bool = false,
     ignore: core.ImportNoUnresolvedIgnorePatterns = .{},
 };
@@ -94,12 +95,30 @@ const DynamicImportVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (!self.options.commonjs) return .proceed;
-        if (!isRequireCall(ctx.tree, call)) return .proceed;
         const arguments = ctx.tree.extra(call.arguments);
-        if (arguments.len != 1) return .proceed;
-        try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, arguments[0], self.options);
+        if (self.options.commonjs and isRequireCall(ctx.tree, call) and arguments.len == 1) {
+            try checkSourceNode(self.allocator, self.io, self.diagnostics, ctx.tree, self.file_path, arguments[0], self.options);
+        }
+        if (self.options.amd and isAmdCall(ctx.tree, call)) {
+            try self.checkAmdDependencies(ctx.tree, arguments);
+        }
         return .proceed;
+    }
+
+    fn checkAmdDependencies(
+        self: *DynamicImportVisitor,
+        tree: *const ast.Tree,
+        arguments: []const ast.NodeIndex,
+    ) Allocator.Error!void {
+        if (arguments.len == 0) return;
+        const dependencies = switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+            .array_expression => |array| array,
+            else => return,
+        };
+        for (tree.extra(dependencies.elements)) |element| {
+            if (element == .null) continue;
+            try checkSourceNode(self.allocator, self.io, self.diagnostics, tree, self.file_path, element, self.options);
+        }
     }
 };
 
@@ -415,6 +434,12 @@ fn readPatternToken(pattern: []const u8, index: usize) PatternToken {
 
 fn isRequireCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
     return isIdentifierReferenceNamed(tree, unwrapTransparent(tree, call.callee), "require");
+}
+
+fn isAmdCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    return isIdentifierReferenceNamed(tree, callee, "define") or
+        isIdentifierReferenceNamed(tree, callee, "require");
 }
 
 fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -742,6 +742,7 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 .{
+                    .amd = options.import_no_unresolved_amd,
                     .commonjs = options.import_no_unresolved_commonjs,
                     .ignore = options.import_no_unresolved_ignore,
                 },

--- a/tests/rules/import_no_unresolved.zig
+++ b/tests/rules/import_no_unresolved.zig
@@ -191,6 +191,58 @@ test "allows import/no-unresolved commonjs requires by default" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
 }
 
+test "supports configured import/no-unresolved amd dependencies" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/resolved.js", .data = "define(function () { return 1; });\n" });
+    const source =
+        \\define(['./resolved', './missing-define'], function () {});
+        \\require(['./missing-require'], function () {});
+        \\require('./commonjs-missing');
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"amd\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = optionsOnly();
+    try options.setByRuleConfigValue("import/no-unresolved", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_unresolved.id));
+    try std.testing.expectEqualStrings("Unable to resolve path to module './missing-define'.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Unable to resolve path to module './missing-require'.", ruleDiagnostic(result, 1).message);
+}
+
+test "allows import/no-unresolved amd dependencies by default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    const source = "define(['./missing'], function () {});\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src/entry.js", .data = source });
+
+    const file_path = try entryPath(&tmp);
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_unresolved.id));
+}
+
 test "can disable import/no-unresolved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
- parse `import/no-unresolved` `amd` from ESLint-style config
- check AMD `define([...])` and `require([...])` string dependencies when the option is enabled
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`