### PR TITLE
Add max-nested-callbacks

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -27,6 +27,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
+| [`max-nested-callbacks`](https://eslint.org/docs/latest/rules/max-nested-callbacks) | Supports `max`, deprecated `maximum`, and call-argument callback detection |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`max-statements`](https://eslint.org/docs/latest/rules/max-statements) | Supports `max`, deprecated `maximum`, `ignoreTopLevelFunctions`, and static block isolation |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1506,6 +1506,8 @@ pub const Options = struct {
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
     max_depth: bool = true,
     max_depth_max: usize = 4,
+    max_nested_callbacks: bool = true,
+    max_nested_callbacks_max: usize = 10,
     max_params: bool = true,
     max_params_max: usize = 3,
     max_params_count_this: MaxParamsCountThis = .except_void,
@@ -2267,6 +2269,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "max-depth")) {
             self.max_depth_max = try maxDepthMaxFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-nested-callbacks")) {
+            self.max_nested_callbacks_max = try maxNestedCallbacksMaxFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "max-params")) {
             self.max_params_max = try maxParamsMaxFromConfig(value);
@@ -3855,6 +3860,36 @@ pub const Options = struct {
                     return nonNegativeIntegerToUsize(max);
                 }
                 return 4;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn maxNestedCallbacksMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 10,
+        };
+        if (items.len < 2) return 10;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("maximum")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 10;
             },
             else => return error.UnsupportedRuleConfigValue,
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -637,6 +637,10 @@ pub fn main(init: std.process.Init) !void {
             options.max_depth = false;
         } else if (std.mem.startsWith(u8, arg, "--max-depth-max=")) {
             parseMaxDepthMax(arg["--max-depth-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-nested-callbacks=off")) {
+            options.max_nested_callbacks = false;
+        } else if (std.mem.startsWith(u8, arg, "--max-nested-callbacks-max=")) {
+            parseMaxNestedCallbacksMax(arg["--max-nested-callbacks-max=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--max-params=off")) {
             options.max_params = false;
         } else if (std.mem.startsWith(u8, arg, "--max-params-max=")) {
@@ -1191,6 +1195,14 @@ fn parseMaxDepthMax(value: []const u8, options: *lint.Options) void {
     options.max_depth_max = max;
 }
 
+fn parseMaxNestedCallbacksMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-nested-callbacks-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_nested_callbacks_max = max;
+}
+
 fn parseMaxParamsMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-params-max value: {s}\n", .{value});
@@ -1674,6 +1686,8 @@ fn printHelp() void {
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
         \\  --max-depth=off           Disable max-depth
         \\  --max-depth-max=N         Set max-depth maximum
+        \\  --max-nested-callbacks=off Disable max-nested-callbacks
+        \\  --max-nested-callbacks-max=N Set max-nested-callbacks maximum
         \\  --max-params=off          Disable max-params
         \\  --max-params-max=N        Set max-params maximum
         \\  --max-statements=off      Disable max-statements

--- a/src/rules/max_nested_callbacks.zig
+++ b/src/rules/max_nested_callbacks.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-nested-callbacks";
+
+pub const Options = struct {
+    max: usize = 10,
+};
+
+pub const State = struct {
+    callbacks: std.ArrayList(ast.NodeIndex) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.callbacks.deinit(allocator);
+    }
+};
+
+pub fn enterFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (function.type != .function_expression) return;
+    try enterCallback(allocator, diagnostics, tree, index, path, state, options);
+}
+
+pub fn enterArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    try enterCallback(allocator, diagnostics, tree, index, path, state, options);
+}
+
+pub fn exitFunction(state: *State, index: ast.NodeIndex) void {
+    if (state.callbacks.items.len > 0 and state.callbacks.items[state.callbacks.items.len - 1] == index) {
+        _ = state.callbacks.pop();
+    }
+}
+
+fn enterCallback(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    if (!isCallArgument(tree, index, path.parent())) return;
+
+    try state.callbacks.append(allocator, index);
+    const depth = state.callbacks.items.len;
+    if (depth <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Too many nested callbacks ({d}). Maximum allowed is {d}.",
+        .{ depth, options.max },
+    );
+}
+
+fn isCallArgument(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    return call.callee != index;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -84,6 +84,7 @@ pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
 pub const max_depth = @import("max_depth.zig");
+pub const max_nested_callbacks = @import("max_nested_callbacks.zig");
 pub const max_params = @import("max_params.zig");
 pub const max_statements = @import("max_statements.zig");
 pub const new_cap = @import("new_cap.zig");
@@ -616,6 +617,7 @@ pub fn runBasic(
     defer visitor.react_forbid_prop_types_state.deinit(allocator);
     defer visitor.react_default_props_match_prop_types_state.deinit(allocator);
     defer visitor.max_statements_state.deinit(allocator);
+    defer visitor.max_nested_callbacks_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -1122,6 +1124,7 @@ const BasicVisitor = struct {
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
     max_statements_state: max_statements.State = .{},
+    max_nested_callbacks_state: max_nested_callbacks.State = .{},
 
     fn curlyOptions(self: *const BasicVisitor) curly.Options {
         return .{
@@ -1156,6 +1159,12 @@ const BasicVisitor = struct {
         return .{
             .max = self.options.max_statements_max,
             .ignore_top_level_functions = self.options.max_statements_ignore_top_level_functions,
+        };
+    }
+
+    fn maxNestedCallbacksOptions(self: *const BasicVisitor) max_nested_callbacks.Options {
+        return .{
+            .max = self.options.max_nested_callbacks_max,
         };
     }
 
@@ -1345,6 +1354,9 @@ const BasicVisitor = struct {
         if (self.options.max_statements) {
             try max_statements.enterFunction(self.allocator, &self.max_statements_state, index);
         }
+        if (self.options.max_nested_callbacks) {
+            try max_nested_callbacks.enterFunction(self.allocator, self.diagnostics, ctx.tree, function, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
+        }
         if (self.options.no_dupe_args) {
             try no_dupe_args.check(self.allocator, self.diagnostics, ctx.tree, function);
         }
@@ -1407,9 +1419,12 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
-    pub fn exit_function(self: *BasicVisitor, _: ast.Function, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
+    pub fn exit_function(self: *BasicVisitor, _: ast.Function, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
         if (self.options.max_statements) {
             max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
+        if (self.options.max_nested_callbacks) {
+            max_nested_callbacks.exitFunction(&self.max_nested_callbacks_state, index);
         }
     }
 
@@ -2609,6 +2624,9 @@ const BasicVisitor = struct {
         if (self.options.max_statements) {
             try max_statements.enterArrowFunction(self.allocator, &self.max_statements_state, index);
         }
+        if (self.options.max_nested_callbacks) {
+            try max_nested_callbacks.enterArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
+        }
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.body, .{
                 .style = self.options.no_return_assign_style,
@@ -2658,9 +2676,12 @@ const BasicVisitor = struct {
         return .proceed;
     }
 
-    pub fn exit_arrow_function_expression(self: *BasicVisitor, _: ast.ArrowFunctionExpression, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
+    pub fn exit_arrow_function_expression(self: *BasicVisitor, _: ast.ArrowFunctionExpression, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
         if (self.options.max_statements) {
             max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
+        if (self.options.max_nested_callbacks) {
+            max_nested_callbacks.exitFunction(&self.max_nested_callbacks_state, index);
         }
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -279,6 +279,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_nested_callbacks.zig");
+}
+
+comptime {
     _ = @import("rules/max_params.zig");
 }
 

--- a/tests/rules/max_nested_callbacks.zig
+++ b/tests/rules/max_nested_callbacks.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-nested-callbacks for deeply nested callback arguments" {
+    const source =
+        \\first(function () {
+        \\  second(() => {
+        \\    third(function () {
+        \\      done();
+        \\    });
+        \\  });
+        \\});
+    ;
+
+    var options = baseOptions();
+    options.max_nested_callbacks_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_nested_callbacks.id));
+    try std.testing.expect(hasMessage(result, "Maximum allowed is 2."));
+}
+
+test "does not count IIFE callees as callbacks" {
+    const source =
+        \\(function () {
+        \\  first(function () {
+        \\    done();
+        \\  });
+        \\})();
+    ;
+
+    var options = baseOptions();
+    options.max_nested_callbacks_max = 0;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_nested_callbacks.id));
+}
+
+test "pops max-nested-callbacks state for sibling callbacks" {
+    const source =
+        \\first(function () {
+        \\  done();
+        \\});
+        \\second(() => {
+        \\  done();
+        \\});
+    ;
+
+    var options = baseOptions();
+    options.max_nested_callbacks_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_nested_callbacks.id));
+}
+
+test "supports configured max-nested-callbacks max and deprecated maximum" {
+    const source =
+        \\first(() => {
+        \\  second(() => {
+        \\    done();
+        \\  });
+        \\});
+    ;
+
+    const max_config =
+        \\["error", { "max": 1 }]
+    ;
+    var max_options = baseOptions();
+    var max_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, max_config, .{});
+    defer max_parsed.deinit();
+    try max_options.setByRuleConfigValue("max-nested-callbacks", max_parsed.value);
+
+    var max_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", max_options);
+    defer max_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(max_result, lint.rules.max_nested_callbacks.id));
+
+    const maximum_config =
+        \\["error", { "maximum": 2 }]
+    ;
+    var maximum_options = baseOptions();
+    var maximum_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, maximum_config, .{});
+    defer maximum_parsed.deinit();
+    try maximum_options.setByRuleConfigValue("max-nested-callbacks", maximum_parsed.value);
+
+    var maximum_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", maximum_options);
+    defer maximum_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(maximum_result, lint.rules.max_nested_callbacks.id));
+}
+
+test "can disable max-nested-callbacks" {
+    const source =
+        \\first(function () {
+        \\  second(function () {
+        \\    done();
+        \\  });
+        \\});
+    ;
+
+    var options = baseOptions();
+    options.max_nested_callbacks = false;
+    options.max_nested_callbacks_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_nested_callbacks.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .max_depth = false,
+        .max_statements = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_nested_callbacks.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the ESLint `max-nested-callbacks` rule with default max 10
- support `max` and deprecated `maximum` configuration plus CLI toggles
- detect function expression and arrow callbacks passed as call arguments while excluding IIFE callees

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
