### PR TITLE
Add no-unsafe-optional-chaining

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -145,6 +145,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
+| [`no-unsafe-optional-chaining`](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining) | Implemented for unsafe member, call, constructor, tagged template, spread, iteration, destructuring, binary object, `with`, and class `extends` usage |
 | [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members) | Implemented for private fields, methods, accessors, and static blocks |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1671,6 +1671,7 @@ pub const Options = struct {
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_unsafe_negation_enforce_for_ordering_relations: bool = false,
+    no_unsafe_optional_chaining: bool = true,
     no_useless_computed_key: bool = true,
     no_useless_computed_key_enforce_for_class_members: NoUselessComputedKeyEnforceForClassMembers = .yes,
     no_useless_call: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -569,6 +569,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_finally = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-negation=off")) {
             options.no_unsafe_negation = false;
+        } else if (std.mem.eql(u8, arg, "--no-unsafe-optional-chaining=off")) {
+            options.no_unsafe_optional_chaining = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key=off")) {
             options.no_useless_computed_key = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key-enforce-for-class-members=off")) {
@@ -1696,6 +1698,7 @@ fn printHelp() void {
         \\  --no-unused-labels=off   Disable no-unused-labels
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
+        \\  --no-unsafe-optional-chaining=off Disable no-unsafe-optional-chaining
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
         \\  --no-useless-computed-key-enforce-for-class-members=off Disable class member checks
         \\  --no-useless-call=off     Disable no-useless-call

--- a/src/rules/no_unsafe_optional_chaining.zig
+++ b/src/rules/no_unsafe_optional_chaining.zig
@@ -1,0 +1,191 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unsafe-optional-chaining";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    if (std.mem.indexOf(u8, tree.source, "?.") == null) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+
+    pub fn enter_chain_expression(
+        self: *Visitor,
+        _: ast.ChainExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const unsafe_parent = unsafeParent(ctx.tree, index, &ctx.path) orelse return .proceed;
+        try self.addDiagnostic(ctx.tree, unsafe_parent.report_index);
+        return .proceed;
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .@"error",
+            id,
+            "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+            tree.span(index),
+        );
+    }
+};
+
+const UnsafeParent = struct {
+    report_index: ast.NodeIndex,
+};
+
+fn unsafeParent(
+    tree: *const ast.Tree,
+    chain_index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+) ?UnsafeParent {
+    var child = chain_index;
+    var depth: usize = 1;
+
+    while (path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            .ts_as_expression => |expression| {
+                if (expression.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            .ts_satisfies_expression => |expression| {
+                if (expression.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            .ts_type_assertion => |assertion| {
+                if (assertion.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            .ts_non_null_expression => |expression| {
+                if (expression.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            .ts_instantiation_expression => |expression| {
+                if (expression.expression != child) return null;
+                child = parent_index;
+                continue;
+            },
+            else => return unsafeDirectParent(tree, parent_index, child, path, depth),
+        }
+    }
+
+    return null;
+}
+
+fn unsafeDirectParent(
+    tree: *const ast.Tree,
+    parent_index: ast.NodeIndex,
+    child: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    parent_depth: usize,
+) ?UnsafeParent {
+    switch (tree.data(parent_index)) {
+        .member_expression => |member| {
+            if (member.object == child and !member.optional) return .{ .report_index = child };
+        },
+        .call_expression => |call| {
+            if (call.callee == child and !call.optional) return .{ .report_index = child };
+        },
+        .new_expression => |expression| {
+            if (expression.callee == child) return .{ .report_index = child };
+        },
+        .tagged_template_expression => |expression| {
+            if (expression.tag == child) return .{ .report_index = child };
+        },
+        .spread_element => |spread| {
+            if (spread.argument == child and isUnsafeSpreadParent(tree, path.ancestor(parent_depth + 1))) {
+                return .{ .report_index = child };
+            }
+        },
+        .for_in_statement => |statement| {
+            if (statement.right == child) return .{ .report_index = child };
+        },
+        .for_of_statement => |statement| {
+            if (statement.right == child) return .{ .report_index = child };
+        },
+        .with_statement => |statement| {
+            if (statement.object == child) return .{ .report_index = child };
+        },
+        .binary_expression => |expression| {
+            if (expression.right == child and isUnsafeBinaryOperator(expression.operator)) {
+                return .{ .report_index = child };
+            }
+        },
+        .variable_declarator => |declarator| {
+            if (declarator.init == child and isDestructuringPattern(tree, declarator.id)) {
+                return .{ .report_index = child };
+            }
+        },
+        .assignment_expression => |expression| {
+            if (expression.right == child and isDestructuringPattern(tree, expression.left)) {
+                return .{ .report_index = child };
+            }
+        },
+        .assignment_pattern => |pattern| {
+            if (pattern.right == child and isDestructuringPattern(tree, pattern.left)) {
+                return .{ .report_index = child };
+            }
+        },
+        .class => |class| {
+            if (class.super_class == child) return .{ .report_index = child };
+        },
+        else => {},
+    }
+
+    return null;
+}
+
+fn isUnsafeSpreadParent(tree: *const ast.Tree, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return false;
+    return switch (tree.data(parent_index)) {
+        .array_expression,
+        .call_expression,
+        .new_expression,
+        => true,
+        else => false,
+    };
+}
+
+fn isUnsafeBinaryOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .in, .instanceof => true,
+        else => false,
+    };
+}
+
+fn isDestructuringPattern(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .array_pattern, .object_pattern => true,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -204,6 +204,7 @@ pub const no_undefined = @import("no_undefined.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
+pub const no_unsafe_optional_chaining = @import("no_unsafe_optional_chaining.zig");
 pub const no_useless_computed_key = @import("no_useless_computed_key.zig");
 pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
@@ -574,6 +575,9 @@ pub fn runBasic(
     }
     if (options.typescript_eslint_no_non_null_asserted_optional_chain) {
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);
+    }
+    if (options.no_unsafe_optional_chaining) {
+        try no_unsafe_optional_chaining.run(allocator, diagnostics, tree);
     }
     if (options.react_hooks_rules_of_hooks) {
         try react_hooks_rules_of_hooks.run(allocator, diagnostics, tree);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -763,6 +763,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unsafe_optional_chaining.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_computed_key.zig");
 }
 

--- a/tests/rules/no_unsafe_optional_chaining.zig
+++ b/tests/rules/no_unsafe_optional_chaining.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unsafe-optional-chaining for unsafe member call and constructor usage" {
+    const source =
+        \\(obj?.foo).bar;
+        \\(obj?.foo)();
+        \\new (obj?.foo)();
+        \\(obj?.foo)`template`;
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unsafe_optional_chaining.id));
+    try std.testing.expectEqualStrings(
+        "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+        result.diagnostics[0].message,
+    );
+}
+
+test "reports no-unsafe-optional-chaining for spread iteration and destructuring usage" {
+    const source =
+        \\foo(...obj?.args);
+        \\const items = [...obj?.items];
+        \\for (const item of obj?.items) {}
+        \\for (const key in obj?.items) {}
+        \\const { value } = obj?.data;
+        \\let first;
+        \\[first] = obj?.items;
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
+test "reports no-unsafe-optional-chaining for object binary with and extends usage" {
+    const source =
+        \\"value" in obj?.data;
+        \\value instanceof obj?.Ctor;
+        \\with (obj?.data) {}
+        \\class Example extends obj?.Base {}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
+test "allows no-unsafe-optional-chaining for safe optional continuation" {
+    const source =
+        \\obj?.foo;
+        \\obj?.foo.bar;
+        \\obj?.foo?.bar;
+        \\(obj?.foo)?.bar;
+        \\(obj?.foo)?.();
+        \\const value = obj?.foo ?? fallback;
+        \\const copy = { ...obj?.data };
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
+test "can disable no-unsafe-optional-chaining" {
+    const source =
+        \\(obj?.foo).bar;
+        \\
+    ;
+
+    var options = baseOptions();
+    options.no_unsafe_optional_chaining = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    };
+}


### PR DESCRIPTION
## Summary

- add the `no-unsafe-optional-chaining` lint rule
- report optional chains used in unsafe runtime contexts such as member access, calls, constructors, spreads, loops, destructuring, binary object checks, `with`, and class `extends`
- wire the rule into CLI options, rule exports, tests, and rule status docs

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
