### PR TITLE
Add consistent-this

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -10,6 +10,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
+| [`consistent-this`](https://eslint.org/docs/latest/rules/consistent-this) | Supports configured aliases for direct `this` captures and same-scope deferred assignment checks |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
 | [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, `multi`, and `multi-or-nest` configuration |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -86,6 +86,7 @@ const BUILTIN_RULE_IDS = [
   "block-scoped-var",
   "capitalized-comments",
   "consistent-return",
+  "consistent-this",
   "constructor-super",
   "curly",
   "default-case",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -89,6 +89,7 @@ const BUILTIN_RULE_IDS = [
   "block-scoped-var",
   "capitalized-comments",
   "consistent-return",
+  "consistent-this",
   "constructor-super",
   "curly",
   "default-case",

--- a/src/core.zig
+++ b/src/core.zig
@@ -22,6 +22,46 @@ pub const EqeqeqStyle = enum {
     smart,
 };
 
+pub const max_consistent_this_aliases = 32;
+pub const max_consistent_this_alias_len = 128;
+
+pub const ConsistentThisAliasesError = error{
+    EmptyConsistentThisAlias,
+    TooManyConsistentThisAliases,
+    ConsistentThisAliasTooLong,
+};
+
+pub const ConsistentThisAliases = struct {
+    custom: bool = false,
+    count: usize = 0,
+    lengths: [max_consistent_this_aliases]usize = undefined,
+    storage: [max_consistent_this_aliases][max_consistent_this_alias_len]u8 = undefined,
+
+    pub fn contains(self: *const ConsistentThisAliases, name: []const u8) bool {
+        if (!self.custom) return std.mem.eql(u8, name, "that");
+
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const ConsistentThisAliases, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ConsistentThisAliases, name: []const u8) ConsistentThisAliasesError!void {
+        if (name.len == 0) return error.EmptyConsistentThisAlias;
+        if (self.count >= max_consistent_this_aliases) return error.TooManyConsistentThisAliases;
+        if (name.len > max_consistent_this_alias_len) return error.ConsistentThisAliasTooLong;
+        if (self.contains(name)) return;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
 pub const CurlyStyle = enum {
     all,
     multi_line,
@@ -1509,6 +1549,8 @@ pub const Options = struct {
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
     capitalized_comments_ignore_consecutive_comments: CapitalizedCommentsIgnoreConsecutiveComments = .no,
+    consistent_this: bool = false,
+    consistent_this_aliases: ConsistentThisAliases = .{},
     consistent_return: bool = true,
     consistent_return_treat_undefined_as_unspecified: bool = false,
     constructor_super: bool = true,
@@ -2263,6 +2305,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "consistent-return")) {
             self.consistent_return_treat_undefined_as_unspecified = try consistentReturnTreatUndefinedAsUnspecifiedFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "consistent-this")) {
+            self.consistent_this_aliases = try consistentThisAliasesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "curly")) {
             self.curly_style = try curlyStyleFromConfig(value);
@@ -3026,6 +3071,24 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn consistentThisAliasesFromConfig(value: std.json.Value) RuleConfigError!ConsistentThisAliases {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        var aliases = ConsistentThisAliases{ .custom = true };
+        for (items[1..]) |item| {
+            const alias = switch (item) {
+                .string => |alias| alias,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            aliases.append(alias) catch return error.UnsupportedRuleConfigValue;
+        }
+        return aliases;
     }
 
     fn accessorPairsGetWithoutSetFromConfig(value: std.json.Value) RuleConfigError!AccessorPairsGetWithoutSet {

--- a/src/main.zig
+++ b/src/main.zig
@@ -114,6 +114,12 @@ pub fn main(init: std.process.Init) !void {
             options.accessor_pairs_set_without_get = .no;
         } else if (std.mem.eql(u8, arg, "--consistent-return=off")) {
             options.consistent_return = false;
+        } else if (std.mem.eql(u8, arg, "--consistent-this=off")) {
+            options.consistent_this = false;
+        } else if (std.mem.eql(u8, arg, "--consistent-this=on")) {
+            options.consistent_this = true;
+        } else if (std.mem.startsWith(u8, arg, "--consistent-this-alias=")) {
+            appendConsistentThisAlias(arg["--consistent-this-alias=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--constructor-super=off")) {
             options.constructor_super = false;
         } else if (std.mem.eql(u8, arg, "--array-callback-return=off")) {
@@ -1215,6 +1221,17 @@ fn appendIdDenylistName(value: []const u8, options: *lint.Options) void {
     };
 }
 
+fn appendConsistentThisAlias(value: []const u8, options: *lint.Options) void {
+    if (!options.consistent_this_aliases.custom) {
+        options.consistent_this_aliases = .{ .custom = true };
+    }
+    options.consistent_this_aliases.append(value) catch {
+        std.debug.print("utoo-lint: invalid --consistent-this-alias value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.consistent_this = true;
+}
+
 fn parseMaxClassesPerFileMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-classes-per-file-max value: {s}\n", .{value});
@@ -1579,6 +1596,9 @@ fn printHelp() void {
         \\  --capitalized-comments=never Require lowercase comment starts
         \\  --capitalized-comments-ignore-inline-comments=on Ignore inline comments
         \\  --consistent-return=off  Disable consistent-return
+        \\  --consistent-this=off    Disable consistent-this
+        \\  --consistent-this=on     Enable consistent-this with default alias
+        \\  --consistent-this-alias=NAME Add a consistent-this alias
         \\  --constructor-super=off  Disable constructor-super
         \\  --curly=off              Disable curly
         \\  --dot-notation=off       Disable dot-notation

--- a/src/rules/consistent_this.zig
+++ b/src/rules/consistent_this.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "consistent-this";
+
+const max_scopes = 64;
+const max_pending_aliases = 64;
+const max_assigned_aliases = 64;
+
+pub const State = struct {
+    scopes: [max_scopes]Scope = undefined,
+    scope_count: usize = 0,
+
+    pub fn enterScope(self: *State) void {
+        if (self.scope_count >= max_scopes) return;
+        self.scopes[self.scope_count] = .{};
+        self.scope_count += 1;
+    }
+
+    pub fn exitScope(
+        self: *State,
+        allocator: Allocator,
+        diagnostics: *core.DiagnosticList,
+    ) Allocator.Error!void {
+        if (self.scope_count == 0) return;
+        self.scope_count -= 1;
+        const scope = self.scopes[self.scope_count];
+        for (scope.pending[0..scope.pending_count]) |pending| {
+            if (pending.assigned) continue;
+            try reportAliasNotAssignedToThis(allocator, diagnostics, pending.span, pending.name);
+        }
+    }
+
+    pub fn rememberPendingAlias(self: *State, name: []const u8, span: ast.Span) void {
+        if (self.scope_count == 0) return;
+        var scope = &self.scopes[self.scope_count - 1];
+        if (scope.pending_count >= max_pending_aliases) return;
+        scope.pending[scope.pending_count] = .{
+            .name = name,
+            .span = span,
+            .assigned = scope.hasAssigned(name),
+        };
+        scope.pending_count += 1;
+    }
+
+    pub fn markAssigned(self: *State, name: []const u8) void {
+        if (self.scope_count == 0) return;
+        var scope = &self.scopes[self.scope_count - 1];
+        scope.rememberAssigned(name);
+        for (scope.pending[0..scope.pending_count]) |*pending| {
+            if (std.mem.eql(u8, pending.name, name)) {
+                pending.assigned = true;
+            }
+        }
+    }
+};
+
+const Scope = struct {
+    pending: [max_pending_aliases]PendingAlias = undefined,
+    pending_count: usize = 0,
+    assigned: [max_assigned_aliases][]const u8 = undefined,
+    assigned_count: usize = 0,
+
+    fn hasAssigned(self: *const Scope, name: []const u8) bool {
+        for (self.assigned[0..self.assigned_count]) |assigned| {
+            if (std.mem.eql(u8, assigned, name)) return true;
+        }
+        return false;
+    }
+
+    fn rememberAssigned(self: *Scope, name: []const u8) void {
+        if (self.hasAssigned(name)) return;
+        if (self.assigned_count >= max_assigned_aliases) return;
+        self.assigned[self.assigned_count] = name;
+        self.assigned_count += 1;
+    }
+};
+
+const PendingAlias = struct {
+    name: []const u8,
+    span: ast.Span,
+    assigned: bool = false,
+};
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    index: ast.NodeIndex,
+    state: *State,
+    aliases: *const core.ConsistentThisAliases,
+) Allocator.Error!void {
+    const name = bindingIdentifierName(tree, declarator.id) orelse return;
+
+    if (declarator.init == .null) {
+        if (aliases.contains(name)) {
+            state.rememberPendingAlias(name, tree.span(index));
+        }
+        return;
+    }
+
+    try checkAssignment(allocator, diagnostics, tree, tree.span(index), name, declarator.init, true, state, aliases);
+}
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    state: *State,
+    aliases: *const core.ConsistentThisAliases,
+) Allocator.Error!void {
+    const name = identifierReferenceName(tree, expression.left) orelse return;
+    try checkAssignment(
+        allocator,
+        diagnostics,
+        tree,
+        tree.span(index),
+        name,
+        expression.right,
+        expression.operator == .assign,
+        state,
+        aliases,
+    );
+}
+
+fn checkAssignment(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    span: ast.Span,
+    name: []const u8,
+    value: ast.NodeIndex,
+    simple_assignment: bool,
+    state: *State,
+    aliases: *const core.ConsistentThisAliases,
+) Allocator.Error!void {
+    const assigns_this = isThisExpression(tree, value);
+
+    if (aliases.contains(name)) {
+        if (!assigns_this or !simple_assignment) {
+            try reportAliasNotAssignedToThis(allocator, diagnostics, span, name);
+            return;
+        }
+        state.markAssigned(name);
+        return;
+    }
+
+    if (assigns_this) {
+        try reportUnexpectedAlias(allocator, diagnostics, span, name);
+    }
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .this_expression => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn reportAliasNotAssignedToThis(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    span: ast.Span,
+    name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        span,
+        "Designated alias '{s}' is not assigned to 'this'.",
+        .{name},
+    );
+}
+
+fn reportUnexpectedAlias(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    span: ast.Span,
+    name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        span,
+        "Unexpected alias '{s}' for 'this'.",
+        .{name},
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -18,6 +18,7 @@ pub const accessor_pairs = @import("accessor_pairs.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
 pub const capitalized_comments = @import("capitalized_comments.zig");
+pub const consistent_this = @import("consistent_this.zig");
 pub const consistent_return = @import("consistent_return.zig");
 pub const constructor_super = @import("constructor_super.zig");
 pub const dot_notation = @import("dot_notation.zig");
@@ -1127,6 +1128,7 @@ const BasicVisitor = struct {
     react_no_unused_state_state: react_no_unused_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
+    consistent_this_state: consistent_this.State = .{},
     max_classes_per_file_state: max_classes_per_file.State = .{},
     max_statements_state: max_statements.State = .{},
     max_nested_callbacks_state: max_nested_callbacks.State = .{},
@@ -1271,6 +1273,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.consistent_this) {
+            self.consistent_this_state.enterScope();
+        }
         if (self.options.max_classes_per_file) {
             max_classes_per_file.enterProgram(&self.max_classes_per_file_state);
         }
@@ -1376,6 +1381,9 @@ const BasicVisitor = struct {
                 .allow = self.options.react_jsx_filename_extension_allow,
             }) catch {};
         }
+        if (self.options.consistent_this) {
+            self.consistent_this_state.exitScope(self.allocator, self.diagnostics) catch {};
+        }
     }
 
     pub fn enter_function(
@@ -1384,6 +1392,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.consistent_this) {
+            self.consistent_this_state.enterScope();
+        }
         if (self.options.max_statements) {
             try max_statements.enterFunction(self.allocator, &self.max_statements_state, index);
         }
@@ -1458,6 +1469,9 @@ const BasicVisitor = struct {
         }
         if (self.options.max_nested_callbacks) {
             max_nested_callbacks.exitFunction(&self.max_nested_callbacks_state, index);
+        }
+        if (self.options.consistent_this) {
+            self.consistent_this_state.exitScope(self.allocator, self.diagnostics) catch {};
         }
     }
 
@@ -1825,6 +1839,17 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.consistent_this) {
+            try consistent_this.checkVariableDeclarator(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                declarator,
+                index,
+                &self.consistent_this_state,
+                &self.options.consistent_this_aliases,
+            );
+        }
         if (self.options.typescript_eslint_prefer_as_const) {
             try typescript_eslint_prefer_as_const.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
@@ -2753,6 +2778,17 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.consistent_this) {
+            try consistent_this.checkAssignmentExpression(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                expression,
+                index,
+                &self.consistent_this_state,
+                &self.options.consistent_this_aliases,
+            );
+        }
         if (self.options.no_bitwise) {
             try no_bitwise.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -19,6 +19,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/consistent_this.zig");
+}
+
+comptime {
     _ = @import("rules/constructor_super.zig");
 }
 

--- a/tests/rules/consistent_this.zig
+++ b/tests/rules/consistent_this.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports unexpected aliases for this" {
+    const source =
+        \\const self = this;
+        \\let that = this;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.consistent_this.id));
+    try std.testing.expect(hasMessage(result, "Unexpected alias 'self' for 'this'."));
+}
+
+test "reports configured aliases assigned to non-this values" {
+    const source =
+        \\const that = window;
+        \\that += this;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.consistent_this.id));
+    try std.testing.expect(hasMessage(result, "Designated alias 'that' is not assigned to 'this'."));
+}
+
+test "allows deferred same-scope assignment to this" {
+    const source =
+        \\let that;
+        \\that = this;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.consistent_this.id));
+}
+
+test "reports configured aliases not assigned to this in their scope" {
+    const source =
+        \\function run() {
+        \\  let that;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.consistent_this.id));
+}
+
+test "supports configured aliases from eslint config" {
+    const source =
+        \\const that = this;
+        \\const self = this;
+        \\const context = this;
+    ;
+
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\", \"self\", \"context\"]",
+        .{},
+    );
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("consistent-this", parsed.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.consistent_this.id));
+    try std.testing.expect(hasMessage(result, "Unexpected alias 'that' for 'this'."));
+}
+
+test "can disable consistent-this" {
+    const source =
+        \\const self = this;
+    ;
+
+    var options = baseOptions();
+    options.consistent_this = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.consistent_this.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .consistent_this = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.consistent_this.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `consistent-this` rule support with ESLint-compatible default alias `that` and configured alias lists
- validate direct `this` captures, alias assignments to non-`this` values, and deferred same-scope alias assignment
- wire the rule into config parsing, CLI flags, visitor traversal, npm built-in rule ids, and rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`