### PR TITLE
Add camelcase rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -9,6 +9,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
 | [`arrow-body-style`](https://eslint.org/docs/latest/rules/arrow-body-style) | Supports `always`, `as-needed`, `never`, and `requireReturnForObjectLiteral` diagnostics |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
+| [`camelcase`](https://eslint.org/docs/latest/rules/camelcase) | Supports declarations, imports, optional property checks, `ignoreDestructuring`, `ignoreImports`, lightweight `allow` patterns, and parses `ignoreGlobals` for migration compatibility |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
 | [`complexity`](https://eslint.org/docs/latest/rules/complexity) | Supports `max`, deprecated `maximum`, `classic` and `modified` variants, functions, arrow functions, and static blocks |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -85,6 +85,7 @@ const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "arrow-body-style",
   "block-scoped-var",
+  "camelcase",
   "capitalized-comments",
   "complexity",
   "consistent-return",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -88,6 +88,7 @@ const BUILTIN_RULE_IDS = [
   "array-callback-return",
   "arrow-body-style",
   "block-scoped-var",
+  "camelcase",
   "capitalized-comments",
   "complexity",
   "consistent-return",

--- a/src/core.zig
+++ b/src/core.zig
@@ -715,6 +715,8 @@ pub const max_id_length_exception_len = 128;
 pub const max_id_length_exception_patterns = 64;
 pub const max_id_length_exception_pattern_len = 256;
 pub const max_id_match_pattern_len = 256;
+pub const max_camelcase_allow_patterns = 64;
+pub const max_camelcase_allow_pattern_len = 256;
 
 pub const NoRestrictedPropertyNameList = struct {
     count: usize = 0,
@@ -1100,6 +1102,56 @@ pub const IdMatchPattern = struct {
     pub fn matches(self: *const IdMatchPattern, name: []const u8) bool {
         if (!self.custom) return true;
         return simplePatternMatches(self.pattern(), name);
+    }
+
+    fn simplePatternMatches(pattern_text: []const u8, name: []const u8) bool {
+        if (pattern_text.len >= 2 and pattern_text[0] == '^' and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.eql(u8, name, pattern_text[1 .. pattern_text.len - 1]);
+        }
+        if (pattern_text.len >= 1 and pattern_text[0] == '^') {
+            return std.mem.startsWith(u8, name, pattern_text[1..]);
+        }
+        if (pattern_text.len >= 1 and pattern_text[pattern_text.len - 1] == '$') {
+            return std.mem.endsWith(u8, name, pattern_text[0 .. pattern_text.len - 1]);
+        }
+        return std.mem.indexOf(u8, name, pattern_text) != null;
+    }
+};
+
+pub const CamelcaseProperties = enum {
+    always,
+    never,
+};
+
+pub const CamelcaseAllowPatternsError = error{
+    EmptyCamelcaseAllowPattern,
+    TooManyCamelcaseAllowPatterns,
+    CamelcaseAllowPatternTooLong,
+};
+
+pub const CamelcaseAllowPatterns = struct {
+    count: usize = 0,
+    lengths: [max_camelcase_allow_patterns]usize = undefined,
+    storage: [max_camelcase_allow_patterns][max_camelcase_allow_pattern_len]u8 = undefined,
+
+    pub fn matches(self: *const CamelcaseAllowPatterns, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (simplePatternMatches(self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const CamelcaseAllowPatterns, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *CamelcaseAllowPatterns, pattern: []const u8) CamelcaseAllowPatternsError!void {
+        if (pattern.len == 0) return error.EmptyCamelcaseAllowPattern;
+        if (self.count >= max_camelcase_allow_patterns) return error.TooManyCamelcaseAllowPatterns;
+        if (pattern.len > max_camelcase_allow_pattern_len) return error.CamelcaseAllowPatternTooLong;
+        @memcpy(self.storage[self.count][0..pattern.len], pattern);
+        self.lengths[self.count] = pattern.len;
+        self.count += 1;
     }
 
     fn simplePatternMatches(pattern_text: []const u8, name: []const u8) bool {
@@ -2022,6 +2074,12 @@ pub const Options = struct {
     arrow_body_style_style: ArrowBodyStyle = .as_needed,
     arrow_body_style_require_return_for_object_literal: bool = false,
     block_scoped_var: bool = true,
+    camelcase: bool = false,
+    camelcase_properties: CamelcaseProperties = .always,
+    camelcase_ignore_destructuring: bool = false,
+    camelcase_ignore_imports: bool = false,
+    camelcase_ignore_globals: bool = false,
+    camelcase_allow: CamelcaseAllowPatterns = .{},
     capitalized_comments: bool = true,
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
@@ -2840,6 +2898,14 @@ pub const Options = struct {
             const config = try arrowBodyStyleFromConfig(value);
             self.arrow_body_style_style = config.style;
             self.arrow_body_style_require_return_for_object_literal = config.require_return_for_object_literal;
+        }
+        if (std.mem.eql(u8, cli_name, "camelcase")) {
+            const config = try camelcaseFromConfig(value);
+            self.camelcase_properties = config.properties;
+            self.camelcase_ignore_destructuring = config.ignore_destructuring;
+            self.camelcase_ignore_imports = config.ignore_imports;
+            self.camelcase_ignore_globals = config.ignore_globals;
+            self.camelcase_allow = config.allow;
         }
         if (std.mem.eql(u8, cli_name, "capitalized-comments")) {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
@@ -3807,6 +3873,62 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         result.require_return_for_object_literal = try boolObjectOption(config, "requireReturnForObjectLiteral", false);
+        return result;
+    }
+
+    const CamelcaseConfig = struct {
+        properties: CamelcaseProperties = .always,
+        ignore_destructuring: bool = false,
+        ignore_imports: bool = false,
+        ignore_globals: bool = false,
+        allow: CamelcaseAllowPatterns = .{},
+    };
+
+    fn camelcaseFromConfig(value: std.json.Value) RuleConfigError!CamelcaseConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = CamelcaseConfig{};
+        if (config.get("properties")) |properties_value| {
+            const properties = switch (properties_value) {
+                .string => |string| string,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, properties, "always")) {
+                result.properties = .always;
+            } else if (std.mem.eql(u8, properties, "never")) {
+                result.properties = .never;
+            } else {
+                return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        result.ignore_destructuring = try boolObjectOption(config, "ignoreDestructuring", false);
+        result.ignore_imports = try boolObjectOption(config, "ignoreImports", false);
+        result.ignore_globals = try boolObjectOption(config, "ignoreGlobals", false);
+
+        if (config.get("allow")) |allow_value| {
+            const allow_items = switch (allow_value) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (allow_items) |allow_item| {
+                const pattern = switch (allow_item) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                result.allow.append(pattern) catch return error.UnsupportedRuleConfigValue;
+            }
+        }
+
         return result;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,6 +150,24 @@ pub fn main(init: std.process.Init) !void {
             options.arrow_body_style_require_return_for_object_literal = true;
         } else if (std.mem.eql(u8, arg, "--block-scoped-var=off")) {
             options.block_scoped_var = false;
+        } else if (std.mem.eql(u8, arg, "--camelcase=off")) {
+            options.camelcase = false;
+        } else if (std.mem.eql(u8, arg, "--camelcase=on")) {
+            options.camelcase = true;
+        } else if (std.mem.eql(u8, arg, "--camelcase-properties=always")) {
+            options.camelcase = true;
+            options.camelcase_properties = .always;
+        } else if (std.mem.eql(u8, arg, "--camelcase-properties=never")) {
+            options.camelcase = true;
+            options.camelcase_properties = .never;
+        } else if (std.mem.eql(u8, arg, "--camelcase-ignore-destructuring=on")) {
+            options.camelcase = true;
+            options.camelcase_ignore_destructuring = true;
+        } else if (std.mem.eql(u8, arg, "--camelcase-ignore-imports=on")) {
+            options.camelcase = true;
+            options.camelcase_ignore_imports = true;
+        } else if (std.mem.startsWith(u8, arg, "--camelcase-allow=")) {
+            appendCamelcaseAllow(arg["--camelcase-allow=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=off")) {
             options.capitalized_comments = false;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments=never")) {
@@ -1415,6 +1433,14 @@ fn parseNoWarningCommentsTerms(value: []const u8, options: *lint.Options) void {
     options.no_warning_comments_terms = terms;
 }
 
+fn appendCamelcaseAllow(value: []const u8, options: *lint.Options) void {
+    options.camelcase_allow.append(value) catch {
+        std.debug.print("utoo-lint: invalid --camelcase-allow value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.camelcase = true;
+}
+
 fn appendNoRestrictedExportName(value: []const u8, options: *lint.Options) void {
     options.no_restricted_exports_names.append(value) catch {
         std.debug.print("utoo-lint: invalid --no-restricted-exports-name value: {s}\n", .{value});
@@ -1919,6 +1945,12 @@ fn printHelp() void {
         \\  --arrow-body-style=never Disallow arrow body braces when possible
         \\  --arrow-body-style-require-return-for-object-literal=on Keep braces for returned object literals
         \\  --block-scoped-var=off   Disable block-scoped-var
+        \\  --camelcase=off          Disable camelcase
+        \\  --camelcase=on           Enable camelcase
+        \\  --camelcase-properties=never Ignore property names
+        \\  --camelcase-ignore-destructuring=on Ignore destructured bindings
+        \\  --camelcase-ignore-imports=on Ignore import bindings
+        \\  --camelcase-allow=PATTERN Add an allowed camelcase name pattern
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --capitalized-comments=never Require lowercase comment starts
         \\  --capitalized-comments-ignore-inline-comments=on Ignore inline comments

--- a/src/rules/camelcase.zig
+++ b/src/rules/camelcase.zig
@@ -1,0 +1,280 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "camelcase";
+
+pub const Properties = enum {
+    always,
+    never,
+};
+
+pub const Options = struct {
+    properties: Properties = .always,
+    ignore_destructuring: bool = false,
+    ignore_imports: bool = false,
+    ignore_globals: bool = false,
+    allow: core.CamelcaseAllowPatterns = .{},
+};
+
+const Identifier = struct {
+    name: []const u8,
+    private: bool = false,
+};
+
+pub fn checkClass(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    class: ast.Class,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, class.id, options);
+}
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    options: Options,
+) Allocator.Error!void {
+    try checkIdentifierNode(allocator, diagnostics, tree, function.id, options);
+    try checkFormalParameters(allocator, diagnostics, tree, function.params, options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ArrowFunctionExpression,
+    options: Options,
+) Allocator.Error!void {
+    try checkFormalParameters(allocator, diagnostics, tree, expression.params, options);
+}
+
+pub fn checkVariableDeclarator(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declarator: ast.VariableDeclarator,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, declarator.id, options, false);
+}
+
+pub fn checkCatchClause(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    clause: ast.CatchClause,
+    options: Options,
+) Allocator.Error!void {
+    try checkBinding(allocator, diagnostics, tree, clause.param, options, false);
+}
+
+pub fn checkObjectProperty(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkMethodDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or method.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, method.key, options);
+}
+
+pub fn checkPropertyDefinition(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    property: ast.PropertyDefinition,
+    options: Options,
+) Allocator.Error!void {
+    if (options.properties == .never or property.computed) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, property.key, options);
+}
+
+pub fn checkImportSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_imports) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportDefaultSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportDefaultSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_imports) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+pub fn checkImportNamespaceSpecifier(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    specifier: ast.ImportNamespaceSpecifier,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_imports) return;
+    try checkIdentifierNode(allocator, diagnostics, tree, specifier.local, options);
+}
+
+fn checkFormalParameters(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    params_index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (params_index == .null) return;
+
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return,
+    };
+
+    for (tree.extra(params.items)) |item_index| {
+        switch (tree.data(item_index)) {
+            .formal_parameter => |parameter| try checkBinding(allocator, diagnostics, tree, parameter.pattern, options, false),
+            .ts_parameter_property => |property| try checkBinding(allocator, diagnostics, tree, property.parameter, options, false),
+            else => {},
+        }
+    }
+    try checkBinding(allocator, diagnostics, tree, params.rest, options, false);
+}
+
+fn checkBinding(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+    destructured: bool,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => if (!options.ignore_destructuring or !destructured) {
+            try checkIdentifierNode(allocator, diagnostics, tree, index, options);
+        },
+        .assignment_pattern => |pattern| try checkBinding(allocator, diagnostics, tree, pattern.left, options, destructured),
+        .binding_rest_element => |element| try checkBinding(allocator, diagnostics, tree, element.argument, options, destructured),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try checkBinding(allocator, diagnostics, tree, element, options, true);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options, true);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => continue,
+                };
+                try checkBinding(allocator, diagnostics, tree, property.value, options, true);
+            }
+            try checkBinding(allocator, diagnostics, tree, pattern.rest, options, true);
+        },
+        else => {},
+    }
+}
+
+fn checkIdentifierNode(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    options: Options,
+) Allocator.Error!void {
+    if (index == .null) return;
+    const identifier = identifierName(tree, index) orelse return;
+    if (isAllowed(identifier.name, options)) return;
+    try report(allocator, diagnostics, tree, index, identifier);
+}
+
+fn isAllowed(name: []const u8, options: Options) bool {
+    if (!hasDisallowedUnderscore(name)) return true;
+    if (isUppercaseConstant(name)) return true;
+    if (options.allow.matches(name)) return true;
+    return false;
+}
+
+fn hasDisallowedUnderscore(name: []const u8) bool {
+    const trimmed = std.mem.trim(u8, name, "_");
+    return std.mem.indexOfScalar(u8, trimmed, '_') != null;
+}
+
+fn isUppercaseConstant(name: []const u8) bool {
+    const trimmed = std.mem.trim(u8, name, "_");
+    var has_alpha = false;
+    for (trimmed) |char| {
+        if (std.ascii.isAlphabetic(char)) {
+            has_alpha = true;
+            if (std.ascii.isLower(char)) return false;
+        }
+    }
+    return has_alpha;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?Identifier {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| .{ .name = tree.string(identifier.name) },
+        .binding_identifier => |identifier| .{ .name = tree.string(identifier.name) },
+        .private_identifier => |identifier| .{ .name = tree.string(identifier.name), .private = true },
+        else => null,
+    };
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    identifier: Identifier,
+) Allocator.Error!void {
+    if (identifier.private) {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Identifier '#{s}' is not in camel case.",
+            .{identifier.name},
+        );
+    } else {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(index),
+            "Identifier '{s}' is not in camel case.",
+            .{identifier.name},
+        );
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -18,6 +18,7 @@ pub const accessor_pairs = @import("accessor_pairs.zig");
 pub const array_callback_return = @import("array_callback_return.zig");
 pub const arrow_body_style = @import("arrow_body_style.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
+pub const camelcase = @import("camelcase.zig");
 pub const capitalized_comments = @import("capitalized_comments.zig");
 pub const complexity = @import("complexity.zig");
 pub const consistent_this = @import("consistent_this.zig");
@@ -417,6 +418,19 @@ fn arrowBodyStyleOptions(options: *const core.Options) arrow_body_style.Options 
             .never => .never,
         },
         .require_return_for_object_literal = options.arrow_body_style_require_return_for_object_literal,
+    };
+}
+
+fn camelcaseOptions(options: *const core.Options) camelcase.Options {
+    return .{
+        .properties = switch (options.camelcase_properties) {
+            .always => .always,
+            .never => .never,
+        },
+        .ignore_destructuring = options.camelcase_ignore_destructuring,
+        .ignore_imports = options.camelcase_ignore_imports,
+        .ignore_globals = options.camelcase_ignore_globals,
+        .allow = options.camelcase_allow,
     };
 }
 
@@ -1576,6 +1590,9 @@ const BasicVisitor = struct {
         if (self.options.func_style) {
             try func_style.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, funcStyleOptions(&self.options));
         }
+        if (self.options.camelcase) {
+            try camelcase.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, camelcaseOptions(&self.options));
+        }
         if (self.options.id_length) {
             try id_length.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idLengthOptions(&self.options));
         }
@@ -1688,6 +1705,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkClass(self.allocator, self.diagnostics, ctx.tree, class, camelcaseOptions(&self.options));
         }
         if (self.options.id_length) {
             try id_length.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idLengthOptions(&self.options));
