### PR TITLE
Support no-children-prop allowFunctions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -239,6 +239,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, `warnOnSpreadAttributes`, `links`, and `forms` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, `allowNamespace`, and `ignore` configuration |
+| [`react/no-children-prop`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md) | Supports `allowFunctions` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1809,6 +1809,7 @@ pub const Options = struct {
     react_forbid_prop_types_check_child_context_types: bool = false,
     react_no_array_index_key: bool = true,
     react_no_children_prop: bool = true,
+    react_no_children_prop_allow_functions: bool = false,
     react_no_find_dom_node: bool = true,
     react_no_is_mounted: bool = true,
     react_no_multi_comp: bool = true,
@@ -2478,6 +2479,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-multi-comp")) {
             self.react_no_multi_comp_ignore_stateless = try reactNoMultiCompIgnoreStatelessFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-children-prop")) {
+            self.react_no_children_prop_allow_functions = try reactNoChildrenPropAllowFunctionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-unknown-property")) {
             self.react_no_unknown_property_ignore = try reactNoUnknownPropertyIgnoreFromConfig(value);
@@ -3426,6 +3430,23 @@ pub const Options = struct {
             }
         }
         return result;
+    }
+
+    fn reactNoChildrenPropAllowFunctionsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("allowFunctions") orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn typescriptEslintBanTypesConfigFromConfig(value: std.json.Value) RuleConfigError!TypescriptEslintBanTypesConfig {
@@ -7214,6 +7235,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("react/no-multi-comp", react_no_multi_comp_config.value);
     try std.testing.expect(options.react_no_multi_comp);
     try std.testing.expect(!options.react_no_multi_comp_ignore_stateless);
+
+    var react_no_children_prop_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowFunctions\":true}]",
+        .{},
+    );
+    defer react_no_children_prop_config.deinit();
+    try options.setByRuleConfigValue("react/no-children-prop", react_no_children_prop_config.value);
+    try std.testing.expect(options.react_no_children_prop);
+    try std.testing.expect(options.react_no_children_prop_allow_functions);
 
     var react_no_unknown_property_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/rules/react_no_children_prop.zig
+++ b/src/rules/react_no_children_prop.zig
@@ -17,6 +17,10 @@ pub const ReactBindings = struct {
     has_bare_create_element: bool = false,
 };
 
