### PR TITLE
Support no-unsafe-optional-chaining arithmetic option

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -145,7 +145,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
-| [`no-unsafe-optional-chaining`](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining) | Implemented for unsafe member, call, constructor, tagged template, spread, iteration, destructuring, binary object, `with`, and class `extends` usage |
+| [`no-unsafe-optional-chaining`](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining) | Implemented for unsafe member, call, constructor, tagged template, spread, iteration, destructuring, binary object, `with`, class `extends`, and optional `disallowArithmeticOperators` behavior |
 | [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members) | Implemented for private fields, methods, accessors, and static blocks |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1672,6 +1672,7 @@ pub const Options = struct {
     no_unsafe_negation: bool = true,
     no_unsafe_negation_enforce_for_ordering_relations: bool = false,
     no_unsafe_optional_chaining: bool = true,
+    no_unsafe_optional_chaining_disallow_arithmetic_operators: bool = false,
     no_useless_computed_key: bool = true,
     no_useless_computed_key_enforce_for_class_members: NoUselessComputedKeyEnforceForClassMembers = .yes,
     no_useless_call: bool = true,
@@ -2300,6 +2301,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-unsafe-negation")) {
             self.no_unsafe_negation_enforce_for_ordering_relations = try noUnsafeNegationBoolOptionFromConfig(value, "enforceForOrderingRelations", false);
+        }
+        if (std.mem.eql(u8, cli_name, "no-unsafe-optional-chaining")) {
+            self.no_unsafe_optional_chaining_disallow_arithmetic_operators = try noUnsafeOptionalChainingBoolOptionFromConfig(value, "disallowArithmeticOperators", false);
         }
         if (std.mem.eql(u8, cli_name, "no-useless-rename")) {
             self.no_useless_rename_ignore_destructuring = try noUselessRenameBoolOptionFromConfig(value, "ignoreDestructuring");
@@ -5321,6 +5325,10 @@ pub const Options = struct {
         };
     }
 
+    fn noUnsafeOptionalChainingBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        return noUnsafeNegationBoolOptionFromConfig(value, key, default);
+    }
+
     fn noIrregularWhitespaceBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -8313,6 +8321,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-unsafe-negation", no_unsafe_negation_config.value);
     try std.testing.expect(options.no_unsafe_negation);
     try std.testing.expect(options.no_unsafe_negation_enforce_for_ordering_relations);
+
+    var no_unsafe_optional_chaining_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"disallowArithmeticOperators\":true}]",
+        .{},
+    );
+    defer no_unsafe_optional_chaining_config.deinit();
+    try options.setByRuleConfigValue("no-unsafe-optional-chaining", no_unsafe_optional_chaining_config.value);
+    try std.testing.expect(options.no_unsafe_optional_chaining);
+    try std.testing.expect(options.no_unsafe_optional_chaining_disallow_arithmetic_operators);
 
     var no_return_assign_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -571,6 +571,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_unsafe_negation = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-optional-chaining=off")) {
             options.no_unsafe_optional_chaining = false;
