### PR TITLE
Add no-useless-backreference rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -164,6 +164,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreClassWithStaticInitBlock`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-useless-backreference`](https://eslint.org/docs/latest/rules/no-useless-backreference) | Detects nested, forward, disjunctive, and negative-lookaround backreferences in regex literals and static `RegExp` constructors |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
 | [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -228,6 +228,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",
+  "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",
   "no-useless-computed-key",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -231,6 +231,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",
+  "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",
   "no-useless-computed-key",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1960,6 +1960,7 @@ pub const Options = struct {
     no_unsafe_optional_chaining_disallow_arithmetic_operators: bool = false,
     no_useless_computed_key: bool = true,
     no_useless_computed_key_enforce_for_class_members: NoUselessComputedKeyEnforceForClassMembers = .yes,
+    no_useless_backreference: bool = true,
     no_useless_call: bool = true,
     no_useless_concat: bool = true,
     no_useless_constructor: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -627,6 +627,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_computed_key = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-computed-key-enforce-for-class-members=off")) {
             options.no_useless_computed_key_enforce_for_class_members = .no;
+        } else if (std.mem.eql(u8, arg, "--no-useless-backreference=off")) {
+            options.no_useless_backreference = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-call=off")) {
             options.no_useless_call = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-concat=off")) {
@@ -1926,6 +1928,7 @@ fn printHelp() void {
         \\  --no-unsafe-optional-chaining-disallow-arithmetic-operators=on Report optional chains in arithmetic operators
         \\  --no-useless-computed-key=off Disable no-useless-computed-key
         \\  --no-useless-computed-key-enforce-for-class-members=off Disable class member checks
+        \\  --no-useless-backreference=off Disable no-useless-backreference
         \\  --no-useless-call=off     Disable no-useless-call
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-constructor=off Disable no-useless-constructor

--- a/src/root.zig
+++ b/src/root.zig
@@ -165,6 +165,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_undef or
         options.react_jsx_no_undef or
         options.no_unused_vars or
+        options.no_useless_backreference or
         options.no_use_before_define or
         options.prefer_const or
         options.prefer_exponentiation_operator or

--- a/src/rules/no_useless_backreference.zig
+++ b/src/rules/no_useless_backreference.zig
@@ -1,0 +1,398 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-useless-backreference";
+
+const max_groups = 128;
+const max_backreferences = 128;
+const max_scopes = 128;
+
+const ProblemKind = enum {
+    nested,
+    forward,
+    disjunctive,
+    into_negative_lookaround,
+};
+
+const Scope = struct {
+    capture: ?usize = null,
+    alternative: usize,
+    negative_lookaround: bool = false,
+};
+
+const Group = struct {
+    start: usize,
+    end: usize = 0,
+    alternative: usize,
+    negative_lookaround: bool,
+};
+
+const Backreference = struct {
+    start: usize,
+    end: usize,
+    target: usize,
+    alternative: usize,
+    negative_lookaround: bool,
+    nested: bool,
+};
+
+const Problem = struct {
+    kind: ProblemKind,
+    backreference: Backreference,
+    group: Group,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, call.callee, call.arguments, index);
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, expression.callee, expression.arguments, index);
+        return .proceed;
+    }
+
+    fn checkConstructor(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+        argument_range: ast.IndexRange,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(argument_range);
+        if (arguments.len == 0) return;
+        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+
+        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
+        try checkPattern(self.allocator, self.diagnostics, tree, index, pattern);
+    }
+};
+
+pub fn checkRegExpLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkPattern(allocator, diagnostics, tree, index, tree.string(literal.pattern));
+}
+
+fn checkPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    pattern: []const u8,
+) Allocator.Error!void {
+    var scanner = Scanner{};
+    scanner.scan(pattern);
+
+    for (scanner.backreferences[0..scanner.backreference_count]) |backreference| {
+        const problem = scanner.problemFor(backreference) orelse continue;
+        try addDiagnostic(allocator, diagnostics, tree, index, pattern, problem);
+    }
+}
+
+const Scanner = struct {
+    groups: [max_groups]Group = undefined,
+    group_count: usize = 0,
+    backreferences: [max_backreferences]Backreference = undefined,
+    backreference_count: usize = 0,
+    scopes: [max_scopes]Scope = undefined,
+    scope_count: usize = 0,
+    next_alternative: usize = 1,
+
+    fn scan(self: *Scanner, pattern: []const u8) void {
+        self.scopes[0] = .{ .alternative = 0 };
+        self.scope_count = 1;
+
+        var index: usize = 0;
+        var in_class = false;
+        while (index < pattern.len) : (index += 1) {
+            const char = pattern[index];
+            if (char == '\\') {
+                if (index + 1 >= pattern.len) return;
+                if (!in_class and std.ascii.isDigit(pattern[index + 1]) and pattern[index + 1] != '0') {
+                    index = self.addBackreference(pattern, index);
+                } else {
+                    index += 1;
+                }
+                continue;
+            }
+
+            if (in_class) {
+                if (char == ']') in_class = false;
+                continue;
+            }
+
+            switch (char) {
+                '[' => in_class = true,
+                '(' => index = self.enterGroup(pattern, index),
+                ')' => self.exitGroup(index + 1),
+                '|' => self.rotateAlternative(),
+                else => {},
+            }
+        }
+    }
+
+    fn addBackreference(self: *Scanner, pattern: []const u8, slash_index: usize) usize {
+        var digit_end = slash_index + 1;
+        var target: usize = 0;
+        while (digit_end < pattern.len and std.ascii.isDigit(pattern[digit_end])) : (digit_end += 1) {
+            target = target * 10 + (pattern[digit_end] - '0');
+        }
+
+        if (self.backreference_count < max_backreferences) {
+            self.backreferences[self.backreference_count] = .{
+                .start = slash_index,
+                .end = digit_end,
+                .target = target,
+                .alternative = self.currentAlternative(),
+                .negative_lookaround = self.inNegativeLookaround(),
+                .nested = self.isOpenCapture(target),
+            };
+            self.backreference_count += 1;
+        }
+
+        return digit_end - 1;
+    }
+
+    fn enterGroup(self: *Scanner, pattern: []const u8, open_index: usize) usize {
+        var capturing = true;
+        var negative_lookaround = false;
+        var skip_to = open_index;
+
+        if (open_index + 1 < pattern.len and pattern[open_index + 1] == '?') {
+            capturing = false;
+            if (open_index + 2 < pattern.len) {
+                switch (pattern[open_index + 2]) {
+                    ':' => skip_to = open_index + 2,
+                    '=' => skip_to = open_index + 2,
+                    '!' => {
+                        negative_lookaround = true;
+                        skip_to = open_index + 2;
+                    },
+                    '<' => {
+                        if (open_index + 3 < pattern.len and (pattern[open_index + 3] == '=' or pattern[open_index + 3] == '!')) {
+                            negative_lookaround = pattern[open_index + 3] == '!';
+                            skip_to = open_index + 3;
+                        } else {
+                            capturing = true;
+                            skip_to = skipNamedCapturePrefix(pattern, open_index + 2);
+                        }
+                    },
+                    else => skip_to = open_index + 2,
+                }
+            }
+        }
+
+        var capture_id: ?usize = null;
+        if (capturing and self.group_count < max_groups) {
+            capture_id = self.group_count + 1;
+            self.groups[self.group_count] = .{
+                .start = open_index,
+                .alternative = self.currentAlternative(),
+                .negative_lookaround = self.inNegativeLookaround() or negative_lookaround,
+            };
+            self.group_count += 1;
+        }
+
+        if (self.scope_count < max_scopes) {
+            self.scopes[self.scope_count] = .{
+                .capture = capture_id,
+                .alternative = self.nextAlternative(),
+                .negative_lookaround = negative_lookaround,
+            };
+            self.scope_count += 1;
+        }
+
+        return skip_to;
+    }
+
+    fn exitGroup(self: *Scanner, end: usize) void {
+        if (self.scope_count <= 1) return;
+        const scope = self.scopes[self.scope_count - 1];
+        if (scope.capture) |capture_id| {
+            if (capture_id > 0 and capture_id <= self.group_count) {
+                self.groups[capture_id - 1].end = end;
+            }
+        }
+        self.scope_count -= 1;
+    }
+
+    fn rotateAlternative(self: *Scanner) void {
+        if (self.scope_count == 0) return;
+        self.scopes[self.scope_count - 1].alternative = self.nextAlternative();
+    }
+
+    fn nextAlternative(self: *Scanner) usize {
+        const alternative = self.next_alternative;
+        self.next_alternative += 1;
+        return alternative;
+    }
+
+    fn currentAlternative(self: *const Scanner) usize {
+        if (self.scope_count == 0) return 0;
+        return self.scopes[self.scope_count - 1].alternative;
+    }
+
+    fn inNegativeLookaround(self: *const Scanner) bool {
+        for (self.scopes[0..self.scope_count]) |scope| {
+            if (scope.negative_lookaround) return true;
+        }
+        return false;
+    }
+
+    fn isOpenCapture(self: *const Scanner, target: usize) bool {
+        for (self.scopes[0..self.scope_count]) |scope| {
+            if (scope.capture != null and scope.capture.? == target) return true;
+        }
+        return false;
+    }
+
+    fn problemFor(self: *const Scanner, backreference: Backreference) ?Problem {
+        if (backreference.target == 0 or backreference.target > self.group_count) return null;
+        const group = self.groups[backreference.target - 1];
+        if (group.end == 0) return null;
+
+        if (backreference.nested) {
+            return .{ .kind = .nested, .backreference = backreference, .group = group };
+        }
+        if (backreference.end <= group.start) {
+            return .{ .kind = .forward, .backreference = backreference, .group = group };
+        }
+        if (group.negative_lookaround and !backreference.negative_lookaround) {
+            return .{ .kind = .into_negative_lookaround, .backreference = backreference, .group = group };
+        }
+        if (group.alternative != backreference.alternative) {
+            return .{ .kind = .disjunctive, .backreference = backreference, .group = group };
+        }
+        return null;
+    }
+};
+
+fn skipNamedCapturePrefix(pattern: []const u8, less_than_index: usize) usize {
+    var index = less_than_index + 1;
+    while (index < pattern.len) : (index += 1) {
+        if (pattern[index] == '>') return index;
+    }
+    return less_than_index;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    pattern: []const u8,
+    problem: Problem,
+) Allocator.Error!void {
+    const backreference = pattern[problem.backreference.start..problem.backreference.end];
+    const group = pattern[problem.group.start..problem.group.end];
+    const reason = switch (problem.kind) {
+        .nested => "from within that group",
+        .forward => "which appears later in the pattern",
+        .disjunctive => "which is in another alternative",
+        .into_negative_lookaround => "which is in a negative lookaround",
+    };
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Backreference '{s}' will be ignored. It references group '{s}' {s}.",
+        .{ backreference, group, reason },
+    );
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -219,6 +219,7 @@ pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_unsafe_optional_chaining = @import("no_unsafe_optional_chaining.zig");
 pub const no_useless_computed_key = @import("no_useless_computed_key.zig");
