### PR TITLE
Add id-match rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -29,6 +29,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`guard-for-in`](https://eslint.org/docs/latest/rules/guard-for-in) | Implemented |
 | [`id-denylist`](https://eslint.org/docs/latest/rules/id-denylist) | Supports configured restricted identifiers, private identifiers, member-write checks, and renamed import/export skips |
 | [`id-length`](https://eslint.org/docs/latest/rules/id-length) | Supports `min`, `max`, `exceptions`, common `exceptionPatterns`, and `properties` for bindings, imports, functions, and class/object properties |
+| [`id-match`](https://eslint.org/docs/latest/rules/id-match) | Supports lightweight pattern matching for declarations and import aliases, with `properties`, `classFields`, `onlyDeclarations`, and `ignoreDestructuring` configuration |
 | [`init-declarations`](https://eslint.org/docs/latest/rules/init-declarations) | Supports `always`, `never`, and `ignoreForLoopInit` |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -104,6 +104,7 @@ const BUILTIN_RULE_IDS = [
   "grouped-accessor-pairs",
   "guard-for-in",
   "id-length",
+  "id-match",
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -107,6 +107,7 @@ const BUILTIN_RULE_IDS = [
   "grouped-accessor-pairs",
   "guard-for-in",
   "id-length",
+  "id-match",
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",

--- a/src/core.zig
+++ b/src/core.zig
@@ -705,6 +705,7 @@ pub const max_id_length_exceptions = 64;
 pub const max_id_length_exception_len = 128;
 pub const max_id_length_exception_patterns = 64;
 pub const max_id_length_exception_pattern_len = 256;
+pub const max_id_match_pattern_len = 256;
 
 pub const NoRestrictedPropertyNameList = struct {
     count: usize = 0,
@@ -1002,17 +1003,58 @@ pub const IdLengthExceptionPatterns = struct {
         self.count += 1;
     }
 
-    fn simplePatternMatches(pattern: []const u8, name: []const u8) bool {
-        if (pattern.len >= 2 and pattern[0] == '^' and pattern[pattern.len - 1] == '$') {
-            return std.mem.eql(u8, name, pattern[1 .. pattern.len - 1]);
+    fn simplePatternMatches(pattern_text: []const u8, name: []const u8) bool {
+        if (pattern_text.len >= 2 and pattern_text[0] == '^' and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.eql(u8, name, pattern_text[1 .. pattern_text.len - 1]);
         }
-        if (pattern.len >= 1 and pattern[0] == '^') {
-            return std.mem.startsWith(u8, name, pattern[1..]);
+        if (pattern_text.len >= 1 and pattern_text[0] == '^') {
+            return std.mem.startsWith(u8, name, pattern_text[1..]);
         }
-        if (pattern.len >= 1 and pattern[pattern.len - 1] == '$') {
-            return std.mem.endsWith(u8, name, pattern[0 .. pattern.len - 1]);
+        if (pattern_text.len >= 1 and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.endsWith(u8, name, pattern_text[0 .. pattern_text.len - 1]);
         }
-        return std.mem.indexOf(u8, name, pattern) != null;
+        return std.mem.indexOf(u8, name, pattern_text) != null;
+    }
+};
+
+pub const IdMatchPatternError = error{
+    EmptyIdMatchPattern,
+    IdMatchPatternTooLong,
+};
+
+pub const IdMatchPattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_id_match_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const IdMatchPattern) []const u8 {
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *IdMatchPattern, value: []const u8) IdMatchPatternError!void {
+        if (value.len == 0) return error.EmptyIdMatchPattern;
+        if (value.len > max_id_match_pattern_len) return error.IdMatchPatternTooLong;
+        @memcpy(self.storage[0..value.len], value);
+        self.length = value.len;
+        self.custom = true;
+    }
+
+    pub fn matches(self: *const IdMatchPattern, name: []const u8) bool {
+        if (!self.custom) return true;
+        return simplePatternMatches(self.pattern(), name);
+    }
+
+    fn simplePatternMatches(pattern_text: []const u8, name: []const u8) bool {
+        if (pattern_text.len >= 2 and pattern_text[0] == '^' and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.eql(u8, name, pattern_text[1 .. pattern_text.len - 1]);
+        }
+        if (pattern_text.len >= 1 and pattern_text[0] == '^') {
+            return std.mem.startsWith(u8, name, pattern_text[1..]);
+        }
+        if (pattern_text.len >= 1 and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.endsWith(u8, name, pattern_text[0 .. pattern_text.len - 1]);
+        }
+        return std.mem.indexOf(u8, name, pattern_text) != null;
     }
 };
 
@@ -1973,6 +2015,12 @@ pub const Options = struct {
     id_length_properties: IdLengthProperties = .always,
     id_length_exceptions: IdLengthExceptions = .{},
     id_length_exception_patterns: IdLengthExceptionPatterns = .{},
+    id_match: bool = false,
+    id_match_pattern: IdMatchPattern = .{},
+    id_match_properties: bool = false,
+    id_match_class_fields: bool = false,
+    id_match_only_declarations: bool = false,
+    id_match_ignore_destructuring: bool = false,
     init_declarations: bool = false,
     init_declarations_mode: InitDeclarationsMode = .always,
     init_declarations_ignore_for_loop_init: bool = false,
@@ -2796,6 +2844,14 @@ pub const Options = struct {
             self.id_length_properties = config.properties;
             self.id_length_exceptions = config.exceptions;
             self.id_length_exception_patterns = config.exception_patterns;
+        }
+        if (std.mem.eql(u8, cli_name, "id-match")) {
+            const config = try idMatchFromConfig(value);
+            self.id_match_pattern = config.pattern;
+            self.id_match_properties = config.properties;
+            self.id_match_class_fields = config.class_fields;
+            self.id_match_only_declarations = config.only_declarations;
+            self.id_match_ignore_destructuring = config.ignore_destructuring;
         }
         if (std.mem.eql(u8, cli_name, "init-declarations")) {
             self.init_declarations_mode = try initDeclarationsModeFromConfig(value);
@@ -4159,6 +4215,41 @@ pub const Options = struct {
             patterns.append(pattern) catch return error.UnsupportedRuleConfigValue;
         }
         return patterns;
+    }
+
+    const IdMatchConfig = struct {
+        pattern: IdMatchPattern = .{},
+        properties: bool = false,
+        class_fields: bool = false,
+        only_declarations: bool = false,
+        ignore_destructuring: bool = false,
+    };
+
+    fn idMatchFromConfig(value: std.json.Value) RuleConfigError!IdMatchConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const pattern_value = switch (items[1]) {
+            .string => |pattern| pattern,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = IdMatchConfig{};
+        result.pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        if (items.len < 3) return result;
+
+        const config = switch (items[2]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        result.properties = try boolObjectOption(config, "properties", false);
+        result.class_fields = try boolObjectOption(config, "classFields", false);
+        result.only_declarations = try boolObjectOption(config, "onlyDeclarations", false);
+        result.ignore_destructuring = try boolObjectOption(config, "ignoreDestructuring", false);
+        return result;
     }
 
     fn jsonNonNegativeIntegerToUsize(value: std.json.Value) RuleConfigError!usize {

--- a/src/main.zig
+++ b/src/main.zig
@@ -716,6 +716,24 @@ pub fn main(init: std.process.Init) !void {
             appendIdLengthException(arg["--id-length-exception=".len..], &options);
         } else if (std.mem.startsWith(u8, arg, "--id-length-exception-pattern=")) {
             appendIdLengthExceptionPattern(arg["--id-length-exception-pattern=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--id-match=off")) {
+            options.id_match = false;
+        } else if (std.mem.eql(u8, arg, "--id-match=on")) {
+            options.id_match = true;
+        } else if (std.mem.startsWith(u8, arg, "--id-match-pattern=")) {
+            setIdMatchPattern(arg["--id-match-pattern=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--id-match-properties=on")) {
+            options.id_match = true;
+            options.id_match_properties = true;
+        } else if (std.mem.eql(u8, arg, "--id-match-class-fields=on")) {
+            options.id_match = true;
+            options.id_match_class_fields = true;
+        } else if (std.mem.eql(u8, arg, "--id-match-only-declarations=on")) {
+            options.id_match = true;
+            options.id_match_only_declarations = true;
+        } else if (std.mem.eql(u8, arg, "--id-match-ignore-destructuring=on")) {
+            options.id_match = true;
+            options.id_match_ignore_destructuring = true;
         } else if (std.mem.eql(u8, arg, "--id-denylist=off")) {
             options.id_denylist = false;
         } else if (std.mem.startsWith(u8, arg, "--id-denylist-name=")) {
@@ -1450,6 +1468,14 @@ fn appendIdLengthExceptionPattern(value: []const u8, options: *lint.Options) voi
     options.id_length = true;
 }
 
+fn setIdMatchPattern(value: []const u8, options: *lint.Options) void {
+    options.id_match_pattern.set(value) catch {
+        std.debug.print("utoo-lint: invalid --id-match-pattern value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.id_match = true;
+}
+
 fn appendConsistentThisAlias(value: []const u8, options: *lint.Options) void {
     if (!options.consistent_this_aliases.custom) {
         options.consistent_this_aliases = .{ .custom = true };
@@ -2024,6 +2050,13 @@ fn printHelp() void {
         \\  --id-length-properties=never Ignore property names
         \\  --id-length-exception=NAME Add an id-length exception
         \\  --id-length-exception-pattern=PATTERN Add an id-length exception pattern
+        \\  --id-match=on             Enable id-match
+        \\  --id-match=off            Disable id-match
+        \\  --id-match-pattern=PATTERN Set id-match pattern
+        \\  --id-match-properties=on  Check object and method property names
+        \\  --id-match-class-fields=on Check class field names
+        \\  --id-match-only-declarations=on Check declarations only
+        \\  --id-match-ignore-destructuring=on Ignore destructured bindings
         \\  --id-denylist=off         Disable id-denylist
         \\  --id-denylist-name=NAME   Add a restricted identifier name
         \\  --logical-assignment-operators=off Disable logical-assignment-operators

--- a/src/rules/id_match.zig
+++ b/src/rules/id_match.zig
@@ -1,0 +1,251 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "id-match";
+
+pub const Options = struct {
+    pattern: core.IdMatchPattern = .{},
+    properties: bool = false,
+    class_fields: bool = false,
+    only_declarations: bool = false,
+    ignore_destructuring: bool = false,
+};
+
+const Identifier = struct {
+    name: []const u8,
+    private: bool = false,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, class.id, options);
+}
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, function.id, options);
+    try checkFormalParameters(allocator, diagnostics, tree, function.params, options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
+    try checkFormalParameters(allocator, diagnostics, tree, expression.params, options);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, declarator.id, options, false);
+}
+
+pub fn checkCatchClause(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    clause: ast.CatchClause,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, clause.param, options, false);
+}
+
+pub fn checkObjectProperty(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.properties or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (!options.properties or method.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, method.key, options);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if ((!options.properties and !options.class_fields) or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkImportSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    if (specifier.imported == specifier.local) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportDefaultSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportDefaultSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportNamespaceSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportNamespaceSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+fn checkFormalParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern, options, false),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter, options, false),
+            else => {},
+        }
+    }
+    try checkBinding(allocator, diagnostics, tree, params.rest, options, false);
+}
+
+fn checkBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+    destructured: bool,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => if (!options.ignore_destructuring or !destructured) {
+            try checkIdentifierNode(allocator, diagnostics, tree, index, options);
+        },
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left, options, destructured),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument, options, destructured),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBinding(allocator, diagnostics, tree, element, options, true);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options, true);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBinding(allocator, diagnostics, tree, property.value, options, true);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options, true);
+        },
+        else => {},
+    }
+}
+
+fn checkIdentifierNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+    const identifier = identifierName(tree, index) orelse return;
+    if (options.pattern.matches(identifier.name)) return;
+    try report(allocator, diagnostics, tree, index, identifier, options);
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?Identifier {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| .{ .name = tree.string(identifier.name) },
+        .binding_identifier => |identifier| .{ .name = tree.string(identifier.name) },
+        .private_identifier => |identifier| .{ .name = tree.string(identifier.name), .private = true },
+        else => null,
+    };
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    identifier: Identifier,
+    options: Options,
+) Allocator.Error!void {
+    const expected = if (options.pattern.custom) options.pattern.pattern() else "";
+    if (identifier.private) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Identifier '#{s}' does not match the pattern '{s}'.",
+            .{ identifier.name, expected },
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Identifier '{s}' does not match the pattern '{s}'.",
+            .{ identifier.name, expected },
+        );
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -37,6 +37,7 @@ pub const grouped_accessor_pairs = @import("grouped_accessor_pairs.zig");
 pub const guard_for_in = @import("guard_for_in.zig");
 pub const id_denylist = @import("id_denylist.zig");
 pub const id_length = @import("id_length.zig");
+pub const id_match = @import("id_match.zig");
 pub const init_declarations = @import("init_declarations.zig");
 pub const alipay_ant_disallow_typos = @import("alipay_ant_disallow_typos.zig");
 pub const alipay_ant_exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
@@ -414,6 +415,16 @@ fn idLengthOptions(options: *const core.Options) id_length.Options {
         .properties = options.id_length_properties,
         .exceptions = options.id_length_exceptions,
         .exception_patterns = options.id_length_exception_patterns,
+    };
+}
+
+fn idMatchOptions(options: *const core.Options) id_match.Options {
+    return .{
+        .pattern = options.id_match_pattern,
+        .properties = options.id_match_properties,
+        .class_fields = options.id_match_class_fields,
+        .only_declarations = options.id_match_only_declarations,
+        .ignore_destructuring = options.id_match_ignore_destructuring,
     };
 }
 
@@ -1552,6 +1563,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idLengthOptions(&self.options));
         }
