### PR TITLE
Support import/no-cycle amd

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -199,7 +199,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/namespace`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md) | Implemented for relative namespace imports resolved with fishlint's configured extensions |
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count`, `exactCount`, and `considerComments` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
-| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth` and `commonjs` configuration |
+| [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth`, `commonjs`, and `amd` configuration |
 | [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1476,6 +1476,7 @@ pub const Options = struct {
     import_newline_after_import_consider_comments: bool = false,
     import_no_amd: bool = true,
     import_no_cycle: bool = true,
+    import_no_cycle_amd: bool = false,
     import_no_cycle_commonjs: bool = false,
     import_no_cycle_max_depth: usize = 1024,
     import_no_duplicates: bool = true,
@@ -2079,6 +2080,7 @@ pub const Options = struct {
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-cycle")) {
+            self.import_no_cycle_amd = try importNoCycleBoolOptionFromConfig(value, "amd", false);
             self.import_no_cycle_commonjs = try importNoCycleBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_cycle_max_depth = try importNoCycleMaxDepthFromConfig(value);
         }
@@ -6710,6 +6712,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_cycle);
     try std.testing.expect(options.setByCliName("import/no-cycle", true));
     try std.testing.expect(options.import_no_cycle);
+    try std.testing.expect(!options.import_no_cycle_amd);
     try std.testing.expect(!options.import_no_cycle_commonjs);
     try std.testing.expectEqual(@as(usize, 1024), options.import_no_cycle_max_depth);
 
@@ -7220,12 +7223,13 @@ test "Options can apply ESLint-style rule config values" {
     var import_no_cycle_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"commonjs\":true,\"maxDepth\":1}]",
+        "[\"error\",{\"amd\":true,\"commonjs\":true,\"maxDepth\":1}]",
         .{},
     );
     defer import_no_cycle_config.deinit();
     try options.setByRuleConfigValue("import/no-cycle", import_no_cycle_config.value);
     try std.testing.expect(options.import_no_cycle);
+    try std.testing.expect(options.import_no_cycle_amd);
     try std.testing.expect(options.import_no_cycle_commonjs);
     try std.testing.expectEqual(@as(usize, 1), options.import_no_cycle_max_depth);
 

--- a/src/rules/import_no_cycle.zig
+++ b/src/rules/import_no_cycle.zig
@@ -12,6 +12,7 @@ pub const id = "import/no-cycle";
 const max_source_size = 1024 * 1024;
 
 pub const Options = struct {
+    amd: bool = false,
     commonjs: bool = false,
     max_depth: usize = 1024,
 };
@@ -226,41 +227,68 @@ fn collectDependenciesFromSource(
         }
     }
 
