### PR TITLE
Add no-unreachable-loop

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -143,6 +143,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
+| [`no-unreachable-loop`](https://eslint.org/docs/latest/rules/no-unreachable-loop) | Supports loop body exit detection and `ignore` configuration |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |
 | [`no-unsafe-negation`](https://eslint.org/docs/latest/rules/no-unsafe-negation) | Supports `enforceForOrderingRelations` configuration |
 | [`no-unsafe-optional-chaining`](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining) | Implemented for unsafe member, call, constructor, tagged template, spread, iteration, destructuring, binary object, `with`, class `extends`, and optional `disallowArithmeticOperators` behavior |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1668,6 +1668,12 @@ pub const Options = struct {
     no_unneeded_ternary: bool = true,
     no_unneeded_ternary_default_assignment: bool = true,
     no_unused_labels: bool = true,
+    no_unreachable_loop: bool = true,
+    no_unreachable_loop_ignore_while: bool = false,
+    no_unreachable_loop_ignore_do_while: bool = false,
+    no_unreachable_loop_ignore_for: bool = false,
+    no_unreachable_loop_ignore_for_in: bool = false,
+    no_unreachable_loop_ignore_for_of: bool = false,
     no_unsafe_finally: bool = true,
     no_unsafe_negation: bool = true,
     no_unsafe_negation_enforce_for_ordering_relations: bool = false,
@@ -2298,6 +2304,14 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-trailing-spaces")) {
             self.no_trailing_spaces_skip_blank_lines = try noTrailingSpacesBoolOptionFromConfig(value, "skipBlankLines");
             self.no_trailing_spaces_ignore_comments = try noTrailingSpacesBoolOptionFromConfig(value, "ignoreComments");
+        }
+        if (std.mem.eql(u8, cli_name, "no-unreachable-loop")) {
+            const ignore = try noUnreachableLoopIgnoreFromConfig(value);
+            self.no_unreachable_loop_ignore_while = ignore.while_statement;
+            self.no_unreachable_loop_ignore_do_while = ignore.do_while_statement;
+            self.no_unreachable_loop_ignore_for = ignore.for_statement;
+            self.no_unreachable_loop_ignore_for_in = ignore.for_in_statement;
+            self.no_unreachable_loop_ignore_for_of = ignore.for_of_statement;
         }
         if (std.mem.eql(u8, cli_name, "no-unsafe-negation")) {
             self.no_unsafe_negation_enforce_for_ordering_relations = try noUnsafeNegationBoolOptionFromConfig(value, "enforceForOrderingRelations", false);
@@ -5306,6 +5320,54 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    const NoUnreachableLoopIgnore = struct {
+        while_statement: bool = false,
+        do_while_statement: bool = false,
+        for_statement: bool = false,
+        for_in_statement: bool = false,
+        for_of_statement: bool = false,
+    };
+
+    fn noUnreachableLoopIgnoreFromConfig(value: std.json.Value) RuleConfigError!NoUnreachableLoopIgnore {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore_value = config.get("ignore") orelse return .{};
+        const ignore_items = switch (ignore_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var ignore = NoUnreachableLoopIgnore{};
+        for (ignore_items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, name, "WhileStatement")) {
+                ignore.while_statement = true;
+            } else if (std.mem.eql(u8, name, "DoWhileStatement")) {
+                ignore.do_while_statement = true;
+            } else if (std.mem.eql(u8, name, "ForStatement")) {
+                ignore.for_statement = true;
+            } else if (std.mem.eql(u8, name, "ForInStatement")) {
+                ignore.for_in_statement = true;
+            } else if (std.mem.eql(u8, name, "ForOfStatement")) {
+                ignore.for_of_statement = true;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        return ignore;
     }
 
     fn noUnsafeNegationBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -8321,6 +8383,19 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-unsafe-negation", no_unsafe_negation_config.value);
     try std.testing.expect(options.no_unsafe_negation);
     try std.testing.expect(options.no_unsafe_negation_enforce_for_ordering_relations);
+
+    var no_unreachable_loop_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[\"WhileStatement\",\"ForOfStatement\"]}]",
+        .{},
+    );
+    defer no_unreachable_loop_config.deinit();
+    try options.setByRuleConfigValue("no-unreachable-loop", no_unreachable_loop_config.value);
+    try std.testing.expect(options.no_unreachable_loop);
+    try std.testing.expect(options.no_unreachable_loop_ignore_while);
+    try std.testing.expect(options.no_unreachable_loop_ignore_for_of);
+    try std.testing.expect(!options.no_unreachable_loop_ignore_for);
 
     var no_unsafe_optional_chaining_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -537,6 +537,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_trailing_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-unreachable=off")) {
             options.no_unreachable = false;
+        } else if (std.mem.eql(u8, arg, "--no-unreachable-loop=off")) {
+            options.no_unreachable_loop = false;
         } else if (std.mem.eql(u8, arg, "--no-undef-init=off")) {
             options.no_undef_init = false;
         } else if (std.mem.eql(u8, arg, "--no-underscore-dangle=off")) {
@@ -1684,6 +1686,7 @@ fn printHelp() void {
         \\  --no-tabs=off             Disable no-tabs
         \\  --no-trailing-spaces=off  Disable no-trailing-spaces
         \\  --no-unreachable=off      Disable no-unreachable
+        \\  --no-unreachable-loop=off Disable no-unreachable-loop
         \\  --no-undef-init=off       Disable no-undef-init
         \\  --no-underscore-dangle=off Disable no-underscore-dangle
         \\  --no-underscore-dangle-allow-after-this=on Allow dangling underscores after this

--- a/src/rules/no_unreachable_loop.zig
+++ b/src/rules/no_unreachable_loop.zig
@@ -1,0 +1,173 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-unreachable-loop";
+
+pub const LoopKind = enum {
+    while_statement,
+    do_while_statement,
+    for_statement,
+    for_in_statement,
+    for_of_statement,
+};
+
+pub const Options = struct {
+    ignore_while: bool = false,
+    ignore_do_while: bool = false,
+    ignore_for: bool = false,
+    ignore_for_in: bool = false,
+    ignore_for_of: bool = false,
+
+    fn ignores(self: Options, kind: LoopKind) bool {
+        return switch (kind) {
+            .while_statement => self.ignore_while,
+            .do_while_statement => self.ignore_do_while,
+            .for_statement => self.ignore_for,
+            .for_in_statement => self.ignore_for_in,
+            .for_of_statement => self.ignore_for_of,
+        };
+    }
+};
+
+pub fn checkWhileStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.WhileStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkLoop(allocator, diagnostics, tree, statement.body, index, .while_statement, options);
+}
+
+pub fn checkDoWhileStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.DoWhileStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkLoop(allocator, diagnostics, tree, statement.body, index, .do_while_statement, options);
+}
+
+pub fn checkForStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ForStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkLoop(allocator, diagnostics, tree, statement.body, index, .for_statement, options);
+}
+
+pub fn checkForInStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ForInStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkLoop(allocator, diagnostics, tree, statement.body, index, .for_in_statement, options);
+}
+
+pub fn checkForOfStatement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.ForOfStatement,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkLoop(allocator, diagnostics, tree, statement.body, index, .for_of_statement, options);
+}
+
+fn checkLoop(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+    loop_index: ast.NodeIndex,
+    kind: LoopKind,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignores(kind)) return;
+    if (!statementExitsLoop(tree, body, .{ .bare_break_exits_loop = true })) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "This loop will never iterate more than once.",
+        tree.span(loop_index),
+    );
+}
+
+const ExitContext = struct {
+    bare_break_exits_loop: bool,
+};
+
+fn statementExitsLoop(tree: *const ast.Tree, index: ast.NodeIndex, ctx: ExitContext) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(index)) {
+        .return_statement,
+        .throw_statement,
+        => true,
+        .break_statement => |statement| statement.label == .null and ctx.bare_break_exits_loop,
+        .block_statement => |block| statementRangeExitsLoop(tree, block.body, ctx),
+        .if_statement => |statement| statement.alternate != .null and
+            statementExitsLoop(tree, statement.consequent, ctx) and
+            statementExitsLoop(tree, statement.alternate, ctx),
+        .labeled_statement => |statement| statementExitsLoop(tree, statement.body, ctx),
+        .switch_statement => |statement| switchExitsLoop(tree, statement),
+        .try_statement => |statement| tryExitsLoop(tree, statement, ctx),
+        .catch_clause => |clause| statementExitsLoop(tree, clause.body, ctx),
+        .while_statement,
+        .do_while_statement,
+        .for_statement,
+        .for_in_statement,
+        .for_of_statement,
+        .function,
+        .arrow_function_expression,
+        .class,
+        => false,
+        else => false,
+    };
+}
+
+fn statementRangeExitsLoop(tree: *const ast.Tree, range: ast.IndexRange, ctx: ExitContext) bool {
+    for (tree.extra(range)) |statement| {
+        if (statementExitsLoop(tree, statement, ctx)) return true;
+    }
+    return false;
+}
+
+fn switchExitsLoop(tree: *const ast.Tree, statement: ast.SwitchStatement) bool {
+    var has_default = false;
+    const switch_ctx = ExitContext{ .bare_break_exits_loop = false };
+
+    for (tree.extra(statement.cases)) |case_index| {
+        const case = switch (tree.data(case_index)) {
+            .switch_case => |case| case,
+            else => continue,
+        };
+        if (case.@"test" == .null) has_default = true;
+        if (!statementRangeExitsLoop(tree, case.consequent, switch_ctx)) return false;
+    }
+
+    return has_default and statement.cases.len > 0;
+}
+
+fn tryExitsLoop(tree: *const ast.Tree, statement: ast.TryStatement, ctx: ExitContext) bool {
+    if (statement.finalizer != .null and statementExitsLoop(tree, statement.finalizer, ctx)) return true;
+    if (!statementExitsLoop(tree, statement.block, ctx)) return false;
+    if (statement.handler == .null) return true;
+    return statementExitsLoop(tree, statement.handler, ctx);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -198,6 +198,7 @@ pub const no_throw_literal = @import("no_throw_literal.zig");
 pub const no_this_before_super = @import("no_this_before_super.zig");
 pub const no_trailing_spaces = @import("no_trailing_spaces.zig");
 pub const no_unreachable = @import("no_unreachable.zig");
+pub const no_unreachable_loop = @import("no_unreachable_loop.zig");
 pub const no_undef_init = @import("no_undef_init.zig");
 pub const no_underscore_dangle = @import("no_underscore_dangle.zig");
 pub const no_undefined = @import("no_undefined.zig");
@@ -1122,6 +1123,16 @@ const BasicVisitor = struct {
         };
     }
 
