### PR TITLE
Support import/no-duplicates considerQueryString

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -200,7 +200,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`import/newline-after-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md) | Implemented for `count`, `exactCount`, and `considerComments` configurations |
 | [`import/no-amd`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md) | Implemented |
 | [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) | Implemented for relative imports and re-exports resolved with fishlint's configured extensions, with `maxDepth`, `commonjs`, and `amd` configuration |
-| [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented |
+| [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) | Implemented with `considerQueryString` configuration |
 | [`import/no-named-as-default`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-named-as-default-member`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 | [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, `commonjs`, `amd`, and common `ignore` pattern behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1480,6 +1480,7 @@ pub const Options = struct {
     import_no_cycle_commonjs: bool = false,
     import_no_cycle_max_depth: usize = 1024,
     import_no_duplicates: bool = true,
+    import_no_duplicates_consider_query_string: bool = false,
     import_no_named_as_default: bool = true,
     import_no_named_as_default_member: bool = true,
     import_no_unresolved: bool = true,
@@ -2083,6 +2084,9 @@ pub const Options = struct {
             self.import_no_cycle_amd = try importNoCycleBoolOptionFromConfig(value, "amd", false);
             self.import_no_cycle_commonjs = try importNoCycleBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_cycle_max_depth = try importNoCycleMaxDepthFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "import/no-duplicates")) {
+            self.import_no_duplicates_consider_query_string = try importNoDuplicatesBoolOptionFromConfig(value, "considerQueryString", false);
         }
         if (std.mem.eql(u8, cli_name, "import/newline-after-import")) {
             self.import_newline_after_import_count = try importNewlineAfterImportCountFromConfig(value);
@@ -4007,6 +4011,23 @@ pub const Options = struct {
     }
 
     fn importNoCycleBoolOptionFromConfig(value: std.json.Value, name: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(name) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn importNoDuplicatesBoolOptionFromConfig(value: std.json.Value, name: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return default,
@@ -6660,6 +6681,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.import_no_duplicates);
     try std.testing.expect(options.setByCliName("import/no-duplicates", true));
     try std.testing.expect(options.import_no_duplicates);
+    try std.testing.expect(!options.import_no_duplicates_consider_query_string);
 
     try std.testing.expect(!options.alipay_ant_no_import_src);
     try std.testing.expect(options.setByCliName("@alipay/ant/no-import-src", true));
@@ -7232,6 +7254,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.import_no_cycle_amd);
     try std.testing.expect(options.import_no_cycle_commonjs);
     try std.testing.expectEqual(@as(usize, 1), options.import_no_cycle_max_depth);
+
+    var import_no_duplicates_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"considerQueryString\":true}]",
+        .{},
+    );
+    defer import_no_duplicates_config.deinit();
+    try options.setByRuleConfigValue("import/no-duplicates", import_no_duplicates_config.value);
+    try std.testing.expect(options.import_no_duplicates);
+    try std.testing.expect(options.import_no_duplicates_consider_query_string);
 
     var import_no_unresolved_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/import_no_duplicates.zig
+++ b/src/rules/import_no_duplicates.zig
@@ -7,8 +7,13 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "import/no-duplicates";
 
+pub const Options = struct {
+    consider_query_string: bool = false,
+};
+
 const SeenImport = struct {
     source: []const u8,
+    key: []const u8,
     source_node: ast.NodeIndex,
     reported: bool = false,
 };
@@ -19,6 +24,16 @@ pub fn check(
     tree: *const ast.Tree,
     program: ast.Program,
 ) Allocator.Error!void {
+    try checkWithOptions(allocator, diagnostics, tree, program, .{});
+}
+
+pub fn checkWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    options: Options,
+) Allocator.Error!void {
     var seen: std.ArrayList(SeenImport) = .empty;
     defer seen.deinit(allocator);
 
@@ -28,17 +43,22 @@ pub fn check(
             else => continue,
         };
         const source = importSource(tree, declaration) orelse continue;
+        const key = importKey(source, options);
 
-        if (findSeen(seen.items, source)) |seen_index| {
+        if (findSeen(seen.items, key)) |seen_index| {
             if (!seen.items[seen_index].reported) {
-                try addDiagnostic(allocator, diagnostics, tree, seen.items[seen_index].source_node, source);
+                try addDiagnostic(allocator, diagnostics, tree, seen.items[seen_index].source_node, seen.items[seen_index].source);
                 seen.items[seen_index].reported = true;
             }
             try addDiagnostic(allocator, diagnostics, tree, declaration.source, source);
             continue;
         }
 
-        try seen.append(allocator, .{ .source = source, .source_node = declaration.source });
+        try seen.append(allocator, .{
+            .source = source,
+            .key = key,
+            .source_node = declaration.source,
+        });
     }
 }
 
@@ -67,9 +87,15 @@ fn importSource(tree: *const ast.Tree, declaration: ast.ImportDeclaration) ?[]co
     };
 }
 
-fn findSeen(items: []const SeenImport, source: []const u8) ?usize {
+fn importKey(source: []const u8, options: Options) []const u8 {
+    if (options.consider_query_string) return source;
+    const query_index = std.mem.indexOfScalar(u8, source, '?') orelse return source;
+    return source[0..query_index];
+}
+
+fn findSeen(items: []const SeenImport, key: []const u8) ?usize {
     for (items, 0..) |item, i| {
-        if (std.mem.eql(u8, item.source, source)) return i;
+        if (std.mem.eql(u8, item.key, key)) return i;
     }
     return null;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1203,7 +1203,9 @@ const BasicVisitor = struct {
             );
         }
         if (self.options.import_no_duplicates) {
-            try import_no_duplicates.check(self.allocator, self.diagnostics, ctx.tree, program);
+            try import_no_duplicates.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, program, .{
+                .consider_query_string = self.options.import_no_duplicates_consider_query_string,
+            });
         }
         if (self.options.alipay_ant_no_import_src) {
             try alipay_ant_no_import_src.check(self.allocator, self.diagnostics, ctx.tree, program);

--- a/tests/rules/import_no_duplicates.zig
+++ b/tests/rules/import_no_duplicates.zig
@@ -41,6 +41,46 @@ test "does not report import/no-duplicates for distinct module sources" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_duplicates.id));
 }
 
+test "reports import/no-duplicates for repeated module sources with query strings by default" {
+    const source =
+        \\import view from "./template?raw";
+        \\import compiled from "./template?compiled";
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.import_no_duplicates.id));
+}
+
+test "supports configured import/no-duplicates considerQueryString option" {
+    const source =
+        \\import view from "./template?raw";
+        \\import compiled from "./template?compiled";
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"considerQueryString\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("import/no-duplicates", config.value);
+    options.parser_semantic_errors = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.import_no_duplicates.id));
+}
+
 test "falls back to no-duplicate-imports when import/no-duplicates is disabled" {
     const source =
         \\import foo from "alpha";


### PR DESCRIPTION
## Summary
- parse `import/no-duplicates` `considerQueryString` from ESLint-style config
- match duplicate imports without query strings by default, while preserving full-source matching when the option is enabled
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`