### PR TITLE
Add max-params

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -26,6 +26,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
+| [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |

--- a/src/core.zig
+++ b/src/core.zig
@@ -213,6 +213,12 @@ pub const RadixStyle = enum {
     as_needed,
 };
 
+pub const MaxParamsCountThis = enum {
+    always,
+    never,
+    except_void,
+};
+
 pub const RequireUnicodeRegexpRequireFlag = enum {
     any,
     u,
@@ -1498,6 +1504,9 @@ pub const Options = struct {
     logical_assignment_operators: bool = true,
     logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
+    max_params: bool = true,
+    max_params_max: usize = 3,
+    max_params_count_this: MaxParamsCountThis = .except_void,
     new_cap: bool = true,
     new_cap_new_is_cap: bool = true,
     new_cap_cap_is_new: bool = true,
@@ -2250,6 +2259,10 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-params")) {
+            self.max_params_max = try maxParamsMaxFromConfig(value);
+            self.max_params_count_this = try maxParamsCountThisFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-cycle")) {
             self.import_no_cycle_amd = try importNoCycleBoolOptionFromConfig(value, "amd", false);
@@ -3773,6 +3786,72 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return if (enforce) .yes else .no;
+    }
+
+    fn maxParamsMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 3,
+        };
+        if (items.len < 2) return 3;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                if (object.get("maximum")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 3;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn nonNegativeIntegerToUsize(value: i64) RuleConfigError!usize {
+        if (value < 0) return error.UnsupportedRuleConfigValue;
+        return @intCast(value);
+    }
+
+    fn maxParamsCountThisFromConfig(value: std.json.Value) RuleConfigError!MaxParamsCountThis {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .except_void,
+        };
+        if (items.len < 2) return .except_void;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return .except_void,
+        };
+        if (config.get("countThis")) |count_this_value| {
+            const count_this = switch (count_this_value) {
+                .string => |count_this| count_this,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, count_this, "always")) return .always;
+            if (std.mem.eql(u8, count_this, "never")) return .never;
+            if (std.mem.eql(u8, count_this, "except-void")) return .except_void;
+            return error.UnsupportedRuleConfigValue;
+        }
+        if (config.get("countVoidThis")) |count_void_this_value| {
+            const count_void_this = switch (count_void_this_value) {
+                .bool => |enabled| enabled,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            return if (count_void_this) .always else .except_void;
+        }
+        return .except_void;
     }
 
     fn newCapBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
@@ -7897,6 +7976,18 @@ test "Options can apply ESLint-style rule config values" {
         LogicalAssignmentOperatorsEnforceForIfStatements.yes,
         options.logical_assignment_operators_enforce_for_if_statements,
     );
