### PR TITLE
Add prefer-named-capture-group rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -183,6 +183,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
+| [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -247,6 +247,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-named-capture-group",
   "prefer-numeric-literals",
   "prefer-object-has-own",
   "prefer-object-spread",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -250,6 +250,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",
+  "prefer-named-capture-group",
   "prefer-numeric-literals",
   "prefer-object-has-own",
   "prefer-object-spread",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2028,6 +2028,7 @@ pub const Options = struct {
     prefer_const_destructuring: PreferConstDestructuring = .any,
     prefer_const_ignore_read_before_assign: bool = true,
     prefer_exponentiation_operator: bool = true,
+    prefer_named_capture_group: bool = false,
     prefer_numeric_literals: bool = true,
     prefer_object_has_own: bool = true,
     prefer_promise_reject_errors: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -739,6 +739,10 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_const_destructuring = .all;
         } else if (std.mem.eql(u8, arg, "--prefer-exponentiation-operator=off")) {
             options.prefer_exponentiation_operator = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-named-capture-group=on")) {
+            options.prefer_named_capture_group = true;
+        } else if (std.mem.eql(u8, arg, "--prefer-named-capture-group=off")) {
+            options.prefer_named_capture_group = false;
         } else if (std.mem.eql(u8, arg, "--prefer-numeric-literals=off")) {
             options.prefer_numeric_literals = false;
         } else if (std.mem.eql(u8, arg, "--prefer-promise-reject-errors=off")) {
@@ -1961,6 +1965,8 @@ fn printHelp() void {
         \\  --prefer-const=off        Disable prefer-const
         \\  --prefer-const-destructuring=all Require all destructured bindings to be const candidates
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator
+        \\  --prefer-named-capture-group=on Enable prefer-named-capture-group
+        \\  --prefer-named-capture-group=off Disable prefer-named-capture-group
         \\  --prefer-numeric-literals=off Disable prefer-numeric-literals
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
         \\  --prefer-destructuring=off Disable prefer-destructuring

--- a/src/root.zig
+++ b/src/root.zig
@@ -169,6 +169,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_use_before_define or
         options.prefer_const or
         options.prefer_exponentiation_operator or
+        options.prefer_named_capture_group or
         options.prefer_numeric_literals or
         options.prefer_object_has_own or
         options.prefer_object_spread or

--- a/src/rules/prefer_named_capture_group.zig
+++ b/src/rules/prefer_named_capture_group.zig
@@ -1,0 +1,251 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-named-capture-group";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, call.callee, call.arguments, index);
+        return .proceed;
+    }
+
+    pub fn enter_new_expression(
+        self: *Visitor,
+        expression: ast.NewExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.checkConstructor(ctx.tree, expression.callee, expression.arguments, index);
+        return .proceed;
+    }
+
+    fn checkConstructor(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        callee: ast.NodeIndex,
+        argument_range: ast.IndexRange,
+        index: ast.NodeIndex,
+    ) Allocator.Error!void {
+        const arguments = tree.extra(argument_range);
+        if (arguments.len == 0) return;
+        if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
+
+        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
+        try checkPattern(self.allocator, self.diagnostics, tree, index, pattern);
+    }
+};
+
+pub fn checkRegExpLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.RegExpLiteral,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkPattern(allocator, diagnostics, tree, index, tree.string(literal.pattern));
+}
+
+fn checkPattern(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    pattern: []const u8,
+) Allocator.Error!void {
+    var scanner = Scanner{};
+    scanner.scan(pattern);
+
+    for (scanner.groups[0..scanner.group_count]) |group| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Capture group '{s}' should be converted to a named or non-capturing group.",
+            .{pattern[group.start..group.end]},
+        );
+    }
+}
+
+const Group = struct {
+    start: usize,
+    end: usize,
+};
+
+const max_groups = 128;
+
+const Scanner = struct {
+    groups: [max_groups]Group = undefined,
+    group_count: usize = 0,
+
+    fn scan(self: *Scanner, pattern: []const u8) void {
+        var index: usize = 0;
+        var in_class = false;
+        while (index < pattern.len) : (index += 1) {
+            const char = pattern[index];
+            if (char == '\\') {
+                if (index + 1 >= pattern.len) return;
+                index += 1;
+                continue;
+            }
+
+            if (in_class) {
+                if (char == ']') in_class = false;
+                continue;
+            }
+
+            switch (char) {
+                '[' => in_class = true,
+                '(' => index = self.maybeAddCapture(pattern, index),
+                else => {},
+            }
+        }
+    }
+
+    fn maybeAddCapture(self: *Scanner, pattern: []const u8, open_index: usize) usize {
+        if (open_index + 1 < pattern.len and pattern[open_index + 1] == '?') {
+            if (open_index + 2 >= pattern.len) return open_index + 1;
+            switch (pattern[open_index + 2]) {
+                ':' => return open_index + 2,
+                '=' => return open_index + 2,
+                '!' => return open_index + 2,
+                '<' => {
+                    if (open_index + 3 < pattern.len and (pattern[open_index + 3] == '=' or pattern[open_index + 3] == '!')) {
+                        return open_index + 3;
+                    }
+                    return skipNamedCapturePrefix(pattern, open_index + 2);
+                },
+                else => return open_index + 2,
+            }
+        }
+
+        if (self.group_count < max_groups) {
+            self.groups[self.group_count] = .{
+                .start = open_index,
+                .end = findGroupEnd(pattern, open_index),
+            };
+            self.group_count += 1;
+        }
+        return open_index;
+    }
+};
+
+fn findGroupEnd(pattern: []const u8, open_index: usize) usize {
+    var index = open_index + 1;
+    var depth: usize = 1;
+    var in_class = false;
+    while (index < pattern.len) : (index += 1) {
+        const char = pattern[index];
+        if (char == '\\') {
+            if (index + 1 >= pattern.len) return pattern.len;
+            index += 1;
+            continue;
+        }
+        if (in_class) {
+            if (char == ']') in_class = false;
+            continue;
+        }
+        switch (char) {
+            '[' => in_class = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if (depth == 0) return index + 1;
+            },
+            else => {},
+        }
+    }
+    return pattern.len;
+}
+
+fn skipNamedCapturePrefix(pattern: []const u8, less_than_index: usize) usize {
+    var index = less_than_index + 1;
+    while (index < pattern.len) : (index += 1) {
+        if (pattern[index] == '>') return index;
+    }
+    return less_than_index;
+}
+
+fn isGlobalRegExpReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    const name = identifierReferenceName(tree, unwrapped) orelse return false;
+    return std.mem.eql(u8, name, "RegExp") and isUnresolvedReference(symbol_table, unwrapped);
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -242,6 +242,7 @@ pub const operator_assignment = @import("operator_assignment.zig");
 pub const prefer_const = @import("prefer_const.zig");
 pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
