### PR TITLE
Add sort-vars rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -197,6 +197,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-atomic-updates`](https://eslint.org/docs/latest/rules/require-atomic-updates) | Supports `allowProperties` configuration |
 | [`require-unicode-regexp`](https://eslint.org/docs/latest/rules/require-unicode-regexp) | Supports regexp literals, static `RegExp` constructors, and `requireFlag` configuration |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
+| [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting and `ignoreCase` configuration |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -260,6 +260,7 @@ const BUILTIN_RULE_IDS = [
   "require-await",
   "require-atomic-updates",
   "require-yield",
+  "sort-vars",
   "spaced-comment",
   "symbol-description",
   "unicode-bom",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -263,6 +263,7 @@ const BUILTIN_RULE_IDS = [
   "require-await",
   "require-atomic-updates",
   "require-yield",
+  "sort-vars",
   "spaced-comment",
   "symbol-description",
   "unicode-bom",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2144,6 +2144,8 @@ pub const Options = struct {
     require_unicode_regexp: bool = true,
     require_unicode_regexp_require_flag: RequireUnicodeRegexpRequireFlag = .any,
     require_yield: bool = true,
+    sort_vars: bool = false,
+    sort_vars_ignore_case: bool = false,
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
     spaced_comment_markers: SpacedCommentMarkers = .{},
@@ -2705,6 +2707,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "require-unicode-regexp")) {
             self.require_unicode_regexp_require_flag = try requireUnicodeRegexpRequireFlagFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "sort-vars")) {
+            self.sort_vars_ignore_case = try sortVarsIgnoreCaseFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-return-assign")) {
             self.no_return_assign_style = try noReturnAssignStyleFromConfig(value);
@@ -5733,6 +5738,23 @@ pub const Options = struct {
         if (std.mem.eql(u8, require_flag, "u")) return .u;
         if (std.mem.eql(u8, require_flag, "v")) return .v;
         return error.UnsupportedRuleConfigValue;
+    }
+
+    fn sortVarsIgnoreCaseFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("ignoreCase") orelse return false) {
+            .bool => |ignore_case| ignore_case,
+            else => error.UnsupportedRuleConfigValue,
+        };
     }
 
     fn noSequencesAllowInParenthesesFromConfig(value: std.json.Value) RuleConfigError!NoSequencesAllowInParentheses {
@@ -9237,6 +9259,17 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("require-unicode-regexp", require_unicode_regexp_config.value);
     try std.testing.expect(options.require_unicode_regexp);
     try std.testing.expectEqual(RequireUnicodeRegexpRequireFlag.v, options.require_unicode_regexp_require_flag);
+
+    var sort_vars_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignoreCase\":true}]",
+        .{},
+    );
+    defer sort_vars_config.deinit();
+    try options.setByRuleConfigValue("sort-vars", sort_vars_config.value);
+    try std.testing.expect(options.sort_vars);
+    try std.testing.expect(options.sort_vars_ignore_case);
 
     var no_useless_rename_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -857,6 +857,13 @@ pub fn main(init: std.process.Init) !void {
             options.require_unicode_regexp_require_flag = .v;
         } else if (std.mem.eql(u8, arg, "--require-yield=off")) {
             options.require_yield = false;
+        } else if (std.mem.eql(u8, arg, "--sort-vars=on")) {
+            options.sort_vars = true;
+        } else if (std.mem.eql(u8, arg, "--sort-vars=off")) {
+            options.sort_vars = false;
+        } else if (std.mem.eql(u8, arg, "--sort-vars-ignore-case=on")) {
+            options.sort_vars = true;
+            options.sort_vars_ignore_case = true;
         } else if (std.mem.eql(u8, arg, "--spaced-comment=off")) {
             options.spaced_comment = false;
         } else if (std.mem.eql(u8, arg, "--spaced-comment=never")) {
@@ -2024,6 +2031,9 @@ fn printHelp() void {
         \\  --require-unicode-regexp-require-flag=u Require the u flag for regexps
         \\  --require-unicode-regexp-require-flag=v Require the v flag for regexps
         \\  --require-yield=off       Disable require-yield
+        \\  --sort-vars=on            Enable sort-vars
+        \\  --sort-vars=off           Disable sort-vars
+        \\  --sort-vars-ignore-case=on Enable sort-vars and ignore case
         \\  --spaced-comment=off      Disable spaced-comment
         \\  --spaced-comment=never    Disallow spacing after comment markers
         \\  --symbol-description=off  Disable symbol-description

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -298,6 +298,7 @@ pub const require_atomic_updates = @import("require_atomic_updates.zig");
 pub const require_unicode_regexp = @import("require_unicode_regexp.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
+pub const sort_vars = @import("sort_vars.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const symbol_description = @import("symbol_description.zig");
 pub const typescript_eslint_adjacent_overload_signatures = @import("typescript_eslint_adjacent_overload_signatures.zig");
@@ -2686,6 +2687,11 @@ const BasicVisitor = struct {
                 .check_var = self.options.one_var_check_var,
                 .check_let = self.options.one_var_check_let,
                 .check_const = self.options.one_var_check_const,
+            });
+        }
+        if (self.options.sort_vars) {
+            try sort_vars.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, .{
+                .ignore_case = self.options.sort_vars_ignore_case,
             });
         }
         if (self.options.typescript_eslint_typedef and (self.options.typescript_eslint_typedef_variable_declaration or

--- a/src/rules/sort_vars.zig
+++ b/src/rules/sort_vars.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "sort-vars";
+
+pub const Options = struct {
+    ignore_case: bool = false,
+};
+
+pub fn checkVariableDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    options: Options,
+) Allocator.Error!void {
+    var previous_name: ?[]const u8 = null;
+
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => continue,
+        };
+        const name = bindingIdentifierName(tree, declarator.id) orelse continue;
+
+        if (previous_name) |previous| {
+            if (compareNames(name, previous, options.ignore_case) < 0) {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Variables within the same declaration block should be sorted alphabetically.",
+                    tree.span(declarator.id),
+                );
+                continue;
+            }
+        }
+
+        previous_name = name;
+    }
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn compareNames(left: []const u8, right: []const u8, ignore_case: bool) i8 {
+    const min_len = @min(left.len, right.len);
+    for (0..min_len) |index| {
+        const left_char = normalizeChar(left[index], ignore_case);
+        const right_char = normalizeChar(right[index], ignore_case);
+        if (left_char < right_char) return -1;
+        if (left_char > right_char) return 1;
+    }
+
+    if (left.len < right.len) return -1;
+    if (left.len > right.len) return 1;
+    return 0;
+}
+
+fn normalizeChar(char: u8, ignore_case: bool) u8 {
+    return if (ignore_case) std.ascii.toLower(char) else char;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -899,6 +899,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/sort_vars.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_const.zig");
 }
 

--- a/tests/rules/sort_vars.zig
+++ b/tests/rules/sort_vars.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports unsorted variables in the same declaration" {
+    const source =
+        \\let alpha, beta;
+        \\const zebra = 1, apple = 2, carrot = 3;
+        \\var delta, charlie, echo;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.sort_vars.id));
+    try std.testing.expect(hasMessage(result, "Variables within the same declaration block should be sorted alphabetically."));
+}
+
+test "keeps later comparisons anchored to the last sorted variable" {
+    const source =
+        \\let c, d, a, b, e;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.sort_vars.id));
+}
+
+test "supports ignoreCase" {
+    const source =
+        \\let B, a;
+    ;
+
+    var sensitive_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer sensitive_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(sensitive_result, lint.rules.sort_vars.id));
+
+    var options = baseOptions();
+    options.sort_vars_ignore_case = true;
+    var insensitive_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer insensitive_result.deinit(std.testing.allocator);
+    try std.testing.expect(helpers.hasRule(insensitive_result, lint.rules.sort_vars.id));
+}
+
+test "ignores destructuring declarators and can disable rule" {
+    const source =
+        \\let z, { a } = value, y;
+    ;
+
+    var enabled_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer enabled_result.deinit(std.testing.allocator);
+    try std.testing.expect(helpers.hasRule(enabled_result, lint.rules.sort_vars.id));
+
+    var options = baseOptions();
+    options.sort_vars = false;
+    var disabled_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer disabled_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(disabled_result, lint.rules.sort_vars.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .one_var = false,
+        .parser_semantic_errors = false,
+        .sort_vars = true,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.sort_vars.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add sort-vars checks for simple identifiers within the same variable declaration block
- keep the stylistic rule disabled by default while supporting config/CLI opt-in
- support the ESLint `ignoreCase` option and wire docs, npm metadata, and focused tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check
