### PR TITLE
Add id-denylist

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -24,6 +24,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`getter-return`](https://eslint.org/docs/latest/rules/getter-return) | Supports optional `allowImplicit` behavior |
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
+| [`id-denylist`](https://eslint.org/docs/latest/rules/id-denylist) | Supports configured restricted identifiers, private identifiers, member-write checks, and renamed import/export skips |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |

--- a/src/core.zig
+++ b/src/core.zig
@@ -608,6 +608,8 @@ pub const max_no_restricted_properties = 32;
 pub const max_no_restricted_property_name_len = 128;
 pub const max_no_restricted_property_message_len = 256;
 pub const max_no_restricted_property_allow_names = 16;
+pub const max_id_denylist_names = 64;
+pub const max_id_denylist_name_len = 128;
 
 pub const NoRestrictedPropertyNameList = struct {
     count: usize = 0,
@@ -706,6 +708,40 @@ pub const NoRestrictedProperties = struct {
 
     pub fn at(self: *const NoRestrictedProperties, index: usize) *const NoRestrictedPropertyEntry {
         return &self.entries[index];
+    }
+};
+
+pub const IdDenylistNamesError = error{
+    EmptyIdDenylistName,
+    TooManyIdDenylistNames,
+    IdDenylistNameTooLong,
+};
+
+pub const IdDenylistNames = struct {
+    count: usize = 0,
+    lengths: [max_id_denylist_names]usize = undefined,
+    storage: [max_id_denylist_names][max_id_denylist_name_len]u8 = undefined,
+
+    pub fn contains(self: *const IdDenylistNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const IdDenylistNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *IdDenylistNames, name: []const u8) IdDenylistNamesError!void {
+        if (name.len == 0) return error.EmptyIdDenylistName;
+        if (self.count >= max_id_denylist_names) return error.TooManyIdDenylistNames;
+        if (name.len > max_id_denylist_name_len) return error.IdDenylistNameTooLong;
+        if (self.contains(name)) return;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
     }
 };
 
@@ -1499,6 +1535,8 @@ pub const Options = struct {
     grouped_accessor_pairs: bool = true,
     grouped_accessor_pairs_style: GroupedAccessorPairsStyle = .any_order,
     guard_for_in: bool = true,
+    id_denylist: bool = true,
+    id_denylist_names: IdDenylistNames = .{},
     linebreak_style: bool = true,
     linebreak_style_style: LinebreakStyle = .unix,
     logical_assignment_operators: bool = true,
@@ -2255,6 +2293,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "grouped-accessor-pairs")) {
             self.grouped_accessor_pairs_style = try groupedAccessorPairsStyleFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "id-denylist")) {
+            self.id_denylist_names = try idDenylistNamesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "eqeqeq")) {
             self.eqeqeq_style = try eqeqeqStyleFromConfig(value);
@@ -3294,6 +3335,25 @@ pub const Options = struct {
         if (std.mem.eql(u8, style, "getBeforeSet")) return .get_before_set;
         if (std.mem.eql(u8, style, "setBeforeGet")) return .set_before_get;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn idDenylistNamesFromConfig(value: std.json.Value) RuleConfigError!IdDenylistNames {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+
+        var names = IdDenylistNames{};
+        if (items.len < 2) return names;
+
+        for (items[1..]) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            names.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return names;
     }
 
     fn reactNoUnusedPropTypesSkipShapePropsFromConfig(value: std.json.Value) RuleConfigError!bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -623,6 +623,10 @@ pub fn main(init: std.process.Init) !void {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
+        } else if (std.mem.eql(u8, arg, "--id-denylist=off")) {
+            options.id_denylist = false;
+        } else if (std.mem.startsWith(u8, arg, "--id-denylist-name=")) {
+            appendIdDenylistName(arg["--id-denylist-name=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--one-var=off")) {
             options.one_var = false;
         } else if (std.mem.eql(u8, arg, "--object-shorthand=off")) {
@@ -1193,6 +1197,13 @@ fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void 
     options.no_multiple_empty_lines_max = max;
 }
 
+fn appendIdDenylistName(value: []const u8, options: *lint.Options) void {
+    options.id_denylist_names.append(value) catch {
+        std.debug.print("utoo-lint: invalid --id-denylist-name value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+}
+
 fn parseMaxClassesPerFileMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-classes-per-file-max value: {s}\n", .{value});
@@ -1699,6 +1710,8 @@ fn printHelp() void {
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
+        \\  --id-denylist=off         Disable id-denylist
+        \\  --id-denylist-name=NAME   Add a restricted identifier name
         \\  --logical-assignment-operators=off Disable logical-assignment-operators
         \\  --logical-assignment-operators=never Disallow logical assignment operators
         \\  --logical-assignment-operators-enforce-for-if-statements=on Enable logical-assignment-operators if-statement checks

--- a/src/rules/id_denylist.zig
+++ b/src/rules/id_denylist.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "id-denylist";
+
+pub const State = struct {
+    reported_spans: std.ArrayList(ast.Span) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.reported_spans.deinit(allocator);
+    }
+};
+
+pub fn checkNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    data: ast.NodeData,
+    index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    state: *State,
+    names: *const core.IdDenylistNames,
+) Allocator.Error!void {
+    if (names.count == 0) return;
+
+    const identifier = identifierName(tree, data) orelse return;
+    if (!names.contains(identifier.name)) return;
+    if (!shouldCheck(tree, index, path)) return;
+
+    try report(allocator, diagnostics, tree, index, identifier, state);
+}
+
+const Identifier = struct {
+    name: []const u8,
+    private: bool = false,
+};
+
+fn identifierName(tree: *const ast.Tree, data: ast.NodeData) ?Identifier {
+    return switch (data) {
+        .identifier_reference => |identifier| .{ .name = tree.string(identifier.name) },
+        .binding_identifier => |identifier| .{ .name = tree.string(identifier.name) },
+        .identifier_name => |identifier| .{ .name = tree.string(identifier.name) },
+        .private_identifier => |identifier| .{ .name = tree.string(identifier.name), .private = true },
+        else => null,
+    };
+}
+
+fn shouldCheck(tree: *const ast.Tree, index: ast.NodeIndex, path: *const traverser.NodePath) bool {
+    const parent_index = path.parent() orelse return true;
+    const parent_data = tree.data(parent_index);
+
+    switch (parent_data) {
+        .member_expression => |member| {
+            if (member.property == index and !member.computed) {
+                return isAssignmentTarget(tree, parent_index, path);
+            }
+        },
+        .call_expression,
+        .new_expression,
+        => return false,
+        .binding_property => |property| {
+            if (!property.computed and property.key == index and isObjectPatternParent(tree, path.ancestor(2))) {
+                return false;
+            }
+        },
+        .import_specifier => |specifier| {
+            if (specifier.imported == index and specifier.imported != specifier.local) return false;
+        },
+        .export_specifier => |specifier| {
+            if (specifier.local == index and specifier.local != specifier.exported and isReExport(tree, path.ancestor(2))) return false;
+        },
+        else => {},
+    }
+
+    return true;
+}
+
+fn isAssignmentTarget(tree: *const ast.Tree, index: ast.NodeIndex, path: *const traverser.NodePath) bool {
+    const parent = path.ancestor(2) orelse return false;
+    return switch (tree.data(parent)) {
+        .assignment_expression => |assignment| assignment.left == index,
+        .array_pattern => true,
+        .binding_rest_element => true,
+        .assignment_pattern => |pattern| pattern.left == index,
+        .binding_property => |property| property.value == index and isObjectPatternParent(tree, path.ancestor(3)),
+        else => false,
+    };
+}
+
+fn isObjectPatternParent(tree: *const ast.Tree, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    return switch (tree.data(parent)) {
+        .object_pattern => true,
+        else => false,
+    };
+}
+
+fn isReExport(tree: *const ast.Tree, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    return switch (tree.data(parent)) {
+        .export_named_declaration => |declaration| declaration.source != .null,
+        else => false,
+    };
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    identifier: Identifier,
+    state: *State,
+) Allocator.Error!void {
+    const span = tree.span(index);
+    for (state.reported_spans.items) |reported| {
+        if (reported.start == span.start and reported.end == span.end) return;
+    }
+    try state.reported_spans.append(allocator, span);
+
+    if (identifier.private) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            span,
+            "Identifier '#{s}' is restricted.",
+            .{identifier.name},
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            span,
+            "Identifier '{s}' is restricted.",
+            .{identifier.name},
+        );
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -32,6 +32,7 @@ pub const func_names = @import("func_names.zig");
 pub const getter_return = @import("getter_return.zig");
 pub const grouped_accessor_pairs = @import("grouped_accessor_pairs.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
+pub const id_denylist = @import("id_denylist.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
 pub const alipay_ant_jsx_handler_names = @import("alipay_ant_jsx_handler_names.zig");
@@ -619,6 +620,7 @@ pub fn runBasic(
     defer visitor.react_default_props_match_prop_types_state.deinit(allocator);
     defer visitor.max_statements_state.deinit(allocator);
     defer visitor.max_nested_callbacks_state.deinit(allocator);
+    defer visitor.id_denylist_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -1127,6 +1129,7 @@ const BasicVisitor = struct {
     max_classes_per_file_state: max_classes_per_file.State = .{},
     max_statements_state: max_statements.State = .{},
     max_nested_callbacks_state: max_nested_callbacks.State = .{},
+    id_denylist_state: id_denylist.State = .{},
 
     fn curlyOptions(self: *const BasicVisitor) curly.Options {
         return .{
@@ -1236,6 +1239,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.alipay_ant_no_negative_conditionals) {
             try alipay_ant_no_negative_conditionals.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index);
+        }
+        if (self.options.id_denylist) {
+            try id_denylist.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index, &ctx.path, &self.id_denylist_state, &self.options.id_denylist_names);
         }
         if (self.options.no_undefined) {
             switch (data) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -75,6 +75,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/id_denylist.zig");
+}
+
+comptime {
     _ = @import("rules/alipay_ant_disallow_typos.zig");
 }
 

--- a/tests/rules/id_denylist.zig
+++ b/tests/rules/id_denylist.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports id-denylist for restricted identifiers" {
+    const source =
+        \\const bad = 1;
+        \\function run(bad) {
+        \\  return bad;
+        \\}
+    ;
+
+    const options = try optionsWithNames(
+        \\["error", "bad"]
+    );
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.id_denylist.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad' is restricted."));
+}
+
+test "allows read-only member properties but reports property writes" {
+    const source =
+        \\const obj = {};
+        \\obj.bad;
+        \\obj.bad = 1;
+    ;
+
+    const options = try optionsWithNames(
+        \\["error", "bad"]
+    );
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.id_denylist.id));
+}
+
+test "skips renamed imports, re-exports, and destructuring property keys" {
+    const source =
+        \\import { bad as renamed } from "pkg";
+        \\export { bad as renamedAgain } from "pkg";
+        \\const { bad: local } = source;
+        \\renamed;
+        \\renamedAgain;
+        \\local;
+    ;
+
+    const options = try optionsWithNames(
+        \\["error", "bad"]
+    );
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_denylist.id));
+}
+
+test "reports private identifiers" {
+    const source =
+        \\class Example {
+        \\  #bad;
+        \\}
+    ;
+
+    const options = try optionsWithNames(
+        \\["error", "bad"]
+    );
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.id_denylist.id));
+    try std.testing.expect(hasMessage(result, "Identifier '#bad' is restricted."));
+}
+
+test "can disable id-denylist" {
+    const source =
+        \\const bad = 1;
+    ;
+
+    var options = try optionsWithNames(
+        \\["error", "bad"]
+    );
+    options.id_denylist = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_denylist.id));
+}
+
+fn optionsWithNames(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("id-denylist", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .import_no_unresolved = false,
+        .max_classes_per_file = false,
+        .max_statements = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_private_class_members = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.id_denylist.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add the ESLint `id-denylist` rule with configured restricted identifier names
- support identifier references, bindings, property names, private identifiers, member-write checks, and renamed import/export skips
- add config parsing, CLI toggles, documentation, and focused rule coverage

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
