### PR TITLE
Support no-require-imports allowAsImport

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -289,7 +289,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
-| [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Implemented |
+| [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Supports `allowAsImport` configuration |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreOnInitialization`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Supports `allowedNames` and `allowDestructuring` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1864,6 +1864,7 @@ pub const Options = struct {
     typescript_eslint_no_redeclare_builtin_globals: bool = false,
     typescript_eslint_no_redeclare_ignore_declaration_merge: bool = true,
     typescript_eslint_no_require_imports: bool = true,
+    typescript_eslint_no_require_imports_allow_as_import: bool = false,
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
@@ -2509,6 +2510,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-redeclare")) {
             self.typescript_eslint_no_redeclare_builtin_globals = try typescriptEslintNoRedeclareBuiltinGlobalsFromConfig(value);
             self.typescript_eslint_no_redeclare_ignore_declaration_merge = try typescriptEslintNoRedeclareIgnoreDeclarationMergeFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-require-imports")) {
+            self.typescript_eslint_no_require_imports_allow_as_import = try typescriptEslintNoRequireImportsBoolOptionFromConfig(value, "allowAsImport", false);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
             self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
@@ -6266,6 +6270,10 @@ pub const Options = struct {
         return noShadowBuiltinGlobalsFromConfig(value);
     }
 
+    fn typescriptEslintNoRequireImportsBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        return typescriptEslintNoNamespaceBoolOptionFromConfig(value, key, default);
+    }
+
     fn typescriptEslintNoThisAliasAllowedNamesFromConfig(value: std.json.Value) RuleConfigError!NoThisAliasAllowedNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6661,6 +6669,11 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.typescript_eslint_no_unnecessary_parameter_property_assignment);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unnecessary-parameter-property-assignment", true));
     try std.testing.expect(options.typescript_eslint_no_unnecessary_parameter_property_assignment);
+
+    try std.testing.expect(!options.typescript_eslint_no_require_imports);
+    try std.testing.expect(options.setByCliName("@typescript-eslint/no-require-imports", true));
+    try std.testing.expect(options.typescript_eslint_no_require_imports);
+    try std.testing.expect(!options.typescript_eslint_no_require_imports_allow_as_import);
 
     try std.testing.expect(!options.typescript_eslint_no_unsafe_declaration_merging);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unsafe-declaration-merging", true));
@@ -8398,6 +8411,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("Promise"));
     try std.testing.expect(options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("React.VoidFunctionComponent"));
     try std.testing.expect(!options.typescript_eslint_no_invalid_void_type_allowed_generic_type_names.contains("Map"));
+
+    var typescript_no_require_imports_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAsImport\":true}]",
+        .{},
+    );
+    defer typescript_no_require_imports_config.deinit();
+    try options.setByRuleConfigValue("@typescript-eslint/no-require-imports", typescript_no_require_imports_config.value);
+    try std.testing.expect(options.typescript_eslint_no_require_imports);
+    try std.testing.expect(options.typescript_eslint_no_require_imports_allow_as_import);
 
     var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -919,7 +919,9 @@ pub fn runSemantic(
     }
 
     if (options.typescript_eslint_no_require_imports) {
-        try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+        try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .allow_as_import = options.typescript_eslint_no_require_imports_allow_as_import,
+        });
     }
 
     if (options.typescript_eslint_no_var_requires) {

--- a/src/rules/typescript_eslint_no_require_imports.zig
+++ b/src/rules/typescript_eslint_no_require_imports.zig
@@ -10,11 +10,16 @@ pub const id = "@typescript-eslint/no-require-imports";
 
 const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
 
+pub const Options = struct {
+    allow_as_import: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 ) Allocator.Error!void {
     if (std.mem.indexOf(u8, tree.source, "require") == null) return;
 
@@ -25,6 +30,7 @@ pub fn run(
         .allocator = allocator,
         .diagnostics = diagnostics,
         .reference_lookup = &reference_lookup,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -34,6 +40,7 @@ const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     reference_lookup: *const ReferenceLookup,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -53,6 +60,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.allow_as_import) return .proceed;
         try self.addDiagnostic(ctx.tree, index);
         return .proceed;
     }

--- a/tests/rules/typescript_eslint_no_require_imports.zig
+++ b/tests/rules/typescript_eslint_no_require_imports.zig
@@ -35,6 +35,33 @@ test "does not report @typescript-eslint/no-require-imports for local require fu
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_require_imports.id));
 }
 
+test "supports configured @typescript-eslint/no-require-imports allowAsImport option" {
+    const source =
+        \\const fs = require('fs');
+        \\import path = require('path');
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowAsImport\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-require-imports", config.value);
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_require_imports.id));
+    try std.testing.expectEqualStrings("A `require()` style import is forbidden.", result.diagnostics[0].message);
+}
+
 test "can disable @typescript-eslint/no-require-imports" {
     const source =
         \\const fs = require('fs');


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-require-imports` `allowAsImport` from ESLint-style config
- allow `import foo = require("foo")` when the option is enabled while still reporting ordinary `require()` calls
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`