### PR TITLE
Add no-restricted-globals rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -133,6 +133,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) | Implemented |
 | [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) | Implemented |
 | [`no-restricted-exports`](https://eslint.org/docs/latest/rules/no-restricted-exports) | Supports `restrictedNamedExports` and `restrictDefaultExports` |
+| [`no-restricted-globals`](https://eslint.org/docs/latest/rules/no-restricted-globals) | Supports direct global restrictions, custom messages, and optional global object checks |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -203,6 +203,7 @@ const BUILTIN_RULE_IDS = [
   "no-proto",
   "no-prototype-builtins",
   "no-restricted-exports",
+  "no-restricted-globals",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -206,6 +206,7 @@ const BUILTIN_RULE_IDS = [
   "no-proto",
   "no-prototype-builtins",
   "no-restricted-exports",
+  "no-restricted-globals",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/src/core.zig
+++ b/src/core.zig
@@ -658,6 +658,10 @@ pub const max_no_restricted_properties = 32;
 pub const max_no_restricted_property_name_len = 128;
 pub const max_no_restricted_property_message_len = 256;
 pub const max_no_restricted_property_allow_names = 16;
+pub const max_no_restricted_globals = 64;
+pub const max_no_restricted_global_name_len = 128;
+pub const max_no_restricted_global_message_len = 256;
+pub const max_no_restricted_global_objects = 16;
 pub const max_no_restricted_export_names = 64;
 pub const max_no_restricted_export_name_len = 128;
 pub const max_id_denylist_names = 64;
@@ -760,6 +764,97 @@ pub const NoRestrictedProperties = struct {
 
     pub fn at(self: *const NoRestrictedProperties, index: usize) *const NoRestrictedPropertyEntry {
         return &self.entries[index];
+    }
+};
+
+pub const NoRestrictedGlobalEntry = struct {
+    name_length: usize = 0,
+    name_storage: [max_no_restricted_global_name_len]u8 = undefined,
+
+    has_message: bool = false,
+    message_length: usize = 0,
+    message_storage: [max_no_restricted_global_message_len]u8 = undefined,
+
+    pub fn name(self: *const NoRestrictedGlobalEntry) []const u8 {
+        return self.name_storage[0..self.name_length];
+    }
+
+    pub fn message(self: *const NoRestrictedGlobalEntry) ?[]const u8 {
+        if (!self.has_message) return null;
+        return self.message_storage[0..self.message_length];
+    }
+
+    pub fn setName(self: *NoRestrictedGlobalEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_global_name_len) return false;
+        @memcpy(self.name_storage[0..value.len], value);
+        self.name_length = value.len;
+        return true;
+    }
+
+    pub fn setMessage(self: *NoRestrictedGlobalEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_global_message_len) return false;
+        @memcpy(self.message_storage[0..value.len], value);
+        self.message_length = value.len;
+        self.has_message = true;
+        return true;
+    }
+};
+
+pub const NoRestrictedGlobalObjects = struct {
+    count: usize = 0,
+    lengths: [max_no_restricted_global_objects]usize = undefined,
+    storage: [max_no_restricted_global_objects][max_no_restricted_global_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoRestrictedGlobalObjects, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoRestrictedGlobalObjects, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoRestrictedGlobalObjects, name: []const u8) bool {
+        if (name.len == 0 or name.len > max_no_restricted_global_name_len) return false;
+        if (self.count >= max_no_restricted_global_objects) return false;
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
+    }
+};
+
+pub const NoRestrictedGlobals = struct {
+    count: usize = 0,
+    entries: [max_no_restricted_globals]NoRestrictedGlobalEntry = undefined,
+    check_global_object: bool = false,
+    global_objects: NoRestrictedGlobalObjects = .{},
+
+    pub fn append(self: *NoRestrictedGlobals, entry: NoRestrictedGlobalEntry) bool {
+        if (self.count >= max_no_restricted_globals) return false;
+        self.entries[self.count] = entry;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn appendName(self: *NoRestrictedGlobals, name: []const u8) bool {
+        var entry = NoRestrictedGlobalEntry{};
+        if (!entry.setName(name)) return false;
+        return self.append(entry);
+    }
+
+    pub fn at(self: *const NoRestrictedGlobals, index: usize) *const NoRestrictedGlobalEntry {
+        return &self.entries[index];
+    }
+
+    pub fn find(self: *const NoRestrictedGlobals, name: []const u8) ?*const NoRestrictedGlobalEntry {
+        for (0..self.count) |index| {
+            const entry = self.at(index);
+            if (std.mem.eql(u8, entry.name(), name)) return entry;
+        }
+        return null;
     }
 };
 
@@ -1906,6 +2001,8 @@ pub const Options = struct {
     no_restricted_exports: bool = false,
     no_restricted_exports_names: NoRestrictedExportNames = .{},
     no_restricted_exports_default: NoRestrictedExportsDefaultOptions = .{},
+    no_restricted_globals: bool = false,
+    no_restricted_globals_entries: NoRestrictedGlobals = .{},
     no_restricted_properties: bool = true,
     no_restricted_properties_entries: NoRestrictedProperties = .{},
     no_regex_spaces: bool = true,
@@ -2635,6 +2732,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-restricted-exports")) {
             self.no_restricted_exports_names = try noRestrictedExportNamesFromConfig(value);
             self.no_restricted_exports_default = try noRestrictedExportsDefaultOptionsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-globals")) {
+            self.no_restricted_globals_entries = try noRestrictedGlobalsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
             self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
@@ -5496,6 +5596,93 @@ pub const Options = struct {
             if (!restrictions.append(entry)) return error.UnsupportedRuleConfigValue;
         }
         return restrictions;
+    }
+
+    fn noRestrictedGlobalsFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedGlobals {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        switch (items[1]) {
+            .object => |object| {
+                if (object.get("globals") != null) {
+                    return noRestrictedGlobalsFromObjectConfig(object);
+                }
+            },
+            else => {},
+        }
+
+        var restrictions = NoRestrictedGlobals{};
+        for (items[1..]) |item| {
+            const entry = try noRestrictedGlobalEntryFromConfig(item);
+            if (!restrictions.append(entry)) return error.UnsupportedRuleConfigValue;
+        }
+        return restrictions;
+    }
+
+    fn noRestrictedGlobalsFromObjectConfig(config: std.json.ObjectMap) RuleConfigError!NoRestrictedGlobals {
+        var restrictions = NoRestrictedGlobals{};
+
+        const globals_value = config.get("globals") orelse return error.UnsupportedRuleConfigValue;
+        const globals = switch (globals_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        for (globals) |item| {
+            const entry = try noRestrictedGlobalEntryFromConfig(item);
+            if (!restrictions.append(entry)) return error.UnsupportedRuleConfigValue;
+        }
+
+        if (config.get("checkGlobalObject")) |value| {
+            restrictions.check_global_object = switch (value) {
+                .bool => |enabled| enabled,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+        }
+
+        if (config.get("globalObjects")) |value| {
+            const objects = switch (value) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (objects) |item| {
+                const name = switch (item) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!restrictions.global_objects.append(name)) return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        return restrictions;
+    }
+
+    fn noRestrictedGlobalEntryFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedGlobalEntry {
+        var entry = NoRestrictedGlobalEntry{};
+        switch (value) {
+            .string => |name| {
+                if (!entry.setName(name)) return error.UnsupportedRuleConfigValue;
+            },
+            .object => |object| {
+                const name_value = object.get("name") orelse return error.UnsupportedRuleConfigValue;
+                const name = switch (name_value) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!entry.setName(name)) return error.UnsupportedRuleConfigValue;
+                if (object.get("message")) |message_value| {
+                    const message = switch (message_value) {
+                        .string => |string| string,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    if (!entry.setMessage(message)) return error.UnsupportedRuleConfigValue;
+                }
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+        return entry;
     }
 
     const NoRestrictedPropertyStringTarget = enum {
@@ -9015,6 +9202,34 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.no_restricted_properties_entries.at(1).allow_objects.contains("router"));
     try std.testing.expect(options.no_restricted_properties_entries.at(2).allow_properties.contains("settings"));
     try std.testing.expect(options.no_restricted_properties_entries.at(2).allow_properties.contains("version"));
+
+    var no_restricted_globals_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"event\",{\"name\":\"fdescribe\",\"message\":\"Use describe instead.\"}]",
+        .{},
+    );
+    defer no_restricted_globals_config.deinit();
+    try options.setByRuleConfigValue("no-restricted-globals", no_restricted_globals_config.value);
+    try std.testing.expect(options.no_restricted_globals);
+    try std.testing.expectEqual(@as(usize, 2), options.no_restricted_globals_entries.count);
+    try std.testing.expectEqualStrings("event", options.no_restricted_globals_entries.at(0).name());
+    try std.testing.expectEqualStrings("fdescribe", options.no_restricted_globals_entries.at(1).name());
+    try std.testing.expectEqualStrings("Use describe instead.", options.no_restricted_globals_entries.at(1).message().?);
+
+    var no_restricted_globals_object_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"globals\":[\"event\"],\"checkGlobalObject\":true,\"globalObjects\":[\"customGlobal\"]}]",
+        .{},
+    );
+    defer no_restricted_globals_object_config.deinit();
+    try options.setByRuleConfigValue("no-restricted-globals", no_restricted_globals_object_config.value);
+    try std.testing.expect(options.no_restricted_globals);
+    try std.testing.expectEqual(@as(usize, 1), options.no_restricted_globals_entries.count);
+    try std.testing.expectEqualStrings("event", options.no_restricted_globals_entries.at(0).name());
+    try std.testing.expect(options.no_restricted_globals_entries.check_global_object);
+    try std.testing.expect(options.no_restricted_globals_entries.global_objects.contains("customGlobal"));
 
     var typescript_no_redeclare_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -543,6 +543,12 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, arg, "--no-restricted-exports-namespace-from=on")) {
             options.no_restricted_exports = true;
             options.no_restricted_exports_default.namespace_from = true;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-globals=off")) {
+            options.no_restricted_globals = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-globals=on")) {
+            options.no_restricted_globals = true;
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-globals-name=")) {
+            appendNoRestrictedGlobalName(arg["--no-restricted-globals-name=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
             options.no_restricted_properties = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -1285,6 +1291,14 @@ fn appendNoRestrictedExportName(value: []const u8, options: *lint.Options) void 
     options.no_restricted_exports = true;
 }
 
+fn appendNoRestrictedGlobalName(value: []const u8, options: *lint.Options) void {
+    if (!options.no_restricted_globals_entries.appendName(value)) {
+        std.debug.print("utoo-lint: invalid --no-restricted-globals-name value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.no_restricted_globals = true;
+}
+
 fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max value: {s}\n", .{value});
@@ -1929,6 +1943,9 @@ fn printHelp() void {
         \\  --no-restricted-exports-default-from=on Restrict re-exported default exports
         \\  --no-restricted-exports-named-from=on Restrict re-exported named defaults
         \\  --no-restricted-exports-namespace-from=on Restrict namespace default re-exports
+        \\  --no-restricted-globals=off Disable no-restricted-globals
+        \\  --no-restricted-globals=on Enable no-restricted-globals
+        \\  --no-restricted-globals-name=NAME Restrict a global name
         \\  --no-restricted-properties=off Disable no-restricted-properties
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await

--- a/src/root.zig
+++ b/src/root.zig
@@ -160,6 +160,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_object_constructor or
         options.no_promise_executor_return or
         options.no_redeclare or
+        options.no_restricted_globals or
         options.no_regex_spaces or
         options.no_shadow or
         options.no_undef or

--- a/src/rules/no_restricted_globals.zig
+++ b/src/rules/no_restricted_globals.zig
@@ -1,0 +1,227 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-globals";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    restrictions: core.NoRestrictedGlobals,
+) Allocator.Error!void {
+    if (restrictions.count == 0) return;
+
+    var iter = symbol_table.iterUnresolved();
+    while (iter.next()) |entry| {
+        const reference = entry.reference;
+        if (reference.kind != .value) continue;
+
+        const name = tree.string(reference.name);
+        const restriction = restrictions.find(name) orelse continue;
+        try addDiagnostic(allocator, diagnostics, tree, reference.node, restriction, name);
+    }
+
+    if (!restrictions.check_global_object) return;
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .restrictions = restrictions,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    restrictions: core.NoRestrictedGlobals,
+
+    pub fn enter_member_expression(
+        self: *Visitor,
+        member: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const property = propertyName(ctx.tree, member) orelse return .proceed;
+        const restriction = self.restrictions.find(property) orelse return .proceed;
+
+        if (!isGlobalObjectAccess(ctx.tree, self.symbol_table, member.object, self.restrictions)) {
+            return .proceed;
+        }
+
+        try addDiagnostic(self.allocator, self.diagnostics, ctx.tree, index, restriction, property);
+        return .proceed;
+    }
+};
+
+fn isGlobalObjectAccess(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    restrictions: core.NoRestrictedGlobals,
+) bool {
+    const object = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, object)) |name| {
+        return isConfiguredGlobalObject(restrictions, name) and isUnresolvedReference(symbol_table, object);
+    }
+
+    const member = switch (tree.data(object)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+
+    const property = propertyName(tree, member) orelse return false;
+    const root = globalObjectRoot(tree, member.object) orelse return false;
+    if (!std.mem.eql(u8, property, root)) return false;
+
+    return isConfiguredGlobalObject(restrictions, root) and isUnresolvedRootReference(tree, symbol_table, member.object, root);
+}
+
+fn globalObjectRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const unwrapped = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, unwrapped)) |name| return name;
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    const property = propertyName(tree, member) orelse return null;
+    const root = globalObjectRoot(tree, member.object) orelse return null;
+    if (!std.mem.eql(u8, property, root)) return null;
+    return root;
+}
+
+fn isUnresolvedRootReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    root: []const u8,
+) bool {
+    const unwrapped = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, unwrapped)) |name| {
+        return std.mem.eql(u8, name, root) and isUnresolvedReference(symbol_table, unwrapped);
+    }
+
+    const member = switch (tree.data(unwrapped)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    if (!std.mem.eql(u8, property, root)) return false;
+    return isUnresolvedRootReference(tree, symbol_table, member.object, root);
+}
+
+fn isConfiguredGlobalObject(restrictions: core.NoRestrictedGlobals, name: []const u8) bool {
+    return isDefaultGlobalObject(name) or restrictions.global_objects.contains(name);
+}
+
+fn isDefaultGlobalObject(name: []const u8) bool {
+    return std.mem.eql(u8, name, "globalThis") or
+        std.mem.eql(u8, name, "self") or
+        std.mem.eql(u8, name, "window");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            .template_literal => |literal| templateStringValue(tree, literal),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .numeric_literal => |literal| tree.string(literal.raw),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    restriction: *const core.NoRestrictedGlobalEntry,
+    name: []const u8,
+) Allocator.Error!void {
+    if (restriction.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Unexpected use of '{s}'. {s}",
+            .{ name, message },
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Unexpected use of '{s}'.",
+            .{name},
+        );
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -192,6 +192,7 @@ pub const no_process_exit = @import("no_process_exit.zig");
 pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_redeclare = @import("no_redeclare.zig");
 pub const no_restricted_exports = @import("no_restricted_exports.zig");
+pub const no_restricted_globals = @import("no_restricted_globals.zig");
 pub const no_restricted_properties = @import("no_restricted_properties.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
@@ -843,6 +844,10 @@ pub fn runSemantic(
         try no_redeclare.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .builtin_globals = options.no_redeclare_builtin_globals == .yes,
         });
+    }
+
+    if (options.no_restricted_globals) {
+        try no_restricted_globals.run(allocator, diagnostics, tree, semantic_result.symbol_table, options.no_restricted_globals_entries);
     }
 
     if (use_typescript_no_redeclare) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -707,6 +707,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_globals.zig");
+}
+
+comptime {
     _ = @import("rules/no_restricted_properties.zig");
 }
 