+pub const Options = struct {
+    allow_functions: bool = false,
+};
+
 pub fn bindingsFromProgram(tree: *const ast.Tree, program: ast.Program) ReactBindings {
     var bindings = ReactBindings{
         .pragma = pragmaFromComments(tree) orelse "React",
@@ -39,9 +43,11 @@ pub fn checkJSXAttribute(
     tree: *const ast.Tree,
     attribute: ast.JSXAttribute,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
     const name = jsxAttributeName(tree, attribute.name) orelse return;
     if (!std.mem.eql(u8, name, "children")) return;
+    if (options.allow_functions and jsxAttributeValueIsFunction(tree, attribute.value)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -59,7 +65,10 @@ pub fn checkJSXElement(
     tree: *const ast.Tree,
     element: ast.JSXElement,
     index: ast.NodeIndex,
+    options: Options,
 ) Allocator.Error!void {
+    if (!options.allow_functions) return;
+
     const children = tree.extra(element.children);
     if (children.len != 1) return;
 
@@ -86,6 +95,7 @@ pub fn checkCallExpression(
     call: ast.CallExpression,
     index: ast.NodeIndex,
     bindings: ReactBindings,
+    options: Options,
 ) Allocator.Error!void {
     if (!isCreateElementCall(tree, call, bindings)) return;
 
@@ -104,6 +114,7 @@ pub fn checkCallExpression(
         };
         const key = objectPropertyKeyName(tree, property) orelse continue;
         if (!std.mem.eql(u8, key, "children")) continue;
+        if (options.allow_functions and isFunctionExpression(tree, property.value)) continue;
 
         try core.addDiagnostic(
             allocator,
@@ -116,7 +127,7 @@ pub fn checkCallExpression(
         return;
     }
 
-    if (arguments.len == 3 and isFunctionExpression(tree, arguments[2])) {
+    if (options.allow_functions and arguments.len == 3 and isFunctionExpression(tree, arguments[2])) {
         try core.addDiagnostic(
             allocator,
             diagnostics,
@@ -297,6 +308,16 @@ fn isFunctionExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
         else => false,
     };
+}
+
+fn jsxAttributeValueIsFunction(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    const container = switch (tree.data(index)) {
+        .jsx_expression_container => |container| container,
+        else => return false,
+    };
+    return isFunctionExpression(tree, container.expression);
 }
 
 fn objectPropertyKeyName(tree: *const ast.Tree, property: ast.ObjectProperty) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2848,7 +2848,9 @@ const BasicVisitor = struct {
             try react_require_render_return.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_require_render_return_state);
         }
         if (self.options.react_no_children_prop) {
-            try react_no_children_prop.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_no_children_prop_bindings);
+            try react_no_children_prop.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, self.react_no_children_prop_bindings, .{
+                .allow_functions = self.options.react_no_children_prop_allow_functions,
+            });
         }
         if (self.options.react_no_danger_with_children) {
             try react_no_danger_with_children.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, &self.react_no_danger_with_children_bindings);
@@ -3076,7 +3078,9 @@ const BasicVisitor = struct {
             try react_style_prop_object.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, ctx.path.ancestor(1), &self.react_style_prop_object_bindings);
         }
         if (self.options.react_no_children_prop) {
-            try react_no_children_prop.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index);
+            try react_no_children_prop.checkJSXAttribute(self.allocator, self.diagnostics, ctx.tree, attribute, index, .{
+                .allow_functions = self.options.react_no_children_prop_allow_functions,
+            });
         }
         if (self.options.react_no_string_refs) {
             try react_no_string_refs.check(self.allocator, self.diagnostics, ctx.tree, attribute, index, .{
@@ -3111,7 +3115,9 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.react_no_children_prop) {
-            try react_no_children_prop.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index);
+            try react_no_children_prop.checkJSXElement(self.allocator, self.diagnostics, ctx.tree, element, index, .{
+                .allow_functions = self.options.react_no_children_prop_allow_functions,
+            });
         }
         if (self.options.react_jsx_filename_extension) {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{

--- a/tests/rules/react_no_children_prop.zig
+++ b/tests/rules/react_no_children_prop.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports react/no-children-prop for JSX children attributes and nested functions" {
+test "reports react/no-children-prop for JSX children attributes" {
     const source =
         \\const prop = <Box children={<span />} />;
         \\const boolProp = <Box children />;
@@ -18,18 +18,14 @@ test "reports react/no-children-prop for JSX children attributes and nested func
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_children_prop.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_children_prop.id));
     try std.testing.expectEqualStrings(
         "Do not pass children as props. Instead, nest children between the opening and closing tags.",
         result.diagnostics[0].message,
     );
-    try std.testing.expectEqualStrings(
-        "Do not nest a function between the opening and closing tags. Instead, pass it as a prop.",
-        result.diagnostics[2].message,
-    );
 }
 
-test "reports react/no-children-prop for createElement props and function children" {
+test "reports react/no-children-prop for createElement props" {
     const source =
         \\import { createElement } from "react";
         \\const a = React.createElement("div", { children: text });
@@ -48,14 +44,10 @@ test "reports react/no-children-prop for createElement props and function childr
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_no_children_prop.id));
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_children_prop.id));
     try std.testing.expectEqualStrings(
         "Do not pass children as props. Instead, pass them as additional arguments to React.createElement.",
         result.diagnostics[0].message,
-    );
-    try std.testing.expectEqualStrings(
-        "Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.",
-        result.diagnostics[2].message,
     );
 }
 
@@ -90,6 +82,7 @@ test "allows regular children nesting and non-react createElement calls" {
     const source =
         \\const nested = <Box><span /></Box>;
         \\const text = <Box>hello</Box>;
+        \\const render = <Box>{() => <span />}</Box>;
         \\const fnProp = <Box render={() => <span />} />;
         \\const local = createElement("div", { children: text });
         \\const stringKey = React.createElement("div", { "children": text });
@@ -104,6 +97,40 @@ test "allows regular children nesting and non-react createElement calls" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_children_prop.id));
+}
+
+test "supports configured react/no-children-prop allowFunctions" {
+    const source =
+        \\import { createElement } from "react";
+        \\const allowedProp = <Box children={() => <span />} />;
+        \\const allowedCreateElementProp = createElement("div", { children: () => null });
+        \\const nestedFunction = <Box>{() => <span />}</Box>;
+        \\const createElementFunction = createElement("div", {}, () => null);
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"allowFunctions\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("react/no-children-prop", config.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.react_no_children_prop.id));
+    try std.testing.expectEqualStrings(
+        "Do not nest a function between the opening and closing tags. Instead, pass it as a prop.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.",
+        result.diagnostics[1].message,
+    );
 }
 
 test "ignores type-only createElement imports" {
@@ -122,6 +149,17 @@ test "ignores type-only createElement imports" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.react_no_children_prop.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .eol_last = false,
+        .import_newline_after_import = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .react_jsx_no_bind = false,
+    };
 }
 
 test "can disable react/no-children-prop" {


### PR DESCRIPTION
## Summary

- add `allowFunctions` config parsing for `react/no-children-prop`
- align function children behavior with eslint-plugin-react: default mode ignores function children, while `allowFunctions: true` allows function props and reports function child positions
- document the supported option and add coverage for JSX and `createElement` forms

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