+    fn noUnreachableLoopOptions(self: *const BasicVisitor) no_unreachable_loop.Options {
+        return .{
+            .ignore_while = self.options.no_unreachable_loop_ignore_while,
+            .ignore_do_while = self.options.no_unreachable_loop_ignore_do_while,
+            .ignore_for = self.options.no_unreachable_loop_ignore_for,
+            .ignore_for_in = self.options.no_unreachable_loop_ignore_for_in,
+            .ignore_for_of = self.options.no_unreachable_loop_ignore_for_of,
+        };
+    }
+
     fn noUselessRenameOptions(self: *const BasicVisitor) no_useless_rename.Options {
         return .{
             .ignore_destructuring = self.options.no_useless_rename_ignore_destructuring,
@@ -1492,7 +1503,7 @@ const BasicVisitor = struct {
     pub fn enter_while_statement(
         self: *BasicVisitor,
         statement: ast.WhileStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
@@ -1510,13 +1521,16 @@ const BasicVisitor = struct {
                 .none => {},
             }
         }
+        if (self.options.no_unreachable_loop) {
+            try no_unreachable_loop.checkWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
         return .proceed;
     }
 
     pub fn enter_do_while_statement(
         self: *BasicVisitor,
         statement: ast.DoWhileStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
@@ -1529,6 +1543,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_constant_condition and self.options.no_constant_condition_check_loops != .none) {
             try no_constant_condition.check(self.allocator, self.diagnostics, ctx.tree, statement.@"test");
+        }
+        if (self.options.no_unreachable_loop) {
+            try no_unreachable_loop.checkDoWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
         return .proceed;
     }
@@ -1555,6 +1572,9 @@ const BasicVisitor = struct {
         }
         if (self.options.for_direction) {
             try for_direction.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+        }
+        if (self.options.no_unreachable_loop) {
+            try no_unreachable_loop.checkForStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
         return .proceed;
     }
@@ -2230,17 +2250,23 @@ const BasicVisitor = struct {
         if (self.options.no_for_in) {
             try no_for_in.check(self.allocator, self.diagnostics, ctx.tree, index);
         }
+        if (self.options.no_unreachable_loop) {
+            try no_unreachable_loop.checkForInStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
         return .proceed;
     }
 
     pub fn enter_for_of_statement(
         self: *BasicVisitor,
         statement: ast.ForOfStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.curly) {
             try curly.checkBodyWithOptions(self.allocator, self.diagnostics, ctx.tree, statement.body, self.curlyOptions());
+        }
+        if (self.options.no_unreachable_loop) {
+            try no_unreachable_loop.checkForOfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -731,6 +731,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unreachable_loop.zig");
+}
+
+comptime {
     _ = @import("rules/no_undef_init.zig");
 }
 

--- a/tests/rules/no_unreachable_loop.zig
+++ b/tests/rules/no_unreachable_loop.zig
@@ -1,0 +1,166 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-unreachable-loop for loops that always exit" {
+    const source =
+        \\function run(items, object) {
+        \\  while (items.length) {
+        \\    break;
+        \\  }
+        \\  do {
+        \\    throw new Error("stop");
+        \\  } while (items.length);
+        \\  for (;;) {
+        \\    return;
+        \\  }
+        \\  for (const key in object) {
+        \\    if (key) {
+        \\      break;
+        \\    } else {
+        \\      throw new Error("stop");
+        \\    }
+        \\  }
+        \\  for (const item of items) {
+        \\    if (item) {
+        \\      return item;
+        \\    } else {
+        \\      throw new Error("stop");
+        \\    }
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_unreachable_loop.id));
+    try std.testing.expectEqualStrings("This loop will never iterate more than once.", result.diagnostics[0].message);
+}
+
+test "allows no-unreachable-loop when a later iteration can be reached" {
+    const source =
+        \\function run(items) {
+        \\  while (items.length) {
+        \\    if (items.shift()) {
+        \\      break;
+        \\    }
+        \\    work();
+        \\  }
+        \\  for (;;) {
+        \\    if (ready()) {
+        \\      return;
+        \\    }
+        \\    work();
+        \\  }
+        \\  for (const item of items) {
+        \\    while (item.pending) {
+        \\      if (done()) {
+        \\        break;
+        \\      }
+        \\      workInner();
+        \\    }
+        \\    work(item);
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable_loop.id));
+}
+
+test "reports no-unreachable-loop for switches whose cases always exit" {
+    const source =
+        \\function run(items, value) {
+        \\  while (items.length) {
+        \\    switch (value) {
+        \\      case 1:
+        \\        return;
+        \\      default:
+        \\        throw new Error("stop");
+        \\    }
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unreachable_loop.id));
+}
+
+test "does not treat switch break as loop exit" {
+    const source =
+        \\function run(items, value) {
+        \\  while (items.length) {
+        \\    switch (value) {
+        \\      default:
+        \\        break;
+        \\    }
+        \\    work();
+        \\  }
+        \\}
+        \\
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable_loop.id));
+}
+
+test "can ignore no-unreachable-loop loop kinds" {
+    const source =
+        \\function run(items) {
+        \\  while (items.length) {
+        \\    break;
+        \\  }
+        \\  for (const item of items) {
+        \\    break;
+        \\  }
+        \\}
+        \\
+    ;
+
+    var options = baseOptions();
+    options.no_unreachable_loop_ignore_while = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unreachable_loop.id));
+}
+
+test "can disable no-unreachable-loop" {
+    const source =
+        \\while (condition) {
+        \\  break;
+        \\}
+        \\
+    ;
+
+    var options = baseOptions();
+    options.no_unreachable_loop = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable_loop.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .consistent_return = false,
+        .no_constant_condition = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}


### PR DESCRIPTION
## Summary
- add the `no-unreachable-loop` rule for loop bodies that always exit via `break`, `return`, or `throw`
- wire the rule into while/do-while/for/for-in/for-of visitors with ESLint `ignore` loop-kind configuration
- add CLI toggle, rule status docs, and focused coverage for switch/ignore/disabled cases

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`