### PR TITLE
Add max-depth

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -26,6 +26,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
+| [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1504,6 +1504,8 @@ pub const Options = struct {
     logical_assignment_operators: bool = true,
     logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
+    max_depth: bool = true,
+    max_depth_max: usize = 4,
     max_params: bool = true,
     max_params_max: usize = 3,
     max_params_count_this: MaxParamsCountThis = .except_void,
@@ -2259,6 +2261,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-depth")) {
+            self.max_depth_max = try maxDepthMaxFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "max-params")) {
             self.max_params_max = try maxParamsMaxFromConfig(value);
@@ -3813,6 +3818,36 @@ pub const Options = struct {
                     return nonNegativeIntegerToUsize(max);
                 }
                 return 3;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn maxDepthMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 4,
+        };
+        if (items.len < 2) return 4;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                if (object.get("maximum")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 4;
             },
             else => return error.UnsupportedRuleConfigValue,
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -633,6 +633,10 @@ pub fn main(init: std.process.Init) !void {
             options.logical_assignment_operators_style = .never;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators-enforce-for-if-statements=on")) {
             options.logical_assignment_operators_enforce_for_if_statements = .yes;
+        } else if (std.mem.eql(u8, arg, "--max-depth=off")) {
+            options.max_depth = false;
+        } else if (std.mem.startsWith(u8, arg, "--max-depth-max=")) {
+            parseMaxDepthMax(arg["--max-depth-max=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--max-params=off")) {
             options.max_params = false;
         } else if (std.mem.startsWith(u8, arg, "--max-params-max=")) {
@@ -1173,6 +1177,14 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn parseMaxDepthMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-depth-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_depth_max = max;
+}
+
 fn parseMaxParamsMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-params-max value: {s}\n", .{value});
@@ -1646,6 +1658,8 @@ fn printHelp() void {
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
         \\  --logical-assignment-operators=never Disallow logical assignment operators
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
+        \\  --max-depth=off           Disable max-depth
+        \\  --max-depth-max=N         Set max-depth maximum
         \\  --max-params=off          Disable max-params
         \\  --max-params-max=N        Set max-params maximum
         \\  --no-loop-func=off        Disable no-loop-func

--- a/src/rules/max_depth.zig
+++ b/src/rules/max_depth.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-depth";
+
+pub const Options = struct {
+    max: usize = 4,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    options: Options,
+) Allocator.Error!void {
+    const depth = nestingDepth(tree, path);
+    if (depth <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Blocks are nested too deeply ({d}). Maximum allowed is {d}.",
+        .{ depth, options.max },
+    );
+}
+
+fn nestingDepth(tree: *const ast.Tree, path: *const traverser.NodePath) usize {
+    var depth: usize = 0;
+    var child: ast.NodeIndex = .null;
+    var it = path.ancestors();
+
+    while (it.next()) |index| {
+        const data = tree.data(index);
+        switch (data) {
+            .program,
+            .function,
+            .function_body,
+            .arrow_function_expression,
+            .static_block,
+            => break,
+            .if_statement => |statement| {
+                if (!isElseIfAncestor(tree, statement, child)) depth += 1;
+            },
+            .for_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .while_statement,
+            .do_while_statement,
+            .switch_statement,
+            .try_statement,
+            .with_statement,
+            => depth += 1,
+            else => {},
+        }
+        child = index;
+    }
+
+    return depth;
+}
+
+fn isElseIfAncestor(tree: *const ast.Tree, statement: ast.IfStatement, child: ast.NodeIndex) bool {
+    if (child == .null or statement.alternate != child) return false;
+    return switch (tree.data(child)) {
+        .if_statement => true,
+        else => false,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -83,6 +83,7 @@ pub const jsx_a11y_role_supports_aria_props = @import("jsx_a11y_role_supports_ar
 pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
+pub const max_depth = @import("max_depth.zig");
 pub const max_params = @import("max_params.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
@@ -1142,6 +1143,12 @@ const BasicVisitor = struct {
         };
     }
 
+    fn maxDepthOptions(self: *const BasicVisitor) max_depth.Options {
+        return .{
+            .max = self.options.max_depth_max,
+        };
+    }
+
     fn noUselessRenameOptions(self: *const BasicVisitor) no_useless_rename.Options {
         return .{
             .ignore_destructuring = self.options.no_useless_rename_ignore_destructuring,
@@ -1494,6 +1501,9 @@ const BasicVisitor = struct {
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
             try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
+        }
         return .proceed;
     }
 
@@ -1539,6 +1549,9 @@ const BasicVisitor = struct {
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
+        }
         return .proceed;
     }
 
@@ -1561,6 +1574,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkDoWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
         return .proceed;
     }
@@ -1590,6 +1606,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
         return .proceed;
     }
@@ -2122,6 +2141,9 @@ const BasicVisitor = struct {
         if (self.options.use_isnan) {
             try use_isnan.checkSwitchStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, self.useIsnanOptions());
         }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
+        }
         return .proceed;
     }
 
@@ -2146,11 +2168,14 @@ const BasicVisitor = struct {
     pub fn enter_try_statement(
         self: *BasicVisitor,
         statement: ast.TryStatement,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.no_unsafe_finally) {
             try no_unsafe_finally.check(self.allocator, self.diagnostics, ctx.tree, statement);
+        }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
         return .proceed;
     }
@@ -2268,6 +2293,9 @@ const BasicVisitor = struct {
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForInStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
+        }
         return .proceed;
     }
 
