### PR TITLE
Add no-unused-private-class-members

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -145,6 +145,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
+| [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members) | Implemented for private fields, methods, accessors, and static blocks |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1683,6 +1683,7 @@ pub const Options = struct {
     no_useless_rename_ignore_destructuring: bool = false,
     no_useless_rename_ignore_import: bool = false,
     no_useless_rename_ignore_export: bool = false,
+    no_unused_private_class_members: bool = true,
     no_unused_expressions: bool = true,
     no_unused_expressions_allow_short_circuit: NoUnusedExpressionsAllowShortCircuit = .no,
     no_unused_expressions_allow_ternary: NoUnusedExpressionsAllowTernary = .no,

--- a/src/main.zig
+++ b/src/main.zig
@@ -585,6 +585,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_escape = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-rename=off")) {
             options.no_useless_rename = false;
+        } else if (std.mem.eql(u8, arg, "--no-unused-private-class-members=off")) {
+            options.no_unused_private_class_members = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-expressions=off")) {
             options.no_unused_expressions = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-expressions-allow-short-circuit=on")) {
@@ -1702,6 +1704,7 @@ fn printHelp() void {
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-escape=off   Disable no-useless-escape
         \\  --no-useless-rename=off   Disable no-useless-rename
+        \\  --no-unused-private-class-members=off Disable no-unused-private-class-members
         \\  --no-unused-expressions=off Disable no-unused-expressions
         \\  --no-unused-expressions-allow-short-circuit=on Allow short-circuit expressions
         \\  --no-unused-expressions-allow-ternary=on Allow ternary expressions

--- a/src/rules/no_unused_private_class_members.zig
+++ b/src/rules/no_unused_private_class_members.zig
@@ -1,0 +1,197 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unused-private-class-members";
+
+const PrivateMember = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+    used: bool = false,
+    write_uses: bool = false,
+};
+
+const UsageKind = enum {
+    read,
+    write,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+) Allocator.Error!void {
+    const body = switch (tree.data(class.body)) {
+        .class_body => |body| body,
+        else => return,
+    };
+
+    var members: std.ArrayList(PrivateMember) = .empty;
+    defer members.deinit(allocator);
+
+    for (tree.extra(body.body)) |member_index| {
+        switch (tree.data(member_index)) {
+            .property_definition => |property| {
+                if (privateName(tree, property.key, property.computed)) |name| {
+                    try members.append(allocator, .{
+                        .name = name,
+                        .node = member_index,
+                        .write_uses = property.accessor,
+                    });
+                }
+            },
+            .method_definition => |method| {
+                if (privateName(tree, method.key, method.computed)) |name| {
+                    try members.append(allocator, .{
+                        .name = name,
+                        .node = member_index,
+                        .write_uses = method.kind == .set,
+                    });
+                }
+            },
+            else => {},
+        }
+    }
+    if (members.items.len == 0) return;
+
+    for (tree.extra(body.body)) |member_index| {
+        try scanClassMember(allocator, tree, member_index, members.items);
+    }
+
+    for (members.items) |member| {
+        if (member.used) continue;
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Private class member is defined but never used.",
+            tree.span(member.node),
+        );
+    }
+}
+
+fn scanClassMember(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    members: []PrivateMember,
+) Allocator.Error!void {
+    switch (tree.data(index)) {
+        .property_definition => |property| {
+            if (property.computed) try scanNode(allocator, tree, property.key, members);
+            try scanNode(allocator, tree, property.value, members);
+        },
+        .method_definition => |method| {
+            if (method.computed) try scanNode(allocator, tree, method.key, members);
+            try scanNode(allocator, tree, method.value, members);
+        },
+        .static_block => |block| try scanRange(allocator, tree, block.body, members),
+        else => {},
+    }
+}
+
+fn scanNode(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    members: []PrivateMember,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .class => return,
+        .member_expression => |member| {
+            try scanNode(allocator, tree, member.object, members);
+            try markPrivateUse(tree, member, members, .read);
+            if (member.computed) try scanNode(allocator, tree, member.property, members);
+        },
+        .assignment_expression => |expression| {
+            try scanNode(allocator, tree, expression.right, members);
+            if (expression.operator == .assign) {
+                try scanAssignmentTarget(allocator, tree, expression.left, members);
+            } else {
+                try scanNode(allocator, tree, expression.left, members);
+            }
+        },
+        .update_expression => |expression| try scanNode(allocator, tree, expression.argument, members),
+        inline else => |node| try scanPayload(allocator, tree, node, members),
+    }
+}
+
+fn scanAssignmentTarget(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    members: []PrivateMember,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .member_expression => |member| {
+            try scanNode(allocator, tree, member.object, members);
+            try markPrivateUse(tree, member, members, .write);
+            if (member.computed) try scanNode(allocator, tree, member.property, members);
+        },
+        inline else => |node| try scanPayload(allocator, tree, node, members),
+    }
+}
+
+fn scanPayload(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    node: anytype,
+    members: []PrivateMember,
+) Allocator.Error!void {
+    const T = @TypeOf(node);
+    if (@typeInfo(T) != .@"struct") return;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            try scanNode(allocator, tree, @field(node, field.name), members);
+        } else if (field.type == ast.IndexRange) {
+            try scanRange(allocator, tree, @field(node, field.name), members);
+        }
+    }
+}
+
+fn scanRange(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    range: ast.IndexRange,
+    members: []PrivateMember,
+) Allocator.Error!void {
+    for (tree.extra(range)) |child| {
+        try scanNode(allocator, tree, child, members);
+    }
+}
+
+fn markPrivateUse(
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    members: []PrivateMember,
+    kind: UsageKind,
+) Allocator.Error!void {
+    const name = privateName(tree, member.property, member.computed) orelse return;
+    for (members) |*candidate| {
+        if (!std.mem.eql(u8, candidate.name, name)) continue;
+        switch (kind) {
+            .read => candidate.used = true,
+            .write => {
+                if (candidate.write_uses) candidate.used = true;
+            },
+        }
+    }
+}
+
+fn privateName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed or index == .null) return null;
+    return switch (tree.data(index)) {
+        .private_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -213,6 +213,7 @@ pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_escape = @import("no_useless_escape.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
 pub const no_unused_expressions = @import("no_unused_expressions.zig");
+pub const no_unused_private_class_members = @import("no_unused_private_class_members.zig");
 pub const no_unused_labels = @import("no_unused_labels.zig");
 pub const no_unused_vars = @import("no_unused_vars.zig");
 pub const no_use_before_define = @import("no_use_before_define.zig");
@@ -1385,6 +1386,9 @@ const BasicVisitor = struct {
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
+        }
+        if (self.options.no_unused_private_class_members) {
+            try no_unused_private_class_members.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }
         if (self.options.no_this_before_super) {
             try no_this_before_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -795,6 +795,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unused_private_class_members.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_vars.zig");
 }
 

--- a/tests/rules/no_unused_private_class_members.zig
+++ b/tests/rules/no_unused_private_class_members.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unused-private-class-members for unused private fields and methods" {
+    const source =
+        \\class Example {
+        \\  #field = 1;
+        \\  #method() {}
+        \\  static #staticField = 1;
+        \\  static #staticMethod() {}
+        \\  run() {
+        \\    return 1;
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unused_private_class_members.id));
+    try std.testing.expectEqualStrings("Private class member is defined but never used.", result.diagnostics[0].message);
+}
+
+test "allows no-unused-private-class-members for read private members" {
+    const source =
+        \\class Example {
+        \\  #field = 1;
+        \\  #method() {
+        \\    return this.#field;
+        \\  }
+        \\  static #staticField = 1;
+        \\  static #staticMethod() {
+        \\    return Example.#staticField;
+        \\  }
+        \\  run() {
+        \\    return this.#method() + Example.#staticMethod();
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_private_class_members.id));
+}
+
+test "does not treat pure private field writes as reads" {
+    const source =
+        \\class Example {
+        \\  #field;
+        \\  #compound = 1;
+        \\  constructor() {
+        \\    this.#field = 1;
+        \\    this.#compound += 1;
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_private_class_members.id));
+}
+
+test "counts private setter and accessor writes as usage" {
+    const source =
+        \\class Example {
+        \\  set #value(next) {}
+        \\  accessor #state = 1;
+        \\  run() {
+        \\    this.#value = 1;
+        \\    this.#state = 2;
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_private_class_members.id));
+}
+
+test "does not leak no-unused-private-class-members across nested classes" {
+    const source =
+        \\class Outer {
+        \\  #outer = 1;
+        \\  run() {
+        \\    class Inner {
+        \\      #outer = 2;
+        \\      read(inner) {
+        \\        return inner.#outer;
+        \\      }
+        \\    }
+        \\    return Inner;
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_private_class_members.id));
+}
+
+test "can disable no-unused-private-class-members" {
+    const source =
+        \\class Example {
+        \\  #field = 1;
+        \\}
+        \\
+    ;
+
+    var options = baseOptions();
+    options.no_unused_private_class_members = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unused_private_class_members.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}


### PR DESCRIPTION
## Summary

- add the `no-unused-private-class-members` lint rule
- scan class-local private fields, methods, setters, accessors, and static blocks for usage
- wire the rule into CLI options, rule exports, tests, and rule status docs

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
