### PR TITLE
Add no-restricted-exports

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -128,6 +128,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-promise-executor-return`](https://eslint.org/docs/latest/rules/no-promise-executor-return) | Supports `allowVoid` configuration |
 | [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) | Implemented |
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
+| [`no-restricted-exports`](https://eslint.org/docs/latest/rules/no-restricted-exports) | Supports `restrictedNamedExports` and `restrictDefaultExports` |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -198,6 +198,7 @@ const BUILTIN_RULE_IDS = [
   "no-promise-executor-return",
   "no-proto",
   "no-prototype-builtins",
+  "no-restricted-exports",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -201,6 +201,7 @@ const BUILTIN_RULE_IDS = [
   "no-promise-executor-return",
   "no-proto",
   "no-prototype-builtins",
+  "no-restricted-exports",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/src/core.zig
+++ b/src/core.zig
@@ -653,6 +653,8 @@ pub const max_no_restricted_properties = 32;
 pub const max_no_restricted_property_name_len = 128;
 pub const max_no_restricted_property_message_len = 256;
 pub const max_no_restricted_property_allow_names = 16;
+pub const max_no_restricted_export_names = 64;
+pub const max_no_restricted_export_name_len = 128;
 pub const max_id_denylist_names = 64;
 pub const max_id_denylist_name_len = 128;
 
@@ -788,6 +790,48 @@ pub const IdDenylistNames = struct {
         self.lengths[self.count] = name.len;
         self.count += 1;
     }
+};
+
+pub const NoRestrictedExportNamesError = error{
+    EmptyNoRestrictedExportName,
+    TooManyNoRestrictedExportNames,
+    NoRestrictedExportNameTooLong,
+};
+
+pub const NoRestrictedExportNames = struct {
+    count: usize = 0,
+    lengths: [max_no_restricted_export_names]usize = undefined,
+    storage: [max_no_restricted_export_names][max_no_restricted_export_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoRestrictedExportNames, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoRestrictedExportNames, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoRestrictedExportNames, name: []const u8) NoRestrictedExportNamesError!void {
+        if (name.len == 0) return error.EmptyNoRestrictedExportName;
+        if (self.count >= max_no_restricted_export_names) return error.TooManyNoRestrictedExportNames;
+        if (name.len > max_no_restricted_export_name_len) return error.NoRestrictedExportNameTooLong;
+        if (self.contains(name)) return;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
+pub const NoRestrictedExportsDefaultOptions = struct {
+    direct: bool = false,
+    named: bool = false,
+    default_from: bool = false,
+    named_from: bool = false,
+    namespace_from: bool = false,
 };
 
 pub const max_no_unused_vars_ignore_pattern_len = 256;
@@ -1841,6 +1885,9 @@ pub const Options = struct {
     no_prototype_builtins: bool = true,
     no_redeclare: bool = true,
     no_redeclare_builtin_globals: NoRedeclareBuiltinGlobals = .no,
+    no_restricted_exports: bool = false,
+    no_restricted_exports_names: NoRestrictedExportNames = .{},
+    no_restricted_exports_default: NoRestrictedExportsDefaultOptions = .{},
     no_restricted_properties: bool = true,
     no_restricted_properties_entries: NoRestrictedProperties = .{},
     no_regex_spaces: bool = true,
@@ -2547,6 +2594,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-redeclare")) {
             self.no_redeclare_builtin_globals = try noRedeclareBuiltinGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-exports")) {
+            self.no_restricted_exports_names = try noRestrictedExportNamesFromConfig(value);
+            self.no_restricted_exports_default = try noRestrictedExportsDefaultOptionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
             self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
@@ -3462,6 +3513,60 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    fn noRestrictedExportNamesFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedExportNames {
+        const config = noRestrictedExportsObjectFromConfig(value) orelse return .{};
+        const entries = switch (config.get("restrictedNamedExports") orelse return .{}) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var names = NoRestrictedExportNames{};
+        for (entries) |entry| {
+            const name = switch (entry) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            names.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return names;
+    }
+
+    fn noRestrictedExportsDefaultOptionsFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedExportsDefaultOptions {
+        const config = noRestrictedExportsObjectFromConfig(value) orelse return .{};
+        const default_config = switch (config.get("restrictDefaultExports") orelse return .{}) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        return .{
+            .direct = try boolObjectOption(default_config, "direct", false),
+            .named = try boolObjectOption(default_config, "named", false),
+            .default_from = try boolObjectOption(default_config, "defaultFrom", false),
+            .named_from = try boolObjectOption(default_config, "namedFrom", false),
+            .namespace_from = try boolObjectOption(default_config, "namespaceFrom", false),
+        };
+    }
+
+    fn noRestrictedExportsObjectFromConfig(value: std.json.Value) ?std.json.ObjectMap {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 2) return null;
+
+        return switch (items[1]) {
+            .object => |object| object,
+            else => null,
+        };
+    }
+
+    fn boolObjectOption(object: std.json.ObjectMap, key: []const u8, default: bool) RuleConfigError!bool {
+        return switch (object.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn reactNoUnusedPropTypesSkipShapePropsFromConfig(value: std.json.Value) RuleConfigError!bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -512,6 +512,27 @@ pub fn main(init: std.process.Init) !void {
             options.no_redeclare = false;
         } else if (std.mem.eql(u8, arg, "--no-redeclare-builtin-globals=on")) {
             options.no_redeclare_builtin_globals = .yes;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports=off")) {
+            options.no_restricted_exports = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports=on")) {
+            options.no_restricted_exports = true;
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-exports-name=")) {
+            appendNoRestrictedExportName(arg["--no-restricted-exports-name=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports-default-direct=on")) {
+            options.no_restricted_exports = true;
+            options.no_restricted_exports_default.direct = true;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports-default-named=on")) {
+            options.no_restricted_exports = true;
+            options.no_restricted_exports_default.named = true;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports-default-from=on")) {
+            options.no_restricted_exports = true;
+            options.no_restricted_exports_default.default_from = true;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports-named-from=on")) {
+            options.no_restricted_exports = true;
+            options.no_restricted_exports_default.named_from = true;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-exports-namespace-from=on")) {
+            options.no_restricted_exports = true;
+            options.no_restricted_exports_default.namespace_from = true;
         } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
             options.no_restricted_properties = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -1206,6 +1227,14 @@ fn parseNoWarningCommentsTerms(value: []const u8, options: *lint.Options) void {
     options.no_warning_comments_terms = terms;
 }
 
+fn appendNoRestrictedExportName(value: []const u8, options: *lint.Options) void {
+    options.no_restricted_exports_names.append(value) catch {
+        std.debug.print("utoo-lint: invalid --no-restricted-exports-name value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.no_restricted_exports = true;
+}
+
 fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max value: {s}\n", .{value});
@@ -1801,6 +1830,14 @@ fn printHelp() void {
         \\  --no-prototype-builtins=off Disable no-prototype-builtins
         \\  --no-redeclare=off        Disable no-redeclare
         \\  --no-redeclare-builtin-globals=on Report redeclarations of built-in globals
+        \\  --no-restricted-exports=off Disable no-restricted-exports
+        \\  --no-restricted-exports=on Enable no-restricted-exports
+        \\  --no-restricted-exports-name=NAME Restrict an exported name
+        \\  --no-restricted-exports-default-direct=on Restrict direct default exports
+        \\  --no-restricted-exports-default-named=on Restrict local named default exports
+        \\  --no-restricted-exports-default-from=on Restrict re-exported default exports
+        \\  --no-restricted-exports-named-from=on Restrict re-exported named defaults
+        \\  --no-restricted-exports-namespace-from=on Restrict namespace default re-exports
         \\  --no-restricted-properties=off Disable no-restricted-properties
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await

--- a/src/rules/no_restricted_exports.zig
+++ b/src/rules/no_restricted_exports.zig
@@ -1,0 +1,231 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-exports";
+
+pub const Options = struct {
+    names: *const core.NoRestrictedExportNames,
+    restrict_default: core.NoRestrictedExportsDefaultOptions = .{},
+};
+
+pub fn checkExportDefaultDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (options.names.contains("default")) {
+        try reportRestrictedNamed(allocator, diagnostics, tree, index, "default");
+        return;
+    }
+
+    if (options.restrict_default.direct) {
+        try reportRestrictedDefault(allocator, diagnostics, tree, index);
+    }
+}
+
+pub fn checkExportAllDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ExportAllDeclaration,
+    _: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (declaration.export_kind == .type) return;
+    if (declaration.exported == .null) return;
+
+    const name = moduleExportName(tree, declaration.exported) orelse return;
+    if (try checkNamedExport(allocator, diagnostics, tree, declaration.exported, name, options)) return;
+
+    if (std.mem.eql(u8, name, "default") and options.restrict_default.namespace_from) {
+        try reportRestrictedDefault(allocator, diagnostics, tree, declaration.exported);
+    }
+}
+
+pub fn checkExportNamedDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ExportNamedDeclaration,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (declaration.export_kind == .type) return;
+
+    if (declaration.declaration != .null) {
+        try checkDeclarationNames(allocator, diagnostics, tree, declaration.declaration, index, options);
+    }
+
+    const has_source = declaration.source != .null;
+    for (tree.extra(declaration.specifiers)) |specifier_index| {
+        const specifier = switch (tree.data(specifier_index)) {
+            .export_specifier => |specifier| specifier,
+            else => continue,
+        };
+        if (specifier.export_kind == .type) continue;
+
+        const exported = moduleExportName(tree, specifier.exported) orelse continue;
+        if (try checkNamedExport(allocator, diagnostics, tree, specifier.exported, exported, options)) continue;
+
+        if (!std.mem.eql(u8, exported, "default")) continue;
+        const local = moduleExportName(tree, specifier.local) orelse continue;
+
+        if (!has_source and options.restrict_default.named) {
+            try reportRestrictedDefault(allocator, diagnostics, tree, specifier.exported);
+        } else if (has_source and std.mem.eql(u8, local, "default") and options.restrict_default.default_from) {
+            try reportRestrictedDefault(allocator, diagnostics, tree, specifier.exported);
+        } else if (has_source and !std.mem.eql(u8, local, "default") and options.restrict_default.named_from) {
+            try reportRestrictedDefault(allocator, diagnostics, tree, specifier.exported);
+        }
+    }
+}
+
+fn checkDeclarationNames(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration_index: ast.NodeIndex,
+    report_node: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    switch (tree.data(declaration_index)) {
+        .variable_declaration => |declaration| {
+            for (tree.extra(declaration.declarators)) |declarator_index| {
+                const declarator = switch (tree.data(declarator_index)) {
+                    .variable_declarator => |declarator| declarator,
+                    else => continue,
+                };
+                try checkBindingNames(allocator, diagnostics, tree, declarator.id, options);
+            }
+        },
+        .function => |function| if (bindingIdentifierName(tree, function.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, function.id, name, options);
+        },
+        .class => |class| if (bindingIdentifierName(tree, class.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, class.id, name, options);
+        },
+        .ts_type_alias_declaration => |declaration| if (bindingIdentifierName(tree, declaration.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, declaration.id, name, options);
+        },
+        .ts_interface_declaration => |declaration| if (bindingIdentifierName(tree, declaration.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, declaration.id, name, options);
+        },
+        .ts_enum_declaration => |declaration| if (bindingIdentifierName(tree, declaration.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, declaration.id, name, options);
+        },
+        .ts_module_declaration => |declaration| if (bindingIdentifierName(tree, declaration.id)) |name| {
+            _ = try checkNamedExport(allocator, diagnostics, tree, declaration.id, name, options);
+        },
+        else => {
+            if (options.names.contains("default")) {
+                try reportRestrictedNamed(allocator, diagnostics, tree, report_node, "default");
+            }
+        },
+    }
+}
+
+fn checkBindingNames(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+    switch (tree.data(index)) {
+        .binding_identifier => |identifier| {
+            const name = tree.string(identifier.name);
+            _ = try checkNamedExport(allocator, diagnostics, tree, index, name, options);
+        },
+        .assignment_pattern => |pattern| try checkBindingNames(allocator, diagnostics, tree, pattern.left, options),
+        .binding_rest_element => |element| try checkBindingNames(allocator, diagnostics, tree, element.argument, options),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBindingNames(allocator, diagnostics, tree, element, options);
+            }
+            try checkBindingNames(allocator, diagnostics, tree, pattern.rest, options);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBindingNames(allocator, diagnostics, tree, property.value, options);
+            }
+            try checkBindingNames(allocator, diagnostics, tree, pattern.rest, options);
+        },
+        else => {},
+    }
+}
+
+fn checkNamedExport(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    name: []const u8,
+    options: Options,
+) Allocator.Error!bool {
+    if (!options.names.contains(name)) return false;
+    try reportRestrictedNamed(allocator, diagnostics, tree, index, name);
+    return true;
+}
+
+fn moduleExportName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn reportRestrictedNamed(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    name: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "'{s}' is restricted from being used as an exported name.",
+        .{name},
+    );
+}
+
+fn reportRestrictedDefault(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Exporting 'default' is restricted.",
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -187,6 +187,7 @@ pub const no_process_env = @import("no_process_env.zig");
 pub const no_process_exit = @import("no_process_exit.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_redeclare = @import("no_redeclare.zig");
+pub const no_restricted_exports = @import("no_restricted_exports.zig");
 pub const no_restricted_properties = @import("no_restricted_properties.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
@@ -1155,6 +1156,13 @@ const BasicVisitor = struct {
             .ignore_for = self.options.no_unreachable_loop_ignore_for,
             .ignore_for_in = self.options.no_unreachable_loop_ignore_for_in,
             .ignore_for_of = self.options.no_unreachable_loop_ignore_for_of,
+        };
+    }
+
+    fn noRestrictedExportsOptions(self: *const BasicVisitor) no_restricted_exports.Options {
+        return .{
+            .names = &self.options.no_restricted_exports_names,
+            .restrict_default = self.options.no_restricted_exports_default,
         };
     }
 
@@ -3909,6 +3917,42 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_useless_rename) {
             try no_useless_rename.checkExportSpecifierWithOptions(self.allocator, self.diagnostics, ctx.tree, specifier, index, self.noUselessRenameOptions());
+        }
+        return .proceed;
+    }
+
+    pub fn enter_export_default_declaration(
+        self: *BasicVisitor,
+        _: ast.ExportDefaultDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_restricted_exports) {
+            try no_restricted_exports.checkExportDefaultDeclaration(self.allocator, self.diagnostics, ctx.tree, index, self.noRestrictedExportsOptions());
+        }
+        return .proceed;
+    }
+
+    pub fn enter_export_all_declaration(
+        self: *BasicVisitor,
+        declaration: ast.ExportAllDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_restricted_exports) {
+            try no_restricted_exports.checkExportAllDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.noRestrictedExportsOptions());
+        }
+        return .proceed;
+    }
+
+    pub fn enter_export_named_declaration(
+        self: *BasicVisitor,
+        declaration: ast.ExportNamedDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_restricted_exports) {
+            try no_restricted_exports.checkExportNamedDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.noRestrictedExportsOptions());
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -687,6 +687,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_exports.zig");
+}
+
+comptime {
     _ = @import("rules/no_restricted_properties.zig");
 }
 

--- a/tests/rules/no_restricted_exports.zig
+++ b/tests/rules/no_restricted_exports.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-restricted-exports for configured exported names" {
+    const source =
+        \\export const disallowed = 1;
+        \\const local = 1;
+        \\export { local as blocked };
+        \\export { remote as denied } from "./mod";
+    ;
+
+    var options = baseOptions();
+    try options.no_restricted_exports_names.append("disallowed");
+    try options.no_restricted_exports_names.append("blocked");
+    try options.no_restricted_exports_names.append("denied");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_restricted_exports.id));
+    try std.testing.expect(hasMessage(result, "'blocked' is restricted from being used as an exported name."));
+}
+
+test "reports no-restricted-exports for variable destructuring names" {
+    const source =
+        \\export const { blocked, nested: { denied } } = source;
+    ;
+
+    var options = baseOptions();
+    try options.no_restricted_exports_names.append("blocked");
+    try options.no_restricted_exports_names.append("denied");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_exports.id));
+}
+
+test "supports restrictDefaultExports options" {
+    const source =
+        \\export default value;
+        \\export { local as default };
+        \\export { default } from "./mod";
+        \\export { named as default } from "./mod";
+        \\export * as default from "./mod";
+    ;
+
+    var options = baseOptions();
+    options.no_restricted_exports_default = .{
+        .direct = true,
+        .named = true,
+        .default_from = true,
+        .named_from = true,
+        .namespace_from = true,
+    };
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_restricted_exports.id));
+    try std.testing.expect(hasMessage(result, "Exporting 'default' is restricted."));
+}
+
+test "parses no-restricted-exports eslint config" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        \\["error", {"restrictedNamedExports": ["blocked"], "restrictDefaultExports": {"direct": true, "namedFrom": true}}]
+    ,
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-restricted-exports", parsed.value);
+
+    try std.testing.expect(options.no_restricted_exports);
+    try std.testing.expect(options.no_restricted_exports_names.contains("blocked"));
+    try std.testing.expect(options.no_restricted_exports_default.direct);
+    try std.testing.expect(options.no_restricted_exports_default.named_from);
+    try std.testing.expect(!options.no_restricted_exports_default.named);
+}
+
+test "can disable no-restricted-exports" {
+    const source =
+        \\export const blocked = 1;
+    ;
+
+    var options = baseOptions();
+    options.no_restricted_exports = false;
+    try options.no_restricted_exports_names.append("blocked");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_exports.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_restricted_exports = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_exports.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `no-restricted-exports` support for configured `restrictedNamedExports`
- support `restrictDefaultExports` for direct, named, defaultFrom, namedFrom, and namespaceFrom default export forms
- wire the rule into config parsing, CLI flags, visitor traversal, npm built-in rule ids, and rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`