### PR TITLE
Add sort-keys rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -207,6 +207,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-unicode-regexp`](https://eslint.org/docs/latest/rules/require-unicode-regexp) | Supports regexp literals, static `RegExp` constructors, and `requireFlag` configuration |
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) | Supports declaration/member sorting, `ignoreCase`, `ignoreDeclarationSort`, `ignoreMemberSort`, `allowSeparatedGroups`, and `memberSyntaxSortOrder` |
+| [`sort-keys`](https://eslint.org/docs/latest/rules/sort-keys) | Supports object literal key ordering with `asc`/`desc`, `caseSensitive`, `natural`, `minKeys`, and `allowLineSeparatedGroups` |
 | [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting and `ignoreCase` configuration |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -270,6 +270,7 @@ const BUILTIN_RULE_IDS = [
   "require-atomic-updates",
   "require-yield",
   "sort-imports",
+  "sort-keys",
   "sort-vars",
   "spaced-comment",
   "strict",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -273,6 +273,7 @@ const BUILTIN_RULE_IDS = [
   "require-atomic-updates",
   "require-yield",
   "sort-imports",
+  "sort-keys",
   "sort-vars",
   "spaced-comment",
   "strict",

--- a/src/core.zig
+++ b/src/core.zig
@@ -86,6 +86,11 @@ pub const LinebreakStyle = enum {
     windows,
 };
 
+pub const SortKeysOrder = enum {
+    asc,
+    desc,
+};
+
 pub const SortImportsMemberSyntax = enum {
     none,
     all,
@@ -2497,6 +2502,12 @@ pub const Options = struct {
     sort_imports_ignore_member_sort: bool = false,
     sort_imports_allow_separated_groups: bool = false,
     sort_imports_member_syntax_order: SortImportsMemberSyntaxOrder = .{},
+    sort_keys: bool = false,
+    sort_keys_order: SortKeysOrder = .asc,
+    sort_keys_case_sensitive: bool = true,
+    sort_keys_natural: bool = false,
+    sort_keys_min_keys: usize = 2,
+    sort_keys_allow_line_separated_groups: bool = false,
     spaced_comment: bool = true,
     spaced_comment_style: SpacedCommentStyle = .always,
     spaced_comment_markers: SpacedCommentMarkers = .{},
@@ -3101,6 +3112,13 @@ pub const Options = struct {
             self.sort_imports_ignore_member_sort = try sortImportsBoolOptionFromConfig(value, "ignoreMemberSort", false);
             self.sort_imports_allow_separated_groups = try sortImportsBoolOptionFromConfig(value, "allowSeparatedGroups", false);
             self.sort_imports_member_syntax_order = try sortImportsMemberSyntaxOrderFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "sort-keys")) {
+            self.sort_keys_order = try sortKeysOrderFromConfig(value);
+            self.sort_keys_case_sensitive = try sortKeysBoolOptionFromConfig(value, "caseSensitive", true);
+            self.sort_keys_natural = try sortKeysBoolOptionFromConfig(value, "natural", false);
+            self.sort_keys_min_keys = try sortKeysMinKeysFromConfig(value);
+            self.sort_keys_allow_line_separated_groups = try sortKeysBoolOptionFromConfig(value, "allowLineSeparatedGroups", false);
         }
         if (std.mem.eql(u8, cli_name, "strict")) {
             self.strict_mode = try strictModeFromConfig(value);
@@ -6622,6 +6640,56 @@ pub const Options = struct {
         if (items.len < 2) return null;
 
         return switch (items[1]) {
+            .object => |object| object,
+            else => null,
+        };
+    }
+
+    fn sortKeysOrderFromConfig(value: std.json.Value) RuleConfigError!SortKeysOrder {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .asc,
+        };
+        if (items.len < 2) return .asc;
+
+        const order = switch (items[1]) {
+            .string => |order| order,
+            .object => return .asc,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (std.mem.eql(u8, order, "asc")) return .asc;
+        if (std.mem.eql(u8, order, "desc")) return .desc;
+        return error.UnsupportedRuleConfigValue;
+    }
+
+    fn sortKeysBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const config = sortKeysConfigObject(value) orelse return default;
+        return switch (config.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn sortKeysMinKeysFromConfig(value: std.json.Value) RuleConfigError!usize {
+        const config = sortKeysConfigObject(value) orelse return 2;
+        return switch (config.get("minKeys") orelse return 2) {
+            .integer => |min_keys| nonNegativeIntegerToUsize(min_keys),
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn sortKeysConfigObject(value: std.json.Value) ?std.json.ObjectMap {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 2) return null;
+        const index: usize = switch (items[1]) {
+            .object => 1,
+            .string => if (items.len >= 3) 2 else return null,
+            else => return null,
+        };
+        return switch (items[index]) {
             .object => |object| object,
             else => null,
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -940,6 +940,24 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, arg, "--sort-imports-allow-separated-groups=on")) {
             options.sort_imports = true;
             options.sort_imports_allow_separated_groups = true;
+        } else if (std.mem.eql(u8, arg, "--sort-keys=on")) {
+            options.sort_keys = true;
+        } else if (std.mem.eql(u8, arg, "--sort-keys=off")) {
+            options.sort_keys = false;
+        } else if (std.mem.eql(u8, arg, "--sort-keys=desc")) {
+            options.sort_keys = true;
+            options.sort_keys_order = .desc;
+        } else if (std.mem.eql(u8, arg, "--sort-keys-case-sensitive=off")) {
+            options.sort_keys = true;
+            options.sort_keys_case_sensitive = false;
+        } else if (std.mem.eql(u8, arg, "--sort-keys-natural=on")) {
+            options.sort_keys = true;
+            options.sort_keys_natural = true;
+        } else if (std.mem.startsWith(u8, arg, "--sort-keys-min-keys=")) {
+            parseSortKeysMinKeys(arg["--sort-keys-min-keys=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--sort-keys-allow-line-separated-groups=on")) {
+            options.sort_keys = true;
+            options.sort_keys_allow_line_separated_groups = true;
         } else if (std.mem.eql(u8, arg, "--sort-vars=on")) {
             options.sort_vars = true;
         } else if (std.mem.eql(u8, arg, "--sort-vars=off")) {
@@ -1503,6 +1521,15 @@ fn parseMaxParamsMax(value: []const u8, options: *lint.Options) void {
         std.process.exit(2);
     };
     options.max_params_max = max;
+}
+
+fn parseSortKeysMinKeys(value: []const u8, options: *lint.Options) void {
+    const min_keys = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("utoo-lint: invalid --sort-keys-min-keys value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.sort_keys = true;
+    options.sort_keys_min_keys = min_keys;
 }
 
 fn parseMaxStatementsMax(value: []const u8, options: *lint.Options) void {
@@ -2223,6 +2250,13 @@ fn printHelp() void {
         \\  --sort-imports-ignore-declaration-sort=on Ignore declaration order
         \\  --sort-imports-ignore-member-sort=on Ignore member order
         \\  --sort-imports-allow-separated-groups=on Allow blank-line separated import groups
+        \\  --sort-keys=on            Enable sort-keys
+        \\  --sort-keys=off           Disable sort-keys
+        \\  --sort-keys=desc          Require descending object keys
+        \\  --sort-keys-case-sensitive=off Compare object keys case-insensitively
+        \\  --sort-keys-natural=on    Compare object keys with natural numeric order
+        \\  --sort-keys-min-keys=N    Require sorting only when an object has at least N keys
+        \\  --sort-keys-allow-line-separated-groups=on Allow blank-line separated key groups
         \\  --sort-vars=on            Enable sort-vars
         \\  --sort-vars=off           Disable sort-vars
         \\  --sort-vars-ignore-case=on Enable sort-vars and ignore case

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -307,6 +307,7 @@ pub const require_unicode_regexp = @import("require_unicode_regexp.zig");
 const reassignment_rules = @import("reassignment_rules.zig");
 pub const require_yield = @import("require_yield.zig");
 pub const sort_imports = @import("sort_imports.zig");
+pub const sort_keys = @import("sort_keys.zig");
 pub const sort_vars = @import("sort_vars.zig");
 pub const spaced_comment = @import("spaced_comment.zig");
 pub const strict = @import("strict.zig");
@@ -3787,6 +3788,15 @@ const BasicVisitor = struct {
         }
         if (self.options.no_dupe_keys) {
             try no_dupe_keys.check(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
+        if (self.options.sort_keys) {
+            try sort_keys.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression, .{
+                .order = self.options.sort_keys_order,
+                .case_sensitive = self.options.sort_keys_case_sensitive,
+                .natural = self.options.sort_keys_natural,
+                .min_keys = self.options.sort_keys_min_keys,
+                .allow_line_separated_groups = self.options.sort_keys_allow_line_separated_groups,
+            });
         }
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectExpression(self.allocator, self.diagnostics, ctx.tree, expression);

--- a/src/rules/sort_keys.zig
+++ b/src/rules/sort_keys.zig
@@ -1,0 +1,267 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "sort-keys";
+
+pub const Options = struct {
+    order: core.SortKeysOrder = .asc,
+    case_sensitive: bool = true,
+    natural: bool = false,
+    min_keys: usize = 2,
+    allow_line_separated_groups: bool = false,
+};
+
+const PropertyName = struct {
+    value: []const u8,
+    owned: bool = false,
+};
+
+pub fn checkObjectExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ObjectExpression,
+    options: Options,
+) Allocator.Error!void {
+    var group_count: usize = 0;
+    var previous_name: ?PropertyName = null;
+    var previous_node: ast.NodeIndex = .null;
+    defer if (previous_name) |name| {
+        if (name.owned) allocator.free(name.value);
+    };
+
+    for (tree.extra(expression.properties)) |property_index| {
+        const property = switch (tree.data(property_index)) {
+            .object_property => |property| property,
+            else => {
+                if (previous_name) |name| {
+                    if (name.owned) allocator.free(name.value);
+                }
+                previous_name = null;
+                previous_node = .null;
+                group_count = 0;
+                continue;
+            },
+        };
+
+        const name = try propertyName(allocator, tree, property) orelse {
+            if (previous_name) |old| {
+                if (old.owned) allocator.free(old.value);
+            }
+            previous_name = null;
+            previous_node = .null;
+            group_count = 0;
+            continue;
+        };
+        errdefer if (name.owned) allocator.free(name.value);
+
+        if (options.allow_line_separated_groups and propertiesAreSeparated(tree, previous_node, property_index)) {
+            if (previous_name) |old| {
+                if (old.owned) allocator.free(old.value);
+            }
+            previous_name = name;
+            previous_node = property_index;
+            group_count = 1;
+            continue;
+        }
+
+        group_count += 1;
+        if (group_count >= options.min_keys) {
+            if (previous_name) |previous| {
+                if (!keysAreSorted(previous.value, name.value, options)) {
+                    try addDiagnostic(allocator, diagnostics, tree, property_index, previous.value, name.value, options);
+                }
+            }
+        }
+
+        if (previous_name) |old| {
+            if (old.owned) allocator.free(old.value);
+        }
+        previous_name = name;
+        previous_node = property_index;
+    }
+}
+
+fn keysAreSorted(previous: []const u8, current: []const u8, options: Options) bool {
+    const comparison = compareNames(previous, current, options);
+    return switch (options.order) {
+        .asc => comparison <= 0,
+        .desc => comparison >= 0,
+    };
+}
+
+fn compareNames(left: []const u8, right: []const u8, options: Options) i8 {
+    if (options.natural) return naturalCompare(left, right, options.case_sensitive);
+
+    const min_len = @min(left.len, right.len);
+    for (0..min_len) |index| {
+        const left_char = normalizeChar(left[index], options.case_sensitive);
+        const right_char = normalizeChar(right[index], options.case_sensitive);
+        if (left_char < right_char) return -1;
+        if (left_char > right_char) return 1;
+    }
+    if (left.len < right.len) return -1;
+    if (left.len > right.len) return 1;
+    return 0;
+}
+
+fn naturalCompare(left: []const u8, right: []const u8, case_sensitive: bool) i8 {
+    var left_index: usize = 0;
+    var right_index: usize = 0;
+
+    while (left_index < left.len and right_index < right.len) {
+        if (std.ascii.isDigit(left[left_index]) and std.ascii.isDigit(right[right_index])) {
+            const left_number = numberSlice(left, &left_index);
+            const right_number = numberSlice(right, &right_index);
+            const number_order = compareNumberSlices(left_number, right_number);
+            if (number_order != 0) return number_order;
+            continue;
+        }
+
+        const left_char = normalizeChar(left[left_index], case_sensitive);
+        const right_char = normalizeChar(right[right_index], case_sensitive);
+        if (left_char < right_char) return -1;
+        if (left_char > right_char) return 1;
+        left_index += 1;
+        right_index += 1;
+    }
+
+    if (left_index < left.len) return 1;
+    if (right_index < right.len) return -1;
+    return 0;
+}
+
+fn numberSlice(value: []const u8, index: *usize) []const u8 {
+    const start = index.*;
+    while (index.* < value.len and std.ascii.isDigit(value[index.*])) {
+        index.* += 1;
+    }
+    return value[start..index.*];
+}
+
+fn compareNumberSlices(left: []const u8, right: []const u8) i8 {
+    const trimmed_left = trimLeadingZeroes(left);
+    const trimmed_right = trimLeadingZeroes(right);
+    if (trimmed_left.len < trimmed_right.len) return -1;
+    if (trimmed_left.len > trimmed_right.len) return 1;
+    const lexical = std.mem.order(u8, trimmed_left, trimmed_right);
+    if (lexical == .lt) return -1;
+    if (lexical == .gt) return 1;
+    if (left.len < right.len) return -1;
+    if (left.len > right.len) return 1;
+    return 0;
+}
+
+fn trimLeadingZeroes(value: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index + 1 < value.len and value[index] == '0') {
+        index += 1;
+    }
+    return value[index..];
+}
+
+fn normalizeChar(char: u8, case_sensitive: bool) u8 {
+    return if (case_sensitive) char else std.ascii.toLower(char);
+}
+
+fn propertiesAreSeparated(tree: *const ast.Tree, previous: ast.NodeIndex, current: ast.NodeIndex) bool {
+    if (previous == .null or current == .null) return false;
+    const previous_span = tree.span(previous);
+    const current_span = tree.span(current);
+    if (previous_span.end >= current_span.start) return false;
+
+    const between = tree.source[previous_span.end..current_span.start];
+    var newline_count: usize = 0;
+    for (between) |char| {
+        if (char == '\n') {
+            newline_count += 1;
+            if (newline_count >= 2) return true;
+        } else if (char != '\r' and char != ' ' and char != '\t' and char != ',') {
+            newline_count = 0;
+        }
+    }
+    return false;
+}
+
+fn propertyName(allocator: Allocator, tree: *const ast.Tree, property: ast.ObjectProperty) Allocator.Error!?PropertyName {
+    if (property.key == .null) return null;
+    if (isPrototypeSetter(tree, property)) return null;
+
+    const key = unwrapTransparent(tree, property.key);
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| if (property.computed) null else .{ .value = tree.string(identifier.name) },
+        .string_literal => |literal| .{ .value = tree.string(literal.value) },
+        .numeric_literal => |literal| .{ .value = try numericPropertyName(allocator, tree, literal), .owned = true },
+        .template_literal => |literal| templatePropertyName(tree, literal),
+        else => null,
+    };
+}
+
+fn isPrototypeSetter(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
+    if (property.computed or property.kind != .init or property.method) return false;
+    const key = unwrapTransparent(tree, property.key);
+    const name = switch (tree.data(key)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => return false,
+    };
+    return std.mem.eql(u8, name, "__proto__");
+}
+
+fn numericPropertyName(allocator: Allocator, tree: *const ast.Tree, literal: ast.NumericLiteral) Allocator.Error![]const u8 {
+    const value = literal.value(tree);
+    return std.fmt.allocPrint(allocator, "{d}", .{value});
+}
+
+fn templatePropertyName(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?PropertyName {
+    if (tree.extra(literal.expressions).len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| .{ .value = tree.string(element.cooked) },
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    previous: []const u8,
+    current: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    const order = switch (options.order) {
+        .asc => "ascending",
+        .desc => "descending",
+    };
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(index),
+        "Expected object keys to be in {s} order. '{s}' should be before '{s}'.",
+        .{ order, current, previous },
+    );
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -931,6 +931,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/sort_keys.zig");
+}
+
+comptime {
     _ = @import("rules/sort_vars.zig");
 }
 

--- a/tests/rules/sort_keys.zig
+++ b/tests/rules/sort_keys.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports ascending sort-keys violations" {
+    const source =
+        \\const value = {
+        \\  zebra: 1,
+        \\  alpha: 2,
+        \\  beta: 3,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.sort_keys.id));
+}
+
+test "supports descending order" {
+    const source =
+        \\const value = {
+        \\  alpha: 1,
+        \\  zebra: 2,
+        \\};
+    ;
+
+    var options = optionsOnly();
+    options.sort_keys_order = .desc;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.sort_keys.id));
+}
+
+test "supports case insensitive sort-keys" {
+    const source =
+        \\const value = {
+        \\  alpha: 1,
+        \\  Beta: 2,
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.sort_keys.id));
+
+    var options = optionsOnly();
+    options.sort_keys_case_sensitive = false;
+    var ignored_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer ignored_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(ignored_result, lint.rules.sort_keys.id));
+}
+
+test "supports natural sort-keys" {
+    const source =
+        \\const value = {
+        \\  item2: 1,
+        \\  item10: 2,
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.sort_keys.id));
+
+    var options = optionsOnly();
+    options.sort_keys_natural = true;
+    var natural_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer natural_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(natural_result, lint.rules.sort_keys.id));
+}
+
+test "supports minKeys" {
+    const source =
+        \\const small = { b: 1, a: 2 };
+        \\const large = { c: 1, b: 2, a: 3 };
+    ;
+
+    var options = optionsOnly();
+    options.sort_keys_min_keys = 3;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.sort_keys.id));
+}
+
+test "supports allowLineSeparatedGroups" {
+    const source =
+        \\const value = {
+        \\  zebra: 1,
+        \\
+        \\  alpha: 2,
+        \\};
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.sort_keys.id));
+
+    var options = optionsOnly();
+    options.sort_keys_allow_line_separated_groups = true;
+    var grouped_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer grouped_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(grouped_result, lint.rules.sort_keys.id));
+}
+
+test "skips dynamic keys and spreads as group boundaries" {
+    const source =
+        \\const value = {
+        \\  z: 1,
+        \\  [dynamic]: 2,
+        \\  a: 3,
+        \\  ...extra,
+        \\  c: 4,
+        \\  b: 5,
+        \\};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.sort_keys.id));
+}
+
+test "parses sort-keys config" {
+    const options = try optionsWithConfig(
+        "[\"error\",\"desc\",{\"caseSensitive\":false,\"natural\":true,\"minKeys\":3,\"allowLineSeparatedGroups\":true}]",
+    );
+
+    try std.testing.expect(options.sort_keys);
+    try std.testing.expect(options.sort_keys_order == .desc);
+    try std.testing.expect(!options.sort_keys_case_sensitive);
+    try std.testing.expect(options.sort_keys_natural);
+    try std.testing.expectEqual(@as(usize, 3), options.sort_keys_min_keys);
+    try std.testing.expect(options.sort_keys_allow_line_separated_groups);
+}
+
+test "can disable sort-keys" {
+    const source =
+        \\const value = { b: 1, a: 2 };
+    ;
+
+    var options = optionsOnly();
+    options.sort_keys = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.sort_keys.id));
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("sort-keys", parsed.value);
+    return options;
+}
+
+fn optionsOnly() lint.Options {
+    var options = baseOptions();
+    options.sort_keys = true;
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .import_no_unresolved = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unassigned_vars = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}


### PR DESCRIPTION
## Summary
- add ESLint `sort-keys` support for object literal key ordering
- parse `asc`/`desc`, `caseSensitive`, `natural`, `minKeys`, and `allowLineSeparatedGroups`
- wire CLI flags, npm metadata, docs, and focused tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
