### PR TITLE
Support no-require-imports allow patterns

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -289,7 +289,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/) | Implemented for `allowDeclarations` and `allowDefinitionFiles` configurations |
 | [`@typescript-eslint/no-non-null-asserted-optional-chain`](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/) | Implemented |
 | [`@typescript-eslint/no-redeclare`](https://typescript-eslint.io/rules/no-redeclare/) | Supports `builtinGlobals` and `ignoreDeclarationMerge` configuration |
-| [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Supports `allowAsImport` configuration |
+| [`@typescript-eslint/no-require-imports`](https://typescript-eslint.io/rules/no-require-imports/) | Supports `allow` and `allowAsImport` configuration |
 | [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) | Supports `allow`, `builtinGlobals`, `hoist`, `ignoreOnInitialization`, `ignoreTypeValueShadow`, and `ignoreFunctionTypeParameterNameValueShadow` configuration |
 | [`@typescript-eslint/no-this-alias`](https://typescript-eslint.io/rules/no-this-alias/) | Supports `allowedNames` and `allowDestructuring` configuration |
 | [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -412,6 +412,30 @@ pub const ImportNoUnresolvedIgnorePatterns = struct {
     }
 };
 
+pub const max_typescript_eslint_no_require_imports_allow_patterns = 32;
+pub const max_typescript_eslint_no_require_imports_allow_pattern_len = 256;
+
+pub const TypescriptEslintNoRequireImportsAllowPatterns = struct {
+    count: usize = 0,
+    lengths: [max_typescript_eslint_no_require_imports_allow_patterns]usize = undefined,
+    storage: [max_typescript_eslint_no_require_imports_allow_patterns][max_typescript_eslint_no_require_imports_allow_pattern_len]u8 = undefined,
+
+    pub fn at(self: *const TypescriptEslintNoRequireImportsAllowPatterns, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *TypescriptEslintNoRequireImportsAllowPatterns, pattern: []const u8) bool {
+        if (pattern.len == 0) return false;
+        if (self.count >= max_typescript_eslint_no_require_imports_allow_patterns) return false;
+        if (pattern.len > max_typescript_eslint_no_require_imports_allow_pattern_len) return false;
+
+        @memcpy(self.storage[self.count][0..pattern.len], pattern);
+        self.lengths[self.count] = pattern.len;
+        self.count += 1;
+        return true;
+    }
+};
+
 pub const max_no_param_reassign_ignored_names = 32;
 pub const max_no_param_reassign_ignored_name_len = 128;
 pub const max_no_param_reassign_ignored_name_patterns = 32;
@@ -1865,6 +1889,7 @@ pub const Options = struct {
     typescript_eslint_no_redeclare_ignore_declaration_merge: bool = true,
     typescript_eslint_no_require_imports: bool = true,
     typescript_eslint_no_require_imports_allow_as_import: bool = false,
+    typescript_eslint_no_require_imports_allow: TypescriptEslintNoRequireImportsAllowPatterns = .{},
     typescript_eslint_no_shadow: bool = true,
     typescript_eslint_no_shadow_allow: NoShadowAllowNames = .{},
     typescript_eslint_no_shadow_builtin_globals: bool = false,
@@ -2513,6 +2538,7 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-require-imports")) {
             self.typescript_eslint_no_require_imports_allow_as_import = try typescriptEslintNoRequireImportsBoolOptionFromConfig(value, "allowAsImport", false);
+            self.typescript_eslint_no_require_imports_allow = try typescriptEslintNoRequireImportsAllowFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-this-alias")) {
             self.typescript_eslint_no_this_alias_allowed_names = try typescriptEslintNoThisAliasAllowedNamesFromConfig(value);
@@ -6274,6 +6300,33 @@ pub const Options = struct {
         return typescriptEslintNoNamespaceBoolOptionFromConfig(value, key, default);
     }
 
+    fn typescriptEslintNoRequireImportsAllowFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintNoRequireImportsAllowPatterns {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const allow = switch (config.get("allow") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var patterns: TypescriptEslintNoRequireImportsAllowPatterns = .{};
+        for (allow) |entry| {
+            const pattern = switch (entry) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!patterns.append(pattern)) return error.UnsupportedRuleConfigValue;
+        }
+        return patterns;
+    }
+
     fn typescriptEslintNoThisAliasAllowedNamesFromConfig(value: std.json.Value) RuleConfigError!NoThisAliasAllowedNames {
         const items = switch (value) {
             .array => |array| array.items,
@@ -6674,6 +6727,7 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-require-imports", true));
     try std.testing.expect(options.typescript_eslint_no_require_imports);
     try std.testing.expect(!options.typescript_eslint_no_require_imports_allow_as_import);
+    try std.testing.expectEqual(@as(usize, 0), options.typescript_eslint_no_require_imports_allow.count);
 
     try std.testing.expect(!options.typescript_eslint_no_unsafe_declaration_merging);
     try std.testing.expect(options.setByCliName("@typescript-eslint/no-unsafe-declaration-merging", true));
@@ -8415,13 +8469,16 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_require_imports_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allowAsImport\":true}]",
+        "[\"error\",{\"allowAsImport\":true,\"allow\":[\"^legacy-\",\"fs$\"]}]",
         .{},
     );
     defer typescript_no_require_imports_config.deinit();
     try options.setByRuleConfigValue("@typescript-eslint/no-require-imports", typescript_no_require_imports_config.value);
     try std.testing.expect(options.typescript_eslint_no_require_imports);
     try std.testing.expect(options.typescript_eslint_no_require_imports_allow_as_import);
+    try std.testing.expectEqual(@as(usize, 2), options.typescript_eslint_no_require_imports_allow.count);
+    try std.testing.expectEqualStrings("^legacy-", options.typescript_eslint_no_require_imports_allow.at(0));
+    try std.testing.expectEqualStrings("fs$", options.typescript_eslint_no_require_imports_allow.at(1));
 
     var typescript_restrict_plus_operands_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -921,6 +921,7 @@ pub fn runSemantic(
     if (options.typescript_eslint_no_require_imports) {
         try typescript_eslint_no_require_imports.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .allow_as_import = options.typescript_eslint_no_require_imports_allow_as_import,
+            .allow = options.typescript_eslint_no_require_imports_allow,
         });
     }
 

--- a/src/rules/typescript_eslint_no_require_imports.zig
+++ b/src/rules/typescript_eslint_no_require_imports.zig
@@ -12,6 +12,7 @@ const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.Symbol
 
 pub const Options = struct {
     allow_as_import: bool = false,
+    allow: core.TypescriptEslintNoRequireImportsAllowPatterns = .{},
 };
 
 pub fn run(
@@ -49,6 +50,9 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.isGlobalRequireReference(ctx.tree, call.callee)) {
+            if (callSource(ctx.tree, call)) |source| {
+                if (isAllowedSource(source, self.options.allow)) return .proceed;
+            }
             try self.addDiagnostic(ctx.tree, index);
         }
         return .proceed;
@@ -56,10 +60,13 @@ const Visitor = struct {
 
     pub fn enter_ts_external_module_reference(
         self: *Visitor,
-        _: ast.TSExternalModuleReference,
+        reference: ast.TSExternalModuleReference,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (stringLiteralValue(ctx.tree, reference.expression)) |source| {
+            if (isAllowedSource(source, self.options.allow)) return .proceed;
+        }
         if (self.options.allow_as_import) return .proceed;
         try self.addDiagnostic(ctx.tree, index);
         return .proceed;
@@ -106,5 +113,111 @@ fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const
     return switch (tree.data(index)) {
         .identifier_reference => |identifier| tree.string(identifier.name),
         else => null,
+    };
+}
+
+fn callSource(tree: *const ast.Tree, call: ast.CallExpression) ?[]const u8 {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len != 1) return null;
+    return stringLiteralValue(tree, arguments[0]);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn isAllowedSource(source: []const u8, allow: core.TypescriptEslintNoRequireImportsAllowPatterns) bool {
+    for (0..allow.count) |index| {
+        if (matchesAllowPattern(allow.at(index), source)) return true;
+    }
+    return false;
+}
+
+fn matchesAllowPattern(pattern: []const u8, source: []const u8) bool {
+    if (pattern.len == 0) return false;
+    const anchored_start = pattern[0] == '^';
+    const anchored_end = hasUnescapedTrailingDollar(pattern);
+    const start: usize = if (anchored_start) 1 else 0;
+    const end: usize = if (anchored_end) pattern.len - 1 else pattern.len;
+    const body = pattern[start..end];
+
+    if (anchored_start) {
+        return matchPatternAt(body, 0, source, 0, anchored_end);
+    }
+
+    for (0..source.len + 1) |source_index| {
+        if (matchPatternAt(body, 0, source, source_index, anchored_end)) return true;
+    }
+    return false;
+}
+
+fn hasUnescapedTrailingDollar(pattern: []const u8) bool {
+    if (pattern.len == 0 or pattern[pattern.len - 1] != '$') return false;
+    var slash_count: usize = 0;
+    var index = pattern.len - 1;
+    while (index > 0) {
+        index -= 1;
+        if (pattern[index] != '\\') break;
+        slash_count += 1;
+    }
+    return slash_count % 2 == 0;
+}
+
+fn matchPatternAt(pattern: []const u8, pattern_index: usize, source: []const u8, source_index: usize, anchored_end: bool) bool {
+    if (pattern_index >= pattern.len) return !anchored_end or source_index == source.len;
+
+    const token = readPatternToken(pattern, pattern_index);
+    const next_index = token.next_index;
+    if (next_index < pattern.len and pattern[next_index] == '*') {
+        var end_index = source_index;
+        while (end_index < source.len and token.matches(source[end_index])) {
+            end_index += 1;
+        }
+        while (true) {
+            if (matchPatternAt(pattern, next_index + 1, source, end_index, anchored_end)) return true;
+            if (end_index == source_index) break;
+            end_index -= 1;
+        }
+        return false;
+    }
+
+    if (source_index >= source.len or !token.matches(source[source_index])) return false;
+    return matchPatternAt(pattern, next_index, source, source_index + 1, anchored_end);
+}
+
+const PatternToken = struct {
+    kind: enum { any, literal },
+    literal: u8 = 0,
+    next_index: usize,
+
+    fn matches(self: PatternToken, value: u8) bool {
+        return switch (self.kind) {
+            .any => true,
+            .literal => self.literal == value,
+        };
+    }
+};
+
+fn readPatternToken(pattern: []const u8, index: usize) PatternToken {
+    if (pattern[index] == '\\' and index + 1 < pattern.len) {
+        return .{
+            .kind = .literal,
+            .literal = pattern[index + 1],
+            .next_index = index + 2,
+        };
+    }
+    if (pattern[index] == '.') {
+        return .{
+            .kind = .any,
+            .next_index = index + 1,
+        };
+    }
+    return .{
+        .kind = .literal,
+        .literal = pattern[index],
+        .next_index = index + 1,
     };
 }

--- a/tests/rules/typescript_eslint_no_require_imports.zig
+++ b/tests/rules/typescript_eslint_no_require_imports.zig
@@ -62,6 +62,34 @@ test "supports configured @typescript-eslint/no-require-imports allowAsImport op
     try std.testing.expectEqualStrings("A `require()` style import is forbidden.", result.diagnostics[0].message);
 }
 
+test "supports configured @typescript-eslint/no-require-imports allow option" {
+    const source =
+        \\const fs = require('fs');
+        \\const legacy = require('legacy-runtime');
+        \\import legacyTypes = require('legacy-types');
+        \\import path = require('path');
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"^legacy-\",\"fs$\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-require-imports", config.value);
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_require_imports.id));
+}
+
 test "can disable @typescript-eslint/no-require-imports" {
     const source =
         \\const fs = require('fs');


### PR DESCRIPTION
## Summary
- parse `@typescript-eslint/no-require-imports` `allow` string patterns from ESLint-style config
- skip diagnostics for matching ordinary `require()` calls and `import = require()` references
- document the newly supported option in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`