### PR TITLE
Add max-statements

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -28,6 +28,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
+| [`max-statements`](https://eslint.org/docs/latest/rules/max-statements) | Supports `max`, deprecated `maximum`, `ignoreTopLevelFunctions`, and static block isolation |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1509,6 +1509,9 @@ pub const Options = struct {
     max_params: bool = true,
     max_params_max: usize = 3,
     max_params_count_this: MaxParamsCountThis = .except_void,
+    max_statements: bool = true,
+    max_statements_max: usize = 10,
+    max_statements_ignore_top_level_functions: bool = false,
     new_cap: bool = true,
     new_cap_new_is_cap: bool = true,
     new_cap_cap_is_new: bool = true,
@@ -2268,6 +2271,10 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "max-params")) {
             self.max_params_max = try maxParamsMaxFromConfig(value);
             self.max_params_count_this = try maxParamsCountThisFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-statements")) {
+            self.max_statements_max = try maxStatementsMaxFromConfig(value);
+            self.max_statements_ignore_top_level_functions = try maxStatementsIgnoreTopLevelFunctionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "import/no-cycle")) {
             self.import_no_cycle_amd = try importNoCycleBoolOptionFromConfig(value, "amd", false);
@@ -3887,6 +3894,52 @@ pub const Options = struct {
             return if (count_void_this) .always else .except_void;
         }
         return .except_void;
+    }
+
+    fn maxStatementsMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 10,
+        };
+        if (items.len < 2) return 10;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("maximum")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 10;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn maxStatementsIgnoreTopLevelFunctionsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 3) return false;
+
+        return switch (items[2]) {
+            .object => |object| switch (object.get("ignoreTopLevelFunctions") orelse return false) {
+                .bool => |enabled| enabled,
+                else => error.UnsupportedRuleConfigValue,
+            },
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn newCapBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -641,6 +641,12 @@ pub fn main(init: std.process.Init) !void {
             options.max_params = false;
         } else if (std.mem.startsWith(u8, arg, "--max-params-max=")) {
             parseMaxParamsMax(arg["--max-params-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-statements=off")) {
+            options.max_statements = false;
+        } else if (std.mem.startsWith(u8, arg, "--max-statements-max=")) {
+            parseMaxStatementsMax(arg["--max-statements-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-statements-ignore-top-level-functions=on")) {
+            options.max_statements_ignore_top_level_functions = true;
         } else if (std.mem.eql(u8, arg, "--operator-assignment=off")) {
             options.operator_assignment = false;
         } else if (std.mem.eql(u8, arg, "--eqeqeq=off")) {
@@ -1193,6 +1199,14 @@ fn parseMaxParamsMax(value: []const u8, options: *lint.Options) void {
     options.max_params_max = max;
 }
 
+fn parseMaxStatementsMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-statements-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_statements_max = max;
+}
+
 fn parseNoMultipleEmptyLinesMaxBof(value: []const u8, options: *lint.Options) void {
     const max_bof = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max-bof value: {s}\n", .{value});
@@ -1662,6 +1676,9 @@ fn printHelp() void {
         \\  --max-depth-max=N         Set max-depth maximum
         \\  --max-params=off          Disable max-params
         \\  --max-params-max=N        Set max-params maximum
+        \\  --max-statements=off      Disable max-statements
+        \\  --max-statements-max=N    Set max-statements maximum
+        \\  --max-statements-ignore-top-level-functions=on Ignore single top-level functions
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
         \\  --no-multi-str=off        Disable no-multi-str

--- a/src/rules/max_statements.zig
+++ b/src/rules/max_statements.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-statements";
+
+pub const Options = struct {
+    max: usize = 10,
+    ignore_top_level_functions: bool = false,
+};
+
+const FunctionKind = enum {
+    function,
+    arrow_function,
+    static_block,
+
+    fn label(self: FunctionKind) []const u8 {
+        return switch (self) {
+            .function => "Function",
+            .arrow_function => "Arrow function",
+            .static_block => "Static block",
+        };
+    }
+};
+
+const Frame = struct {
+    index: ast.NodeIndex,
+    count: usize = 0,
+    kind: FunctionKind,
+};
+
+const PendingReport = struct {
+    index: ast.NodeIndex,
+    count: usize,
+    kind: FunctionKind,
+};
+
+pub const State = struct {
+    frames: std.ArrayList(Frame) = .empty,
+    top_level_functions: std.ArrayList(PendingReport) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.frames.deinit(allocator);
+        self.top_level_functions.deinit(allocator);
+    }
+};
+
+pub fn enterFunction(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .function });
+}
+
+pub fn enterArrowFunction(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .arrow_function });
+}
+
+pub fn enterStaticBlock(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .static_block });
+}
+
+pub fn countFunctionBody(tree: *const ast.Tree, state: *State, body: ast.FunctionBody) void {
+    _ = tree;
+    countStatements(state, body.body.len);
+}
+
+pub fn countBlockStatement(tree: *const ast.Tree, state: *State, block: ast.BlockStatement) void {
+    _ = tree;
+    countStatements(state, block.body.len);
+}
+
+pub fn exitFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    const frame = state.frames.pop() orelse return;
+    if (frame.kind == .static_block) return;
+
+    if (options.ignore_top_level_functions and state.frames.items.len == 0) {
+        try state.top_level_functions.append(allocator, .{
+            .index = frame.index,
+            .count = frame.count,
+            .kind = frame.kind,
+        });
+        return;
+    }
+
+    try reportIfTooManyStatements(allocator, diagnostics, tree, frame.index, frame.kind, frame.count, options.max);
+}
+
+pub fn finishProgram(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (state.top_level_functions.items.len == 1) return;
+
+    for (state.top_level_functions.items) |entry| {
+        try reportIfTooManyStatements(allocator, diagnostics, tree, entry.index, entry.kind, entry.count, options.max);
+    }
+}
+
+fn countStatements(state: *State, count: usize) void {
+    if (state.frames.items.len == 0) return;
+    state.frames.items[state.frames.items.len - 1].count += count;
+}
+
+fn reportIfTooManyStatements(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    kind: FunctionKind,
+    count: usize,
+    max: usize,
+) Allocator.Error!void {
+    if (count <= max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "{s} has too many statements ({d}). Maximum allowed is {d}.",
+        .{ kind.label(), count, max },
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -85,6 +85,7 @@ pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
 pub const max_depth = @import("max_depth.zig");
 pub const max_params = @import("max_params.zig");
+pub const max_statements = @import("max_statements.zig");
 pub const new_cap = @import("new_cap.zig");
 pub const new_parens = @import("new_parens.zig");
 pub const no_async_promise_executor = @import("no_async_promise_executor.zig");
@@ -614,6 +615,7 @@ pub fn runBasic(
     defer visitor.react_display_name_state.deinit(allocator);
     defer visitor.react_forbid_prop_types_state.deinit(allocator);
     defer visitor.react_default_props_match_prop_types_state.deinit(allocator);
+    defer visitor.max_statements_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -1119,6 +1121,7 @@ const BasicVisitor = struct {
     react_no_unused_state_state: react_no_unused_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
+    max_statements_state: max_statements.State = .{},
 
     fn curlyOptions(self: *const BasicVisitor) curly.Options {
         return .{
@@ -1146,6 +1149,13 @@ const BasicVisitor = struct {
     fn maxDepthOptions(self: *const BasicVisitor) max_depth.Options {
         return .{
             .max = self.options.max_depth_max,
+        };
+    }
+
+    fn maxStatementsOptions(self: *const BasicVisitor) max_statements.Options {
+        return .{
+            .max = self.options.max_statements_max,
+            .ignore_top_level_functions = self.options.max_statements_ignore_top_level_functions,
         };
     }
 
@@ -1307,6 +1317,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) void {
+        if (self.options.max_statements) {
+            max_statements.finishProgram(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
         if (self.options.react_display_name) {
             react_display_name.finish(self.allocator, self.diagnostics, ctx.tree, &self.react_display_name_state) catch {};
         }
@@ -1329,6 +1342,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_statements) {
+            try max_statements.enterFunction(self.allocator, &self.max_statements_state, index);
+        }
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
         }
@@ -1389,6 +1405,12 @@ const BasicVisitor = struct {
             });
         }
         return .proceed;
+    }
+
+    pub fn exit_function(self: *BasicVisitor, _: ast.Function, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
+        if (self.options.max_statements) {
+            max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
     }
 
     pub fn enter_class(
@@ -2323,6 +2345,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_statements) {
+            max_statements.countBlockStatement(ctx.tree, &self.max_statements_state, block);
+        }
         if (self.options.no_lone_blocks) {
             if (ctx.path.parent()) |parent| {
                 try no_lone_blocks.check(self.allocator, self.diagnostics, ctx.tree, block, index, parent);
@@ -2361,6 +2386,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_statements) {
+            max_statements.countFunctionBody(ctx.tree, &self.max_statements_state, body);
+        }
         if (self.options.react_jsx_no_bind) {
             try react_jsx_no_bind.enterBlock(self.allocator, &self.react_jsx_no_bind_state);
         }
@@ -2402,6 +2430,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_statements) {
+            try max_statements.enterStaticBlock(self.allocator, &self.max_statements_state, index);
+        }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkStaticBlock(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
@@ -2409,6 +2440,12 @@ const BasicVisitor = struct {
             try no_empty_static_block.check(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
         return .proceed;
+    }
+
+    pub fn exit_static_block(self: *BasicVisitor, _: ast.StaticBlock, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
+        if (self.options.max_statements) {
+            max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
     }
 
     pub fn enter_with_statement(
@@ -2569,6 +2606,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_statements) {
+            try max_statements.enterArrowFunction(self.allocator, &self.max_statements_state, index);
+        }
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.body, .{
                 .style = self.options.no_return_assign_style,
@@ -2616,6 +2656,12 @@ const BasicVisitor = struct {
             try react_display_name.checkArrowFunction(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
         }
         return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(self: *BasicVisitor, _: ast.ArrowFunctionExpression, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
+        if (self.options.max_statements) {
+            max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
     }
 
     pub fn enter_assignment_expression(

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -283,6 +283,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_statements.zig");
+}
+
+comptime {
     _ = @import("rules/new_cap.zig");
 }
 

--- a/tests/rules/max_statements.zig
+++ b/tests/rules/max_statements.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-statements for functions with too many statements" {
+    const source =
+        \\function run() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\  four();
+        \\  five();
+        \\  six();
+        \\  seven();
+        \\  eight();
+        \\  nine();
+        \\  ten();
+        \\  eleven();
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_statements.id));
+    try std.testing.expect(hasMessage(result, "Maximum allowed is 10."));
+}
+
+test "counts statements in nested blocks" {
+    const source =
+        \\function run() {
+        \\  if (ready) {
+        \\    one();
+        \\    two();
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_statements_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_statements.id));
+}
+
+test "supports configured max-statements max and deprecated maximum" {
+    const source =
+        \\function run() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\}
+    ;
+
+    const max_config =
+        \\["error", { "max": 2 }]
+    ;
+    var max_options = baseOptions();
+    var max_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, max_config, .{});
+    defer max_parsed.deinit();
+    try max_options.setByRuleConfigValue("max-statements", max_parsed.value);
+
+    var max_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", max_options);
+    defer max_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(max_result, lint.rules.max_statements.id));
+
+    const maximum_config =
+        \\["error", { "maximum": 3 }]
+    ;
+    var maximum_options = baseOptions();
+    var maximum_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, maximum_config, .{});
+    defer maximum_parsed.deinit();
+    try maximum_options.setByRuleConfigValue("max-statements", maximum_parsed.value);
+
+    var maximum_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", maximum_options);
+    defer maximum_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(maximum_result, lint.rules.max_statements.id));
+}
+
+test "supports max-statements ignoreTopLevelFunctions" {
+    const single_source =
+        \\function run() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\}
+    ;
+
+    var single_options = baseOptions();
+    single_options.max_statements_max = 2;
+    single_options.max_statements_ignore_top_level_functions = true;
+
+    var single_result = try lint.lintSource(std.testing.allocator, single_source, "fixture.js", single_options);
+    defer single_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(single_result, lint.rules.max_statements.id));
+
+    const multiple_source =
+        \\function first() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\}
+        \\function second() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\}
+    ;
+
+    var multiple_result = try lint.lintSource(std.testing.allocator, multiple_source, "fixture.js", single_options);
+    defer multiple_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(multiple_result, lint.rules.max_statements.id));
+}
+
+test "does not count static block statements in the enclosing function" {
+    const source =
+        \\function run() {
+        \\  class Example {
+        \\    static {
+        \\      one();
+        \\      two();
+        \\      three();
+        \\    }
+        \\  }
+        \\  done();
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_statements_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_statements.id));
+}
+
+test "can disable max-statements" {
+    const source =
+        \\function run() {
+        \\  one();
+        \\  two();
+        \\  three();
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_statements = false;
+    options.max_statements_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_statements.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .curly = false,
+        .max_depth = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_statements.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the ESLint `max-statements` rule with default max 10
- support `max`, deprecated `maximum`, and `ignoreTopLevelFunctions` configuration plus CLI toggles
- isolate class static blocks from enclosing function counts and cover ESLint's top-level function behavior

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