-    if (options.commonjs) {
-        var visitor = CommonJsDependencyVisitor{
+    if (options.commonjs or options.amd) {
+        var visitor = CallDependencyVisitor{
             .allocator = allocator,
             .io = io,
             .dependencies = &dependencies,
             .path = path,
             .source_text = source_text,
+            .options = options,
         };
-        try traverser.basic.traverse(CommonJsDependencyVisitor, tree, &visitor);
+        try traverser.basic.traverse(CallDependencyVisitor, tree, &visitor);
     }
 
     return dependencies;
 }
 
-const CommonJsDependencyVisitor = struct {
+const CallDependencyVisitor = struct {
     allocator: Allocator,
     io: std.Io,
     dependencies: *std.ArrayList(Dependency),
     path: []const u8,
     source_text: []const u8,
+    options: Options,
 
     pub fn enter_call_expression(
-        self: *CommonJsDependencyVisitor,
+        self: *CallDependencyVisitor,
         call: ast.CallExpression,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (!isRequireCall(ctx.tree, call)) return .proceed;
-
         const arguments = ctx.tree.extra(call.arguments);
-        if (arguments.len != 1) return .proceed;
 
-        const source = stringLiteralValue(ctx.tree, arguments[0]) orelse return .proceed;
-        try appendDependency(self.allocator, self.io, self.dependencies, ctx.tree, self.source_text, self.path, source, index);
+        if (self.options.commonjs and isRequireCall(ctx.tree, call) and arguments.len == 1) {
+            if (stringLiteralValue(ctx.tree, arguments[0])) |source| {
+                try appendDependency(self.allocator, self.io, self.dependencies, ctx.tree, self.source_text, self.path, source, index);
+            }
+        }
+
+        if (self.options.amd and isAmdCall(ctx.tree, call)) {
+            try self.appendAmdDependencies(ctx.tree, arguments, index);
+        }
+
         return .proceed;
+    }
+
+    fn appendAmdDependencies(
+        self: *CallDependencyVisitor,
+        tree: *const ast.Tree,
+        arguments: []const ast.NodeIndex,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        if (arguments.len == 0) return;
+
+        const dependencies = switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+            .array_expression => |array| array,
+            else => return,
+        };
+
+        for (tree.extra(dependencies.elements)) |element| {
+            if (element == .null) continue;
+            const source = stringLiteralValue(tree, element) orelse continue;
+            try appendDependency(self.allocator, self.io, self.dependencies, tree, self.source_text, self.path, source, index);
+        }
     }
 };
 
@@ -345,6 +373,12 @@ fn exportAllSource(tree: *const ast.Tree, declaration: ast.ExportAllDeclaration)
 
 fn isRequireCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
     return isIdentifierReferenceNamed(tree, unwrapTransparent(tree, call.callee), "require");
+}
+
+fn isAmdCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    return isIdentifierReferenceNamed(tree, callee, "define") or
+        isIdentifierReferenceNamed(tree, callee, "require");
 }
 
 fn isIdentifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -706,6 +706,7 @@ pub fn runSemantic(
                 tree,
                 file_path,
                 .{
+                    .amd = options.import_no_cycle_amd,
                     .commonjs = options.import_no_cycle_commonjs,
                     .max_depth = options.import_no_cycle_max_depth,
                 },

--- a/tests/rules/import_no_cycle.zig
+++ b/tests/rules/import_no_cycle.zig
@@ -172,6 +172,79 @@ test "allows import/no-cycle commonjs dependencies by default" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
 }
 
+test "supports configured import/no-cycle amd dependencies" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.js",
+        .data = "define(['./entry'], function (entry) { return entry; });\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/middle.js",
+        .data = "require(['./leaf'], function (leaf) { return leaf; });\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/leaf.js",
+        .data = "define(['./entry'], function (entry) { return entry; });\n",
+    });
+
+    const source =
+        \\define(['./direct', './middle'], function (direct, middle) {
+        \\  return direct + middle;
+        \\});
+    ;
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.js",
+        .data = source,
+    });
+    const file_path = try fixturePath(&tmp, "entry.js");
+    defer std.testing.allocator.free(file_path);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"amd\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("import/no-cycle", config.value);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_cycle.id));
+    try std.testing.expectEqualStrings("Dependency cycle detected.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Dependency cycle via ./leaf:1", ruleDiagnostic(result, 1).message);
+}
+
+test "allows import/no-cycle amd dependencies by default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/direct.js",
+        .data = "define(['./entry'], function (entry) { return entry; });\n",
+    });
+
+    const source = "define(['./direct'], function (direct) { return direct; });\n";
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "src/entry.js",
+        .data = source,
+    });
+    const file_path = try fixturePath(&tmp, "entry.js");
+    defer std.testing.allocator.free(file_path);
+
+    var result = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source, file_path, baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_cycle.id));
+}
+
 test "ignores import/no-cycle type imports unresolved modules and self imports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
- parse `import/no-cycle` `amd` from ESLint-style config
- include relative AMD `define([...])` and `require([...])` dependencies in the cycle graph when the option is enabled
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`