@@ -2069,6 +2089,9 @@ const BasicVisitor = struct {
         }
         if (self.options.func_style) {
             try func_style.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, index, ctx, funcStyleOptions(&self.options));
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, camelcaseOptions(&self.options));
         }
         if (self.options.id_length) {
             try id_length.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idLengthOptions(&self.options));
@@ -2509,6 +2532,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, clause.param, false);
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, camelcaseOptions(&self.options));
         }
         if (self.options.id_length) {
             try id_length.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idLengthOptions(&self.options));
@@ -2973,6 +2999,9 @@ const BasicVisitor = struct {
                 .max = self.options.max_params_max,
                 .count_this = self.options.max_params_count_this,
             });
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, camelcaseOptions(&self.options));
         }
         if (self.options.id_length) {
             try id_length.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idLengthOptions(&self.options));
@@ -3901,6 +3930,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
         }
+        if (self.options.camelcase) {
+            try camelcase.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(&self.options));
+        }
         if (self.options.id_match) {
             try id_match.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
         }
@@ -4005,6 +4037,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idLengthOptions(&self.options));
         }
+        if (self.options.camelcase) {
+            try camelcase.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, camelcaseOptions(&self.options));
+        }
         if (self.options.id_match) {
             try id_match.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idMatchOptions(&self.options));
         }