+pub const no_useless_backreference = @import("no_useless_backreference.zig");
 pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_useless_constructor = @import("no_useless_constructor.zig");
@@ -914,6 +915,10 @@ pub fn runSemantic(
 
     if (options.no_misleading_character_class) {
         try no_misleading_character_class.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.no_useless_backreference) {
+        try no_useless_backreference.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     const use_typescript_no_loop_func = options.typescript_eslint_no_loop_func and tree.isTs();
@@ -4073,6 +4078,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_regex_spaces) {
             try no_regex_spaces.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.no_useless_backreference) {
+            try no_useless_backreference.checkRegExpLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.require_unicode_regexp) {
             try require_unicode_regexp.checkRegExpLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, .{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -823,6 +823,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_backreference.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_call.zig");
 }
 

--- a/tests/rules/no_useless_backreference.zig
+++ b/tests/rules/no_useless_backreference.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-useless-backreference for nested and forward references" {
+    const source =
+        \\const nested = /((a)\1)/;
+        \\const forward = /\1(a)/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_backreference.id));
+    try std.testing.expect(hasMessage(result, "from within that group"));
+    try std.testing.expect(hasMessage(result, "which appears later in the pattern"));
+}
+
+test "reports no-useless-backreference across alternatives and negative lookaround" {
+    const source =
+        \\const disjunctive = /(a)|\1/;
+        \\const negative = /(?!(a))\1/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_backreference.id));
+    try std.testing.expect(hasMessage(result, "which is in another alternative"));
+    try std.testing.expect(hasMessage(result, "which is in a negative lookaround"));
+}
+
+test "does not report useful backreferences" {
+    const source =
+        \\const simple = /(a)\1/;
+        \\const named = /(?<word>a)\1/;
+        \\const missing = /(a)\2/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_backreference.id));
+}
+
+test "reports no-useless-backreference for static RegExp constructors" {
+    const source =
+        \\RegExp("\\1(a)");
+        \\new RegExp("(a)|\\1");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_useless_backreference.id));
+}
+
+test "does not report shadowed or dynamic RegExp constructors" {
+    const source =
+        \\function local(RegExp, pattern) {
+        \\  RegExp("\\1(a)");
+        \\  new RegExp(pattern);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_backreference.id));
+}
+
+test "can disable no-useless-backreference" {
+    const source =
+        \\const forward = /\1(a)/;
+    ;
+
+    var options = baseOptions();
+    options.no_useless_backreference = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_backreference.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .prefer_regex_literals = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_useless_backreference.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add no-useless-backreference checks for regex literals and static global RegExp constructors
- detect nested, forward, disjunctive, and negative-lookaround backreferences
- wire the rule through options, CLI, semantic trigger, npm rule metadata, docs, and focused tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check