### PR TITLE
Add require-unicode-regexp

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -182,6 +182,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`radix`](https://eslint.org/docs/latest/rules/radix) | Implemented |
 | [`require-await`](https://eslint.org/docs/latest/rules/require-await) | Implemented |
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Supports `allowProperties` configuration |
+| [`require-unicode-regexp`](https://eslint.org/docs/latest/rules/require-unicode-regexp) | Supports regexp literals, static `RegExp` constructors, and `requireFlag` configuration |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -213,6 +213,12 @@ pub const RadixStyle = enum {
     as_needed,
 };
 
+pub const RequireUnicodeRegexpRequireFlag = enum {
+    any,
+    u,
+    v,
+};
+
 pub const NoSequencesAllowInParentheses = enum {
     yes,
     no,
@@ -1967,6 +1973,8 @@ pub const Options = struct {
     require_await: bool = true,
     require_atomic_updates: bool = true,
     require_atomic_updates_allow_properties: bool = false,
+    require_unicode_regexp: bool = true,
+    require_unicode_regexp_require_flag: RequireUnicodeRegexpRequireFlag = .any,
     require_yield: bool = true,
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
@@ -2485,6 +2493,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "require-atomic-updates")) {
             self.require_atomic_updates_allow_properties = try requireAtomicUpdatesBoolOptionFromConfig(value, "allowProperties", false);
+        }
+        if (std.mem.eql(u8, cli_name, "require-unicode-regexp")) {
+            self.require_unicode_regexp_require_flag = try requireUnicodeRegexpRequireFlagFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
@@ -5069,6 +5080,26 @@ pub const Options = struct {
         };
         if (std.mem.eql(u8, style, "always")) return .always;
         if (std.mem.eql(u8, style, "as-needed")) return .as_needed;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn requireUnicodeRegexpRequireFlagFromConfig(value: std.json.Value) RuleConfigError!RequireUnicodeRegexpRequireFlag {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .any,
+        };
+        if (items.len < 2) return .any;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const require_flag = switch (config.get("requireFlag") orelse return .any) {
+            .string => |flag| flag,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, require_flag, "u")) return .u;
+        if (std.mem.eql(u8, require_flag, "v")) return .v;
         return error.UnsupportedRuleConfigValue;
     }
 
@@ -8551,6 +8582,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("require-atomic-updates", require_atomic_updates_config.value);
     try std.testing.expect(options.require_atomic_updates);
     try std.testing.expect(options.require_atomic_updates_allow_properties);
+
+    var require_unicode_regexp_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"requireFlag\":\"v\"}]",
+        .{},
+    );
+    defer require_unicode_regexp_config.deinit();
+    try options.setByRuleConfigValue("require-unicode-regexp", require_unicode_regexp_config.value);
+    try std.testing.expect(options.require_unicode_regexp);
+    try std.testing.expectEqual(RequireUnicodeRegexpRequireFlag.v, options.require_unicode_regexp_require_flag);
 
     var no_useless_rename_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -757,6 +757,12 @@ pub fn main(init: std.process.Init) !void {
             options.require_await = false;
         } else if (std.mem.eql(u8, arg, "--require-atomic-updates=off")) {
             options.require_atomic_updates = false;
+        } else if (std.mem.eql(u8, arg, "--require-unicode-regexp=off")) {
+            options.require_unicode_regexp = false;
+        } else if (std.mem.eql(u8, arg, "--require-unicode-regexp-require-flag=u")) {
+            options.require_unicode_regexp_require_flag = .u;
+        } else if (std.mem.eql(u8, arg, "--require-unicode-regexp-require-flag=v")) {
+            options.require_unicode_regexp_require_flag = .v;
         } else if (std.mem.eql(u8, arg, "--require-yield=off")) {
             options.require_yield = false;
         } else if (std.mem.eql(u8, arg, "--spaced-comment=off")) {
@@ -1795,6 +1801,9 @@ fn printHelp() void {
         \\  --radix=off               Disable radix
         \\  --require-await=off      Disable require-await
         \\  --require-atomic-updates=off Disable require-atomic-updates
+        \\  --require-unicode-regexp=off Disable require-unicode-regexp
+        \\  --require-unicode-regexp-require-flag=u Require the u flag for regexps
+        \\  --require-unicode-regexp-require-flag=v Require the v flag for regexps
         \\  --require-yield=off       Disable require-yield
         \\  --spaced-comment=off      Disable spaced-comment
         \\  --spaced-comment=never    Disallow spacing after comment markers

--- a/src/root.zig
+++ b/src/root.zig
@@ -175,6 +175,7 @@ fn hasSemanticRules(options: Options) bool {
         options.prefer_regex_literals or
         options.radix or
         options.require_atomic_updates or
+        options.require_unicode_regexp or
         options.symbol_description or
         options.typescript_eslint_no_redeclare or
         options.typescript_eslint_no_require_imports or

--- a/src/rules/require_unicode_regexp.zig
+++ b/src/rules/require_unicode_regexp.zig
@@ -1,0 +1,182 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "require-unicode-regexp";
+
+pub const Options = struct {
+    require_flag: core.RequireUnicodeRegexpRequireFlag = .any,
+};
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .options = options,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, call.callee, call.arguments, index);
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, expression.callee, expression.arguments, index);
+        return .proceed;
+    }
+
+    fn checkConstructor(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+        argument_range: ast.IndexRange,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(argument_range);
+        if (arguments.len == 0) return;
+        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+
+        const flags = if (arguments.len >= 2) staticStringValue(tree, arguments[1]) orelse return else "";
+        try checkFlags(self.allocator, self.diagnostics, tree, index, flags, self.options);
+    }
+};
+
+pub fn checkRegExpLiteralWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkFlags(allocator, diagnostics, tree, index, tree.string(literal.flags), options);
+}
+
+fn checkFlags(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    flags: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    const expected = missingFlag(flags, options.require_flag) orelse return;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Use the '{c}' flag.",
+        .{expected},
+    );
+}
+
+fn missingFlag(flags: []const u8, require_flag: core.RequireUnicodeRegexpRequireFlag) ?u8 {
+    return switch (require_flag) {
+        .any => if (hasFlag(flags, 'u') or hasFlag(flags, 'v')) null else 'u',
+        .u => if (hasFlag(flags, 'u')) null else 'u',
+        .v => if (hasFlag(flags, 'v')) null else 'v',
+    };
+}
+
+fn hasFlag(flags: []const u8, flag: u8) bool {
+    return std.mem.indexOfScalar(u8, flags, flag) != null;
+}
+
+fn staticStringValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -282,6 +282,7 @@ pub const react_hooks_rules_of_hooks = @import("react_hooks_rules_of_hooks.zig")
 pub const radix = @import("radix.zig");
 pub const require_await = @import("require_await.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
+pub const require_unicode_regexp = @import("require_unicode_regexp.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
@@ -1001,6 +1002,12 @@ pub fn runSemantic(
     if (options.require_atomic_updates) {
         try require_atomic_updates.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .allow_properties = options.require_atomic_updates_allow_properties,
+        });
+    }
+
+    if (options.require_unicode_regexp) {
+        try require_unicode_regexp.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .require_flag = options.require_unicode_regexp_require_flag,
         });
     }
 
