### PR TITLE
Add max-classes-per-file

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -26,6 +26,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
+| [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
 | [`max-nested-callbacks`](https://eslint.org/docs/latest/rules/max-nested-callbacks) | Supports `max`, deprecated `maximum`, and call-argument callback detection |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -1504,6 +1504,9 @@ pub const Options = struct {
     logical_assignment_operators: bool = true,
     logical_assignment_operators_style: LogicalAssignmentOperatorsStyle = .always,
     logical_assignment_operators_enforce_for_if_statements: LogicalAssignmentOperatorsEnforceForIfStatements = .no,
+    max_classes_per_file: bool = true,
+    max_classes_per_file_max: usize = 1,
+    max_classes_per_file_ignore_expressions: bool = false,
     max_depth: bool = true,
     max_depth_max: usize = 4,
     max_nested_callbacks: bool = true,
@@ -2266,6 +2269,10 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "logical-assignment-operators")) {
             self.logical_assignment_operators_style = try logicalAssignmentOperatorsStyleFromConfig(value);
             self.logical_assignment_operators_enforce_for_if_statements = try logicalAssignmentOperatorsEnforceForIfStatementsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-classes-per-file")) {
+            self.max_classes_per_file_max = try maxClassesPerFileMaxFromConfig(value);
+            self.max_classes_per_file_ignore_expressions = try maxClassesPerFileIgnoreExpressionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "max-depth")) {
             self.max_depth_max = try maxDepthMaxFromConfig(value);
@@ -3863,6 +3870,43 @@ pub const Options = struct {
             },
             else => return error.UnsupportedRuleConfigValue,
         }