+        if (self.options.id_match) {
+            try id_match.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idMatchOptions(&self.options));
+        }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
         }
@@ -1661,6 +1675,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idMatchOptions(&self.options));
         }
         if (self.options.no_useless_constructor and !self.options.typescript_eslint_no_useless_constructor) {
             try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
@@ -2039,6 +2056,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idMatchOptions(&self.options));
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
@@ -2476,6 +2496,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idMatchOptions(&self.options));
         }
         if (self.options.complexity) {
             complexity.increase(&self.complexity_state);
@@ -2934,6 +2957,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idMatchOptions(&self.options));
         }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_arrow_parameter) {
             try typescript_eslint_typedef.checkArrowFunctionParameters(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -3856,6 +3882,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
         }
+        if (self.options.id_match) {
+            try id_match.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
+        }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
         }
@@ -3957,6 +3986,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idLengthOptions(&self.options));
         }
+        if (self.options.id_match) {
+            try id_match.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idMatchOptions(&self.options));
+        }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(
                 self.allocator,
@@ -4020,6 +4052,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(
@@ -4118,6 +4153,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
         }
+        if (self.options.id_match) {
+            try id_match.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
+        }
         return .proceed;
     }
 
@@ -4133,6 +4171,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
         }
+        if (self.options.id_match) {
+            try id_match.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
+        }
         return .proceed;
     }
 