@@ -3726,6 +3733,11 @@ const BasicVisitor = struct {
         }
         if (self.options.no_regex_spaces) {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.require_unicode_regexp) {
+            try require_unicode_regexp.checkRegExpLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, .{
+                .require_flag = self.options.require_unicode_regexp_require_flag,
+            });
         }
         if (self.options.no_useless_escape) {
             try no_useless_escape.checkRegExpLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, .{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -899,6 +899,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/require_unicode_regexp.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_danger.zig");
 }
 

--- a/tests/rules/require_unicode_regexp.zig
+++ b/tests/rules/require_unicode_regexp.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports require-unicode-regexp for literals and constructors without unicode flags" {
+    const source =
+        \\const a = /aaa/;
+        \\const b = /bbb/gi;
+        \\const c = new RegExp("ccc");
+        \\const d = RegExp("ddd", "gi");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.require_unicode_regexp.id));
+    try std.testing.expect(hasMessage(result, "Use the 'u' flag."));
+}
+
+test "allows require-unicode-regexp when u or v flags are present" {
+    const source =
+        \\const a = /aaa/u;
+        \\const b = /bbb/giv;
+        \\const c = new RegExp("ccc", "u");
+        \\const d = RegExp("ddd", `giv`);
+        \\function local(RegExp) {
+        \\  return RegExp("eee");
+        \\}
+        \\function dynamic(flags) {
+        \\  return new RegExp("fff", flags);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_unicode_regexp.id));
+}
+
+test "supports configured require-unicode-regexp u flag" {
+    const source =
+        \\const a = /aaa/v;
+        \\const b = new RegExp("bbb", "v");
+        \\const c = /ccc/u;
+        \\const d = new RegExp("ddd", "giu");
+    ;
+
+    var options = baseOptions();
+    options.require_unicode_regexp_require_flag = .u;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.require_unicode_regexp.id));
+}
+
+test "supports configured require-unicode-regexp v flag" {
+    const source =
+        \\const a = /aaa/u;
+        \\const b = new RegExp("bbb", "u");
+        \\const c = /ccc/v;
+        \\const d = new RegExp("ddd", "giv");
+    ;
+
+    var options = baseOptions();
+    options.require_unicode_regexp_require_flag = .v;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.require_unicode_regexp.id));
+    try std.testing.expect(hasMessage(result, "Use the 'v' flag."));
+}
+
+test "can disable require-unicode-regexp" {
+    const source =
+        \\const a = /aaa/;
+        \\const b = new RegExp("bbb");
+    ;
+
+    var options = baseOptions();
+    options.require_unicode_regexp = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.require_unicode_regexp.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_invalid_regexp = false,
+        .no_regex_spaces = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .prefer_regex_literals = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.require_unicode_regexp.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `require-unicode-regexp` for regexp literals and static global `RegExp` calls/constructors
- support the `requireFlag` config for requiring either `u` or `v` specifically
- add CLI toggles, rule status docs, and focused rule/config coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`