### PR TITLE
Add no-restricted-properties

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -120,6 +120,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-promise-executor-return`](https://eslint.org/docs/latest/rules/no-promise-executor-return) | Supports `allowVoid` configuration |
 | [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) | Implemented |
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
+| [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
 | [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented for return statements, async arrow expression bodies, and nested tail expressions |

--- a/src/core.zig
+++ b/src/core.zig
@@ -592,6 +592,111 @@ pub const NoShadowAllowNames = struct {
     }
 };
 
+pub const max_no_restricted_properties = 32;
+pub const max_no_restricted_property_name_len = 128;
+pub const max_no_restricted_property_message_len = 256;
+pub const max_no_restricted_property_allow_names = 16;
+
+pub const NoRestrictedPropertyNameList = struct {
+    count: usize = 0,
+    lengths: [max_no_restricted_property_allow_names]usize = undefined,
+    storage: [max_no_restricted_property_allow_names][max_no_restricted_property_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoRestrictedPropertyNameList, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoRestrictedPropertyNameList, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoRestrictedPropertyNameList, name: []const u8) bool {
+        if (name.len == 0) return false;
+        if (self.count >= max_no_restricted_property_allow_names) return false;
+        if (name.len > max_no_restricted_property_name_len) return false;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
+    }
+};
+
+pub const NoRestrictedPropertyEntry = struct {
+    has_object: bool = false,
+    object_length: usize = 0,
+    object_storage: [max_no_restricted_property_name_len]u8 = undefined,
+
+    has_property: bool = false,
+    property_length: usize = 0,
+    property_storage: [max_no_restricted_property_name_len]u8 = undefined,
+
+    has_message: bool = false,
+    message_length: usize = 0,
+    message_storage: [max_no_restricted_property_message_len]u8 = undefined,
+
+    allow_objects: NoRestrictedPropertyNameList = .{},
+    allow_properties: NoRestrictedPropertyNameList = .{},
+
+    pub fn object(self: *const NoRestrictedPropertyEntry) ?[]const u8 {
+        if (!self.has_object) return null;
+        return self.object_storage[0..self.object_length];
+    }
+
+    pub fn property(self: *const NoRestrictedPropertyEntry) ?[]const u8 {
+        if (!self.has_property) return null;
+        return self.property_storage[0..self.property_length];
+    }
+
+    pub fn message(self: *const NoRestrictedPropertyEntry) ?[]const u8 {
+        if (!self.has_message) return null;
+        return self.message_storage[0..self.message_length];
+    }
+
+    pub fn setObject(self: *NoRestrictedPropertyEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_property_name_len) return false;
+        @memcpy(self.object_storage[0..value.len], value);
+        self.object_length = value.len;
+        self.has_object = true;
+        return true;
+    }
+
+    pub fn setProperty(self: *NoRestrictedPropertyEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_property_name_len) return false;
+        @memcpy(self.property_storage[0..value.len], value);
+        self.property_length = value.len;
+        self.has_property = true;
+        return true;
+    }
+
+    pub fn setMessage(self: *NoRestrictedPropertyEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_property_message_len) return false;
+        @memcpy(self.message_storage[0..value.len], value);
+        self.message_length = value.len;
+        self.has_message = true;
+        return true;
+    }
+};
+
+pub const NoRestrictedProperties = struct {
+    count: usize = 0,
+    entries: [max_no_restricted_properties]NoRestrictedPropertyEntry = undefined,
+
+    pub fn append(self: *NoRestrictedProperties, entry: NoRestrictedPropertyEntry) bool {
+        if (self.count >= max_no_restricted_properties) return false;
+        self.entries[self.count] = entry;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn at(self: *const NoRestrictedProperties, index: usize) *const NoRestrictedPropertyEntry {
+        return &self.entries[index];
+    }
+};
+
 pub const max_no_unused_vars_ignore_pattern_len = 256;
 
 pub const NoUnusedVarsIgnorePatternError = error{
@@ -1623,6 +1728,8 @@ pub const Options = struct {
     no_prototype_builtins: bool = true,
     no_redeclare: bool = true,
     no_redeclare_builtin_globals: NoRedeclareBuiltinGlobals = .no,
+    no_restricted_properties: bool = true,
+    no_restricted_properties_entries: NoRestrictedProperties = .{},
     no_regex_spaces: bool = true,
     no_return_await: bool = true,
     no_return_assign: bool = true,
@@ -2297,6 +2404,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
+            self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-self-assign")) {
             self.no_self_assign_props = try noSelfAssignPropsFromConfig(value);
@@ -4695,6 +4805,84 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enabled) .yes else .no;
+    }
+
+    fn noRestrictedPropertiesFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedProperties {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        var restrictions = NoRestrictedProperties{};
+        for (items[1..]) |item| {
+            const config = switch (item) {
+                .object => |object| object,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+
+            var entry = NoRestrictedPropertyEntry{};
+            const has_object = try noRestrictedPropertyOptionalString(config, "object", &entry, .object);
+            const has_property = try noRestrictedPropertyOptionalString(config, "property", &entry, .property);
+            _ = try noRestrictedPropertyOptionalString(config, "message", &entry, .message);
+            const has_allow_objects = try noRestrictedPropertyNameListFromConfig(config, "allowObjects", &entry.allow_objects);
+            const has_allow_properties = try noRestrictedPropertyNameListFromConfig(config, "allowProperties", &entry.allow_properties);
+
+            if (has_object and has_allow_objects) return error.UnsupportedRuleConfigValue;
+            if (has_property and has_allow_properties) return error.UnsupportedRuleConfigValue;
+            if (!has_object and !has_property) return error.UnsupportedRuleConfigValue;
+            if (has_allow_objects and !has_property) return error.UnsupportedRuleConfigValue;
+            if (has_allow_properties and !has_object) return error.UnsupportedRuleConfigValue;
+            if (!restrictions.append(entry)) return error.UnsupportedRuleConfigValue;
+        }
+        return restrictions;
+    }
+
+    const NoRestrictedPropertyStringTarget = enum {
+        object,
+        property,
+        message,
+    };
+
+    fn noRestrictedPropertyOptionalString(
+        config: std.json.ObjectMap,
+        key: []const u8,
+        entry: *NoRestrictedPropertyEntry,
+        target: NoRestrictedPropertyStringTarget,
+    ) RuleConfigError!bool {
+        const value = config.get(key) orelse return false;
+        const string = switch (value) {
+            .string => |string| string,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ok = switch (target) {
+            .object => entry.setObject(string),
+            .property => entry.setProperty(string),
+            .message => entry.setMessage(string),
+        };
+        if (!ok) return error.UnsupportedRuleConfigValue;
+        return true;
+    }
+
+    fn noRestrictedPropertyNameListFromConfig(
+        config: std.json.ObjectMap,
+        key: []const u8,
+        names: *NoRestrictedPropertyNameList,
+    ) RuleConfigError!bool {
+        const value = config.get(key) orelse return false;
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        for (items) |item| {
+            const name = switch (item) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!names.append(name)) return error.UnsupportedRuleConfigValue;
+        }
+        return true;
     }
 
     fn preferConstDestructuringFromConfig(value: std.json.Value) RuleConfigError!PreferConstDestructuring {
@@ -8101,6 +8289,23 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("no-redeclare", no_redeclare_config.value);
     try std.testing.expect(options.no_redeclare);
     try std.testing.expectEqual(NoRedeclareBuiltinGlobals.yes, options.no_redeclare_builtin_globals);
+
+    var no_restricted_properties_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"object\":\"disallowedObject\",\"property\":\"disallowedProperty\",\"message\":\"Use allowedObject.allowedProperty.\"},{\"property\":\"push\",\"allowObjects\":[\"router\"]},{\"object\":\"config\",\"allowProperties\":[\"settings\",\"version\"]}]",
+        .{},
+    );
+    defer no_restricted_properties_config.deinit();
+    try options.setByRuleConfigValue("no-restricted-properties", no_restricted_properties_config.value);
+    try std.testing.expect(options.no_restricted_properties);
+    try std.testing.expectEqual(@as(usize, 3), options.no_restricted_properties_entries.count);
+    try std.testing.expectEqualStrings("disallowedObject", options.no_restricted_properties_entries.at(0).object().?);
+    try std.testing.expectEqualStrings("disallowedProperty", options.no_restricted_properties_entries.at(0).property().?);
+    try std.testing.expectEqualStrings("Use allowedObject.allowedProperty.", options.no_restricted_properties_entries.at(0).message().?);
+    try std.testing.expect(options.no_restricted_properties_entries.at(1).allow_objects.contains("router"));
+    try std.testing.expect(options.no_restricted_properties_entries.at(2).allow_properties.contains("settings"));
+    try std.testing.expect(options.no_restricted_properties_entries.at(2).allow_properties.contains("version"));
 
     var typescript_no_redeclare_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -495,6 +495,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_redeclare = false;
         } else if (std.mem.eql(u8, arg, "--no-redeclare-builtin-globals=on")) {
             options.no_redeclare_builtin_globals = .yes;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
+            options.no_restricted_properties = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-await=off")) {
@@ -1665,6 +1667,7 @@ fn printHelp() void {
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-redeclare=off        Disable no-redeclare
         \\  --no-redeclare-builtin-globals=on Report redeclarations of built-in globals
+        \\  --no-restricted-properties=off Disable no-restricted-properties
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign

--- a/src/rules/no_restricted_properties.zig
+++ b/src/rules/no_restricted_properties.zig
@@ -1,0 +1,185 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-properties";
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+    index: ast.NodeIndex,
+    restrictions: core.NoRestrictedProperties,
+) Allocator.Error!void {
+    const object = objectName(tree, member.object) orelse return;
+    const property = propertyNameFromMember(tree, member) orelse return;
+
+    for (0..restrictions.count) |restriction_index| {
+        const restriction = restrictions.at(restriction_index);
+        if (!matchesMemberRestriction(restriction, object, property)) continue;
+        try addDiagnostic(allocator, diagnostics, tree, index, restriction, object, property);
+    }
+}
+
+pub fn checkObjectPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    pattern: ast.ObjectPattern,
+    restrictions: core.NoRestrictedProperties,
+) Allocator.Error!void {
+    for (tree.extra(pattern.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .binding_property => |property| property,
+            else => continue,
+        };
+        const name = propertyName(tree, property.key, property.computed) orelse continue;
+
+        for (0..restrictions.count) |restriction_index| {
+            const restriction = restrictions.at(restriction_index);
+            if (restriction.has_object) continue;
+            if (!matchesPropertyRestriction(restriction, name)) continue;
+            try addPropertyDiagnostic(allocator, diagnostics, tree, property_index, restriction, name);
+        }
+    }
+}
+
+fn matchesMemberRestriction(restriction: *const core.NoRestrictedPropertyEntry, object: []const u8, property: []const u8) bool {
+    if (restriction.object()) |restricted_object| {
+        if (!std.mem.eql(u8, restricted_object, object)) return false;
+    }
+    if (restriction.property()) |restricted_property| {
+        if (!std.mem.eql(u8, restricted_property, property)) return false;
+    }
+    if (restriction.allow_objects.contains(object)) return false;
+    if (restriction.allow_properties.contains(property)) return false;
+    return true;
+}
+
+fn matchesPropertyRestriction(restriction: *const core.NoRestrictedPropertyEntry, property: []const u8) bool {
+    const restricted_property = restriction.property() orelse return false;
+    if (!std.mem.eql(u8, restricted_property, property)) return false;
+    return true;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    restriction: *const core.NoRestrictedPropertyEntry,
+    object: []const u8,
+    property: []const u8,
+) Allocator.Error!void {
+    if (restriction.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Disallowed object property: {s}.{s}. {s}",
+            .{ object, property, message },
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Disallowed object property: {s}.{s}.",
+            .{ object, property },
+        );
+    }
+}
+
+fn addPropertyDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    restriction: *const core.NoRestrictedPropertyEntry,
+    property: []const u8,
+) Allocator.Error!void {
+    if (restriction.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Disallowed object property: {s}. {s}",
+            .{ property, message },
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Disallowed object property: {s}.",
+            .{property},
+        );
+    }
+}
+
+fn objectName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyNameFromMember(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+    return propertyName(tree, member.property, member.computed);
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (computed) {
+        return switch (tree.data(index)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
+            else => null,
+        };
+    }
+
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -179,6 +179,7 @@ pub const no_process_env = @import("no_process_env.zig");
 pub const no_process_exit = @import("no_process_exit.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_redeclare = @import("no_redeclare.zig");
+pub const no_restricted_properties = @import("no_restricted_properties.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
@@ -3029,6 +3030,9 @@ const BasicVisitor = struct {
         if (self.options.no_iterator) {
             try no_iterator.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
+        if (self.options.no_restricted_properties) {
+            try no_restricted_properties.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member, index, self.options.no_restricted_properties_entries);
+        }
         if (self.options.no_process_env) {
             try no_process_env.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
@@ -3440,6 +3444,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
+        }
+        if (self.options.no_restricted_properties) {
+            try no_restricted_properties.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, self.options.no_restricted_properties_entries);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -655,6 +655,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_properties.zig");
+}
+
+comptime {
     _ = @import("rules/no_regex_spaces.zig");
 }
 

--- a/tests/rules/no_restricted_properties.zig
+++ b/tests/rules/no_restricted_properties.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-restricted-properties for configured object properties" {
+    const source =
+        \\disallowedObject.disallowedProperty;
+        \\disallowedObject.disallowedProperty();
+        \\disallowedObject["disallowedProperty"];
+        \\allowedObject.disallowedProperty;
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"object\":\"disallowedObject\",\"property\":\"disallowedProperty\",\"message\":\"Use allowedObject.allowedProperty.\"}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_restricted_properties.id));
+    try std.testing.expect(hasMessage(result, "Use allowedObject.allowedProperty."));
+}
+
+test "reports no-restricted-properties for global properties and destructuring" {
+    const source =
+        \\foo.__defineGetter__(bar, baz);
+        \\const { __defineGetter__ } = qux();
+        \\({ __defineGetter__ }) => {};
+    ;
+
+    const options = try optionsWithConfig("[\"error\",{\"property\":\"__defineGetter__\"}]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_restricted_properties.id));
+}
+
+test "reports no-restricted-properties for any property on an object" {
+    const source =
+        \\require.resolve("foo");
+        \\require.cache;
+        \\require("foo");
+        \\other.resolve("foo");
+    ;
+
+    const options = try optionsWithConfig("[\"error\",{\"object\":\"require\"}]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_properties.id));
+}
+
+test "honors no-restricted-properties allowObjects and allowProperties" {
+    const source =
+        \\myArray.push(5);
+        \\router.push(5);
+        \\config.apiKey = "12345";
+        \\config.settings = {};
+        \\config.version = "1.0.0";
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"property\":\"push\",\"allowObjects\":[\"router\"]},{\"object\":\"config\",\"allowProperties\":[\"settings\",\"version\"]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_properties.id));
+}
+
+test "allows no-restricted-properties for unrelated access and dynamic names" {
+    const source =
+        \\allowedObject.disallowedProperty;
+        \\disallowedObject.allowedProperty;
+        \\disallowedObject[dynamicName];
+        \\const { allowedProperty } = qux();
+    ;
+
+    const options = try optionsWithConfig("[\"error\",{\"object\":\"disallowedObject\",\"property\":\"disallowedProperty\"}]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_properties.id));
+}
+
+test "can disable no-restricted-properties" {
+    const source =
+        \\disallowedObject.disallowedProperty;
+    ;
+
+    var options = try optionsWithConfig("[\"error\",{\"object\":\"disallowedObject\",\"property\":\"disallowedProperty\"}]");
+    options.no_restricted_properties = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_properties.id));
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("no-restricted-properties", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_properties.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the `no-restricted-properties` rule for configured object/property member access
- support property-only destructuring checks plus `allowObjects` and `allowProperties` config migration
- add CLI toggle, rule status docs, and focused rule/config coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`