### PR TITLE
Add no-unassigned-vars rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -157,6 +157,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Supports `skipBlankLines` and `ignoreComments` configuration |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
+| [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars) | Reports read `let`/`var` bindings that have no initializer and no assignment |
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -225,6 +225,7 @@ const BUILTIN_RULE_IDS = [
   "no-trailing-spaces",
   "no-undef",
   "no-undef-init",
+  "no-unassigned-vars",
   "no-underscore-dangle",
   "no-undefined",
   "no-unneeded-ternary",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -228,6 +228,7 @@ const BUILTIN_RULE_IDS = [
   "no-trailing-spaces",
   "no-undef",
   "no-undef-init",
+  "no-unassigned-vars",
   "no-underscore-dangle",
   "no-undefined",
   "no-unneeded-ternary",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2155,6 +2155,7 @@ pub const Options = struct {
     no_trailing_spaces_ignore_comments: bool = false,
     no_unreachable: bool = true,
     no_undef_init: bool = true,
+    no_unassigned_vars: bool = true,
     no_underscore_dangle: bool = true,
     no_underscore_dangle_allow_after_this: bool = false,
     no_underscore_dangle_allow_after_super: bool = false,

--- a/src/main.zig
+++ b/src/main.zig
@@ -781,6 +781,8 @@ pub fn main(init: std.process.Init) !void {
             options.use_isnan = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-vars=off")) {
             options.no_unused_vars = false;
+        } else if (std.mem.eql(u8, arg, "--no-unassigned-vars=off")) {
+            options.no_unassigned_vars = false;
         } else if (std.mem.eql(u8, arg, "--no-use-before-define=off")) {
             options.no_use_before_define = false;
         } else if (std.mem.eql(u8, arg, "--no-undef=off")) {
@@ -2106,6 +2108,7 @@ fn printHelp() void {
         \\  --eqeqeq=off              Disable eqeqeq
         \\  --use-isnan=off           Disable use-isnan
         \\  --no-unused-vars=off      Disable no-unused-vars
+        \\  --no-unassigned-vars=off Disable no-unassigned-vars
         \\  --no-use-before-define=off Disable no-use-before-define
         \\  --no-undef=off            Disable no-undef
         \\  --prefer-const=off        Disable prefer-const

--- a/src/root.zig
+++ b/src/root.zig
@@ -163,6 +163,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_restricted_globals or
         options.no_regex_spaces or
         options.no_shadow or
+        options.no_unassigned_vars or
         options.no_undef or
         options.react_jsx_no_undef or
         options.no_unused_vars or

--- a/src/rules/no_unassigned_vars.zig
+++ b/src/rules/no_unassigned_vars.zig
@@ -1,0 +1,219 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unassigned-vars";
+
+const SymbolId = traverser.semantic.SymbolId;
+const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
+
+const Candidate = struct {
+    symbol_id: SymbolId,
+    node: ast.NodeIndex,
+    name: []const u8,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var decl_symbols = DeclSymbolMap.init(allocator);
+    defer decl_symbols.deinit();
+
+    var symbol_iter = symbol_table.iterSymbols();
+    while (symbol_iter.next()) |entry| {
+        if (!isCandidateSymbol(entry.symbol.flags)) continue;
+        for (symbol_table.symbolDecls(entry.id)) |decl| {
+            try decl_symbols.put(decl, entry.id);
+        }
+    }
+
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    const assigned_symbols = try allocator.alloc(bool, symbol_table.symbols.len);
+    defer allocator.free(assigned_symbols);
+    @memset(assigned_symbols, false);
+
+    var candidates: std.ArrayList(Candidate) = .empty;
+    defer candidates.deinit(allocator);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .decl_symbols = &decl_symbols,
+        .reference_lookup = &reference_lookup,
+        .symbol_table = symbol_table,
+        .assigned_symbols = assigned_symbols,
+        .candidates = &candidates,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+
+    const read_symbols = try allocator.alloc(bool, symbol_table.symbols.len);
+    defer allocator.free(read_symbols);
+    @memset(read_symbols, false);
+
+    var reference_iter = symbol_table.iterReferences();
+    while (reference_iter.next()) |entry| {
+        if (entry.reference.kind != .value) continue;
+        const symbol_id = symbol_table.referenceSymbol(entry.id);
+        if (symbol_id == .none) continue;
+        read_symbols[@intFromEnum(symbol_id)] = true;
+    }
+
+    for (candidates.items) |candidate| {
+        const symbol_index = @intFromEnum(candidate.symbol_id);
+        if (assigned_symbols[symbol_index]) continue;
+        if (!read_symbols[symbol_index]) continue;
+
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(candidate.node),
+            "'{s}' is always 'undefined' because it's never assigned.",
+            .{candidate.name},
+        );
+    }
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    decl_symbols: *const DeclSymbolMap,
+    reference_lookup: *const ReferenceLookup,
+    symbol_table: traverser.semantic.SymbolTable,
+    assigned_symbols: []bool,
+    candidates: *std.ArrayList(Candidate),
+
+    pub fn enter_variable_declarator(
+        self: *Visitor,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (declarator.init != .null) return .proceed;
+
+        const declaration = switch (ctx.tree.data(ctx.path.ancestor(1) orelse return .proceed)) {
+            .variable_declaration => |declaration| declaration,
+            else => return .proceed,
+        };
+        if (declaration.kind == .@"const" or declaration.declare) return .proceed;
+
+        const name = bindingIdentifierName(ctx.tree, declarator.id) orelse return .proceed;
+        const symbol_id = self.decl_symbols.get(declarator.id) orelse return .proceed;
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!isCandidateSymbol(symbol.flags)) return .proceed;
+
+        try self.candidates.append(self.allocator, .{
+            .symbol_id = symbol_id,
+            .node = declarator.id,
+            .name = name,
+        });
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        expression: ast.AssignmentExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.collectWriteTarget(ctx.tree, expression.left);
+        return .proceed;
+    }
+
+    pub fn enter_update_expression(
+        self: *Visitor,
+        expression: ast.UpdateExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.collectWriteTarget(ctx.tree, expression.argument);
+        return .proceed;
+    }
+
+    fn collectWriteTarget(self: *Visitor, tree: *const ast.Tree, target: ast.NodeIndex) void {
+        if (target == .null) return;
+
+        switch (tree.data(unwrapTransparent(tree, target))) {
+            .identifier_reference => {
+                const symbol_id = self.reference_lookup.get(unwrapTransparent(tree, target)) orelse return;
+                if (symbol_id == .none) return;
+                const symbol_index = @intFromEnum(symbol_id);
+                if (symbol_index < self.assigned_symbols.len) {
+                    self.assigned_symbols[symbol_index] = true;
+                }
+            },
+            .assignment_pattern => |pattern| self.collectWriteTarget(tree, pattern.left),
+            .binding_rest_element => |element| self.collectWriteTarget(tree, element.argument),
+            .array_pattern => |pattern| {
+                for (tree.extra(pattern.elements)) |element| {
+                    self.collectWriteTarget(tree, element);
+                }
+                self.collectWriteTarget(tree, pattern.rest);
+            },
+            .object_pattern => |pattern| {
+                for (tree.extra(pattern.properties)) |property_index| {
+                    const property = switch (tree.data(property_index)) {
+                        .binding_property => |property| property,
+                        else => continue,
+                    };
+                    self.collectWriteTarget(tree, property.value);
+                }
+                self.collectWriteTarget(tree, pattern.rest);
+            },
+            else => {},
+        }
+    }
+};
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+fn isCandidateSymbol(flags: traverser.semantic.Symbol.Flags) bool {
+    return (flags.function_scoped_var or flags.block_scoped_var) and
+        !flags.const_var and
+        !flags.ambient;
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -229,6 +229,7 @@ pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_useless_constructor = @import("no_useless_constructor.zig");
 pub const no_undef = @import("no_undef.zig");
+pub const no_unassigned_vars = @import("no_unassigned_vars.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
 pub const no_useless_escape = @import("no_useless_escape.zig");
 pub const no_useless_rename = @import("no_useless_rename.zig");
@@ -887,6 +888,10 @@ pub fn runSemantic(
 
     if (options.no_restricted_globals) {
         try no_restricted_globals.run(allocator, diagnostics, tree, semantic_result.symbol_table, options.no_restricted_globals_entries);
+    }
+
+    if (options.no_unassigned_vars) {
+        try no_unassigned_vars.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (use_typescript_no_redeclare) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -891,6 +891,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unassigned_vars.zig");
+}
+
+comptime {
     _ = @import("rules/no_warning_comments.zig");
 }
 

--- a/tests/rules/no_unassigned_vars.zig
+++ b/tests/rules/no_unassigned_vars.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports read vars that are never assigned" {
+    const source =
+        \\let x;
+        \\var y;
+        \\console.log(x, y);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unassigned_vars.id));
+    try std.testing.expect(hasMessage(result, "'x' is always 'undefined' because it's never assigned."));
+    try std.testing.expect(hasMessage(result, "'y' is always 'undefined' because it's never assigned."));
+}
+
+test "ignores variables that are never read" {
+    const source =
+        \\let x;
+        \\var y;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unassigned_vars.id));
+}
+
+test "ignores assigned variables and initialized declarations" {
+    const source =
+        \\let x;
+        \\x = 1;
+        \\console.log(x);
+        \\var y;
+        \\y++;
+        \\console.log(y);
+        \\let z = 1;
+        \\console.log(z);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unassigned_vars.id));
+}
+
+test "ignores const declarations, destructuring, and ambient declarations" {
+    const source =
+        \\declare var ambient: string;
+        \\const constant = 1;
+        \\let { a } = obj;
+        \\console.log(ambient, constant, a);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unassigned_vars.id));
+}
+
+test "can disable no-unassigned-vars" {
+    const source =
+        \\let x;
+        \\console.log(x);
+    ;
+
+    var options = baseOptions();
+    options.no_unassigned_vars = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unassigned_vars.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .import_no_unresolved = false,
+        .no_undef = false,
+        .no_unassigned_vars = true,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_unassigned_vars.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint `no-unassigned-vars` support for read `let`/`var` bindings without initializers or assignments
- wire the semantic rule into default options, CLI, npm builtin rule metadata, and docs
- add focused coverage for read-only, unread, assigned, initialized, destructuring, ambient, and disabled cases

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
