### PR TITLE
Support no-empty-function TS method allows

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -277,7 +277,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |
-| [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Supports base `allow` kinds plus `private-constructors` and `protected-constructors` configuration |
+| [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Supports base `allow` kinds plus `private-constructors`, `protected-constructors`, `decoratedFunctions`, and `overrideMethods` configuration |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Supports `allowSingleExtends` configuration |
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -130,6 +130,8 @@ pub const NoEmptyFunctionAllow = struct {
     constructors: bool = false,
     privateConstructors: bool = false,
     protectedConstructors: bool = false,
+    decoratedFunctions: bool = false,
+    overrideMethods: bool = false,
 
     pub fn contains(self: NoEmptyFunctionAllow, name: []const u8) bool {
         inline for (@typeInfo(NoEmptyFunctionAllow).@"struct".fields) |field| {
@@ -145,6 +147,14 @@ pub const NoEmptyFunctionAllow = struct {
         }
         if (std.mem.eql(u8, name, "protected-constructors")) {
             self.protectedConstructors = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "decoratedFunctions")) {
+            self.decoratedFunctions = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "overrideMethods")) {
+            self.overrideMethods = true;
             return true;
         }
         inline for (@typeInfo(NoEmptyFunctionAllow).@"struct".fields) |field| {
@@ -7742,7 +7752,7 @@ test "Options can apply ESLint-style rule config values" {
     var typescript_no_empty_function_config = try std.json.parseFromSlice(
         std.json.Value,
         std.testing.allocator,
-        "[\"error\",{\"allow\":[\"arrowFunctions\",\"methods\",\"private-constructors\",\"protected-constructors\"]}]",
+        "[\"error\",{\"allow\":[\"arrowFunctions\",\"methods\",\"private-constructors\",\"protected-constructors\",\"decoratedFunctions\",\"overrideMethods\"]}]",
         .{},
     );
     defer typescript_no_empty_function_config.deinit();
@@ -7752,6 +7762,8 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.methods);
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.privateConstructors);
     try std.testing.expect(options.typescript_eslint_no_empty_function_allow.protectedConstructors);
+    try std.testing.expect(options.typescript_eslint_no_empty_function_allow.decoratedFunctions);
+    try std.testing.expect(options.typescript_eslint_no_empty_function_allow.overrideMethods);
     try std.testing.expect(!options.typescript_eslint_no_empty_function_allow.functions);
 
     var typescript_no_empty_interface_config = try std.json.parseFromSlice(

--- a/src/rules/typescript_eslint_no_empty_function.zig
+++ b/src/rules/typescript_eslint_no_empty_function.zig
@@ -37,6 +37,8 @@ pub fn checkFunctionBodyWithOptions(
     if (body.body.len != 0) return;
     if (no_empty_function.allowsKind(options.allow, options.kind)) return;
     if (allowsTypescriptConstructor(options.allow, tree, ctx)) return;
+    if (allowsDecoratedFunction(options.allow, tree, ctx)) return;
+    if (allowsOverrideMethod(options.allow, tree, ctx)) return;
     if (no_empty_function.hasCommentInsideBraces(tree, index)) return;
     if (hasParameterPropertyConstructor(tree, ctx)) return;
 
@@ -59,6 +61,18 @@ fn allowsTypescriptConstructor(allow: core.NoEmptyFunctionAllow, tree: *const as
         .protected => allow.protectedConstructors,
         else => false,
     };
+}
+
+fn allowsDecoratedFunction(allow: core.NoEmptyFunctionAllow, tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    if (!allow.decoratedFunctions) return false;
+    const method = parentMethod(tree, ctx) orelse return false;
+    return method.decorators.len != 0;
+}
+
+fn allowsOverrideMethod(allow: core.NoEmptyFunctionAllow, tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    if (!allow.overrideMethods) return false;
+    const method = parentMethod(tree, ctx) orelse return false;
+    return method.override;
 }
 
 fn hasParameterPropertyConstructor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {

--- a/tests/rules/typescript_eslint_no_empty_function.zig
+++ b/tests/rules/typescript_eslint_no_empty_function.zig
@@ -110,6 +110,37 @@ test "supports configured @typescript-eslint/no-empty-function private and prote
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_function.id));
 }
 
+test "supports configured @typescript-eslint/no-empty-function decorated and override methods" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allow\":[\"decoratedFunctions\",\"overrideMethods\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("@typescript-eslint/no-empty-function", config.value);
+    options.no_empty_block_statements = false;
+    options.no_unused_vars = false;
+    options.no_undef = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\class Example extends Base {
+        \\  @noop
+        \\  decorated() {}
+        \\  override inherited() {}
+        \\  plain() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.typescript_eslint_no_empty_function.id));
+}
+
 test "can disable @typescript-eslint/no-empty-function and fall back to core rule" {
     const source =
         \\function empty() {}


### PR DESCRIPTION
## Summary
- parse TypeScript-specific `@typescript-eslint/no-empty-function` allow entries for decorated and override methods
- skip diagnostics for empty decorated/override methods when configured
- document the newly supported allow entries in the rule status table

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`