+        } else if (std.mem.eql(u8, arg, "--no-unsafe-optional-chaining-disallow-arithmetic-operators=on")) {
+            options.no_unsafe_optional_chaining_disallow_arithmetic_operators = true;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key=off")) {
             options.no_useless_computed_key = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key-enforce-for-class-members=off")) {
@@ -1699,6 +1701,7 @@ fn printHelp() void {
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation
         \\  --no-unsafe-optional-chaining=off Disable no-unsafe-optional-chaining
+        \\  --no-unsafe-optional-chaining-disallow-arithmetic-operators=on Report optional chains in arithmetic operators
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
         \\  --no-useless-computed-key-enforce-for-class-members=off Disable class member checks
         \\  --no-useless-call=off     Disable no-useless-call

--- a/src/rules/no_unsafe_optional_chaining.zig
+++ b/src/rules/no_unsafe_optional_chaining.zig
@@ -8,16 +8,30 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "no-unsafe-optional-chaining";
 
+pub const Options = struct {
+    disallow_arithmetic_operators: bool = false,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     if (std.mem.indexOf(u8, tree.source, "?.") == null) return;
 
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .options = options,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -26,6 +40,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    options: Options,
 
     pub fn enter_chain_expression(
         self: *Visitor,
@@ -33,7 +48,7 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        const unsafe_parent = unsafeParent(ctx.tree, index, &ctx.path) orelse return .proceed;
+        const unsafe_parent = unsafeParent(ctx.tree, index, &ctx.path, self.options) orelse return .proceed;
         try self.addDiagnostic(ctx.tree, unsafe_parent.report_index);
         return .proceed;
     }
@@ -58,6 +73,7 @@ fn unsafeParent(
     tree: *const ast.Tree,
     chain_index: ast.NodeIndex,
     path: *const traverser.NodePath,
+    options: Options,
 ) ?UnsafeParent {
     var child = chain_index;
     var depth: usize = 1;
@@ -94,7 +110,7 @@ fn unsafeParent(
                 child = parent_index;
                 continue;
             },
-            else => return unsafeDirectParent(tree, parent_index, child, path, depth),
+            else => return unsafeDirectParent(tree, parent_index, child, path, depth, options),
         }
     }
 
@@ -107,6 +123,7 @@ fn unsafeDirectParent(
     child: ast.NodeIndex,
     path: *const traverser.NodePath,
     parent_depth: usize,
+    options: Options,
 ) ?UnsafeParent {
     switch (tree.data(parent_index)) {
         .member_expression => |member| {
@@ -139,6 +156,20 @@ fn unsafeDirectParent(
             if (expression.right == child and isUnsafeBinaryOperator(expression.operator)) {
                 return .{ .report_index = child };
             }
+            if (options.disallow_arithmetic_operators and
+                (expression.left == child or expression.right == child) and
+                isArithmeticBinaryOperator(expression.operator))
+            {
+                return .{ .report_index = child };
+            }
+        },
+        .unary_expression => |expression| {
+            if (options.disallow_arithmetic_operators and
+                expression.argument == child and
+                isArithmeticUnaryOperator(expression.operator))
+            {
+                return .{ .report_index = child };
+            }
         },
         .variable_declarator => |declarator| {
             if (declarator.init == child and isDestructuringPattern(tree, declarator.id)) {
@@ -147,6 +178,12 @@ fn unsafeDirectParent(
         },
         .assignment_expression => |expression| {
             if (expression.right == child and isDestructuringPattern(tree, expression.left)) {
+                return .{ .report_index = child };
+            }
+            if (options.disallow_arithmetic_operators and
+                (expression.left == child or expression.right == child) and
+                isArithmeticAssignmentOperator(expression.operator))
+            {
                 return .{ .report_index = child };
             }
         },
@@ -178,6 +215,39 @@ fn isUnsafeSpreadParent(tree: *const ast.Tree, parent: ?ast.NodeIndex) bool {
 fn isUnsafeBinaryOperator(operator: ast.BinaryOperator) bool {
     return switch (operator) {
         .in, .instanceof => true,
+        else => false,
+    };
+}
+
+fn isArithmeticBinaryOperator(operator: ast.BinaryOperator) bool {
+    return switch (operator) {
+        .add,
+        .subtract,
+        .multiply,
+        .divide,
+        .modulo,
+        .exponent,
+        => true,
+        else => false,
+    };
+}
+
+fn isArithmeticAssignmentOperator(operator: ast.AssignmentOperator) bool {
+    return switch (operator) {
+        .add_assign,
+        .subtract_assign,
+        .multiply_assign,
+        .divide_assign,
+        .modulo_assign,
+        .exponent_assign,
+        => true,
+        else => false,
+    };
+}
+
+fn isArithmeticUnaryOperator(operator: ast.UnaryOperator) bool {
+    return switch (operator) {
+        .positive, .negate => true,
         else => false,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -577,7 +577,9 @@ pub fn runBasic(
         try typescript_eslint_no_non_null_asserted_optional_chain.run(allocator, diagnostics, tree);
     }
     if (options.no_unsafe_optional_chaining) {
-        try no_unsafe_optional_chaining.run(allocator, diagnostics, tree);
+        try no_unsafe_optional_chaining.runWithOptions(allocator, diagnostics, tree, .{
+            .disallow_arithmetic_operators = options.no_unsafe_optional_chaining_disallow_arithmetic_operators,
+        });
     }
     if (options.react_hooks_rules_of_hooks) {
         try react_hooks_rules_of_hooks.run(allocator, diagnostics, tree);

--- a/tests/rules/no_unsafe_optional_chaining.zig
+++ b/tests/rules/no_unsafe_optional_chaining.zig
@@ -72,6 +72,39 @@ test "allows no-unsafe-optional-chaining for safe optional continuation" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_optional_chaining.id));
 }
 
+test "allows arithmetic optional chains by default" {
+    const source =
+        \\+obj?.value;
+        \\obj?.value - 1;
+        \\total += obj?.value;
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
+test "reports arithmetic optional chains when configured" {
+    const source =
+        \\+obj?.first;
+        \\-obj?.second;
+        \\obj?.third - 1;
+        \\1 * obj?.fourth;
+        \\total += obj?.fifth;
+        \\
+    ;
+
+    var options = baseOptions();
+    options.no_unsafe_optional_chaining_disallow_arithmetic_operators = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_unsafe_optional_chaining.id));
+}
+
 test "can disable no-unsafe-optional-chaining" {
     const source =
         \\(obj?.foo).bar;


### PR DESCRIPTION
## Summary

- support `no-unsafe-optional-chaining`'s `disallowArithmeticOperators` option
- report optional chains used with unary, binary, and compound arithmetic operators only when configured
- add config parsing, CLI toggle, tests, and rule status docs

## Validation

- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
