### PR TITLE
Add preserve-caught-error rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -195,6 +195,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Supports `allowEmptyReject` configuration |
+| [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) | Reports rethrown built-in errors in `catch` blocks that omit or replace the caught error `cause`, with `requireCatchParameter` support |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Supports `disallowRedundantWrapping` configuration |
 | [`prefer-rest-params`](https://eslint.org/docs/latest/rules/prefer-rest-params) | Implemented |
 | [`prefer-spread`](https://eslint.org/docs/latest/rules/prefer-spread) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -259,6 +259,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-object-has-own",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
+  "preserve-caught-error",
   "prefer-regex-literals",
   "prefer-rest-params",
   "prefer-spread",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -262,6 +262,7 @@ const BUILTIN_RULE_IDS = [
   "prefer-object-has-own",
   "prefer-object-spread",
   "prefer-promise-reject-errors",
+  "preserve-caught-error",
   "prefer-regex-literals",
   "prefer-rest-params",
   "prefer-spread",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2257,6 +2257,8 @@ pub const Options = struct {
     prefer_object_has_own: bool = true,
     prefer_promise_reject_errors: bool = true,
     prefer_promise_reject_errors_allow_empty_reject: bool = false,
+    preserve_caught_error: bool = true,
+    preserve_caught_error_require_catch_parameter: bool = false,
     prefer_destructuring: bool = true,
     prefer_destructuring_variable_declarator_array: bool = true,
     prefer_destructuring_variable_declarator_object: bool = true,
@@ -2946,6 +2948,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "prefer-promise-reject-errors")) {
             self.prefer_promise_reject_errors_allow_empty_reject = try preferPromiseRejectErrorsAllowEmptyRejectFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "preserve-caught-error")) {
+            self.preserve_caught_error_require_catch_parameter = try preserveCaughtErrorRequireCatchParameterFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "prefer-regex-literals")) {
             self.prefer_regex_literals_disallow_redundant_wrapping = try preferRegexLiteralsDisallowRedundantWrappingFromConfig(value);
@@ -6154,6 +6159,23 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return switch (config.get("allowEmptyReject") orelse return false) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn preserveCaughtErrorRequireCatchParameterFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get("requireCatchParameter") orelse return false) {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -801,6 +801,11 @@ pub fn main(init: std.process.Init) !void {
             options.prefer_numeric_literals = false;
         } else if (std.mem.eql(u8, arg, "--prefer-promise-reject-errors=off")) {
             options.prefer_promise_reject_errors = false;
+        } else if (std.mem.eql(u8, arg, "--preserve-caught-error=off")) {
+            options.preserve_caught_error = false;
+        } else if (std.mem.eql(u8, arg, "--preserve-caught-error-require-catch-parameter=on")) {
+            options.preserve_caught_error = true;
+            options.preserve_caught_error_require_catch_parameter = true;
         } else if (std.mem.eql(u8, arg, "--prefer-destructuring=off")) {
             options.prefer_destructuring = false;
         } else if (std.mem.eql(u8, arg, "--prefer-regex-literals=off")) {
@@ -2118,6 +2123,8 @@ fn printHelp() void {
         \\  --prefer-named-capture-group=off Disable prefer-named-capture-group
         \\  --prefer-numeric-literals=off Disable prefer-numeric-literals
         \\  --prefer-promise-reject-errors=off Disable prefer-promise-reject-errors
+        \\  --preserve-caught-error=off Disable preserve-caught-error
+        \\  --preserve-caught-error-require-catch-parameter=on Require catch parameters
         \\  --prefer-destructuring=off Disable prefer-destructuring
         \\  --prefer-object-has-own=off Disable prefer-object-has-own
         \\  --prefer-object-spread=off Disable prefer-object-spread

--- a/src/root.zig
+++ b/src/root.zig
@@ -176,6 +176,7 @@ fn hasSemanticRules(options: Options) bool {
         options.prefer_object_has_own or
         options.prefer_object_spread or
         options.prefer_promise_reject_errors or
+        options.preserve_caught_error or
         options.prefer_regex_literals or
         options.radix or
         options.require_atomic_updates or

--- a/src/rules/preserve_caught_error.zig
+++ b/src/rules/preserve_caught_error.zig
@@ -1,0 +1,361 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "preserve-caught-error";
+
+const SymbolId = traverser.semantic.SymbolId;
+const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
+
+pub const Options = struct {
+    require_catch_parameter: bool = false,
+};
+
+const CatchContext = struct {
+    index: ast.NodeIndex,
+    barrier_depth: usize,
+    has_parameter: bool = false,
+    destructured: bool = false,
+    name: []const u8 = "",
+    symbol_id: SymbolId = .none,
+};
+
+const CauseInfo = union(enum) {
+    none,
+    unknown,
+    value: ast.NodeIndex,
+};
+
+const CallLike = struct {
+    callee: ast.NodeIndex,
+    arguments: ast.IndexRange,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
+) Allocator.Error!void {
+    var decl_symbols = try buildDeclSymbolMap(allocator, symbol_table);
+    defer decl_symbols.deinit();
+
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .decl_symbols = &decl_symbols,
+        .reference_lookup = &reference_lookup,
+        .options = options,
+    };
+    defer visitor.catch_stack.deinit(allocator);
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    decl_symbols: *const DeclSymbolMap,
+    reference_lookup: *const ReferenceLookup,
+    options: Options,
+    catch_stack: std.ArrayList(CatchContext) = .empty,
+    barrier_depth: usize = 0,
+
+    pub fn enter_catch_clause(
+        self: *Visitor,
+        clause: ast.CatchClause,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        var catch_context = CatchContext{
+            .index = index,
+            .barrier_depth = self.barrier_depth,
+        };
+
+        if (clause.param != .null) {
+            catch_context.has_parameter = true;
+            if (bindingIdentifierName(ctx.tree, clause.param)) |name| {
+                catch_context.name = name;
+                catch_context.symbol_id = self.decl_symbols.get(clause.param) orelse .none;
+            } else {
+                catch_context.destructured = true;
+            }
+        }
+
+        try self.catch_stack.append(self.allocator, catch_context);
+        return .proceed;
+    }
+
+    pub fn exit_catch_clause(self: *Visitor, _: ast.CatchClause, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        _ = self.catch_stack.pop();
+    }
+
+    pub fn enter_function(self: *Visitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.barrier_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_function(self: *Visitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.barrier_depth -= 1;
+    }
+
+    pub fn enter_arrow_function_expression(self: *Visitor, _: ast.ArrowFunctionExpression, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.barrier_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(self: *Visitor, _: ast.ArrowFunctionExpression, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.barrier_depth -= 1;
+    }
+
+    pub fn enter_class(self: *Visitor, _: ast.Class, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.barrier_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_class(self: *Visitor, _: ast.Class, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.barrier_depth -= 1;
+    }
+
+    pub fn enter_static_block(self: *Visitor, _: ast.StaticBlock, _: ast.NodeIndex, _: *traverser.basic.Ctx) traverser.Action {
+        self.barrier_depth += 1;
+        return .proceed;
+    }
+
+    pub fn exit_static_block(self: *Visitor, _: ast.StaticBlock, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.barrier_depth -= 1;
+    }
+
+    pub fn enter_throw_statement(
+        self: *Visitor,
+        statement: ast.ThrowStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const catch_context = self.currentCatch() orelse return .proceed;
+        if (!self.isThrowingGlobalError(ctx.tree, statement.argument)) return .proceed;
+
+        if (catch_context.destructured) {
+            try self.addDiagnostic(ctx.tree, catch_context.index, "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring.");
+            return .proceed;
+        }
+
+        if (!catch_context.has_parameter) {
+            if (self.options.require_catch_parameter) {
+                try self.addDiagnostic(ctx.tree, index, "The caught error is not accessible because the catch clause lacks the error parameter. Start referencing the caught error using the catch parameter.");
+            }
+            return .proceed;
+        }
+
+        switch (errorCause(ctx.tree, statement.argument)) {
+            .unknown => return .proceed,
+            .none => try self.addDiagnostic(ctx.tree, index, "There is no `cause` attached to the symptom error being thrown."),
+            .value => |cause| {
+                const cause_name = identifierReferenceName(ctx.tree, unwrapTransparent(ctx.tree, cause)) orelse {
+                    try self.addDiagnostic(ctx.tree, cause, "The symptom error is being thrown with an incorrect `cause`.");
+                    return .proceed;
+                };
+                if (!std.mem.eql(u8, cause_name, catch_context.name)) {
+                    try self.addDiagnostic(ctx.tree, cause, "The symptom error is being thrown with an incorrect `cause`.");
+                    return .proceed;
+                }
+
+                const cause_symbol = self.reference_lookup.get(unwrapTransparent(ctx.tree, cause)) orelse .none;
+                if (catch_context.symbol_id != .none and cause_symbol != catch_context.symbol_id) {
+                    try self.addDiagnostic(ctx.tree, index, "The caught error is being attached as `cause`, but is shadowed by a closer scoped redeclaration.");
+                }
+            },
+        }
+
+        return .proceed;
+    }
+
+    fn currentCatch(self: *const Visitor) ?CatchContext {
+        var index = self.catch_stack.items.len;
+        while (index > 0) {
+            index -= 1;
+            const catch_context = self.catch_stack.items[index];
+            if (catch_context.barrier_depth == self.barrier_depth) return catch_context;
+        }
+        return null;
+    }
+
+    fn isThrowingGlobalError(self: *const Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        const expression = unwrapTransparent(tree, index);
+        const callee = switch (tree.data(expression)) {
+            .new_expression => |new_expression| new_expression.callee,
+            .call_expression => |call_expression| call_expression.callee,
+            else => return false,
+        };
+
+        const callee_index = unwrapTransparent(tree, callee);
+        const name = identifierReferenceName(tree, callee_index) orelse return false;
+        if (!isBuiltInErrorName(name)) return false;
+        return isUnresolvedReference(self.symbol_table, callee_index);
+    }
+
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        message: []const u8,
+    ) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+        );
+    }
+};
+
+fn errorCause(tree: *const ast.Tree, thrown_index: ast.NodeIndex) CauseInfo {
+    const thrown = unwrapTransparent(tree, thrown_index);
+    const call: CallLike = switch (tree.data(thrown)) {
+        .new_expression => |new_expression| .{ .callee = new_expression.callee, .arguments = new_expression.arguments },
+        .call_expression => |call_expression| .{ .callee = call_expression.callee, .arguments = call_expression.arguments },
+        else => return .unknown,
+    };
+
+    const callee_name = identifierReferenceName(tree, unwrapTransparent(tree, call.callee)) orelse return .unknown;
+    const options_index: usize = if (std.mem.eql(u8, callee_name, "AggregateError")) 2 else 1;
+    const arguments = tree.extra(call.arguments);
+
+    for (arguments, 0..) |argument, argument_index| {
+        if (argument_index > options_index) break;
+        if (tree.data(argument) == .spread_element) return .unknown;
+    }
+
+    if (arguments.len <= options_index) return .none;
+    const options = unwrapTransparent(tree, arguments[options_index]);
+    const object = switch (tree.data(options)) {
+        .object_expression => |object| object,
+        else => return .unknown,
+    };
+
+    var cause: ast.NodeIndex = .null;
+    for (tree.extra(object.properties)) |property_index| {
+        switch (tree.data(property_index)) {
+            .spread_element => return .unknown,
+            .object_property => |property| {
+                const name = staticPropertyName(tree, property) orelse continue;
+                if (std.mem.eql(u8, name, "cause")) cause = property.value;
+            },
+            else => {},
+        }
+    }
+
+    if (cause == .null) return .none;
+    return .{ .value = cause };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, property: ast.ObjectProperty) ?[]const u8 {
+    if (!property.computed) {
+        return switch (tree.data(property.key)) {
+            .identifier_name => |identifier| tree.string(identifier.name),
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        };
+    }
+    return switch (tree.data(unwrapTransparent(tree, property.key))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn buildDeclSymbolMap(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!DeclSymbolMap {
+    var map = DeclSymbolMap.init(allocator);
+    errdefer map.deinit();
+
+    var iter = symbol_table.iterSymbols();
+    while (iter.next()) |entry| {
+        for (symbol_table.symbolDecls(entry.id)) |decl| {
+            try map.put(decl, entry.id);
+        }
+    }
+    return map;
+}
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+
+    return lookup;
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn isBuiltInErrorName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Error") or
+        std.mem.eql(u8, name, "EvalError") or
+        std.mem.eql(u8, name, "RangeError") or
+        std.mem.eql(u8, name, "ReferenceError") or
+        std.mem.eql(u8, name, "SyntaxError") or
+        std.mem.eql(u8, name, "TypeError") or
+        std.mem.eql(u8, name, "URIError") or
+        std.mem.eql(u8, name, "AggregateError");
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+    return false;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -253,6 +253,7 @@ pub const prefer_numeric_literals = @import("prefer_numeric_literals.zig");
 pub const prefer_object_has_own = @import("prefer_object_has_own.zig");
 pub const prefer_object_spread = @import("prefer_object_spread.zig");
 pub const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
+pub const preserve_caught_error = @import("preserve_caught_error.zig");
 pub const prefer_regex_literals = @import("prefer_regex_literals.zig");
 pub const prefer_rest_params = @import("prefer_rest_params.zig");
 pub const prefer_spread = @import("prefer_spread.zig");
@@ -1050,6 +1051,12 @@ pub fn runSemantic(
 
     if (options.prefer_exponentiation_operator) {
         try prefer_exponentiation_operator.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.preserve_caught_error) {
+        try preserve_caught_error.run(allocator, diagnostics, tree, semantic_result.symbol_table, .{
+            .require_catch_parameter = options.preserve_caught_error_require_catch_parameter,
+        });
     }
 
     if (options.prefer_regex_literals) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -959,6 +959,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/preserve_caught_error.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_regex_literals.zig");
 }
 

--- a/tests/rules/preserve_caught_error.zig
+++ b/tests/rules/preserve_caught_error.zig
@@ -1,0 +1,155 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports rethrown errors without cause" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (err) {
+        \\  throw new Error("failed");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.preserve_caught_error.id));
+    try std.testing.expect(hasMessage(result, "There is no `cause` attached to the symptom error being thrown."));
+}
+
+test "allows matching cause on built-in errors" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (err) {
+        \\  throw new TypeError("failed", { cause: err });
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  throw new AggregateError([], "failed", { cause: error });
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.preserve_caught_error.id));
+}
+
+test "reports incorrect and shadowed causes" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch (err) {
+        \\  const other = err;
+        \\  throw new Error("failed", { cause: other });
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch (error) {
+        \\  {
+        \\    const error = otherError;
+        \\    throw new Error("failed", { cause: error });
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.preserve_caught_error.id));
+    try std.testing.expect(hasMessage(result, "The symptom error is being thrown with an incorrect `cause`."));
+    try std.testing.expect(hasMessage(result, "The caught error is being attached as `cause`, but is shadowed by a closer scoped redeclaration."));
+}
+
+test "reports destructured catches and optional catch binding when configured" {
+    const source =
+        \\try {
+        \\  risky();
+        \\} catch ({ message }) {
+        \\  throw new Error("failed");
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch {
+        \\  throw new Error("failed");
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.preserve_caught_error_require_catch_parameter = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.preserve_caught_error.id));
+    try std.testing.expect(hasMessage(result, "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring."));
+    try std.testing.expect(hasMessage(result, "The caught error is not accessible because the catch clause lacks the error parameter."));
+}
+
+test "skips non-global error constructors and nested functions" {
+    const source =
+        \\function wrap(Error) {
+        \\  try {
+        \\    risky();
+        \\  } catch (err) {
+        \\    throw new Error("custom");
+        \\  }
+        \\}
+        \\try {
+        \\  risky();
+        \\} catch (err) {
+        \\  function later() {
+        \\    throw new Error("not this catch");
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.preserve_caught_error.id));
+}
+
+test "parses preserve-caught-error config and can disable" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"requireCatchParameter\":true}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("preserve-caught-error", parsed.value);
+    try std.testing.expect(options.preserve_caught_error);
+    try std.testing.expect(options.preserve_caught_error_require_catch_parameter);
+
+    options.preserve_caught_error = false;
+    var result = try lint.lintSource(std.testing.allocator, "try {} catch (err) { throw new Error('x'); }", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.preserve_caught_error.id));
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .import_no_unresolved = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unassigned_vars = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .preserve_caught_error = true,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.preserve_caught_error.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint `preserve-caught-error` support for built-in Error rethrows inside catch blocks
- parse `requireCatchParameter`, wire semantic runner, CLI, npm metadata, and docs
- add focused tests for missing/incorrect/shadowed cause, destructured catches, optional catch bindings, and local Error shadows

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