@@ -4147,6 +4188,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+        }
+        if (self.options.id_match) {
+            try id_match.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -95,6 +95,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/id_match.zig");
+}
+
+comptime {
     _ = @import("rules/init_declarations.zig");
 }
 

--- a/tests/rules/id_match.zig
+++ b/tests/rules/id_match.zig
@@ -1,0 +1,157 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports declaration identifiers that do not match the pattern" {
+    const source =
+        \\const okValue = 1;
+        \\const badValue = 2;
+        \\function okFn(okParam, badParam) {
+        \\  return okParam + badParam;
+        \\}
+        \\class badClass {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.id_match.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'badValue' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badParam' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badClass' does not match the pattern '^ok'."));
+}
+
+test "reports import aliases but skips unrenamed named imports" {
+    const source =
+        \\import badDefault, { value as badAlias, okNamed } from "pkg";
+        \\import * as badNamespace from "other";
+        \\okNamed;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.id_match.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'badDefault' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badAlias' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badNamespace' does not match the pattern '^ok'."));
+}
+
+test "checks properties and class fields when configured" {
+    const source =
+        \\class okClass {
+        \\  #badPrivate;
+        \\  badField = 1;
+        \\  badMethod() {}
+        \\  okMethod() {}
+        \\}
+        \\const okValue = { badKey: 1, okKey: 2, [computed]: 3 };
+    ;
+
+    var options = baseOptions();
+    options.id_match_properties = true;
+    options.id_match_class_fields = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.id_match.id));
+    try std.testing.expect(hasMessage(result, "Identifier '#badPrivate' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badField' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badMethod' does not match the pattern '^ok'."));
+    try std.testing.expect(hasMessage(result, "Identifier 'badKey' does not match the pattern '^ok'."));
+}
+
+test "ignores properties and class fields by default" {
+    const source =
+        \\class okClass {
+        \\  badField = 1;
+        \\  badMethod() {}
+        \\}
+        \\const okValue = { badKey: 1 };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_match.id));
+}
+
+test "can ignore destructured bindings" {
+    const source =
+        \\const { badKey: badLocal, okKey } = sourceObject;
+        \\const [badItem] = sourceList;
+        \\const badValue = 1;
+    ;
+
+    var options = baseOptions();
+    options.id_match_ignore_destructuring = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.id_match.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'badValue' does not match the pattern '^ok'."));
+}
+
+test "parses eslint id-match config" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"^ok\",{\"properties\":true,\"classFields\":true,\"onlyDeclarations\":true,\"ignoreDestructuring\":true}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("id-match", parsed.value);
+
+    try std.testing.expect(options.id_match);
+    try std.testing.expect(options.id_match_pattern.matches("okName"));
+    try std.testing.expect(!options.id_match_pattern.matches("badName"));
+    try std.testing.expect(options.id_match_properties);
+    try std.testing.expect(options.id_match_class_fields);
+    try std.testing.expect(options.id_match_only_declarations);
+    try std.testing.expect(options.id_match_ignore_destructuring);
+}
+
+test "can disable id-match" {
+    const source =
+        \\const badValue = 1;
+    ;
+
+    var options = baseOptions();
+    options.id_match = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.id_match.id));
+}
+
+fn baseOptions() lint.Options {
+    var options = lint.Options{
+        .consistent_return = false,
+        .import_no_unresolved = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unassigned_vars = false,
+        .no_unused_private_class_members = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+        .typescript_eslint_no_empty_function = false,
+    };
+    options.id_match = true;
+    options.id_match_pattern.set("^ok") catch unreachable;
+    return options;
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.id_match.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add ESLint-compatible `id-match` lint rule with lightweight pattern matching for declarations, parameters, imports, properties, and class fields
- parse `.eslintrc` `id-match` options plus CLI flags for pattern/properties/classFields/onlyDeclarations/ignoreDestructuring
- publish the rule in npm metadata, status docs, and test aggregation

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
