### PR TITLE
Add no-restricted-syntax rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -140,6 +140,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-restricted-globals`](https://eslint.org/docs/latest/rules/no-restricted-globals) | Supports direct global restrictions, custom messages, and optional global object checks |
 | [`no-restricted-imports`](https://eslint.org/docs/latest/rules/no-restricted-imports) | Supports restricted `paths`, simple `patterns`, custom messages, import name allow/deny lists, type-only allowances, and re-export checks |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
+| [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) | Supports lightweight AST node selector restrictions with custom messages |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
 | [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented for return statements, async arrow expression bodies, and nested tail expressions |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -209,6 +209,7 @@ const BUILTIN_RULE_IDS = [
   "no-restricted-exports",
   "no-restricted-globals",
   "no-restricted-imports",
+  "no-restricted-syntax",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -212,6 +212,7 @@ const BUILTIN_RULE_IDS = [
   "no-restricted-exports",
   "no-restricted-globals",
   "no-restricted-imports",
+  "no-restricted-syntax",
   "no-regex-spaces",
   "no-return-assign",
   "no-return-await",

--- a/src/core.zig
+++ b/src/core.zig
@@ -692,6 +692,9 @@ pub const max_no_restricted_globals = 64;
 pub const max_no_restricted_global_name_len = 128;
 pub const max_no_restricted_global_message_len = 256;
 pub const max_no_restricted_global_objects = 16;
+pub const max_no_restricted_syntax = 64;
+pub const max_no_restricted_syntax_selector_len = 128;
+pub const max_no_restricted_syntax_message_len = 256;
 pub const max_no_restricted_export_names = 64;
 pub const max_no_restricted_export_name_len = 128;
 pub const max_no_restricted_imports = 16;
@@ -895,6 +898,55 @@ pub const NoRestrictedGlobals = struct {
             if (std.mem.eql(u8, entry.name(), name)) return entry;
         }
         return null;
+    }
+};
+
+pub const NoRestrictedSyntaxEntry = struct {
+    selector_length: usize = 0,
+    selector_storage: [max_no_restricted_syntax_selector_len]u8 = undefined,
+
+    has_message: bool = false,
+    message_length: usize = 0,
+    message_storage: [max_no_restricted_syntax_message_len]u8 = undefined,
+
+    pub fn selector(self: *const NoRestrictedSyntaxEntry) []const u8 {
+        return self.selector_storage[0..self.selector_length];
+    }
+
+    pub fn message(self: *const NoRestrictedSyntaxEntry) ?[]const u8 {
+        if (!self.has_message) return null;
+        return self.message_storage[0..self.message_length];
+    }
+
+    pub fn setSelector(self: *NoRestrictedSyntaxEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_syntax_selector_len) return false;
+        @memcpy(self.selector_storage[0..value.len], value);
+        self.selector_length = value.len;
+        return true;
+    }
+
+    pub fn setMessage(self: *NoRestrictedSyntaxEntry, value: []const u8) bool {
+        if (value.len == 0 or value.len > max_no_restricted_syntax_message_len) return false;
+        @memcpy(self.message_storage[0..value.len], value);
+        self.message_length = value.len;
+        self.has_message = true;
+        return true;
+    }
+};
+
+pub const NoRestrictedSyntax = struct {
+    count: usize = 0,
+    entries: [max_no_restricted_syntax]NoRestrictedSyntaxEntry = undefined,
+
+    pub fn append(self: *NoRestrictedSyntax, entry: NoRestrictedSyntaxEntry) bool {
+        if (self.count >= max_no_restricted_syntax) return false;
+        self.entries[self.count] = entry;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn at(self: *const NoRestrictedSyntax, index: usize) *const NoRestrictedSyntaxEntry {
+        return &self.entries[index];
     }
 };
 
@@ -2297,6 +2349,8 @@ pub const Options = struct {
     no_restricted_imports_entries: NoRestrictedImports = .{},
     no_restricted_properties: bool = true,
     no_restricted_properties_entries: NoRestrictedProperties = .{},
+    no_restricted_syntax: bool = false,
+    no_restricted_syntax_entries: NoRestrictedSyntax = .{},
     no_regex_spaces: bool = true,
     no_return_await: bool = true,
     no_return_assign: bool = true,
@@ -3074,6 +3128,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
             self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-syntax")) {
+            self.no_restricted_syntax_entries = try noRestrictedSyntaxFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-self-assign")) {
             self.no_self_assign_props = try noSelfAssignPropsFromConfig(value);
@@ -6382,6 +6439,48 @@ pub const Options = struct {
                     else => return error.UnsupportedRuleConfigValue,
                 };
                 if (!entry.setName(name)) return error.UnsupportedRuleConfigValue;
+                if (object.get("message")) |message_value| {
+                    const message = switch (message_value) {
+                        .string => |string| string,
+                        else => return error.UnsupportedRuleConfigValue,
+                    };
+                    if (!entry.setMessage(message)) return error.UnsupportedRuleConfigValue;
+                }
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+        return entry;
+    }
+
+    fn noRestrictedSyntaxFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedSyntax {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        var restrictions = NoRestrictedSyntax{};
+        for (items[1..]) |item| {
+            const entry = try noRestrictedSyntaxEntryFromConfig(item);
+            if (!restrictions.append(entry)) return error.UnsupportedRuleConfigValue;
+        }
+        return restrictions;
+    }
+
+    fn noRestrictedSyntaxEntryFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedSyntaxEntry {
+        var entry = NoRestrictedSyntaxEntry{};
+        switch (value) {
+            .string => |selector| {
+                if (!entry.setSelector(selector)) return error.UnsupportedRuleConfigValue;
+            },
+            .object => |object| {
+                const selector_value = object.get("selector") orelse return error.UnsupportedRuleConfigValue;
+                const selector = switch (selector_value) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!entry.setSelector(selector)) return error.UnsupportedRuleConfigValue;
+
                 if (object.get("message")) |message_value| {
                     const message = switch (message_value) {
                         .string => |string| string,

--- a/src/main.zig
+++ b/src/main.zig
@@ -570,6 +570,12 @@ pub fn main(init: std.process.Init) !void {
             appendNoRestrictedImportName(arg["--no-restricted-imports-pattern=".len..], &options, .pattern);
         } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
             options.no_restricted_properties = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-syntax=off")) {
+            options.no_restricted_syntax = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-syntax=on")) {
+            options.no_restricted_syntax = true;
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-syntax-selector=")) {
+            appendNoRestrictedSyntaxSelector(arg["--no-restricted-syntax-selector=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--no-regex-spaces=off")) {
             options.no_regex_spaces = false;
         } else if (std.mem.eql(u8, arg, "--no-return-await=off")) {
@@ -1418,6 +1424,15 @@ fn appendNoRestrictedImportName(value: []const u8, options: *lint.Options, kind:
     options.no_restricted_imports = true;
 }
 
+fn appendNoRestrictedSyntaxSelector(value: []const u8, options: *lint.Options) void {
+    var entry = lint.NoRestrictedSyntaxEntry{};
+    if (!entry.setSelector(value) or !options.no_restricted_syntax_entries.append(entry)) {
+        std.debug.print("utoo-lint: invalid --no-restricted-syntax-selector value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.no_restricted_syntax = true;
+}
+
 fn parseNoMultipleEmptyLinesMax(value: []const u8, options: *lint.Options) void {
     const max = std.fmt.parseInt(usize, value, 10) catch {
         std.debug.print("utoo-lint: invalid --no-multiple-empty-lines-max value: {s}\n", .{value});
@@ -2140,6 +2155,9 @@ fn printHelp() void {
         \\  --no-restricted-imports-name=NAME Restrict an import source
         \\  --no-restricted-imports-pattern=PATTERN Restrict import sources matching a simple * pattern
         \\  --no-restricted-properties=off Disable no-restricted-properties
+        \\  --no-restricted-syntax=off Disable no-restricted-syntax
+        \\  --no-restricted-syntax=on Enable no-restricted-syntax
+        \\  --no-restricted-syntax-selector=SELECTOR Restrict a simple AST node selector
         \\  --no-regex-spaces=off     Disable no-regex-spaces
         \\  --no-return-await=off     Disable no-return-await
         \\  --no-return-assign=off    Disable no-return-assign

--- a/src/root.zig
+++ b/src/root.zig
@@ -12,6 +12,7 @@ pub const Result = core.Result;
 pub const SourcePosition = core.SourcePosition;
 pub const NoRestrictedImportEntry = core.NoRestrictedImportEntry;
 pub const NoRestrictedImportKind = core.NoRestrictedImportKind;
+pub const NoRestrictedSyntaxEntry = core.NoRestrictedSyntaxEntry;
 pub const SortImportsMemberSyntax = core.SortImportsMemberSyntax;
 pub const rules = @import("rules/root.zig");
 

--- a/src/rules/no_restricted_syntax.zig
+++ b/src/rules/no_restricted_syntax.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-syntax";
+
+pub fn checkNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    data: ast.NodeData,
+    index: ast.NodeIndex,
+    restrictions: core.NoRestrictedSyntax,
+) Allocator.Error!void {
+    if (restrictions.count == 0) return;
+
+    const tag_name = @tagName(data);
+    for (0..restrictions.count) |restriction_index| {
+        const restriction = restrictions.at(restriction_index);
+        if (!matchesSelector(restriction.selector(), tag_name)) continue;
+        try addDiagnostic(allocator, diagnostics, tree, index, restriction);
+    }
+}
+
+fn matchesSelector(selector: []const u8, tag_name: []const u8) bool {
+    return std.mem.eql(u8, selector, tag_name) or normalizedEqual(selector, tag_name);
+}
+
+fn normalizedEqual(selector: []const u8, tag_name: []const u8) bool {
+    var selector_index: usize = 0;
+    var tag_index: usize = 0;
+
+    while (true) {
+        selector_index = nextComparable(selector, selector_index);
+        tag_index = nextComparable(tag_name, tag_index);
+
+        if (selector_index == selector.len or tag_index == tag_name.len) {
+            return selector_index == selector.len and tag_index == tag_name.len;
+        }
+
+        if (std.ascii.toLower(selector[selector_index]) != std.ascii.toLower(tag_name[tag_index])) {
+            return false;
+        }
+
+        selector_index += 1;
+        tag_index += 1;
+    }
+}
+
+fn nextComparable(value: []const u8, start: usize) usize {
+    var index = start;
+    while (index < value.len and (value[index] == '_' or value[index] == '-')) {
+        index += 1;
+    }
+    return index;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    restriction: *const core.NoRestrictedSyntaxEntry,
+) Allocator.Error!void {
+    if (restriction.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "{s}",
+            .{message},
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Using '{s}' is not allowed.",
+            .{restriction.selector()},
+        );
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -198,6 +198,7 @@ pub const no_restricted_exports = @import("no_restricted_exports.zig");
 pub const no_restricted_globals = @import("no_restricted_globals.zig");
 pub const no_restricted_imports = @import("no_restricted_imports.zig");
 pub const no_restricted_properties = @import("no_restricted_properties.zig");
+pub const no_restricted_syntax = @import("no_restricted_syntax.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
 pub const no_return_await = @import("no_return_await.zig");
 pub const no_return_assign = @import("no_return_assign.zig");
@@ -1377,6 +1378,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_denylist) {
             try id_denylist.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index, &ctx.path, &self.id_denylist_state, &self.options.id_denylist_names);
+        }
+        if (self.options.no_restricted_syntax) {
+            try no_restricted_syntax.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index, self.options.no_restricted_syntax_entries);
         }
         if (self.options.no_undefined) {
             switch (data) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -731,6 +731,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_syntax.zig");
+}
+
+comptime {
     _ = @import("rules/no_regex_spaces.zig");
 }
 

--- a/tests/rules/no_restricted_syntax.zig
+++ b/tests/rules/no_restricted_syntax.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports restricted syntax selectors" {
+    const source =
+        \\with (scope) {
+        \\  value;
+        \\}
+        \\label: while (value) {
+        \\  break label;
+        \\}
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",\"WithStatement\",{\"selector\":\"labeled_statement\",\"message\":\"Labels are not allowed.\"}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_syntax.id));
+    try std.testing.expect(hasMessage(result, "Using 'WithStatement' is not allowed."));
+    try std.testing.expect(hasMessage(result, "Labels are not allowed."));
+}
+
+test "supports cli-style selector entries" {
+    const source =
+        \\debugger;
+    ;
+
+    var options = baseOptions();
+    var entry = lint.NoRestrictedSyntaxEntry{};
+    try std.testing.expect(entry.setSelector("DebuggerStatement"));
+    try std.testing.expect(options.no_restricted_syntax_entries.append(entry));
+    options.no_restricted_syntax = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_restricted_syntax.id));
+}
+
+test "does not treat complex esquery selectors as node selectors" {
+    const source =
+        \\setTimeout(work, 100);
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\",\"CallExpression[callee.name='setTimeout']\"]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_syntax.id));
+}
+
+test "parses no-restricted-syntax config" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"WithStatement\",{\"selector\":\"LabeledStatement\",\"message\":\"No labels.\"}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = baseOptions();
+    try options.setByRuleConfigValue("no-restricted-syntax", parsed.value);
+
+    try std.testing.expect(options.no_restricted_syntax);
+    try std.testing.expectEqual(@as(usize, 2), options.no_restricted_syntax_entries.count);
+    try std.testing.expectEqualStrings("WithStatement", options.no_restricted_syntax_entries.at(0).selector());
+    try std.testing.expectEqualStrings("LabeledStatement", options.no_restricted_syntax_entries.at(1).selector());
+    try std.testing.expectEqualStrings("No labels.", options.no_restricted_syntax_entries.at(1).message().?);
+}
+
+test "can disable no-restricted-syntax" {
+    const source =
+        \\with (scope) {
+        \\  value;
+        \\}
+    ;
+
+    var options = try optionsWithConfig("[\"error\",\"WithStatement\"]");
+    options.no_restricted_syntax = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_syntax.id));
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("no-restricted-syntax", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.parser_semantic_errors = false;
+    return options;
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_syntax.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `no-restricted-syntax` with lightweight AST node selector restrictions and custom messages
- parse ESLint-style string selectors and `{ selector, message }` entries
- expose CLI selector configuration plus npm metadata, status docs, and tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
