### PR TITLE
Support import/no-cycle commonjs

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -199,7 +199,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count`, `exactCount`, and `considerComments` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
-| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth` configuration |
+| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth` and `commonjs` configuration |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1476,6 +1476,7 @@ pub const Options = struct {
     import_newline_after_import_consider_comments: bool = false,
     import_no_amd: bool = true,
     import_no_cycle: bool = true,
+    import_no_cycle_commonjs: bool = false,
     import_no_cycle_max_depth: usize = 1024,
     import_no_duplicates: bool = true,
     import_no_named_as_default: bool = true,
@@ -2078,6 +2079,7 @@ pub const Options = struct {
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-cycle")) {
+            self.import_no_cycle_commonjs = try importNoCycleBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_cycle_max_depth = try importNoCycleMaxDepthFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/newline-after-import")) {
@@ -4000,6 +4002,23 @@ pub const Options = struct {
         };
         if (max_depth < 1) return error.UnsupportedRuleConfigValue;
         return @intCast(max_depth);
+    }
+
+    fn importNoCycleBoolOptionFromConfig(value: std.json.Value, name: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(name) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn importNewlineAfterImportCountFromConfig(value: std.json.Value) RuleConfigError!usize {
@@ -6691,6 +6710,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_cycle);
     try std.testing.expect(options.setByCliName("import/no-cycle", true));
     try std.testing.expect(options.import_no_cycle);
+    try std.testing.expect(!options.import_no_cycle_commonjs);
     try std.testing.expectEqual(@as(usize, 1024), options.import_no_cycle_max_depth);
 
     try std.testing.expect(!options.import_no_named_as_default);
@@ -7200,12 +7220,13 @@ test "Options can apply ESLint-style rule config values" {
     var import_no_cycle_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"maxDepth\":1}]",
+        "[\"error\",{\"commonjs\":true,\"maxDepth\":1}]",
         .{},
     );
     defer import_no_cycle_config.deinit();
     try options.setByRuleConfigValue("import/no-cycle", import_no_cycle_config.value);
     try std.testing.expect(options.import_no_cycle);
+    try std.testing.expect(options.import_no_cycle_commonjs);
     try std.testing.expectEqual(@as(usize, 1), options.import_no_cycle_max_depth);
 
     var import_no_unresolved_config = try std.json.parseFromSlice(

--- a/src/rules/import_no_cycle.zig
+++ b/src/rules/import_no_cycle.zig
@@ -4,6 +4,7 @@ const core = @import("../core.zig");
 const export_map = @import("import_export_map.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "import/no-cycle";
@@ -11,12 +12,14 @@ pub const id = "import/no-cycle";
 const max_source_size = 1024 * 1024;
 
 pub const Options = struct {
+    commonjs: bool = false,
     max_depth: usize = 1024,
 };
 
 const Dependency = struct {
     source: []const u8,
     resolved: []const u8,
+    node: ast.NodeIndex,
     line: usize,
 
     fn deinit(self: Dependency, allocator: Allocator) void {
@@ -45,7 +48,7 @@ pub fn run(
     const normalized_file_path = try std.fs.path.resolve(allocator, &.{file_path});
     defer allocator.free(normalized_file_path);
 
-    var dependencies = try collectDependencies(allocator, io, tree, normalized_file_path);
+    var dependencies = try collectDependencies(allocator, io, tree, normalized_file_path, options);
     defer deinitDependencies(allocator, &dependencies);
 
     for (dependencies.items) |dependency| {
@@ -57,8 +60,8 @@ pub fn run(
         var route: std.ArrayList(RouteStep) = .empty;
         defer deinitRoute(allocator, &route);
 
-        if (try hasCycle(allocator, io, dependency.resolved, normalized_file_path, &visited, &route, 0, options.max_depth)) {
-            try reportCycle(allocator, diagnostics, tree, dependency.line, dependency.source, &route);
+        if (try hasCycle(allocator, io, dependency.resolved, normalized_file_path, &visited, &route, 0, options)) {
+            try reportCycle(allocator, diagnostics, tree, dependency.node, &route);
         }
     }
 }
@@ -71,16 +74,16 @@ fn hasCycle(
     visited: *std.StringHashMap(void),
     route: *std.ArrayList(RouteStep),
     depth: usize,
-    max_depth: usize,
+    options: Options,
 ) Allocator.Error!bool {
-    if (depth >= max_depth) return false;
+    if (depth >= options.max_depth) return false;
     if (visited.contains(path)) return false;
 
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
     try visited.put(owned_path, {});
 
-    var dependencies = try collectFileDependencies(allocator, io, path);
+    var dependencies = try collectFileDependencies(allocator, io, path, options);
     defer deinitDependencies(allocator, &dependencies);
 
     for (dependencies.items) |dependency| {
@@ -97,7 +100,7 @@ fn hasCycle(
             .line = dependency.line,
         });
 
-        if (try hasCycle(allocator, io, dependency.resolved, target, visited, route, depth + 1, max_depth)) {
+        if (try hasCycle(allocator, io, dependency.resolved, target, visited, route, depth + 1, options)) {
             return true;
         }
 
@@ -112,12 +115,9 @@ fn reportCycle(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    line: usize,
-    source: []const u8,
+    node: ast.NodeIndex,
     route: *const std.ArrayList(RouteStep),
 ) Allocator.Error!void {
-    const node = findDependencyNode(tree, line, source) orelse tree.root;
-
     if (route.items.len == 0) {
         try core.addDiagnostic(
             allocator,
@@ -158,43 +158,11 @@ fn formatRoute(allocator: Allocator, route: *const std.ArrayList(RouteStep)) All
     return out.toOwnedSlice(allocator);
 }
 
-fn findDependencyNode(tree: *const ast.Tree, line: usize, source: []const u8) ?ast.NodeIndex {
-    const program = switch (tree.data(tree.root)) {
-        .program => |program| program,
-        else => return null,
-    };
-
-    for (tree.extra(program.body)) |statement_index| {
-        switch (tree.data(statement_index)) {
-            .import_declaration => |declaration| {
-                if (declaration.import_kind == .type) continue;
-                if (declaration.specifiers.len == 0) continue;
-                if (isOnlyTypeImport(tree, declaration)) continue;
-                const import_source = export_map.importSource(tree, declaration) orelse continue;
-                if (std.mem.eql(u8, import_source, source)) return statement_index;
-            },
-            .export_named_declaration => |declaration| {
-                if (declaration.export_kind == .type) continue;
-                const export_source = exportNamedSource(tree, declaration) orelse continue;
-                if (std.mem.eql(u8, export_source, source)) return statement_index;
-            },
-            .export_all_declaration => |declaration| {
-                if (declaration.export_kind == .type) continue;
-                const export_source = exportAllSource(tree, declaration) orelse continue;
-                if (std.mem.eql(u8, export_source, source)) return statement_index;
-            },
-            else => {},
-        }
-    }
-
-    _ = line;
-    return null;
-}
-
 fn collectFileDependencies(
     allocator: Allocator,
     io: std.Io,
     path: []const u8,
+    options: Options,
 ) Allocator.Error!std.ArrayList(Dependency) {
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_source_size)) catch return .empty;
     defer allocator.free(source);
@@ -206,7 +174,7 @@ fn collectFileDependencies(
     defer tree.deinit();
     if (tree.hasErrors()) return .empty;
 
-    return collectDependenciesFromSource(allocator, io, &tree, path, source);
+    return collectDependenciesFromSource(allocator, io, &tree, path, source, options);
 }
 
 fn collectDependencies(
@@ -214,8 +182,9 @@ fn collectDependencies(
     io: std.Io,
     tree: *const ast.Tree,
     path: []const u8,
+    options: Options,
 ) Allocator.Error!std.ArrayList(Dependency) {
-    return collectDependenciesFromSource(allocator, io, tree, path, "");
+    return collectDependenciesFromSource(allocator, io, tree, path, "", options);
 }
 
 fn collectDependenciesFromSource(
@@ -224,6 +193,7 @@ fn collectDependenciesFromSource(
     tree: *const ast.Tree,
     path: []const u8,
     source_text: []const u8,
+    options: Options,
 ) Allocator.Error!std.ArrayList(Dependency) {
     var dependencies: std.ArrayList(Dependency) = .empty;
     errdefer deinitDependencies(allocator, &dependencies);
@@ -256,8 +226,43 @@ fn collectDependenciesFromSource(
         }
     }
 
+    if (options.commonjs) {
+        var visitor = CommonJsDependencyVisitor{
+            .allocator = allocator,
+            .io = io,
+            .dependencies = &dependencies,
+            .path = path,
+            .source_text = source_text,
+        };
+        try traverser.basic.traverse(CommonJsDependencyVisitor, tree, &visitor);
+    }
+
     return dependencies;
 }
+
+const CommonJsDependencyVisitor = struct {
+    allocator: Allocator,
+    io: std.Io,
+    dependencies: *std.ArrayList(Dependency),
+    path: []const u8,
+    source_text: []const u8,
+
+    pub fn enter_call_expression(
+        self: *CommonJsDependencyVisitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isRequireCall(ctx.tree, call)) return .proceed;
+
+        const arguments = ctx.tree.extra(call.arguments);
+        if (arguments.len != 1) return .proceed;
+
+        const source = stringLiteralValue(ctx.tree, arguments[0]) orelse return .proceed;
+        try appendDependency(self.allocator, self.io, self.dependencies, ctx.tree, self.source_text, self.path, source, index);
+        return .proceed;
+    }
+};
 
 fn appendDependency(
     allocator: Allocator,
@@ -277,6 +282,7 @@ fn appendDependency(
     try dependencies.append(allocator, .{
         .source = owned_source,
         .resolved = resolved,
+        .node = statement_index,
         .line = lineForOffset(source_text, tree.span(statement_index).start),
     });
 }
@@ -335,4 +341,36 @@ fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration)
         .string_literal => |literal| tree.string(literal.value),
         else => null,
     };
+}
+
+fn isRequireCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    return isIdentifierReferenceNamed(tree, unwrapTransparent(tree, call.callee), "require");
+}
+
+fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
+        else => false,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -706,6 +706,7 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 .{
+                    .commonjs = options.import_no_cycle_commonjs,
                     .max_depth = options.import_no_cycle_max_depth,
                 },
             );

--- a/tests/rules/import_no_cycle.zig
+++ b/tests/rules/import_no_cycle.zig
@@ -99,6 +99,79 @@ test "supports configured import/no-cycle maxDepth option" {
     try std.testing.expectEqualStrings("Dependency cycle detected.", ruleDiagnostic(result, 0).message);
 }
 
+test "supports configured import/no-cycle commonjs dependencies" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.js",
+        .data = "const entry = require('./entry');\nmodule.exports = entry;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/middle.js",
+        .data = "const leaf = require('./leaf');\nmodule.exports = leaf;\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/leaf.js",
+        .data = "const entry = require('./entry');\nmodule.exports = entry;\n",
+    });
+
+    const source =
+        \\const direct = require('./direct');
+        \\const middle = require('./middle');
+        \\module.exports = direct + middle;
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.js",
+        .data = source,
+    });
+    const file_path = try fixturePath(&tmp, "entry.js");
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"commonjs\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("import/no-cycle", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_cycle.id));
+    try std.testing.expectEqualStrings("Dependency cycle detected.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Dependency cycle via ./leaf:1", ruleDiagnostic(result, 1).message);
+}
+
+test "allows import/no-cycle commonjs dependencies by default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.js",
+        .data = "const entry = require('./entry');\nmodule.exports = entry;\n",
+    });
+
+    const source = "const direct = require('./direct');\nmodule.exports = direct;\n";
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.js",
+        .data = source,
+    });
+    const file_path = try fixturePath(&tmp, "entry.js");
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
+}
+
 test "ignores import/no-cycle type imports unresolved modules and self imports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -183,12 +256,16 @@ fn baseOptions() lint.Options {
 }
 
 fn entryPath(tmp: *std.testing.TmpDir) ![]u8 {
+    return fixturePath(tmp, "entry.ts");
+}
+
+fn fixturePath(tmp: *std.testing.TmpDir, name: []const u8) ![]u8 {
     return std.fs.path.resolve(std.testing.allocator, &.{
         ".zig-cache",
         "tmp",
         &tmp.sub_path,
         "src",
-        "entry.ts",
+        name,
     });
 }
 


### PR DESCRIPTION
## Summary
- parse `import/no-cycle` `commonjs` from ESLint-style config
- include relative `require()` dependencies in the cycle graph when the option is enabled
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`