### PR TITLE
Add no-restricted-imports rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -137,6 +137,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-redeclare`](https://eslint.org/docs/latest/rules/no-redeclare) | Implemented with TypeScript-aware fallback to `@typescript-eslint/no-redeclare` |
 | [`no-restricted-exports`](https://eslint.org/docs/latest/rules/no-restricted-exports) | Supports `restrictedNamedExports` and `restrictDefaultExports` |
 | [`no-restricted-globals`](https://eslint.org/docs/latest/rules/no-restricted-globals) | Supports direct global restrictions, custom messages, and optional global object checks |
+| [`no-restricted-imports`](https://eslint.org/docs/latest/rules/no-restricted-imports) | Supports restricted `paths`, simple `patterns`, custom messages, import name allow/deny lists, type-only allowances, and re-export checks |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -207,6 +207,7 @@ const BUILTIN_RULE_IDS = [
   "no-redeclare",
   "no-restricted-exports",
   "no-restricted-globals",
+  "no-restricted-imports",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -210,6 +210,7 @@ const BUILTIN_RULE_IDS = [
   "no-redeclare",
   "no-restricted-exports",
   "no-restricted-globals",
+  "no-restricted-imports",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/src/core.zig
+++ b/src/core.zig
@@ -671,6 +671,11 @@ pub const max_no_restricted_global_message_len = 256;
 pub const max_no_restricted_global_objects = 16;
 pub const max_no_restricted_export_names = 64;
 pub const max_no_restricted_export_name_len = 128;
+pub const max_no_restricted_imports = 16;
+pub const max_no_restricted_import_source_len = 256;
+pub const max_no_restricted_import_message_len = 256;
+pub const max_no_restricted_import_names = 8;
+pub const max_no_restricted_import_name_len = 128;
 pub const max_id_denylist_names = 64;
 pub const max_id_denylist_name_len = 128;
 pub const max_id_length_exceptions = 64;
@@ -1028,6 +1033,100 @@ pub const NoRestrictedExportsDefaultOptions = struct {
     default_from: bool = false,
     named_from: bool = false,
     namespace_from: bool = false,
+};
+
+pub const NoRestrictedImportKind = enum {
+    path,
+    pattern,
+};
+
+pub const NoRestrictedImportNameList = struct {
+    count: usize = 0,
+    lengths: [max_no_restricted_import_names]usize = undefined,
+    storage: [max_no_restricted_import_names][max_no_restricted_import_name_len]u8 = undefined,
+
+    pub fn contains(self: *const NoRestrictedImportNameList, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const NoRestrictedImportNameList, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *NoRestrictedImportNameList, name: []const u8) bool {
+        if (name.len == 0 or name.len > max_no_restricted_import_name_len) return false;
+        if (self.count >= max_no_restricted_import_names) return false;
+        if (self.contains(name)) return true;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
+    }
+};
+
+pub const NoRestrictedImportEntry = struct {
+    kind: NoRestrictedImportKind = .path,
+    source_length: usize = 0,
+    source_storage: [max_no_restricted_import_source_len]u8 = undefined,
+
+    has_message: bool = false,
+    message_length: usize = 0,
+    message_storage: [max_no_restricted_import_message_len]u8 = undefined,
+
+    import_names: NoRestrictedImportNameList = .{},
+    allow_import_names: NoRestrictedImportNameList = .{},
+    allow_type_imports: bool = false,
+
+    pub fn source(self: *const NoRestrictedImportEntry) []const u8 {
+        return self.source_storage[0..self.source_length];
+    }
+
+    pub fn message(self: *const NoRestrictedImportEntry) ?[]const u8 {
+        if (!self.has_message) return null;
+        return self.message_storage[0..self.message_length];
+    }
+
+    pub fn setSource(self: *NoRestrictedImportEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_import_source_len) return false;
+        @memcpy(self.source_storage[0..value.len], value);
+        self.source_length = value.len;
+        return true;
+    }
+
+    pub fn setMessage(self: *NoRestrictedImportEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_import_message_len) return false;
+        @memcpy(self.message_storage[0..value.len], value);
+        self.message_length = value.len;
+        self.has_message = true;
+        return true;
+    }
+};
+
+pub const NoRestrictedImports = struct {
+    count: usize = 0,
+    entries: [max_no_restricted_imports]NoRestrictedImportEntry = undefined,
+
+    pub fn append(self: *NoRestrictedImports, entry: NoRestrictedImportEntry) bool {
+        if (self.count >= max_no_restricted_imports) return false;
+        self.entries[self.count] = entry;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn appendPath(self: *NoRestrictedImports, name: []const u8) bool {
+        var entry = NoRestrictedImportEntry{};
+        entry.kind = .path;
+        if (!entry.setSource(name)) return false;
+        return self.append(entry);
+    }
+
+    pub fn at(self: *const NoRestrictedImports, index: usize) *const NoRestrictedImportEntry {
+        return &self.entries[index];
+    }
 };
 
 pub const max_no_unused_vars_ignore_pattern_len = 256;
@@ -2123,6 +2222,8 @@ pub const Options = struct {
     no_restricted_exports_default: NoRestrictedExportsDefaultOptions = .{},
     no_restricted_globals: bool = false,
     no_restricted_globals_entries: NoRestrictedGlobals = .{},
+    no_restricted_imports: bool = false,
+    no_restricted_imports_entries: NoRestrictedImports = .{},
     no_restricted_properties: bool = true,
     no_restricted_properties_entries: NoRestrictedProperties = .{},
     no_regex_spaces: bool = true,
@@ -2876,6 +2977,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-globals")) {
             self.no_restricted_globals_entries = try noRestrictedGlobalsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-imports")) {
+            self.no_restricted_imports_entries = try noRestrictedImportsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
             self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
@@ -4061,6 +4165,161 @@ pub const Options = struct {
             .object => |object| object,
             else => null,
         };
+    }
+
+    fn noRestrictedImportsFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedImports {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+
+        var result = NoRestrictedImports{};
+        if (items.len < 2) return result;
+
+        for (items[1..]) |item| {
+            switch (item) {
+                .string => |source| {
+                    if (!result.appendPath(source)) return error.UnsupportedRuleConfigValue;
+                },
+                .object => |object| {
+                    if (object.get("paths") != null or object.get("patterns") != null) {
+                        if (object.get("paths")) |paths_value| {
+                            try appendNoRestrictedImportConfigItems(&result, paths_value, .path);
+                        }
+                        if (object.get("patterns")) |patterns_value| {
+                            try appendNoRestrictedImportPatternItems(&result, patterns_value);
+                        }
+                    } else {
+                        try appendNoRestrictedImportObject(&result, object, .path);
+                    }
+                },
+                else => return error.UnsupportedRuleConfigValue,
+            }
+        }
+
+        return result;
+    }
+
+    fn appendNoRestrictedImportConfigItems(
+        result: *NoRestrictedImports,
+        value: std.json.Value,
+        kind: NoRestrictedImportKind,
+    ) RuleConfigError!void {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        for (items) |item| {
+            switch (item) {
+                .string => |source| {
+                    var entry = NoRestrictedImportEntry{ .kind = kind };
+                    if (!entry.setSource(source)) return error.UnsupportedRuleConfigValue;
+                    if (!result.append(entry)) return error.UnsupportedRuleConfigValue;
+                },
+                .object => |object| try appendNoRestrictedImportObject(result, object, kind),
+                else => return error.UnsupportedRuleConfigValue,
+            }
+        }
+    }
+
+    fn appendNoRestrictedImportPatternItems(result: *NoRestrictedImports, value: std.json.Value) RuleConfigError!void {
+        switch (value) {
+            .array => try appendNoRestrictedImportConfigItems(result, value, .pattern),
+            .object => |object| try appendNoRestrictedImportPatternObject(result, object),
+            else => return error.UnsupportedRuleConfigValue,
+        }
+    }
+
+    fn appendNoRestrictedImportPatternObject(result: *NoRestrictedImports, object: std.json.ObjectMap) RuleConfigError!void {
+        if (object.get("group")) |group_value| {
+            const groups = switch (group_value) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (groups) |group_item| {
+                const source = switch (group_item) {
+                    .string => |source| source,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                var entry = try noRestrictedImportEntryFromObject(object, .pattern);
+                if (!entry.setSource(source)) return error.UnsupportedRuleConfigValue;
+                if (!result.append(entry)) return error.UnsupportedRuleConfigValue;
+            }
+            return;
+        }
+
+        try appendNoRestrictedImportObject(result, object, .pattern);
+    }
+
+    fn appendNoRestrictedImportObject(
+        result: *NoRestrictedImports,
+        object: std.json.ObjectMap,
+        kind: NoRestrictedImportKind,
+    ) RuleConfigError!void {
+        var entry = try noRestrictedImportEntryFromObject(object, kind);
+        if (entry.source_length == 0) {
+            const source = switch (object.get("name") orelse return error.UnsupportedRuleConfigValue) {
+                .string => |source| source,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!entry.setSource(source)) return error.UnsupportedRuleConfigValue;
+        }
+        if (!result.append(entry)) return error.UnsupportedRuleConfigValue;
+    }
+
+    fn noRestrictedImportEntryFromObject(
+        object: std.json.ObjectMap,
+        kind: NoRestrictedImportKind,
+    ) RuleConfigError!NoRestrictedImportEntry {
+        var entry = NoRestrictedImportEntry{ .kind = kind };
+
+        if (object.get("name")) |name_value| {
+            const source = switch (name_value) {
+                .string => |source| source,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!entry.setSource(source)) return error.UnsupportedRuleConfigValue;
+        }
+        if (object.get("message")) |message_value| {
+            const message = switch (message_value) {
+                .string => |message| message,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!entry.setMessage(message)) return error.UnsupportedRuleConfigValue;
+        }
+        if (object.get("importNames")) |names_value| {
+            try appendNoRestrictedImportNames(&entry.import_names, names_value);
+        }
+        if (object.get("allowImportNames")) |names_value| {
+            try appendNoRestrictedImportNames(&entry.allow_import_names, names_value);
+        }
+        if (object.get("allowTypeImports")) |allow_type_imports_value| {
+            entry.allow_type_imports = switch (allow_type_imports_value) {
+                .bool => |enabled| enabled,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+        }
+
+        return entry;
+    }
+
+    fn appendNoRestrictedImportNames(
+        names: *NoRestrictedImportNameList,
+        value: std.json.Value,
+    ) RuleConfigError!void {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        for (items) |item| {
+            const name = switch (item) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!names.append(name)) return error.UnsupportedRuleConfigValue;
+        }
     }
 
     fn boolObjectOption(object: std.json.ObjectMap, key: []const u8, default: bool) RuleConfigError!bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -560,6 +560,14 @@ pub fn main(init: std.process.Init) !void {
             options.no_restricted_globals = true;
         } else if (std.mem.startsWith(u8, arg, "--no-restricted-globals-name=")) {
             appendNoRestrictedGlobalName(arg["--no-restricted-globals-name=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--no-restricted-imports=off")) {
+            options.no_restricted_imports = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-imports=on")) {
+            options.no_restricted_imports = true;
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-imports-name=")) {
+            appendNoRestrictedImportName(arg["--no-restricted-imports-name=".len..], &options, .path);
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-imports-pattern=")) {
+            appendNoRestrictedImportName(arg["--no-restricted-imports-pattern=".len..], &options, .pattern);
         } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
             options.no_restricted_properties = false;
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
@@ -1349,6 +1357,15 @@ fn appendNoRestrictedGlobalName(value: []const u8, options: *lint.Options) void 
     options.no_restricted_globals = true;
 }
 
+fn appendNoRestrictedImportName(value: []const u8, options: *lint.Options, kind: lint.NoRestrictedImportKind) void {
+    var entry = lint.NoRestrictedImportEntry{ .kind = kind };
+    if (!entry.setSource(value) or !options.no_restricted_imports_entries.append(entry)) {
+        std.debug.print("utoo-lint: invalid no-restricted-imports value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.no_restricted_imports = true;
+}
+
 fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max value: {s}\n", .{value});
@@ -2042,6 +2059,10 @@ fn printHelp() void {
         \\  --no-restricted-globals=off Disable no-restricted-globals
         \\  --no-restricted-globals=on Enable no-restricted-globals
         \\  --no-restricted-globals-name=NAME Restrict a global name
+        \\  --no-restricted-imports=off Disable no-restricted-imports
+        \\  --no-restricted-imports=on Enable no-restricted-imports
+        \\  --no-restricted-imports-name=NAME Restrict an import source
+        \\  --no-restricted-imports-pattern=PATTERN Restrict import sources matching a simple * pattern
         \\  --no-restricted-properties=off Disable no-restricted-properties
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await

--- a/src/root.zig
+++ b/src/root.zig
@@ -10,6 +10,8 @@ pub const Options = core.Options;
 pub const Diagnostic = core.Diagnostic;
 pub const Result = core.Result;
 pub const SourcePosition = core.SourcePosition;
+pub const NoRestrictedImportEntry = core.NoRestrictedImportEntry;
+pub const NoRestrictedImportKind = core.NoRestrictedImportKind;
 pub const rules = @import("rules/root.zig");
 
 pub fn lintSource(

--- a/src/rules/no_restricted_imports.zig
+++ b/src/rules/no_restricted_imports.zig
@@ -1,0 +1,331 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-imports";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    restrictions: core.NoRestrictedImports,
+) Allocator.Error!void {
+    if (restrictions.count == 0) return;
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| try checkImportDeclaration(
+                allocator,
+                diagnostics,
+                tree,
+                declaration,
+                restrictions,
+            ),
+            .export_named_declaration => |declaration| try checkExportNamedDeclaration(
+                allocator,
+                diagnostics,
+                tree,
+                declaration,
+                restrictions,
+            ),
+            .export_all_declaration => |declaration| try checkExportAllDeclaration(
+                allocator,
+                diagnostics,
+                tree,
+                declaration,
+                restrictions,
+            ),
+            else => {},
+        }
+    }
+}
+
+fn checkImportDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    restrictions: core.NoRestrictedImports,
+) Allocator.Error!void {
+    const source = stringLiteralValue(tree, declaration.source) orelse return;
+
+    for (0..restrictions.count) |index| {
+        const entry = restrictions.at(index);
+        if (!entryMatches(entry, source)) continue;
+
+        if (entry.import_names.count == 0 and entry.allow_import_names.count == 0) {
+            if (declaration.import_kind == .type and entry.allow_type_imports) continue;
+            try reportModule(allocator, diagnostics, tree, declaration.source, source, entry);
+            continue;
+        }
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            switch (tree.data(specifier_index)) {
+                .import_default_specifier => try checkImportName(
+                    allocator,
+                    diagnostics,
+                    tree,
+                    specifier_index,
+                    source,
+                    "default",
+                    declaration.import_kind,
+                    entry,
+                ),
+                .import_namespace_specifier => try checkImportName(
+                    allocator,
+                    diagnostics,
+                    tree,
+                    specifier_index,
+                    source,
+                    "*",
+                    declaration.import_kind,
+                    entry,
+                ),
+                .import_specifier => |specifier| {
+                    const imported = moduleName(tree, specifier.imported) orelse continue;
+                    const import_kind: ast.ImportOrExportKind = if (declaration.import_kind == .type)
+                        .type
+                    else
+                        specifier.import_kind;
+                    try checkImportName(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        specifier.imported,
+                        source,
+                        imported,
+                        import_kind,
+                        entry,
+                    );
+                },
+                else => {},
+            }
+        }
+    }
+}
+
+fn checkExportNamedDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ExportNamedDeclaration,
+    restrictions: core.NoRestrictedImports,
+) Allocator.Error!void {
+    const source = stringLiteralValue(tree, declaration.source) orelse return;
+
+    for (0..restrictions.count) |index| {
+        const entry = restrictions.at(index);
+        if (!entryMatches(entry, source)) continue;
+
+        if (entry.import_names.count == 0 and entry.allow_import_names.count == 0) {
+            if (declaration.export_kind == .type and entry.allow_type_imports) continue;
+            try reportModule(allocator, diagnostics, tree, declaration.source, source, entry);
+            continue;
+        }
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .export_specifier => |specifier| specifier,
+                else => continue,
+            };
+            const imported = moduleName(tree, specifier.local) orelse continue;
+            const import_kind: ast.ImportOrExportKind = if (declaration.export_kind == .type)
+                .type
+            else
+                specifier.export_kind;
+            try checkImportName(
+                allocator,
+                diagnostics,
+                tree,
+                specifier.local,
+                source,
+                imported,
+                import_kind,
+                entry,
+            );
+        }
+    }
+}
+
+fn checkExportAllDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ExportAllDeclaration,
+    restrictions: core.NoRestrictedImports,
+) Allocator.Error!void {
+    const source = stringLiteralValue(tree, declaration.source) orelse return;
+
+    for (0..restrictions.count) |index| {
+        const entry = restrictions.at(index);
+        if (!entryMatches(entry, source)) continue;
+
+        if (entry.import_names.count == 0 and entry.allow_import_names.count == 0) {
+            if (declaration.export_kind == .type and entry.allow_type_imports) continue;
+            try reportModule(allocator, diagnostics, tree, declaration.source, source, entry);
+            continue;
+        }
+
+        try checkImportName(
+            allocator,
+            diagnostics,
+            tree,
+            if (declaration.exported == .null) declaration.source else declaration.exported,
+            source,
+            "*",
+            declaration.export_kind,
+            entry,
+        );
+    }
+}
+
+fn checkImportName(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    source: []const u8,
+    name: []const u8,
+    import_kind: ast.ImportOrExportKind,
+    entry: *const core.NoRestrictedImportEntry,
+) Allocator.Error!void {
+    if (entry.allow_type_imports and import_kind == .type) return;
+
+    if (entry.import_names.count > 0 and !entry.import_names.contains(name)) return;
+    if (entry.allow_import_names.count > 0 and entry.allow_import_names.contains(name)) return;
+
+    if (entry.import_names.count == 0 and entry.allow_import_names.count == 0) {
+        try reportModule(allocator, diagnostics, tree, node, source, entry);
+        return;
+    }
+
+    try reportImportName(allocator, diagnostics, tree, node, source, name, entry);
+}
+
+fn entryMatches(entry: *const core.NoRestrictedImportEntry, source: []const u8) bool {
+    return switch (entry.kind) {
+        .path => std.mem.eql(u8, entry.source(), source),
+        .pattern => wildcardMatches(entry.source(), source),
+    };
+}
+
+fn wildcardMatches(pattern: []const u8, source: []const u8) bool {
+    if (pattern.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, pattern, '*') == null) {
+        return std.mem.eql(u8, pattern, source);
+    }
+
+    var source_index: usize = 0;
+    var part_index: usize = 0;
+    var parts = std.mem.splitScalar(u8, pattern, '*');
+    while (parts.next()) |part| : (part_index += 1) {
+        if (part.len == 0) continue;
+
+        if (part_index == 0 and pattern[0] != '*') {
+            if (!std.mem.startsWith(u8, source, part)) return false;
+            source_index = part.len;
+            continue;
+        }
+
+        const found = std.mem.indexOf(u8, source[source_index..], part) orelse return false;
+        source_index += found + part.len;
+    }
+
+    if (pattern[pattern.len - 1] != '*') {
+        var last_parts = std.mem.splitScalar(u8, pattern, '*');
+        var last: []const u8 = "";
+        while (last_parts.next()) |part| {
+            if (part.len > 0) last = part;
+        }
+        return std.mem.endsWith(u8, source, last);
+    }
+
+    return true;
+}
+
+fn moduleName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn reportModule(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    source: []const u8,
+    entry: *const core.NoRestrictedImportEntry,
+) Allocator.Error!void {
+    if (entry.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(node),
+            "'{s}' import is restricted from being used. {s}",
+            .{ source, message },
+        );
+        return;
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(node),
+        "'{s}' import is restricted from being used.",
+        .{source},
+    );
+}
+
+fn reportImportName(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    source: []const u8,
+    name: []const u8,
+    entry: *const core.NoRestrictedImportEntry,
+) Allocator.Error!void {
+    if (entry.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(node),
+            "'{s}' import from '{s}' is restricted. {s}",
+            .{ name, source, message },
+        );
+        return;
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(node),
+        "'{s}' import from '{s}' is restricted.",
+        .{ name, source },
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -195,6 +195,7 @@ pub const no_prototype_builtins = @import("no_prototype_builtins.zig");
 pub const no_redeclare = @import("no_redeclare.zig");
 pub const no_restricted_exports = @import("no_restricted_exports.zig");
 pub const no_restricted_globals = @import("no_restricted_globals.zig");
+pub const no_restricted_imports = @import("no_restricted_imports.zig");
 pub const no_restricted_properties = @import("no_restricted_properties.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
@@ -1410,6 +1411,9 @@ const BasicVisitor = struct {
         }
         if (self.options.import_no_self_import) {
             try import_no_self_import.check(self.allocator, self.diagnostics, ctx.tree, program, self.file_path);
+        }
+        if (self.options.no_restricted_imports) {
+            try no_restricted_imports.check(self.allocator, self.diagnostics, ctx.tree, program, self.options.no_restricted_imports_entries);
         }
         if (self.options.react_no_deprecated) {
             try react_no_deprecated.checkProgram(self.allocator, self.diagnostics, ctx.tree, program);

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -719,6 +719,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_imports.zig");
+}
+
+comptime {
     _ = @import("rules/no_restricted_properties.zig");
 }
 

--- a/tests/rules/no_restricted_imports.zig
+++ b/tests/rules/no_restricted_imports.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-restricted-imports for restricted modules" {
+    const source =
+        \\import fs from "fs";
+        \\import "path";
+        \\import ok from "ok";
+    ;
+
+    const options = try optionsWithConfig("[\"error\",\"fs\",\"path\"]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_imports.id));
+}
+
+test "reports restricted importNames with custom messages" {
+    const source =
+        \\import banned, { danger, safe as local } from "lib";
+        \\import { other } from "lib";
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"paths\":[{\"name\":\"lib\",\"importNames\":[\"default\",\"danger\"],\"message\":\"Use safe-lib instead.\"}]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_imports.id));
+    try std.testing.expect(hasMessage(result, "Use safe-lib instead."));
+}
+
+test "reports imports outside allowImportNames" {
+    const source =
+        \\import { safe, danger } from "lib";
+        \\import * as everything from "lib";
+        \\import "lib";
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"paths\":[{\"name\":\"lib\",\"allowImportNames\":[\"safe\"]}]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_imports.id));
+}
+
+test "reports simple pattern matches and re-exports" {
+    const source =
+        \\import thing from "@internal/thing";
+        \\export { value } from "@internal/value";
+        \\export * from "@internal/all";
+        \\import ok from "@public/thing";
+    ;
+
+    const options = try optionsWithConfig("[\"error\",{\"patterns\":[\"@internal/*\"]}]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_restricted_imports.id));
+}
+
+test "allows type-only imports when configured" {
+    const source =
+        \\import type { T } from "types";
+        \\export type { U } from "types";
+        \\import { value } from "types";
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",{\"paths\":[{\"name\":\"types\",\"allowTypeImports\":true}]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_restricted_imports.id));
+}
+
+test "can disable no-restricted-imports" {
+    const source =
+        \\import fs from "fs";
+    ;
+
+    var options = try optionsWithConfig("[\"error\",\"fs\"]");
+    options.no_restricted_imports = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_imports.id));
+}
+
+test "parses object pattern groups" {
+    var options = try optionsWithConfig(
+        "[\"error\",{\"patterns\":{\"group\":[\"private/*\",\"secret/*\"],\"importNames\":[\"leak\"],\"message\":\"Use public API.\"}}]",
+    );
+
+    try std.testing.expect(options.no_restricted_imports);
+    try std.testing.expectEqual(@as(usize, 2), options.no_restricted_imports_entries.count);
+    try std.testing.expectEqualStrings("private/*", options.no_restricted_imports_entries.at(0).source());
+    try std.testing.expect(options.no_restricted_imports_entries.at(0).import_names.contains("leak"));
+    try std.testing.expectEqualStrings("Use public API.", options.no_restricted_imports_entries.at(1).message().?);
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("no-restricted-imports", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .import_no_unresolved = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unassigned_vars = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_imports.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint `no-restricted-imports` support for static imports and re-exports
- parse common `paths` and `patterns` config forms, including custom messages, `importNames`, `allowImportNames`, and `allowTypeImports`
- wire the rule through CLI flags, npm metadata, docs, and focused tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