@@ -2282,6 +2310,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForOfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
         return .proceed;
     }
@@ -2388,6 +2419,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_with) {
             try no_with.check(self.allocator, self.diagnostics, ctx.tree, index);
+        }
+        if (self.options.max_depth) {
+            try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -275,6 +275,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_depth.zig");
+}
+
+comptime {
     _ = @import("rules/max_params.zig");
 }
 

--- a/tests/rules/max_depth.zig
+++ b/tests/rules/max_depth.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-depth for deeply nested statements" {
+    const source =
+        \\function run() {
+        \\  if (a) {
+        \\    for (;;) {
+        \\      while (b) {
+        \\        switch (c) {
+        \\          case 1:
+        \\            try {
+        \\              work();
+        \\            } catch (error) {
+        \\              recover(error);
+        \\            }
+        \\        }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_depth.id));
+    try std.testing.expect(hasMessage(result, "Maximum allowed is 4."));
+}
+
+test "supports configured max-depth max and deprecated maximum" {
+    const source =
+        \\if (a) {
+        \\  if (b) {
+        \\    work();
+        \\  }
+        \\}
+    ;
+
+    const max_config =
+        \\["error", { "max": 1 }]
+    ;
+    var max_options = baseOptions();
+    var max_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, max_config, .{});
+    defer max_parsed.deinit();
+    try max_options.setByRuleConfigValue("max-depth", max_parsed.value);
+
+    var max_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", max_options);
+    defer max_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(max_result, lint.rules.max_depth.id));
+
+    const maximum_config =
+        \\["error", { "maximum": 2 }]
+    ;
+    var maximum_options = baseOptions();
+    var maximum_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, maximum_config, .{});
+    defer maximum_parsed.deinit();
+    try maximum_options.setByRuleConfigValue("max-depth", maximum_parsed.value);
+
+    var maximum_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", maximum_options);
+    defer maximum_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(maximum_result, lint.rules.max_depth.id));
+}
+
+test "does not count else-if chains as additional depth" {
+    const source =
+        \\if (a) {
+        \\  work();
+        \\} else if (b) {
+        \\  work();
+        \\} else if (c) {
+        \\  if (d) {
+        \\    work();
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_depth_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_depth.id));
+}
+
+test "calculates function and static block depth independently" {
+    const source =
+        \\if (outer) {
+        \\  function nested() {
+        \\    if (a) {
+        \\      if (b) {
+        \\        work();
+        \\      }
+        \\    }
+        \\  }
+        \\  class Example {
+        \\    static {
+        \\      if (c) {
+        \\        if (d) {
+        \\          work();
+        \\        }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_depth_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.max_depth.id));
+}
+
+test "can disable max-depth" {
+    const source =
+        \\if (a) {
+        \\  if (b) {
+        \\    work();
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_depth = false;
+    options.max_depth_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_depth.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .consistent_return = false,
+        .curly = false,
+        .no_constant_condition = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_depth.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the ESLint `max-depth` rule with default max depth 4
- support `max` and deprecated `maximum` config values plus CLI toggles
- document the rule and add focused coverage for nesting, else-if chains, function scopes, and static blocks

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