+    }
+
+    fn maxClassesPerFileMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 1,
+        };
+        if (items.len < 2) return 1;
+
+        const max = switch (items[1]) {
+            .integer => |max| max,
+            .object => |object| switch (object.get("max") orelse return 1) {
+                .integer => |max| max,
+                else => return error.UnsupportedRuleConfigValue,
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        if (max < 1) return error.UnsupportedRuleConfigValue;
+        return @intCast(max);
+    }
+
+    fn maxClassesPerFileIgnoreExpressionsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        return switch (items[1]) {
+            .object => |object| switch (object.get("ignoreExpressions") orelse return false) {
+                .bool => |enabled| enabled,
+                else => return error.UnsupportedRuleConfigValue,
+            },
+            .integer => false,
+            else => return error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn maxNestedCallbacksMaxFromConfig(value: std.json.Value) RuleConfigError!usize {

--- a/src/main.zig
+++ b/src/main.zig
@@ -633,6 +633,12 @@ pub fn main(init: std.process.Init) !void {
             options.logical_assignment_operators_style = .never;
         } else if (std.mem.eql(u8, arg, "--logical-assignment-operators-enforce-for-if-statements=on")) {
             options.logical_assignment_operators_enforce_for_if_statements = .yes;
+        } else if (std.mem.eql(u8, arg, "--max-classes-per-file=off")) {
+            options.max_classes_per_file = false;
+        } else if (std.mem.startsWith(u8, arg, "--max-classes-per-file-max=")) {
+            parseMaxClassesPerFileMax(arg["--max-classes-per-file-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-classes-per-file-ignore-expressions=on")) {
+            options.max_classes_per_file_ignore_expressions = true;
         } else if (std.mem.eql(u8, arg, "--max-depth=off")) {
             options.max_depth = false;
         } else if (std.mem.startsWith(u8, arg, "--max-depth-max=")) {
@@ -1187,6 +1193,18 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn parseMaxClassesPerFileMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-classes-per-file-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    if (max < 1) {
+        std.debug.print("utoo-lint: invalid --max-classes-per-file-max value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.max_classes_per_file_max = max;
+}
+
 fn parseMaxDepthMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-depth-max value: {s}\n", .{value});
@@ -1684,6 +1702,9 @@ fn printHelp() void {
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
         \\  --logical-assignment-operators=never Disallow logical assignment operators
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks
+        \\  --max-classes-per-file=off Disable max-classes-per-file
+        \\  --max-classes-per-file-max=N Set max-classes-per-file maximum
+        \\  --max-classes-per-file-ignore-expressions=on Ignore class expressions
         \\  --max-depth=off           Disable max-depth
         \\  --max-depth-max=N         Set max-depth maximum
         \\  --max-nested-callbacks=off Disable max-nested-callbacks

--- a/src/rules/max_classes_per_file.zig
+++ b/src/rules/max_classes_per_file.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-classes-per-file";
+
+pub const Options = struct {
+    max: usize = 1,
+    ignore_expressions: bool = false,
+};
+
+pub const State = struct {
+    class_count: usize = 0,
+};
+
+pub fn enterProgram(state: *State) void {
+    state.class_count = 0;
+}
+
+pub fn checkClass(class: ast.Class, state: *State, options: Options) void {
+    switch (class.type) {
+        .class_declaration => state.class_count += 1,
+        .class_expression => if (!options.ignore_expressions) {
+            state.class_count += 1;
+        },
+    }
+}
+
+pub fn exitProgram(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    state: State,
+    options: Options,
+) Allocator.Error!void {
+    if (state.class_count <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "File has too many classes ({d}). Maximum allowed is {d}.",
+        .{ state.class_count, options.max },
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -83,6 +83,7 @@ pub const jsx_a11y_role_supports_aria_props = @import("jsx_a11y_role_supports_ar
 pub const jsx_a11y_scope = @import("jsx_a11y_scope.zig");
 pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
+pub const max_classes_per_file = @import("max_classes_per_file.zig");
 pub const max_depth = @import("max_depth.zig");
 pub const max_nested_callbacks = @import("max_nested_callbacks.zig");
 pub const max_params = @import("max_params.zig");
@@ -1123,6 +1124,7 @@ const BasicVisitor = struct {
     react_no_unused_state_state: react_no_unused_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
+    max_classes_per_file_state: max_classes_per_file.State = .{},
     max_statements_state: max_statements.State = .{},
     max_nested_callbacks_state: max_nested_callbacks.State = .{},
 
@@ -1165,6 +1167,13 @@ const BasicVisitor = struct {
     fn maxNestedCallbacksOptions(self: *const BasicVisitor) max_nested_callbacks.Options {
         return .{
             .max = self.options.max_nested_callbacks_max,
+        };
+    }
+
+    fn maxClassesPerFileOptions(self: *const BasicVisitor) max_classes_per_file.Options {
+        return .{
+            .max = self.options.max_classes_per_file_max,
+            .ignore_expressions = self.options.max_classes_per_file_ignore_expressions,
         };
     }
 
@@ -1244,6 +1253,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_classes_per_file) {
+            max_classes_per_file.enterProgram(&self.max_classes_per_file_state);
+        }
         if (self.options.import_first) {
             try import_first.check(self.allocator, self.diagnostics, ctx.tree, program);
         }
@@ -1326,6 +1338,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) void {
+        if (self.options.max_classes_per_file) {
+            max_classes_per_file.exitProgram(self.allocator, self.diagnostics, ctx.tree, index, self.max_classes_per_file_state, self.maxClassesPerFileOptions()) catch {};
+        }
         if (self.options.max_statements) {
             max_statements.finishProgram(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
         }
@@ -1434,6 +1449,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.max_classes_per_file) {
+            max_classes_per_file.checkClass(class, &self.max_classes_per_file_state, self.maxClassesPerFileOptions());
+        }
         if (self.options.constructor_super) {
             try constructor_super.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -275,6 +275,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_classes_per_file.zig");
+}
+
+comptime {
     _ = @import("rules/max_depth.zig");
 }
 

--- a/tests/rules/max_classes_per_file.zig
+++ b/tests/rules/max_classes_per_file.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-classes-per-file for too many class declarations" {
+    const source =
+        \\class One {}
+        \\class Two {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_classes_per_file.id));
+    try std.testing.expect(hasMessage(result, "Maximum allowed is 1."));
+}
+
+test "allows configured max-classes-per-file maximum" {
+    const source =
+        \\class One {}
+        \\class Two {}
+    ;
+
+    var options = baseOptions();
+    options.max_classes_per_file_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_classes_per_file.id));
+}
+
+test "supports max-classes-per-file config object" {
+    const source =
+        \\class One {}
+        \\class Two {}
+        \\const Three = class {};
+    ;
+
+    const config =
+        \\["error", { "max": 1, "ignoreExpressions": true }]
+    ;
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("max-classes-per-file", parsed.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_classes_per_file.id));
+}
+
+test "can ignore class expressions" {
+    const source =
+        \\class One {}
+        \\const Two = class {};
+    ;
+
+    var options = baseOptions();
+    options.max_classes_per_file_ignore_expressions = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_classes_per_file.id));
+}
+
+test "can disable max-classes-per-file" {
+    const source =
+        \\class One {}
+        \\class Two {}
+    ;
+
+    var options = baseOptions();
+    options.max_classes_per_file = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_classes_per_file.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .max_statements = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_classes_per_file.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the ESLint `max-classes-per-file` rule with default max 1
- support `max` and `ignoreExpressions` configuration plus CLI toggles
- report a single file-level diagnostic when the class count exceeds the configured maximum

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