+
+    var max_params_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"max\":2,\"countThis\":\"always\"}]",
+        .{},
+    );
+    defer max_params_config.deinit();
+    try options.setByRuleConfigValue("max-params", max_params_config.value);
+    try std.testing.expect(options.max_params);
+    try std.testing.expectEqual(@as(usize, 2), options.max_params_max);
+    try std.testing.expectEqual(MaxParamsCountThis.always, options.max_params_count_this);
 
     var no_bitwise_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -633,6 +633,10 @@ pub fn main(init: std.process.Init) !void {
             options.logical_assignment_operators_style = .never;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators-enforce-for-if-statements=on")) {
             options.logical_assignment_operators_enforce_for_if_statements = .yes;
+        } else if (std.mem.eql(u8, arg, "--max-params=off")) {
+            options.max_params = false;
+        } else if (std.mem.startsWith(u8, arg, "--max-params-max=")) {
+            parseMaxParamsMax(arg["--max-params-max=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
             options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -1169,6 +1173,14 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn parseMaxParamsMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-params-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_params_max = max;
+}
+
 fn parseNoMultipleEmptyLinesMaxBof(value: []const u8, options: *lint.Options) void {
     const max_bof = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max-bof value: {s}\n", .{value});
@@ -1634,6 +1646,8 @@ fn printHelp() void {
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
         \\  --logical-assignment-operators=never Disallow logical assignment operators
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
+        \\  --max-params=off          Disable max-params
+        \\  --max-params-max=N        Set max-params maximum
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str

--- a/src/rules/max_params.zig
+++ b/src/rules/max_params.zig
@@ -1,0 +1,108 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-params";
+
+pub const Options = struct {
+    max: usize = 3,
+    count_this: core.MaxParamsCountThis = .except_void,
+};
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkParams(allocator, diagnostics, tree, function.params, index, "Function", options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    try checkParams(allocator, diagnostics, tree, expression.params, index, "Arrow function", options);
+}
+
+fn checkParams(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    index: ast.NodeIndex,
+    kind: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    const params = formalParameters(tree, params_index) orelse return;
+    const count = parameterCount(tree, params, options);
+    if (count <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "{s} has too many parameters ({d}). Maximum allowed is {d}.",
+        .{ kind, count, options.max },
+    );
+}
+
+fn parameterCount(tree: *const ast.Tree, params: ast.FormalParameters, options: Options) usize {
+    var count: usize = 0;
+    for (tree.extra(params.items)) |item| {
+        switch (tree.data(item)) {
+            .formal_parameter => |parameter| {
+                if (isSkippedThisParameter(tree, parameter.pattern, options.count_this)) continue;
+                count += 1;
+            },
+            .ts_parameter_property => count += 1,
+            else => {},
+        }
+    }
+    if (params.rest != .null) count += 1;
+    return count;
+}
+
+fn isSkippedThisParameter(tree: *const ast.Tree, pattern: ast.NodeIndex, count_this: core.MaxParamsCountThis) bool {
+    const this_parameter = switch (tree.data(pattern)) {
+        .ts_this_parameter => |parameter| parameter,
+        else => return false,
+    };
+
+    return switch (count_this) {
+        .always => false,
+        .never => true,
+        .except_void => isVoidThisParameter(tree, this_parameter),
+    };
+}
+
+fn isVoidThisParameter(tree: *const ast.Tree, parameter: ast.TSThisParameter) bool {
+    if (parameter.type_annotation == .null) return false;
+    const annotation = switch (tree.data(parameter.type_annotation)) {
+        .ts_type_annotation => |annotation| annotation,
+        else => return false,
+    };
+    return switch (tree.data(annotation.type_annotation)) {
+        .ts_void_keyword => true,
+        else => false,
+    };
+}
+
+fn formalParameters(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.FormalParameters {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .formal_parameters => |params| params,
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -83,6 +83,7 @@ pub const jsx_a11y_role_supports_aria_props = @import("jsx_a11y_role_supports_ar
 pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
+pub const max_params = @import("max_params.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
@@ -1341,6 +1342,12 @@ const BasicVisitor = struct {
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
+        if (self.options.max_params) {
+            try max_params.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, .{
+                .max = self.options.max_params_max,
+                .count_this = self.options.max_params_count_this,
+            });
+        }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_parameter) {
             try typescript_eslint_typedef.checkFunctionParameters(self.allocator, self.diagnostics, ctx.tree, function);
         }
@@ -2540,6 +2547,12 @@ const BasicVisitor = struct {
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, expression.params);
+        }
+        if (self.options.max_params) {
+            try max_params.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+                .max = self.options.max_params_max,
+                .count_this = self.options.max_params_count_this,
+            });
         }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_arrow_parameter) {
             try typescript_eslint_typedef.checkArrowFunctionParameters(self.allocator, self.diagnostics, ctx.tree, expression);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -275,6 +275,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_params.zig");
+}
+
+comptime {
     _ = @import("rules/new_cap.zig");
 }
 

--- a/tests/rules/max_params.zig
+++ b/tests/rules/max_params.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-params for functions with too many parameters" {
+    const source =
+        \\function foo(a, b, c, d) {
+        \\  return a;
+        \\}
+        \\const bar = (a, b, c, d) => a;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.max_params.id));
+    try std.testing.expect(hasMessage(result, "Maximum allowed is 3."));
+}
+
+test "allows max-params at or below the configured maximum" {
+    const source =
+        \\function foo(a, b, c) {
+        \\  return a;
+        \\}
+        \\const bar = (a, b, c) => a;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_params.id));
+}
+
+test "supports configured max-params maximum and rest parameters" {
+    const source =
+        \\function foo(a, b, ...rest) {
+        \\  return rest;
+        \\}
+        \\const bar = (a, b, c) => c;
+    ;
+
+    var options = baseOptions();
+    options.max_params_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.max_params.id));
+}
+
+test "supports max-params countThis modes" {
+    const source =
+        \\function hasNoThis(this: void, first: string, second: string) {
+        \\  return first;
+        \\}
+        \\function hasThis(this: unknown, first: string, second: string) {
+        \\  return first;
+        \\}
+    ;
+
+    var default_options = baseOptions();
+    default_options.max_params_max = 2;
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", default_options);
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.max_params.id));
+
+    var always_options = baseOptions();
+    always_options.max_params_max = 2;
+    always_options.max_params_count_this = .always;
+    var always_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", always_options);
+    defer always_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(always_result, lint.rules.max_params.id));
+
+    var never_options = baseOptions();
+    never_options.max_params_max = 2;
+    never_options.max_params_count_this = .never;
+    var never_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", never_options);
+    defer never_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(never_result, lint.rules.max_params.id));
+}
+
+test "can disable max-params" {
+    const source =
+        \\function foo(a, b, c, d) {
+        \\  return a;
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_params = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_params.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .consistent_return = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+        .typescript_eslint_no_invalid_void_type = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_params.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `max-params` for ordinary and arrow function definitions
- support `max`, deprecated `maximum`, and TypeScript `countThis`/`countVoidThis` configuration
- add CLI toggle/max option, rule status docs, and focused rule/config coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`