### PR TITLE
Add max-lines rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -31,6 +31,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
+| [`max-lines`](https://eslint.org/docs/latest/rules/max-lines) | Supports `max`, `skipBlankLines`, and `skipComments` configuration |
 | [`max-nested-callbacks`](https://eslint.org/docs/latest/rules/max-nested-callbacks) | Supports `max`, deprecated `maximum`, and call-argument callback detection |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`max-statements`](https://eslint.org/docs/latest/rules/max-statements) | Supports `max`, deprecated `maximum`, `ignoreTopLevelFunctions`, and static block isolation |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -104,6 +104,7 @@ const BUILTIN_RULE_IDS = [
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",
+  "max-lines",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -107,6 +107,7 @@ const BUILTIN_RULE_IDS = [
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",
+  "max-lines",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1641,6 +1641,10 @@ pub const Options = struct {
     max_classes_per_file_ignore_expressions: bool = false,
     max_depth: bool = true,
     max_depth_max: usize = 4,
+    max_lines: bool = false,
+    max_lines_max: usize = 300,
+    max_lines_skip_blank_lines: bool = false,
+    max_lines_skip_comments: bool = false,
     max_nested_callbacks: bool = true,
     max_nested_callbacks_max: usize = 10,
     max_params: bool = true,
@@ -2421,6 +2425,11 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "max-depth")) {
             self.max_depth_max = try maxDepthMaxFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "max-lines")) {
+            self.max_lines_max = try maxLinesMaxFromConfig(value);
+            self.max_lines_skip_blank_lines = try maxLinesBoolOptionFromConfig(value, "skipBlankLines");
+            self.max_lines_skip_comments = try maxLinesBoolOptionFromConfig(value, "skipComments");
         }
         if (std.mem.eql(u8, cli_name, "max-nested-callbacks")) {
             self.max_nested_callbacks_max = try maxNestedCallbacksMaxFromConfig(value);
@@ -4143,6 +4152,46 @@ pub const Options = struct {
             },
             else => return error.UnsupportedRuleConfigValue,
         }
+    }
+
+    fn maxLinesMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 300,
+        };
+        if (items.len < 2) return 300;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 300;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn maxLinesBoolOptionFromConfig(value: std.json.Value, option_name: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const object = switch (items[1]) {
+            .object => |object| object,
+            else => return false,
+        };
+        return switch (object.get(option_name) orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn maxClassesPerFileMaxFromConfig(value: std.json.Value) RuleConfigError!usize {

--- a/src/main.zig
+++ b/src/main.zig
@@ -685,6 +685,18 @@ pub fn main(init: std.process.Init) !void {
             options.max_depth = false;
         } else if (std.mem.startsWith(u8, arg, "--max-depth-max=")) {
             parseMaxDepthMax(arg["--max-depth-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-lines=off")) {
+            options.max_lines = false;
+        } else if (std.mem.eql(u8, arg, "--max-lines=on")) {
+            options.max_lines = true;
+        } else if (std.mem.startsWith(u8, arg, "--max-lines-max=")) {
+            parseMaxLinesMax(arg["--max-lines-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-lines-skip-blank-lines=on")) {
+            options.max_lines = true;
+            options.max_lines_skip_blank_lines = true;
+        } else if (std.mem.eql(u8, arg, "--max-lines-skip-comments=on")) {
+            options.max_lines = true;
+            options.max_lines_skip_comments = true;
         } else if (std.mem.eql(u8, arg, "--max-nested-callbacks=off")) {
             options.max_nested_callbacks = false;
         } else if (std.mem.startsWith(u8, arg, "--max-nested-callbacks-max=")) {
@@ -1281,6 +1293,15 @@ fn parseMaxDepthMax(value: []const u8, options: *lint.Options) void {
     options.max_depth_max = max;
 }
 
+fn parseMaxLinesMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-lines-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_lines = true;
+    options.max_lines_max = max;
+}
+
 fn parseMaxNestedCallbacksMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-nested-callbacks-max value: {s}\n", .{value});
@@ -1784,6 +1805,11 @@ fn printHelp() void {
         \\  --max-classes-per-file-ignore-expressions=on Ignore class expressions
         \\  --max-depth=off           Disable max-depth
         \\  --max-depth-max=N         Set max-depth maximum
+        \\  --max-lines=on            Enable max-lines
+        \\  --max-lines=off           Disable max-lines
+        \\  --max-lines-max=N         Set max-lines maximum
+        \\  --max-lines-skip-blank-lines=on Ignore blank lines for max-lines
+        \\  --max-lines-skip-comments=on Ignore comment-only lines for max-lines
         \\  --max-nested-callbacks=off Disable max-nested-callbacks
         \\  --max-nested-callbacks-max=N Set max-nested-callbacks maximum
         \\  --max-params=off          Disable max-params

--- a/src/rules/max_lines.zig
+++ b/src/rules/max_lines.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-lines";
+
+pub const Options = struct {
+    max: usize = 300,
+    skip_blank_lines: bool = false,
+    skip_comments: bool = false,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    try runWithOptions(allocator, diagnostics, tree, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
+    const source = tree.source;
+    var line_start: usize = 0;
+    var index: usize = 0;
+    var actual: usize = 0;
+    var first_excess_start: ?usize = null;
+
+    while (index < source.len) {
+        const line_end = findLineEnd(source, index);
+        const should_count = !shouldSkipLine(source, tree.comments, line_start, line_end, options);
+
+        if (should_count) {
+            actual += 1;
+            if (actual == options.max + 1) {
+                first_excess_start = line_start;
+            }
+        }
+
+        if (line_end >= source.len) break;
+
+        index = line_end + 1;
+        if (source[line_end] == '\r' and index < source.len and source[index] == '\n') {
+            index += 1;
+        }
+        line_start = index;
+    }
+
+    if (actual <= options.max) return;
+
+    const start = first_excess_start orelse source.len;
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        .{ .start = @intCast(start), .end = @intCast(source.len) },
+        "File has too many lines ({d}). Maximum allowed is {d}.",
+        .{ actual, options.max },
+    );
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn shouldSkipLine(
+    source: []const u8,
+    comments: []const ast.Comment,
+    line_start: usize,
+    line_end: usize,
+    options: Options,
+) bool {
+    const line = source[line_start..line_end];
+    if (options.skip_blank_lines and std.mem.trim(u8, line, " \t\r\n").len == 0) return true;
+    if (options.skip_comments and isCommentOnlyLine(source, comments, line_start, line_end)) return true;
+    return false;
+}
+
+fn isCommentOnlyLine(
+    source: []const u8,
+    comments: []const ast.Comment,
+    line_start: usize,
+    line_end: usize,
+) bool {
+    var saw_comment = false;
+
+    var index = line_start;
+    while (index < line_end) : (index += 1) {
+        if (std.ascii.isWhitespace(source[index])) continue;
+        if (!isInsideComment(comments, index, line_start, line_end)) return false;
+        saw_comment = true;
+    }
+
+    return saw_comment;
+}
+
+fn isInsideComment(
+    comments: []const ast.Comment,
+    index: usize,
+    line_start: usize,
+    line_end: usize,
+) bool {
+    for (comments) |comment| {
+        const start: usize = comment.start;
+        const end: usize = comment.end;
+        if (end <= line_start or start >= line_end) continue;
+        if (start <= index and index < end) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -88,6 +88,7 @@ pub const linebreak_style = @import("linebreak_style.zig");
 pub const logical_assignment_operators = @import("logical_assignment_operators.zig");
 pub const max_classes_per_file = @import("max_classes_per_file.zig");
 pub const max_depth = @import("max_depth.zig");
+pub const max_lines = @import("max_lines.zig");
 pub const max_nested_callbacks = @import("max_nested_callbacks.zig");
 pub const max_params = @import("max_params.zig");
 pub const max_statements = @import("max_statements.zig");
@@ -524,6 +525,13 @@ pub fn runBasic(
                 .unix => .unix,
                 .windows => .windows,
             },
+        });
+    }
+    if (options.max_lines) {
+        try max_lines.runWithOptions(allocator, diagnostics, tree, .{
+            .max = options.max_lines_max,
+            .skip_blank_lines = options.max_lines_skip_blank_lines,
+            .skip_comments = options.max_lines_skip_comments,
         });
     }
     if (options.no_irregular_whitespace) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -295,6 +295,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_lines.zig");
+}
+
+comptime {
     _ = @import("rules/max_nested_callbacks.zig");
 }
 

--- a/tests/rules/max_lines.zig
+++ b/tests/rules/max_lines.zig
@@ -1,0 +1,136 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports max-lines for files with too many lines" {
+    const source =
+        \\const one = 1;
+        \\const two = 2;
+        \\const three = 3;
+    ;
+
+    var options = baseOptions();
+    options.max_lines_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_lines.id));
+    try std.testing.expect(hasMessage(result, "File has too many lines (3). Maximum allowed is 2."));
+}
+
+test "does not count the final trailing linebreak as an extra line" {
+    const source = "const one = 1;\n";
+
+    var options = baseOptions();
+    options.max_lines_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_lines.id));
+}
+
+test "supports max-lines skipBlankLines" {
+    const source =
+        \\const one = 1;
+        \\
+        \\const two = 2;
+    ;
+
+    var strict_options = baseOptions();
+    strict_options.max_lines_max = 2;
+
+    var strict_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", strict_options);
+    defer strict_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(strict_result, lint.rules.max_lines.id));
+
+    var skipped_options = strict_options;
+    skipped_options.max_lines_skip_blank_lines = true;
+
+    var skipped_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", skipped_options);
+    defer skipped_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(skipped_result, lint.rules.max_lines.id));
+}
+
+test "supports max-lines skipComments without skipping inline comments" {
+    const source =
+        \\// header
+        \\const one = 1; // inline
+        \\/* block
+        \\ * comment
+        \\ */
+        \\const two = 2;
+    ;
+
+    var skipped_options = baseOptions();
+    skipped_options.max_lines_max = 2;
+    skipped_options.max_lines_skip_comments = true;
+
+    var skipped_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", skipped_options);
+    defer skipped_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(skipped_result, lint.rules.max_lines.id));
+
+    var strict_options = skipped_options;
+    strict_options.max_lines_max = 1;
+
+    var strict_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", strict_options);
+    defer strict_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(strict_result, lint.rules.max_lines.id));
+}
+
+test "supports max-lines config object" {
+    const source =
+        \\// header
+        \\const one = 1;
+        \\
+        \\const two = 2;
+    ;
+
+    const config =
+        \\["error", { "max": 2, "skipBlankLines": true, "skipComments": true }]
+    ;
+
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("max-lines", parsed.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_lines.id));
+}
+
+test "can disable max-lines" {
+    const source =
+        \\const one = 1;
+        \\const two = 2;
+    ;
+
+    var options = baseOptions();
+    options.max_lines = false;
+    options.max_lines_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_lines.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .max_lines = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_lines.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint-compatible max-lines counting with max, skipBlankLines, and skipComments options
- wire max-lines through config parsing, CLI flags, rule registry, npm compatibility list, and docs
- add focused tests for trailing final linebreak, blank-line skipping, comment-only skipping, config, and disable behavior

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check