@@ -4071,6 +4106,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(&self.options));
         }
         if (self.options.id_match) {
             try id_match.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
@@ -4172,6 +4210,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
         }
+        if (self.options.camelcase) {
+            try camelcase.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
+        }
         if (self.options.id_match) {
             try id_match.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
         }
@@ -4190,6 +4231,9 @@ const BasicVisitor = struct {
         if (self.options.id_length) {
             try id_length.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
         }
+        if (self.options.camelcase) {
+            try camelcase.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
+        }
         if (self.options.id_match) {
             try id_match.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
         }
@@ -4207,6 +4251,9 @@ const BasicVisitor = struct {
         }
         if (self.options.id_length) {
             try id_length.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+        }
+        if (self.options.camelcase) {
+            try camelcase.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
         }
         if (self.options.id_match) {
             try id_match.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -15,6 +15,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/camelcase.zig");
+}
+
+comptime {
     _ = @import("rules/capitalized_comments.zig");
 }
 

--- a/tests/rules/camelcase.zig
+++ b/tests/rules/camelcase.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports non-camelcase declarations and parameters" {
+    const source =
+        \\const bad_name = 1;
+        \\const FOO_BAR = 2;
+        \\function goodFn(bad_param, goodParam) {
+        \\  return bad_param + goodParam;
+        \\}
+        \\class bad_class {}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.camelcase.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_name' is not in camel case."));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_param' is not in camel case."));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_class' is not in camel case."));
+}
+
+test "reports property names by default" {
+    const source =
+        \\class GoodClass {
+        \\  #bad_private;
+        \\  bad_field = 1;
+        \\  bad_method() {}
+        \\}
+        \\const okName = { bad_key: 1, goodKey: 2, [computed_key]: 3 };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.camelcase.id));
+    try std.testing.expect(hasMessage(result, "Identifier '#bad_private' is not in camel case."));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_field' is not in camel case."));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_method' is not in camel case."));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_key' is not in camel case."));
+}
+
+test "can ignore property names" {
+    const source =
+        \\class GoodClass {
+        \\  bad_field = 1;
+        \\  bad_method() {}
+        \\}
+        \\const okName = { bad_key: 1 };
+    ;
+
+    var options = baseOptions();
+    options.camelcase_properties = .never;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.camelcase.id));
+}
+
+test "can ignore destructured bindings" {
+    const source =
+        \\const { bad_key: bad_local, bad_shorthand } = sourceObject;
+        \\const [bad_item] = sourceList;
+        \\const bad_name = 1;
+    ;
+
+    var options = baseOptions();
+    options.camelcase_ignore_destructuring = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.camelcase.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_name' is not in camel case."));
+}
+
+test "checks imports unless configured to ignore them" {
+    const source =
+        \\import bad_default, { snake_case, ok as bad_alias } from "pkg";
+        \\import * as bad_namespace from "other";
+        \\snake_case;
+        \\bad_alias;
+        \\bad_default;
+        \\bad_namespace;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.camelcase.id));
+
+    var options = baseOptions();
+    options.camelcase_ignore_imports = true;
+    var ignored = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer ignored.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(ignored, lint.rules.camelcase.id));
+}
+
+test "supports allow patterns" {
+    const source =
+        \\const legacy_name = 1;
+        \\const bad_name = 2;
+        \\const UNSAFE_VALUE = 3;
+    ;
+
+    var options = baseOptions();
+    try options.camelcase_allow.append("legacy_name");
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.camelcase.id));
+    try std.testing.expect(hasMessage(result, "Identifier 'bad_name' is not in camel case."));
+}
+
+test "parses camelcase config" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"properties\":\"never\",\"ignoreDestructuring\":true,\"ignoreImports\":true,\"ignoreGlobals\":true,\"allow\":[\"legacy_name\",\"^UNSAFE_\"]}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("camelcase", parsed.value);
+
+    try std.testing.expect(options.camelcase);
+    try std.testing.expectEqual(@as(@TypeOf(options.camelcase_properties), .never), options.camelcase_properties);
+    try std.testing.expect(options.camelcase_ignore_destructuring);
+    try std.testing.expect(options.camelcase_ignore_imports);
+    try std.testing.expect(options.camelcase_ignore_globals);
+    try std.testing.expect(options.camelcase_allow.matches("legacy_name"));
+    try std.testing.expect(options.camelcase_allow.matches("UNSAFE_value"));
+}
+
+test "can disable camelcase" {
+    const source =
+        \\const bad_name = 1;
+    ;
+
+    var options = baseOptions();
+    options.camelcase = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.camelcase.id));
+}
+
+fn baseOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.camelcase = true;
+    options.camelcase_properties = .always;
+    return options;
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.camelcase.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `camelcase` diagnostics for declarations, parameters, imports, and property names
- parse ESLint-style `properties`, `ignoreDestructuring`, `ignoreImports`, `ignoreGlobals`, and `allow` config; `allow` uses lightweight pattern matching
- expose CLI toggles plus npm metadata, status docs, and focused tests

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`