+pub const prefer_named_capture_group = @import("prefer_named_capture_group.zig");
 pub const prefer_numeric_literals = @import("prefer_numeric_literals.zig");
 pub const prefer_object_has_own = @import("prefer_object_has_own.zig");
 pub const prefer_object_spread = @import("prefer_object_spread.zig");
@@ -1003,6 +1004,10 @@ pub fn runSemantic(
         try prefer_regex_literals.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .disallow_redundant_wrapping = options.prefer_regex_literals_disallow_redundant_wrapping,
         });
+    }
+
+    if (options.prefer_named_capture_group) {
+        try prefer_named_capture_group.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.prefer_numeric_literals) {
@@ -4081,6 +4086,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_useless_backreference) {
             try no_useless_backreference.checkRegExpLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
+        }
+        if (self.options.prefer_named_capture_group) {
+            try prefer_named_capture_group.checkRegExpLiteral(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
         if (self.options.require_unicode_regexp) {
             try require_unicode_regexp.checkRegExpLiteralWithOptions(self.allocator, self.diagnostics, ctx.tree, literal, index, .{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -911,6 +911,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_named_capture_group.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_numeric_literals.zig");
 }
 

--- a/tests/rules/prefer_named_capture_group.zig
+++ b/tests/rules/prefer_named_capture_group.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports unnamed capture groups in regex literals" {
+    const source =
+        \\const first = /(foo)/;
+        \\const second = /(?:foo)(bar)(?<baz>baz)/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_named_capture_group.id));
+    try std.testing.expect(hasMessage(result, "Capture group '(foo)' should be converted"));
+    try std.testing.expect(hasMessage(result, "Capture group '(bar)' should be converted"));
+}
+
+test "does not report named or non-capturing groups" {
+    const source =
+        \\const named = /(?<name>foo)/;
+        \\const nonCapturing = /(?:foo)(?=bar)(?!baz)(?<=qux)(?<!quux)/;
+        \\const characterClass = /[(]/;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_named_capture_group.id));
+}
+
+test "reports static RegExp constructors and ignores shadowed constructors" {
+    const source =
+        \\RegExp("(foo)");
+        \\new RegExp("(?<name>foo)");
+        \\function local(RegExp) {
+        \\  RegExp("(bar)");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.prefer_named_capture_group.id));
+}
+
+test "can disable prefer-named-capture-group" {
+    const source =
+        \\const first = /(foo)/;
+    ;
+
+    var options = baseOptions();
+    options.prefer_named_capture_group = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_named_capture_group.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .prefer_named_capture_group = true,
+        .prefer_regex_literals = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_named_capture_group.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add prefer-named-capture-group checks for regex literals and static global RegExp constructors
- keep the stylistic rule disabled by default while allowing config/CLI opt-in
- wire the rule through options, CLI, semantic trigger, npm rule metadata, docs, and focused tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check