--- a/tests/rules/no_restricted_globals.zig
+++ b/tests/rules/no_restricted_globals.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-restricted-globals for configured global references" {
+    const source =
+        \\event;
+        \\fdescribe("suite", () => {});
+        \\const local = 1;
+        \\local;
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",\"event\",{\"name\":\"fdescribe\",\"message\":\"Use describe instead.\"}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_globals.id));
+    try std.testing.expect(hasMessage(result, "Use describe instead."));
+}
+
+test "ignores no-restricted-globals when references are locally declared" {
+    const source =
+        \\function run(event) {
+        \\  const fdescribe = () => {};
+        \\  event.target;
+        \\  fdescribe();
+        \\}
+    ;
+
+    const options = try optionsWithConfig("[\"error\",\"event\",\"fdescribe\"]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_globals.id));
+}
+
+test "reports no-restricted-globals global object property access" {
+    const source =
+        \\window.event;
+        \\globalThis.event;
+        \\self["event"];
+        \\customGlobal.event;
+        \\local.event;
+        \\const local = {};
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"globals\":[\"event\"],\"checkGlobalObject\":true,\"globalObjects\":[\"customGlobal\"]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_restricted_globals.id));
+}
+
+test "allows no-restricted-globals global object checks to be disabled" {
+    const source =
+        \\event;
+        \\window.event;
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"globals\":[\"event\"],\"checkGlobalObject\":false}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_restricted_globals.id));
+}
+
+test "can disable no-restricted-globals" {
+    const source =
+        \\event;
+    ;
+
+    var options = try optionsWithConfig("[\"error\",\"event\"]");
+    options.no_restricted_globals = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_globals.id));
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("no-restricted-globals", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_globals.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint-compatible `no-restricted-globals` configuration parsing
- report unresolved restricted global references and optional global object property access
- expose the rule through CLI/npm metadata and update rule status docs

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
