### PR TITLE
Add complexity rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -9,6 +9,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
+| [`complexity`](https://eslint.org/docs/latest/rules/complexity) | Supports `max`, deprecated `maximum`, `classic` and `modified` variants, functions, arrow functions, and static blocks |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`consistent-this`](https://eslint.org/docs/latest/rules/consistent-this) | Supports configured aliases for direct `this` captures and same-scope deferred assignment checks |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -85,6 +85,7 @@ const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "block-scoped-var",
   "capitalized-comments",
+  "complexity",
   "consistent-return",
   "consistent-this",
   "constructor-super",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -88,6 +88,7 @@ const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "block-scoped-var",
   "capitalized-comments",
+  "complexity",
   "consistent-return",
   "consistent-this",
   "constructor-super",

--- a/src/core.zig
+++ b/src/core.zig
@@ -86,6 +86,11 @@ pub const LinebreakStyle = enum {
     windows,
 };
 
+pub const ComplexityVariant = enum {
+    classic,
+    modified,
+};
+
 pub const InitDeclarationsMode = enum {
     always,
     never,
@@ -1593,6 +1598,9 @@ pub const Options = struct {
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
     capitalized_comments_ignore_consecutive_comments: CapitalizedCommentsIgnoreConsecutiveComments = .no,
+    complexity: bool = true,
+    complexity_max: usize = 20,
+    complexity_variant: ComplexityVariant = .classic,
     consistent_this: bool = false,
     consistent_this_aliases: ConsistentThisAliases = .{},
     consistent_return: bool = true,
@@ -2353,6 +2361,10 @@ pub const Options = struct {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
             self.capitalized_comments_ignore_consecutive_comments = try capitalizedCommentsIgnoreConsecutiveCommentsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "complexity")) {
+            self.complexity_max = try complexityMaxFromConfig(value);
+            self.complexity_variant = try complexityVariantFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "consistent-return")) {
             self.consistent_return_treat_undefined_as_unspecified = try consistentReturnTreatUndefinedAsUnspecifiedFromConfig(value);
@@ -3262,6 +3274,56 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => return error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn complexityMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return 20,
+        };
+        if (items.len < 2) return 20;
+
+        switch (items[1]) {
+            .integer => |max| return nonNegativeIntegerToUsize(max),
+            .object => |object| {
+                if (object.get("maximum")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                if (object.get("max")) |max_value| {
+                    const max = switch (max_value) {
+                        .integer => |max| max,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    return nonNegativeIntegerToUsize(max);
+                }
+                return 20;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn complexityVariantFromConfig(value: std.json.Value) RuleConfigError!ComplexityVariant {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .classic,
+        };
+        if (items.len < 2) return .classic;
+
+        const object = switch (items[1]) {
+            .object => |object| object,
+            else => return .classic,
+        };
+        const variant = switch (object.get("variant") orelse return .classic) {
+            .string => |variant| variant,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, variant, "classic")) return .classic;
+        if (std.mem.eql(u8, variant, "modified")) return .modified;
+        return error.UnsupportedRuleConfigValue;
     }
 
     fn deprecatedDependenceProfileFromConfig(value: std.json.Value) DeprecatedDependenceProfile {

--- a/src/main.zig
+++ b/src/main.zig
@@ -140,6 +140,14 @@ pub fn main(init: std.process.Init) !void {
             options.capitalized_comments_mode = .never;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments-ignore-inline-comments=on")) {
             options.capitalized_comments_ignore_inline_comments = .yes;
+        } else if (std.mem.eql(u8, arg, "--complexity=off")) {
+            options.complexity = false;
+        } else if (std.mem.startsWith(u8, arg, "--complexity-max=")) {
+            parseComplexityMax(arg["--complexity-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--complexity-variant=classic")) {
+            options.complexity_variant = .classic;
+        } else if (std.mem.eql(u8, arg, "--complexity-variant=modified")) {
+            options.complexity_variant = .modified;
         } else if (std.mem.eql(u8, arg, "--curly=off")) {
             options.curly = false;
         } else if (std.mem.eql(u8, arg, "--dot-notation=off")) {
@@ -1273,6 +1281,14 @@ fn appendConsistentThisAlias(value: []const u8, options: *lint.Options) void {
     options.consistent_this = true;
 }
 
+fn parseComplexityMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --complexity-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.complexity_max = max;
+}
+
 fn parseMaxClassesPerFileMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-classes-per-file-max value: {s}\n", .{value});
@@ -1645,6 +1661,9 @@ fn printHelp() void {
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --capitalized-comments=never Require lowercase comment starts
         \\  --capitalized-comments-ignore-inline-comments=on Ignore inline comments
+        \\  --complexity=off          Disable complexity
+        \\  --complexity-max=N        Set complexity maximum
+        \\  --complexity-variant=modified Use modified switch complexity
         \\  --consistent-return=off  Disable consistent-return
         \\  --consistent-this=off    Disable consistent-this
         \\  --consistent-this=on     Enable consistent-this with default alias

--- a/src/rules/complexity.zig
+++ b/src/rules/complexity.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "complexity";
+
+pub const Variant = enum {
+    classic,
+    modified,
+};
+
+pub const Options = struct {
+    max: usize = 20,
+    variant: Variant = .classic,
+};
+
+const FunctionKind = enum {
+    function,
+    arrow_function,
+    static_block,
+
+    fn label(self: FunctionKind) []const u8 {
+        return switch (self) {
+            .function => "Function",
+            .arrow_function => "Arrow function",
+            .static_block => "Class static block",
+        };
+    }
+};
+
+const Frame = struct {
+    index: ast.NodeIndex,
+    complexity: usize = 1,
+    kind: FunctionKind,
+};
+
+pub const State = struct {
+    frames: std.ArrayList(Frame) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.frames.deinit(allocator);
+    }
+};
+
+pub fn enterFunction(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .function });
+}
+
+pub fn enterArrowFunction(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .arrow_function });
+}
+
+pub fn enterStaticBlock(allocator: Allocator, state: *State, index: ast.NodeIndex) Allocator.Error!void {
+    try state.frames.append(allocator, .{ .index = index, .kind = .static_block });
+}
+
+pub fn exitFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    state: *State,
+    options: Options,
+) Allocator.Error!void {
+    const frame = state.frames.pop() orelse return;
+    if (frame.complexity <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(frame.index),
+        "{s} has a complexity of {d}. Maximum allowed is {d}.",
+        .{ frame.kind.label(), frame.complexity, options.max },
+    );
+}
+
+pub fn increase(state: *State) void {
+    if (state.frames.items.len == 0) return;
+    state.frames.items[state.frames.items.len - 1].complexity += 1;
+}
+
+pub fn countSwitchStatement(state: *State, options: Options) void {
+    if (options.variant == .modified) increase(state);
+}
+
+pub fn countSwitchCase(state: *State, switch_case: ast.SwitchCase, options: Options) void {
+    if (options.variant == .classic and switch_case.@"test" != .null) increase(state);
+}
+
+pub fn countAssignmentExpression(state: *State, expression: ast.AssignmentExpression) void {
+    switch (expression.operator) {
+        .logical_or_assign,
+        .logical_and_assign,
+        .nullish_assign,
+        => increase(state),
+        else => {},
+    }
+}
+
+pub fn countCallExpression(state: *State, call: ast.CallExpression) void {
+    if (call.optional) increase(state);
+}
+
+pub fn countMemberExpression(state: *State, member: ast.MemberExpression) void {
+    if (member.optional) increase(state);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -18,6 +18,7 @@ pub const accessor_pairs = @import("accessor_pairs.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
 pub const capitalized_comments = @import("capitalized_comments.zig");
+pub const complexity = @import("complexity.zig");
 pub const consistent_this = @import("consistent_this.zig");
 pub const consistent_return = @import("consistent_return.zig");
 pub const constructor_super = @import("constructor_super.zig");
@@ -629,6 +630,7 @@ pub fn runBasic(
     defer visitor.react_display_name_state.deinit(allocator);
     defer visitor.react_forbid_prop_types_state.deinit(allocator);
     defer visitor.react_default_props_match_prop_types_state.deinit(allocator);
+    defer visitor.complexity_state.deinit(allocator);
     defer visitor.max_statements_state.deinit(allocator);
     defer visitor.max_nested_callbacks_state.deinit(allocator);
     defer visitor.id_denylist_state.deinit(allocator);
@@ -1138,6 +1140,7 @@ const BasicVisitor = struct {
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
     consistent_this_state: consistent_this.State = .{},
+    complexity_state: complexity.State = .{},
     max_classes_per_file_state: max_classes_per_file.State = .{},
     max_statements_state: max_statements.State = .{},
     max_nested_callbacks_state: max_nested_callbacks.State = .{},
@@ -1171,6 +1174,16 @@ const BasicVisitor = struct {
         return .{
             .names = &self.options.no_restricted_exports_names,
             .restrict_default = self.options.no_restricted_exports_default,
+        };
+    }
+
+    fn complexityOptions(self: *const BasicVisitor) complexity.Options {
+        return .{
+            .max = self.options.complexity_max,
+            .variant = switch (self.options.complexity_variant) {
+                .classic => .classic,
+                .modified => .modified,
+            },
         };
     }
 
@@ -1414,6 +1427,9 @@ const BasicVisitor = struct {
         if (self.options.max_statements) {
             try max_statements.enterFunction(self.allocator, &self.max_statements_state, index);
         }
+        if (self.options.complexity) {
+            try complexity.enterFunction(self.allocator, &self.complexity_state, index);
+        }
         if (self.options.max_nested_callbacks) {
             try max_nested_callbacks.enterFunction(self.allocator, self.diagnostics, ctx.tree, function, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
         }
@@ -1482,6 +1498,9 @@ const BasicVisitor = struct {
     pub fn exit_function(self: *BasicVisitor, _: ast.Function, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
         if (self.options.max_statements) {
             max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
+        if (self.options.complexity) {
+            complexity.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.complexity_state, self.complexityOptions()) catch {};
         }
         if (self.options.max_nested_callbacks) {
             max_nested_callbacks.exitFunction(&self.max_nested_callbacks_state, index);
@@ -1604,6 +1623,9 @@ const BasicVisitor = struct {
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
             try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
+        }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
@@ -1652,6 +1674,9 @@ const BasicVisitor = struct {
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
+        }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
@@ -1677,6 +1702,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkDoWhileStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
@@ -1710,6 +1738,9 @@ const BasicVisitor = struct {
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
+        }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
@@ -1738,6 +1769,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_negated_condition) {
             try no_negated_condition.checkConditionalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         return .proceed;
     }
@@ -1954,6 +1988,9 @@ const BasicVisitor = struct {
                 .ignore_parameters = self.options.typescript_eslint_no_inferrable_types_ignore_parameters,
                 .ignore_properties = self.options.typescript_eslint_no_inferrable_types_ignore_properties,
             });
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         return .proceed;
     }
@@ -2269,6 +2306,9 @@ const BasicVisitor = struct {
         if (self.options.use_isnan) {
             try use_isnan.checkSwitchStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, self.useIsnanOptions());
         }
+        if (self.options.complexity) {
+            complexity.countSwitchStatement(&self.complexity_state, self.complexityOptions());
+        }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
@@ -2289,6 +2329,9 @@ const BasicVisitor = struct {
         }
         if (self.options.use_isnan) {
             try use_isnan.checkSwitchCaseWithOptions(self.allocator, self.diagnostics, ctx.tree, switch_case, self.useIsnanOptions());
+        }
+        if (self.options.complexity) {
+            complexity.countSwitchCase(&self.complexity_state, switch_case, self.complexityOptions());
         }
         return .proceed;
     }
@@ -2319,6 +2362,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, clause.param, false);
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         return .proceed;
     }
@@ -2421,6 +2467,9 @@ const BasicVisitor = struct {
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForInStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
         }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
+        }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
         }
@@ -2438,6 +2487,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_unreachable_loop) {
             try no_unreachable_loop.checkForOfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noUnreachableLoopOptions());
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         if (self.options.max_depth) {
             try max_depth.check(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, self.maxDepthOptions());
@@ -2539,6 +2591,9 @@ const BasicVisitor = struct {
         if (self.options.max_statements) {
             try max_statements.enterStaticBlock(self.allocator, &self.max_statements_state, index);
         }
+        if (self.options.complexity) {
+            try complexity.enterStaticBlock(self.allocator, &self.complexity_state, index);
+        }
         if (self.options.no_empty_block_statements) {
             try no_empty_block_statements.checkStaticBlock(self.allocator, self.diagnostics, ctx.tree, block, index);
         }
@@ -2551,6 +2606,9 @@ const BasicVisitor = struct {
     pub fn exit_static_block(self: *BasicVisitor, _: ast.StaticBlock, _: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
         if (self.options.max_statements) {
             max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
+        if (self.options.complexity) {
+            complexity.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.complexity_state, self.complexityOptions()) catch {};
         }
     }
 
@@ -2727,6 +2785,9 @@ const BasicVisitor = struct {
         if (self.options.max_statements) {
             try max_statements.enterArrowFunction(self.allocator, &self.max_statements_state, index);
         }
+        if (self.options.complexity) {
+            try complexity.enterArrowFunction(self.allocator, &self.complexity_state, index);
+        }
         if (self.options.max_nested_callbacks) {
             try max_nested_callbacks.enterArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
         }
@@ -2782,6 +2843,9 @@ const BasicVisitor = struct {
     pub fn exit_arrow_function_expression(self: *BasicVisitor, _: ast.ArrowFunctionExpression, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) void {
         if (self.options.max_statements) {
             max_statements.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.max_statements_state, self.maxStatementsOptions()) catch {};
+        }
+        if (self.options.complexity) {
+            complexity.exitFunction(self.allocator, self.diagnostics, ctx.tree, &self.complexity_state, self.complexityOptions()) catch {};
         }
         if (self.options.max_nested_callbacks) {
             max_nested_callbacks.exitFunction(&self.max_nested_callbacks_state, index);
@@ -2871,6 +2935,9 @@ const BasicVisitor = struct {
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
+        if (self.options.complexity) {
+            complexity.countAssignmentExpression(&self.complexity_state, expression);
+        }
         return .proceed;
     }
 
@@ -2882,6 +2949,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.logical_assignment_operators and self.options.logical_assignment_operators_style == .always) {
             try logical_assignment_operators.checkLogicalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+        }
+        if (self.options.complexity) {
+            complexity.increase(&self.complexity_state);
         }
         return .proceed;
     }
@@ -3166,6 +3236,9 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_array_constructor) {
             try typescript_eslint_no_array_constructor.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
         }
+        if (self.options.complexity) {
+            complexity.countCallExpression(&self.complexity_state, call);
+        }
         return .proceed;
     }
 
@@ -3298,6 +3371,9 @@ const BasicVisitor = struct {
         }
         if (self.options.typescript_eslint_no_extra_non_null_assertion) {
             try typescript_eslint_no_extra_non_null_assertion.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);
+        }
+        if (self.options.complexity) {
+            complexity.countMemberExpression(&self.complexity_state, member);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -15,6 +15,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/complexity.zig");
+}
+
+comptime {
     _ = @import("rules/consistent_return.zig");
 }
 

--- a/tests/rules/complexity.zig
+++ b/tests/rules/complexity.zig
@@ -1,0 +1,161 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports complexity above the configured maximum" {
+    const source =
+        \\function run(value) {
+        \\  if (value) {
+        \\    while (value.ready) {
+        \\      value.next();
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.complexity_max = 2;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.complexity.id));
+    try std.testing.expect(hasMessage(result, "Function has a complexity of 3. Maximum allowed is 2."));
+}
+
+test "counts expression branches and optional chaining" {
+    const source =
+        \\const run = (value = fallback, obj) => {
+        \\  if (value && obj?.ready) {
+        \\    value ||= other ? one() : two();
+        \\  }
+        \\  return obj?.call?.();
+        \\};
+    ;
+
+    var options = baseOptions();
+    options.complexity_max = 6;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.complexity.id));
+    try std.testing.expect(hasMessage(result, "Arrow function has a complexity of 9. Maximum allowed is 6."));
+}
+
+test "supports classic and modified switch variants" {
+    const source =
+        \\function run(value) {
+        \\  switch (value) {
+        \\    case 1:
+        \\      break;
+        \\    case 2:
+        \\      break;
+        \\    default:
+        \\      break;
+        \\  }
+        \\}
+    ;
+
+    var classic_options = baseOptions();
+    classic_options.complexity_max = 2;
+
+    var classic_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", classic_options);
+    defer classic_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(classic_result, lint.rules.complexity.id));
+
+    var modified_options = classic_options;
+    modified_options.complexity_variant = .modified;
+
+    var modified_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", modified_options);
+    defer modified_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(modified_result, lint.rules.complexity.id));
+}
+
+test "supports complexity config object and deprecated maximum" {
+    const source =
+        \\function run(value) {
+        \\  if (value) {
+        \\    return one();
+        \\  }
+        \\  return two();
+        \\}
+    ;
+
+    const config =
+        \\["error", { "maximum": 1, "variant": "modified" }]
+    ;
+
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("complexity", parsed.value);
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.complexity.id));
+    try std.testing.expectEqualStrings("modified", @tagName(options.complexity_variant));
+}
+
+test "reports class static block complexity" {
+    const source =
+        \\class Example {
+        \\  static {
+        \\    if (ready) {
+        \\      work();
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.complexity_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.complexity.id));
+    try std.testing.expect(hasMessage(result, "Class static block has a complexity of 2. Maximum allowed is 1."));
+}
+
+test "can disable complexity" {
+    const source =
+        \\function run(value) {
+        \\  if (value) {
+        \\    return one();
+        \\  }
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.complexity = false;
+    options.complexity_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.complexity.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .complexity = true,
+        .curly = false,
+        .max_depth = false,
+        .max_statements = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.complexity.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint-compatible complexity tracking for functions, arrow functions, and class static blocks
- support numeric max, max/maximum config objects, and classic/modified switch variants
- wire complexity through CLI options, config parsing, rule registry, npm compatibility list, docs, and focused tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check