### PR TITLE
Add id-length rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -28,6 +28,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) | Implemented for `anyOrder`, `getBeforeSet`, and `setBeforeGet` options |
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`id-denylist`](https://eslint.org/docs/latest/rules/id-denylist) | Supports configured restricted identifiers, private identifiers, member-write checks, and renamed import/export skips |
+| [`id-length`](https://eslint.org/docs/latest/rules/id-length) | Supports `min`, `max`, `exceptions`, common `exceptionPatterns`, and `properties` for bindings, imports, functions, and class/object properties |
 | [`init-declarations`](https://eslint.org/docs/latest/rules/init-declarations) | Supports `always`, `never`, and `ignoreForLoopInit` |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -103,6 +103,7 @@ const BUILTIN_RULE_IDS = [
   "getter-return",
   "grouped-accessor-pairs",
   "guard-for-in",
+  "id-length",
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -106,6 +106,7 @@ const BUILTIN_RULE_IDS = [
   "getter-return",
   "grouped-accessor-pairs",
   "guard-for-in",
+  "id-length",
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",

--- a/src/core.zig
+++ b/src/core.zig
@@ -673,6 +673,10 @@ pub const max_no_restricted_export_names = 64;
 pub const max_no_restricted_export_name_len = 128;
 pub const max_id_denylist_names = 64;
 pub const max_id_denylist_name_len = 128;
+pub const max_id_length_exceptions = 64;
+pub const max_id_length_exception_len = 128;
+pub const max_id_length_exception_patterns = 64;
+pub const max_id_length_exception_pattern_len = 256;
 
 pub const NoRestrictedPropertyNameList = struct {
     count: usize = 0,
@@ -896,6 +900,91 @@ pub const IdDenylistNames = struct {
         @memcpy(self.storage[self.count][0..name.len], name);
         self.lengths[self.count] = name.len;
         self.count += 1;
+    }
+};
+
+pub const IdLengthProperties = enum {
+    always,
+    never,
+};
+
+pub const IdLengthExceptionsError = error{
+    EmptyIdLengthException,
+    TooManyIdLengthExceptions,
+    IdLengthExceptionTooLong,
+};
+
+pub const IdLengthExceptions = struct {
+    count: usize = 0,
+    lengths: [max_id_length_exceptions]usize = undefined,
+    storage: [max_id_length_exceptions][max_id_length_exception_len]u8 = undefined,
+
+    pub fn contains(self: *const IdLengthExceptions, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const IdLengthExceptions, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *IdLengthExceptions, name: []const u8) IdLengthExceptionsError!void {
+        if (name.len == 0) return error.EmptyIdLengthException;
+        if (self.count >= max_id_length_exceptions) return error.TooManyIdLengthExceptions;
+        if (name.len > max_id_length_exception_len) return error.IdLengthExceptionTooLong;
+        if (self.contains(name)) return;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
+pub const IdLengthExceptionPatternsError = error{
+    EmptyIdLengthExceptionPattern,
+    TooManyIdLengthExceptionPatterns,
+    IdLengthExceptionPatternTooLong,
+};
+
+pub const IdLengthExceptionPatterns = struct {
+    count: usize = 0,
+    lengths: [max_id_length_exception_patterns]usize = undefined,
+    storage: [max_id_length_exception_patterns][max_id_length_exception_pattern_len]u8 = undefined,
+
+    pub fn matches(self: *const IdLengthExceptionPatterns, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (simplePatternMatches(self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const IdLengthExceptionPatterns, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *IdLengthExceptionPatterns, pattern: []const u8) IdLengthExceptionPatternsError!void {
+        if (pattern.len == 0) return error.EmptyIdLengthExceptionPattern;
+        if (self.count >= max_id_length_exception_patterns) return error.TooManyIdLengthExceptionPatterns;
+        if (pattern.len > max_id_length_exception_pattern_len) return error.IdLengthExceptionPatternTooLong;
+
+        @memcpy(self.storage[self.count][0..pattern.len], pattern);
+        self.lengths[self.count] = pattern.len;
+        self.count += 1;
+    }
+
+    fn simplePatternMatches(pattern: []const u8, name: []const u8) bool {
+        if (pattern.len >= 2 and pattern[0] == '^' and pattern[pattern.len - 1] == '$') {
+            return std.mem.eql(u8, name, pattern[1 .. pattern.len - 1]);
+        }
+        if (pattern.len >= 1 and pattern[0] == '^') {
+            return std.mem.startsWith(u8, name, pattern[1..]);
+        }
+        if (pattern.len >= 1 and pattern[pattern.len - 1] == '$') {
+            return std.mem.endsWith(u8, name, pattern[0 .. pattern.len - 1]);
+        }
+        return std.mem.indexOf(u8, name, pattern) != null;
     }
 };
 
@@ -1755,6 +1844,13 @@ pub const Options = struct {
     guard_for_in: bool = true,
     id_denylist: bool = true,
     id_denylist_names: IdDenylistNames = .{},
+    id_length: bool = false,
+    id_length_min: usize = 2,
+    id_length_has_max: bool = false,
+    id_length_max: usize = 0,
+    id_length_properties: IdLengthProperties = .always,
+    id_length_exceptions: IdLengthExceptions = .{},
+    id_length_exception_patterns: IdLengthExceptionPatterns = .{},
     init_declarations: bool = false,
     init_declarations_mode: InitDeclarationsMode = .always,
     init_declarations_ignore_for_loop_init: bool = false,
@@ -2552,6 +2648,15 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "id-denylist")) {
             self.id_denylist_names = try idDenylistNamesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "id-length")) {
+            const config = try idLengthFromConfig(value);
+            self.id_length_min = config.min;
+            self.id_length_has_max = config.has_max;
+            self.id_length_max = config.max;
+            self.id_length_properties = config.properties;
+            self.id_length_exceptions = config.exceptions;
+            self.id_length_exception_patterns = config.exception_patterns;
         }
         if (std.mem.eql(u8, cli_name, "init-declarations")) {
             self.init_declarations_mode = try initDeclarationsModeFromConfig(value);
@@ -3810,6 +3915,99 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    const IdLengthConfig = struct {
+        min: usize = 2,
+        has_max: bool = false,
+        max: usize = 0,
+        properties: IdLengthProperties = .always,
+        exceptions: IdLengthExceptions = .{},
+        exception_patterns: IdLengthExceptionPatterns = .{},
+    };
+
+    fn idLengthFromConfig(value: std.json.Value) RuleConfigError!IdLengthConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = IdLengthConfig{};
+        if (config.get("min")) |min_value| {
+            result.min = try jsonNonNegativeIntegerToUsize(min_value);
+        }
+        if (config.get("max")) |max_value| {
+            result.max = try jsonNonNegativeIntegerToUsize(max_value);
+            result.has_max = true;
+        }
+        if (config.get("properties")) |properties_value| {
+            const properties = switch (properties_value) {
+                .string => |properties| properties,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, properties, "always")) {
+                result.properties = .always;
+            } else if (std.mem.eql(u8, properties, "never")) {
+                result.properties = .never;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+        if (config.get("exceptions")) |exceptions_value| {
+            result.exceptions = try idLengthExceptionsFromValue(exceptions_value);
+        }
+        if (config.get("exceptionPatterns")) |patterns_value| {
+            result.exception_patterns = try idLengthExceptionPatternsFromValue(patterns_value);
+        }
+        return result;
+    }
+
+    fn idLengthExceptionsFromValue(value: std.json.Value) RuleConfigError!IdLengthExceptions {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var exceptions = IdLengthExceptions{};
+        for (items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            exceptions.append(name) catch return error.UnsupportedRuleConfigValue;
+        }
+        return exceptions;
+    }
+
+    fn idLengthExceptionPatternsFromValue(value: std.json.Value) RuleConfigError!IdLengthExceptionPatterns {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var patterns = IdLengthExceptionPatterns{};
+        for (items) |item| {
+            const pattern = switch (item) {
+                .string => |pattern| pattern,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            patterns.append(pattern) catch return error.UnsupportedRuleConfigValue;
+        }
+        return patterns;
+    }
+
+    fn jsonNonNegativeIntegerToUsize(value: std.json.Value) RuleConfigError!usize {
+        const integer = switch (value) {
+            .integer => |integer| integer,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return nonNegativeIntegerToUsize(integer);
     }
 
     fn noRestrictedExportNamesFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedExportNames {

--- a/src/main.zig
+++ b/src/main.zig
@@ -690,6 +690,24 @@ pub fn main(init: std.process.Init) !void {
             options.no_with = false;
         } else if (std.mem.eql(u8, arg, "--no-var=off")) {
             options.no_var = false;
+        } else if (std.mem.eql(u8, arg, "--id-length=off")) {
+            options.id_length = false;
+        } else if (std.mem.eql(u8, arg, "--id-length=on")) {
+            options.id_length = true;
+        } else if (std.mem.startsWith(u8, arg, "--id-length-min=")) {
+            parseIdLengthMin(arg["--id-length-min=".len..], &options);
+        } else if (std.mem.startsWith(u8, arg, "--id-length-max=")) {
+            parseIdLengthMax(arg["--id-length-max=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--id-length-properties=always")) {
+            options.id_length = true;
+            options.id_length_properties = .always;
+        } else if (std.mem.eql(u8, arg, "--id-length-properties=never")) {
+            options.id_length = true;
+            options.id_length_properties = .never;
+        } else if (std.mem.startsWith(u8, arg, "--id-length-exception=")) {
+            appendIdLengthException(arg["--id-length-exception=".len..], &options);
+        } else if (std.mem.startsWith(u8, arg, "--id-length-exception-pattern=")) {
+            appendIdLengthExceptionPattern(arg["--id-length-exception-pattern=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--id-denylist=off")) {
             options.id_denylist = false;
         } else if (std.mem.startsWith(u8, arg, "--id-denylist-name=")) {
@@ -1339,6 +1357,41 @@ fn appendIdDenylistName(value: []const u8, options: *lint.Options) void {
     };
 }
 
+fn parseIdLengthMin(value: []const u8, options: *lint.Options) void {
+    const min = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --id-length-min value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.id_length_min = min;
+    options.id_length = true;
+}
+
+fn parseIdLengthMax(value: []const u8, options: *lint.Options) void {
+    const max = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --id-length-max value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.id_length_max = max;
+    options.id_length_has_max = true;
+    options.id_length = true;
+}
+
+fn appendIdLengthException(value: []const u8, options: *lint.Options) void {
+    options.id_length_exceptions.append(value) catch {
+        std.debug.print("utoo-lint: invalid --id-length-exception value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.id_length = true;
+}
+
+fn appendIdLengthExceptionPattern(value: []const u8, options: *lint.Options) void {
+    options.id_length_exception_patterns.append(value) catch {
+        std.debug.print("utoo-lint: invalid --id-length-exception-pattern value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.id_length = true;
+}
+
 fn appendConsistentThisAlias(value: []const u8, options: *lint.Options) void {
     if (!options.consistent_this_aliases.custom) {
         options.consistent_this_aliases = .{ .custom = true };
@@ -1897,6 +1950,13 @@ fn printHelp() void {
         \\  --no-labels=off           Disable no-labels
         \\  --no-lone-blocks=off      Disable no-lone-blocks
         \\  --no-lonely-if=off        Disable no-lonely-if
+        \\  --id-length=on            Enable id-length
+        \\  --id-length=off           Disable id-length
+        \\  --id-length-min=N         Set id-length minimum
+        \\  --id-length-max=N         Set id-length maximum
+        \\  --id-length-properties=never Ignore property names
+        \\  --id-length-exception=NAME Add an id-length exception
+        \\  --id-length-exception-pattern=PATTERN Add an id-length exception pattern
         \\  --id-denylist=off         Disable id-denylist
         \\  --id-denylist-name=NAME   Add a restricted identifier name
         \\  --logical-assignment-operators=off Disable logical-assignment-operators

--- a/src/rules/id_length.zig
+++ b/src/rules/id_length.zig
@@ -1,0 +1,285 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "id-length";
+
+pub const Options = struct {
+    min: usize = 2,
+    has_max: bool = false,
+    max: usize = 0,
+    properties: core.IdLengthProperties = .always,
+    exceptions: core.IdLengthExceptions = .{},
+    exception_patterns: core.IdLengthExceptionPatterns = .{},
+};
+
+const Identifier = struct {
+    name: []const u8,
+    private: bool = false,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, class.id, options);
+}
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, function.id, options);
+    try checkFormalParameters(allocator, diagnostics, tree, function.params, options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
+    try checkFormalParameters(allocator, diagnostics, tree, expression.params, options);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, declarator.id, options);
+}
+
+pub fn checkCatchClause(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    clause: ast.CatchClause,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, clause.param, options);
+}
+
+pub fn checkObjectProperty(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or method.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, method.key, options);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkImportSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    if (specifier.imported == specifier.local) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportDefaultSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportDefaultSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportNamespaceSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportNamespaceSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+fn checkFormalParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern, options),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter, options),
+            else => {},
+        }
+    }
+    try checkBinding(allocator, diagnostics, tree, params.rest, options);
+}
+
+fn checkBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => try checkIdentifierNode(allocator, diagnostics, tree, index, options),
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left, options),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument, options),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBinding(allocator, diagnostics, tree, element, options);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBinding(allocator, diagnostics, tree, property.value, options);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options);
+        },
+        else => {},
+    }
+}
+
+fn checkIdentifierNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+    const identifier = identifierName(tree, index) orelse return;
+    if (isAllowed(identifier.name, options)) return;
+
+    if (identifier.name.len < options.min) {
+        try report(allocator, diagnostics, tree, index, identifier, .min, options.min);
+        return;
+    }
+    if (options.has_max and identifier.name.len > options.max) {
+        try report(allocator, diagnostics, tree, index, identifier, .max, options.max);
+    }
+}
+
+const LimitKind = enum { min, max };
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    identifier: Identifier,
+    kind: LimitKind,
+    limit: usize,
+) Allocator.Error!void {
+    const span = tree.span(index);
+    switch (kind) {
+        .min => if (identifier.private) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                span,
+                "Identifier name '#{s}' is too short (< {d}).",
+                .{ identifier.name, limit },
+            );
+        } else {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                span,
+                "Identifier name '{s}' is too short (< {d}).",
+                .{ identifier.name, limit },
+            );
+        },
+        .max => if (identifier.private) {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                span,
+                "Identifier name '#{s}' is too long (> {d}).",
+                .{ identifier.name, limit },
+            );
+        } else {
+            try core.addDiagnosticFmt(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                span,
+                "Identifier name '{s}' is too long (> {d}).",
+                .{ identifier.name, limit },
+            );
+        },
+    }
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?Identifier {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| .{ .name = tree.string(identifier.name) },
+        .identifier_name => |identifier| .{ .name = tree.string(identifier.name) },
+        .private_identifier => |identifier| .{ .name = tree.string(identifier.name), .private = true },
+        else => null,
+    };
+}
+
+fn isAllowed(name: []const u8, options: Options) bool {
+    return options.exceptions.contains(name) or options.exception_patterns.matches(name);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -36,6 +36,7 @@ pub const getter_return = @import("getter_return.zig");
 pub const grouped_accessor_pairs = @import("grouped_accessor_pairs.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const id_denylist = @import("id_denylist.zig");
+pub const id_length = @import("id_length.zig");
 pub const init_declarations = @import("init_declarations.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
@@ -397,6 +398,17 @@ fn funcStyleOptions(options: *const core.Options) func_style.Options {
             .declaration => .declaration,
             .ignore => .ignore,
         },
+    };
+}
+
+fn idLengthOptions(options: *const core.Options) id_length.Options {
+    return .{
+        .min = options.id_length_min,
+        .has_max = options.id_length_has_max,
+        .max = options.id_length_max,
+        .properties = options.id_length_properties,
+        .exceptions = options.id_length_exceptions,
+        .exception_patterns = options.id_length_exception_patterns,
     };
 }
 
@@ -1510,6 +1522,9 @@ const BasicVisitor = struct {
         if (self.options.func_style) {
             try func_style.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, funcStyleOptions(&self.options));
         }
+        if (self.options.id_length) {
+            try id_length.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idLengthOptions(&self.options));
+        }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
@@ -1616,6 +1631,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
+        }
+        if (self.options.id_length) {
+            try id_length.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idLengthOptions(&self.options));
         }
         if (self.options.no_useless_constructor and !self.options.typescript_eslint_no_useless_constructor) {
             try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
@@ -1991,6 +2009,9 @@ const BasicVisitor = struct {
         }
         if (self.options.func_style) {
             try func_style.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, index, ctx, funcStyleOptions(&self.options));
+        }
+        if (self.options.id_length) {
+            try id_length.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idLengthOptions(&self.options));
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
@@ -2425,6 +2446,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, clause.param, false);
+        }
+        if (self.options.id_length) {
+            try id_length.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idLengthOptions(&self.options));
         }
         if (self.options.complexity) {
             complexity.increase(&self.complexity_state);
@@ -2880,6 +2904,9 @@ const BasicVisitor = struct {
                 .max = self.options.max_params_max,
                 .count_this = self.options.max_params_count_this,
             });
