### PR TITLE
Add max-lines-per-function rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -33,6 +33,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
 | [`max-lines`](https://eslint.org/docs/latest/rules/max-lines) | Supports `max`, `skipBlankLines`, and `skipComments` configuration |
+| [`max-lines-per-function`](https://eslint.org/docs/latest/rules/max-lines-per-function) | Supports function and arrow-function line counts plus `max`, `skipBlankLines`, `skipComments`, and `IIFEs` configuration |
 | [`max-nested-callbacks`](https://eslint.org/docs/latest/rules/max-nested-callbacks) | Supports `max`, deprecated `maximum`, and call-argument callback detection |
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`max-statements`](https://eslint.org/docs/latest/rules/max-statements) | Supports `max`, deprecated `maximum`, `ignoreTopLevelFunctions`, and static block isolation |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -106,6 +106,7 @@ const BUILTIN_RULE_IDS = [
   "linebreak-style",
   "logical-assignment-operators",
   "max-lines",
+  "max-lines-per-function",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -109,6 +109,7 @@ const BUILTIN_RULE_IDS = [
   "linebreak-style",
   "logical-assignment-operators",
   "max-lines",
+  "max-lines-per-function",
   "new-cap",
   "new-parens",
   "no-alert",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1653,6 +1653,11 @@ pub const Options = struct {
     max_lines_max: usize = 300,
     max_lines_skip_blank_lines: bool = false,
     max_lines_skip_comments: bool = false,
+    max_lines_per_function: bool = false,
+    max_lines_per_function_max: usize = 50,
+    max_lines_per_function_skip_blank_lines: bool = false,
+    max_lines_per_function_skip_comments: bool = false,
+    max_lines_per_function_iifes: bool = false,
     max_nested_callbacks: bool = true,
     max_nested_callbacks_max: usize = 10,
     max_params: bool = true,
@@ -2443,9 +2448,15 @@ pub const Options = struct {
             self.max_depth_max = try maxDepthMaxFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "max-lines")) {
-            self.max_lines_max = try maxLinesMaxFromConfig(value);
+            self.max_lines_max = try maxLinesMaxFromConfig(value, 300);
             self.max_lines_skip_blank_lines = try maxLinesBoolOptionFromConfig(value, "skipBlankLines");
             self.max_lines_skip_comments = try maxLinesBoolOptionFromConfig(value, "skipComments");
+        }
+        if (std.mem.eql(u8, cli_name, "max-lines-per-function")) {
+            self.max_lines_per_function_max = try maxLinesMaxFromConfig(value, 50);
+            self.max_lines_per_function_skip_blank_lines = try maxLinesBoolOptionFromConfig(value, "skipBlankLines");
+            self.max_lines_per_function_skip_comments = try maxLinesBoolOptionFromConfig(value, "skipComments");
+            self.max_lines_per_function_iifes = try maxLinesBoolOptionFromConfig(value, "IIFEs");
         }
         if (std.mem.eql(u8, cli_name, "max-nested-callbacks")) {
             self.max_nested_callbacks_max = try maxNestedCallbacksMaxFromConfig(value);
@@ -4223,12 +4234,12 @@ pub const Options = struct {
         }
     }
 
-    fn maxLinesMaxFromConfig(value: std.json.Value) RuleConfigError!usize {
+    fn maxLinesMaxFromConfig(value: std.json.Value, default: usize) RuleConfigError!usize {
         const items = switch (value) {
             .array => |array| array.items,
-            else => return 300,
+            else => return default,
         };
-        if (items.len < 2) return 300;
+        if (items.len < 2) return default;
 
         switch (items[1]) {
             .integer => |max| return nonNegativeIntegerToUsize(max),
@@ -4240,7 +4251,7 @@ pub const Options = struct {
                     };
                     return nonNegativeIntegerToUsize(max);
                 }
-                return 300;
+                return default;
             },
             else => return error.UnsupportedRuleConfigValue,
         }
@@ -9259,6 +9270,20 @@ test "Options can apply ESLint-style rule config values" {
     try options.setByRuleConfigValue("require-unicode-regexp", require_unicode_regexp_config.value);
     try std.testing.expect(options.require_unicode_regexp);
     try std.testing.expectEqual(RequireUnicodeRegexpRequireFlag.v, options.require_unicode_regexp_require_flag);
+
+    var max_lines_per_function_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"max\":12,\"skipBlankLines\":true,\"skipComments\":true,\"IIFEs\":true}]",
+        .{},
+    );
+    defer max_lines_per_function_config.deinit();
+    try options.setByRuleConfigValue("max-lines-per-function", max_lines_per_function_config.value);
+    try std.testing.expect(options.max_lines_per_function);
+    try std.testing.expectEqual(@as(usize, 12), options.max_lines_per_function_max);
+    try std.testing.expect(options.max_lines_per_function_skip_blank_lines);
+    try std.testing.expect(options.max_lines_per_function_skip_comments);
+    try std.testing.expect(options.max_lines_per_function_iifes);
 
     var sort_vars_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -707,6 +707,21 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, arg, "--max-lines-skip-comments=on")) {
             options.max_lines = true;
             options.max_lines_skip_comments = true;
+        } else if (std.mem.eql(u8, arg, "--max-lines-per-function=off")) {
+            options.max_lines_per_function = false;
+        } else if (std.mem.eql(u8, arg, "--max-lines-per-function=on")) {
+            options.max_lines_per_function = true;
+        } else if (std.mem.startsWith(u8, arg, "--max-lines-per-function-max=")) {
+            parseMaxLinesPerFunctionMax(arg["--max-lines-per-function-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--max-lines-per-function-skip-blank-lines=on")) {
+            options.max_lines_per_function = true;
+            options.max_lines_per_function_skip_blank_lines = true;
+        } else if (std.mem.eql(u8, arg, "--max-lines-per-function-skip-comments=on")) {
+            options.max_lines_per_function = true;
+            options.max_lines_per_function_skip_comments = true;
+        } else if (std.mem.eql(u8, arg, "--max-lines-per-function-iifes=on")) {
+            options.max_lines_per_function = true;
+            options.max_lines_per_function_iifes = true;
         } else if (std.mem.eql(u8, arg, "--max-nested-callbacks=off")) {
             options.max_nested_callbacks = false;
         } else if (std.mem.startsWith(u8, arg, "--max-nested-callbacks-max=")) {
@@ -1331,6 +1346,15 @@ fn parseMaxLinesMax(value: []const u8, options: *lint.Options) void {
     options.max_lines_max = max;
 }
 
+fn parseMaxLinesPerFunctionMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --max-lines-per-function-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.max_lines_per_function = true;
+    options.max_lines_per_function_max = max;
+}
+
 fn parseMaxNestedCallbacksMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --max-nested-callbacks-max value: {s}\n", .{value});
@@ -1842,6 +1866,12 @@ fn printHelp() void {
         \\  --max-lines-max=N         Set max-lines maximum
         \\  --max-lines-skip-blank-lines=on Ignore blank lines for max-lines
         \\  --max-lines-skip-comments=on Ignore comment-only lines for max-lines
+        \\  --max-lines-per-function=on Enable max-lines-per-function
+        \\  --max-lines-per-function=off Disable max-lines-per-function
+        \\  --max-lines-per-function-max=N Set max-lines-per-function maximum
+        \\  --max-lines-per-function-skip-blank-lines=on Ignore blank lines in functions
+        \\  --max-lines-per-function-skip-comments=on Ignore comment-only lines in functions
+        \\  --max-lines-per-function-iifes=on Include IIFEs in max-lines-per-function
         \\  --max-nested-callbacks=off Disable max-nested-callbacks
         \\  --max-nested-callbacks-max=N Set max-nested-callbacks maximum
         \\  --max-params=off          Disable max-params

--- a/src/rules/max_lines_per_function.zig
+++ b/src/rules/max_lines_per_function.zig
@@ -1,0 +1,195 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "max-lines-per-function";
+
+pub const Options = struct {
+    max: usize = 50,
+    skip_blank_lines: bool = false,
+    skip_comments: bool = false,
+    iifes: bool = false,
+};
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.iifes and isIife(tree, index, ctx)) return;
+    try checkSpan(allocator, diagnostics, tree, index, tree.span(index), options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.iifes and isIife(tree, index, ctx)) return;
+    try checkSpan(allocator, diagnostics, tree, index, tree.span(index), options);
+}
+
+fn checkSpan(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    span: ast.Span,
+    options: Options,
+) Allocator.Error!void {
+    const source = tree.source;
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start >= source.len or end <= start) return;
+
+    var line_start = lineStart(source, start);
+    const final = @min(end, source.len);
+    var actual: usize = 0;
+
+    while (line_start < final) {
+        const line_end = findLineEnd(source, line_start);
+        if (!shouldSkipLine(source, tree.comments, line_start, @min(line_end, final), options)) {
+            actual += 1;
+        }
+
+        if (line_end >= source.len or line_end >= final) break;
+
+        line_start = line_end + 1;
+        if (source[line_end] == '\r' and line_start < source.len and source[line_start] == '\n') {
+            line_start += 1;
+        }
+    }
+
+    if (actual <= options.max) return;
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Function has too many lines ({d}). Maximum allowed is {d}.",
+        .{ actual, options.max },
+    );
+}
+
+fn lineStart(source: []const u8, offset: usize) usize {
+    var index = @min(offset, source.len);
+    while (index > 0 and source[index - 1] != '\n' and source[index - 1] != '\r') : (index -= 1) {}
+    return index;
+}
+
+fn findLineEnd(source: []const u8, start: usize) usize {
+    var index = start;
+    while (index < source.len and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+    return index;
+}
+
+fn shouldSkipLine(
+    source: []const u8,
+    comments: []const ast.Comment,
+    line_start: usize,
+    line_end: usize,
+    options: Options,
+) bool {
+    const line = source[line_start..line_end];
+    if (options.skip_blank_lines and std.mem.trim(u8, line, " \t\r\n").len == 0) return true;
+    if (options.skip_comments and isCommentOnlyLine(source, comments, line_start, line_end)) return true;
+    return false;
+}
+
+fn isCommentOnlyLine(
+    source: []const u8,
+    comments: []const ast.Comment,
+    line_start: usize,
+    line_end: usize,
+) bool {
+    var saw_comment = false;
+
+    var index = line_start;
+    while (index < line_end) : (index += 1) {
+        if (std.ascii.isWhitespace(source[index])) continue;
+        if (!isInsideComment(comments, index, line_start, line_end)) return false;
+        saw_comment = true;
+    }
+
+    return saw_comment;
+}
+
+fn isInsideComment(
+    comments: []const ast.Comment,
+    index: usize,
+    line_start: usize,
+    line_end: usize,
+) bool {
+    for (comments) |comment| {
+        const start: usize = comment.start;
+        const end: usize = comment.end;
+        if (end <= line_start or start >= line_end) continue;
+        if (start <= index and index < end) return true;
+    }
+    return false;
+}
+
+fn isIife(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {
+    var current = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent| : (depth += 1) {
+        switch (tree.data(parent)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != current) return isIifeBySource(tree, index);
+                current = parent;
+            },
+            .chain_expression => |chain| {
+                if (chain.expression != current) return isIifeBySource(tree, index);
+                current = parent;
+            },
+            .call_expression => |call| return unwrapTransparent(tree, call.callee) == current or isIifeBySource(tree, index),
+            else => return isIifeBySource(tree, index),
+        }
+    }
+
+    return isIifeBySource(tree, index);
+}
+
+fn isIifeBySource(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const source = tree.source;
+    const span = tree.span(index);
+    var cursor: usize = @intCast(span.end);
+
+    while (cursor < source.len) : (cursor += 1) {
+        switch (source[cursor]) {
+            ' ', '\t', '\r', '\n' => continue,
+            ')' => continue,
+            '(' => return true,
+            else => return false,
+        }
+    }
+
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -90,6 +90,7 @@ pub const logical_assignment_operators = @import("logical_assignment_operators.z
 pub const max_classes_per_file = @import("max_classes_per_file.zig");
 pub const max_depth = @import("max_depth.zig");
 pub const max_lines = @import("max_lines.zig");
+pub const max_lines_per_function = @import("max_lines_per_function.zig");
 pub const max_nested_callbacks = @import("max_nested_callbacks.zig");
 pub const max_params = @import("max_params.zig");
 pub const max_statements = @import("max_statements.zig");
@@ -1211,6 +1212,15 @@ const BasicVisitor = struct {
         };
     }
 
+    fn maxLinesPerFunctionOptions(self: *const BasicVisitor) max_lines_per_function.Options {
+        return .{
+            .max = self.options.max_lines_per_function_max,
+            .skip_blank_lines = self.options.max_lines_per_function_skip_blank_lines,
+            .skip_comments = self.options.max_lines_per_function_skip_comments,
+            .iifes = self.options.max_lines_per_function_iifes,
+        };
+    }
+
     fn maxNestedCallbacksOptions(self: *const BasicVisitor) max_nested_callbacks.Options {
         return .{
             .max = self.options.max_nested_callbacks_max,
@@ -1437,6 +1447,9 @@ const BasicVisitor = struct {
         }
         if (self.options.max_statements) {
             try max_statements.enterFunction(self.allocator, &self.max_statements_state, index);
+        }
+        if (self.options.max_lines_per_function) {
+            try max_lines_per_function.checkFunction(self.allocator, self.diagnostics, ctx.tree, index, ctx, self.maxLinesPerFunctionOptions());
         }
         if (self.options.complexity) {
             try complexity.enterFunction(self.allocator, &self.complexity_state, index);
@@ -2800,6 +2813,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.max_statements) {
             try max_statements.enterArrowFunction(self.allocator, &self.max_statements_state, index);
+        }
+        if (self.options.max_lines_per_function) {
+            try max_lines_per_function.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, ctx, self.maxLinesPerFunctionOptions());
         }
         if (self.options.complexity) {
             try complexity.enterArrowFunction(self.allocator, &self.complexity_state, index);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -303,6 +303,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/max_lines_per_function.zig");
+}
+
+comptime {
     _ = @import("rules/max_nested_callbacks.zig");
 }
 

--- a/tests/rules/max_lines_per_function.zig
+++ b/tests/rules/max_lines_per_function.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports functions with too many lines" {
+    const source =
+        \\function tooMany() {
+        \\  const one = 1;
+        \\  return one;
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_lines_per_function_max = 3;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_lines_per_function.id));
+    try std.testing.expect(hasMessage(result, "Function has too many lines (4). Maximum allowed is 3."));
+}
+
+test "checks arrow functions and skips short functions" {
+    const source =
+        \\const ok = () => 1;
+        \\const tooMany = () => {
+        \\  const one = 1;
+        \\  return one;
+        \\};
+    ;
+
+    var options = baseOptions();
+    options.max_lines_per_function_max = 3;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_lines_per_function.id));
+}
+
+test "supports skipBlankLines and skipComments" {
+    const source =
+        \\function counted() {
+        \\  // comment
+        \\
+        \\  return value;
+        \\}
+    ;
+
+    var strict_options = baseOptions();
+    strict_options.max_lines_per_function_max = 3;
+
+    var strict_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", strict_options);
+    defer strict_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(strict_result, lint.rules.max_lines_per_function.id));
+
+    var skipped_options = strict_options;
+    skipped_options.max_lines_per_function_skip_blank_lines = true;
+    skipped_options.max_lines_per_function_skip_comments = true;
+
+    var skipped_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", skipped_options);
+    defer skipped_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(skipped_result, lint.rules.max_lines_per_function.id));
+}
+
+test "skips IIFEs unless configured" {
+    const source =
+        \\(function () {
+        \\  const one = 1;
+        \\  return one;
+        \\})();
+    ;
+
+    var skipped_options = baseOptions();
+    skipped_options.max_lines_per_function_max = 3;
+
+    var skipped_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", skipped_options);
+    defer skipped_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(skipped_result, lint.rules.max_lines_per_function.id));
+
+    var counted_options = skipped_options;
+    counted_options.max_lines_per_function_iifes = true;
+
+    var counted_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", counted_options);
+    defer counted_result.deinit(std.testing.allocator);
+    try std.testing.expect(helpers.hasRule(counted_result, lint.rules.max_lines_per_function.id));
+}
+
+test "can disable max-lines-per-function" {
+    const source =
+        \\function tooMany() {
+        \\  const one = 1;
+        \\  return one;
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_lines_per_function = false;
+    options.max_lines_per_function_max = 1;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.max_lines_per_function.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .max_lines_per_function = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.max_lines_per_function.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add max-lines-per-function checks for functions and arrow functions
- support `max`, `skipBlankLines`, `skipComments`, and `IIFEs` configuration plus CLI switches
- keep the stylistic rule disabled by default while wiring docs, npm metadata, and focused tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check