+        }
+        if (self.options.id_length) {
+            try id_length.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idLengthOptions(&self.options));
         }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_arrow_parameter) {
             try typescript_eslint_typedef.checkArrowFunctionParameters(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -3790,6 +3817,9 @@ const BasicVisitor = struct {
                 .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
             });
         }
+        if (self.options.id_length) {
+            try id_length.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
+        }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
@@ -3888,6 +3918,9 @@ const BasicVisitor = struct {
                 .enforce_in_method_names = self.options.no_underscore_dangle_enforce_in_method_names,
             });
         }
+        if (self.options.id_length) {
+            try id_length.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idLengthOptions(&self.options));
+        }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(
                 self.allocator,
@@ -3948,6 +3981,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_multi_assign) {
             try no_multi_assign.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
+        }
+        if (self.options.id_length) {
+            try id_length.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(
@@ -4043,6 +4079,9 @@ const BasicVisitor = struct {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
+        if (self.options.id_length) {
+            try id_length.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+        }
         return .proceed;
     }
 
@@ -4055,6 +4094,9 @@ const BasicVisitor = struct {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
+        if (self.options.id_length) {
+            try id_length.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+        }
         return .proceed;
     }
 
@@ -4066,6 +4108,9 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
+        }
+        if (self.options.id_length) {
+            try id_length.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -91,6 +91,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/id_length.zig");
+}
+
+comptime {
     _ = @import("rules/init_declarations.zig");
 }
 

--- a/tests/rules/id_length.zig
+++ b/tests/rules/id_length.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports short binding identifiers" {
+    const source =
+        \\function f(a, goodName) {
+        \\  const b = goodName;
+        \\  return b;
+        \\}
+        \\const [c, { d: e, f: goodValue }] = list;
+        \\try {} catch (g) {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.id_length.id));
+    try std.testing.expect(hasMessage(result, "Identifier name 'f' is too short (< 2)."));
+    try std.testing.expect(hasMessage(result, "Identifier name 'e' is too short (< 2)."));
+}
+
+test "reports property names when configured" {
+    const source =
+        \\class C {
+        \\  #x;
+        \\  y() {}
+        \\  longName() {}
+        \\}
+        \\const obj = { z: 1, okName: 2, [computed]: 3 };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.id_length.id));
+    try std.testing.expect(hasMessage(result, "Identifier name '#x' is too short (< 2)."));
+}
+
+test "can ignore property names" {
+    const source =
+        \\class GoodName {
+        \\  #x;
+        \\  y() {}
+        \\  z = 1;
+        \\}
+        \\const obj = { a: 1 };
+    ;
+
+    var options = baseOptions();
+    options.id_length_properties = .never;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_length.id));
+}
+
+test "supports maximum, exceptions, and exception patterns" {
+    const source =
+        \\const x = 1;
+        \\const ok = 2;
+        \\const tooLongName = 3;
+        \\const endLong = 4;
+        \\const no = 5;
+    ;
+
+    var options = baseOptions();
+    options.id_length_min = 3;
+    options.id_length_has_max = true;
+    options.id_length_max = 5;
+    try options.id_length_exceptions.append("x");
+    try options.id_length_exception_patterns.append("^ok");
+    try options.id_length_exception_patterns.append("Long$");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.id_length.id));
+    try std.testing.expect(hasMessage(result, "Identifier name 'tooLongName' is too long (> 5)."));
+    try std.testing.expect(hasMessage(result, "Identifier name 'no' is too short (< 3)."));
+}
+
+test "reports import aliases but skips unrenamed named imports" {
+    const source =
+        \\import x, { foo as y, bar } from "pkg";
+        \\import * as n from "other";
+        \\bar;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.id_length.id));
+}
+
+test "parses eslint id-length config" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"min\":3,\"max\":8,\"exceptions\":[\"x\"],\"exceptionPatterns\":[\"^ok\"],\"properties\":\"never\"}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("id-length", parsed.value);
+
+    try std.testing.expect(options.id_length);
+    try std.testing.expectEqual(@as(usize, 3), options.id_length_min);
+    try std.testing.expect(options.id_length_has_max);
+    try std.testing.expectEqual(@as(usize, 8), options.id_length_max);
+    try std.testing.expectEqual(@as(@TypeOf(options.id_length_properties), .never), options.id_length_properties);
+    try std.testing.expect(options.id_length_exceptions.contains("x"));
+    try std.testing.expect(options.id_length_exception_patterns.matches("okay"));
+}
+
+test "can disable id-length" {
+    const source =
+        \\const x = 1;
+    ;
+
+    var options = baseOptions();
+    options.id_length = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_length.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .id_length = true,
+        .consistent_return = false,
+        .import_no_unresolved = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.id_length.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint-compatible `id-length` rule support for bindings, params, imports, functions, catch bindings, and class/object property names
- parse `min`, `max`, `exceptions`, `exceptionPatterns`, and `properties` options from ESLint-style config
- expose CLI flags, npm builtin rule metadata, docs, and focused tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
