### PR TITLE
Add no-implicit-globals rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -96,6 +96,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-global-is-finite`](https://eslint.org/docs/latest/rules/no-global-is-finite) | Implemented |
 | [`no-global-is-nan`](https://eslint.org/docs/latest/rules/no-global-is-nan) | Implemented |
 | [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) | Supports `boolean`, `number`, `string`, `allow`, and `disallowTemplateShorthand` configuration |
+| [`no-implicit-globals`](https://eslint.org/docs/latest/rules/no-implicit-globals) | Supports script top-level `var`/function checks and optional `lexicalBindings` checks |
 | [`no-implied-eval`](https://eslint.org/docs/latest/rules/no-implied-eval) | Implemented for global timer and `execScript` calls with evaluated string arguments |
 | [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign) | Implemented |
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Supports `ignorePattern` configuration with common regex-like patterns |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -166,6 +166,7 @@ const BUILTIN_RULE_IDS = [
   "no-global-is-finite",
   "no-global-is-nan",
   "no-implicit-coercion",
+  "no-implicit-globals",
   "no-implied-eval",
   "no-import-assign",
   "no-inline-comments",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -169,6 +169,7 @@ const BUILTIN_RULE_IDS = [
   "no-global-is-finite",
   "no-global-is-nan",
   "no-implicit-coercion",
+  "no-implicit-globals",
   "no-implied-eval",
   "no-import-assign",
   "no-inline-comments",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2267,6 +2267,8 @@ pub const Options = struct {
     no_implicit_coercion_allow_subtract: bool = false,
     no_implicit_coercion_allow_double_negative: bool = false,
     no_implicit_coercion_disallow_template_shorthand: bool = false,
+    no_implicit_globals: bool = false,
+    no_implicit_globals_lexical_bindings: bool = false,
     no_implied_eval: bool = true,
     no_import_assign: bool = true,
     alipay_ant_disallow_typos: bool = true,
@@ -3152,6 +3154,9 @@ pub const Options = struct {
             self.no_implicit_coercion_allow_subtract = try noImplicitCoercionAllowFromConfig(value, "-");
             self.no_implicit_coercion_allow_double_negative = try noImplicitCoercionAllowFromConfig(value, "- -");
             self.no_implicit_coercion_disallow_template_shorthand = try noImplicitCoercionDisallowTemplateShorthandFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-implicit-globals")) {
+            self.no_implicit_globals_lexical_bindings = try noImplicitGlobalsLexicalBindingsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-inner-declarations")) {
             self.no_inner_declarations_mode = try noInnerDeclarationsModeFromConfig(value);
@@ -5852,6 +5857,20 @@ pub const Options = struct {
 
     fn noFallthroughReportUnusedFallthroughCommentFromConfig(value: std.json.Value) RuleConfigError!bool {
         return noFallthroughBoolOptionFromConfig(value, "reportUnusedFallthroughComment", false);
+    }
+
+    fn noImplicitGlobalsLexicalBindingsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return try boolObjectOption(config, "lexicalBindings", false);
     }
 
     fn noFallthroughCommentPatternFromConfig(value: std.json.Value) RuleConfigError!NoFallthroughCommentPattern {

--- a/src/main.zig
+++ b/src/main.zig
@@ -366,6 +366,12 @@ pub fn main(init: std.process.Init) !void {
             options.no_implicit_coercion_number = .no;
         } else if (std.mem.eql(u8, arg, "--no-implicit-coercion-string=off")) {
             options.no_implicit_coercion_string = .no;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-globals=off")) {
+            options.no_implicit_globals = false;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-globals=on")) {
+            options.no_implicit_globals = true;
+        } else if (std.mem.eql(u8, arg, "--no-implicit-globals-lexical-bindings=on")) {
+            options.no_implicit_globals_lexical_bindings = true;
         } else if (std.mem.eql(u8, arg, "--no-implied-eval=off")) {
             options.no_implied_eval = false;
         } else if (std.mem.eql(u8, arg, "--no-import-assign=off")) {
@@ -2052,6 +2058,9 @@ fn printHelp() void {
         \\  --no-implicit-coercion-boolean=off Disable boolean coercion checks
         \\  --no-implicit-coercion-number=off Disable number coercion checks
         \\  --no-implicit-coercion-string=off Disable string coercion checks
+        \\  --no-implicit-globals=off Disable no-implicit-globals
+        \\  --no-implicit-globals=on Enable no-implicit-globals
+        \\  --no-implicit-globals-lexical-bindings=on Check top-level lexical declarations
         \\  --no-implied-eval=off      Disable no-implied-eval
         \\  --no-import-assign=off     Disable no-import-assign
         \\  --alipay-ant-disallow-typos=off Disable @alipay/ant/disallow-typos

--- a/src/rules/no_implicit_globals.zig
+++ b/src/rules/no_implicit_globals.zig
@@ -1,0 +1,85 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "no-implicit-globals";
+
+pub const Options = struct {
+    lexical_bindings: bool = false,
+};
+
+pub fn checkProgram(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    program: ast.Program,
+    options: Options,
+) Allocator.Error!void {
+    if (program.source_type == .module) return;
+
+    for (tree.extra(program.body)) |statement_index| {
+        switch (tree.data(statement_index)) {
+            .variable_declaration => |declaration| {
+                if (declaration.kind == .@"var") {
+                    try addImplicitGlobalDiagnostic(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        statement_index,
+                        "Implicit global variable declaration.",
+                    );
+                } else if (options.lexical_bindings) {
+                    try addImplicitGlobalDiagnostic(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        statement_index,
+                        "Implicit global lexical declaration.",
+                    );
+                }
+            },
+            .function => |function| {
+                if (function.type == .function_declaration) {
+                    try addImplicitGlobalDiagnostic(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        statement_index,
+                        "Implicit global function declaration.",
+                    );
+                }
+            },
+            .class => |class| {
+                if (options.lexical_bindings and class.type == .class_declaration) {
+                    try addImplicitGlobalDiagnostic(
+                        allocator,
+                        diagnostics,
+                        tree,
+                        statement_index,
+                        "Implicit global class declaration.",
+                    );
+                }
+            },
+            else => {},
+        }
+    }
+}
+
+fn addImplicitGlobalDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    message: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        tree.span(index),
+    );
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -154,6 +154,7 @@ pub const no_global_assign = @import("no_global_assign.zig");
 pub const no_global_is_finite = @import("no_global_is_finite.zig");
 pub const no_global_is_nan = @import("no_global_is_nan.zig");
 pub const no_implicit_coercion = @import("no_implicit_coercion.zig");
+pub const no_implicit_globals = @import("no_implicit_globals.zig");
 pub const no_implied_eval = @import("no_implied_eval.zig");
 pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_inline_comments = @import("no_inline_comments.zig");
@@ -1443,6 +1444,11 @@ const BasicVisitor = struct {
                 self.options.import_newline_after_import_exact_count,
                 self.options.import_newline_after_import_consider_comments,
             );
+        }
+        if (self.options.no_implicit_globals) {
+            try no_implicit_globals.checkProgram(self.allocator, self.diagnostics, ctx.tree, program, .{
+                .lexical_bindings = self.options.no_implicit_globals_lexical_bindings,
+            });
         }
         if (self.options.import_no_duplicates) {
             try import_no_duplicates.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, program, .{

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -559,6 +559,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_implicit_globals.zig");
+}
+
+comptime {
     _ = @import("rules/no_implied_eval.zig");
 }
 

--- a/tests/rules/no_implicit_globals.zig
+++ b/tests/rules/no_implicit_globals.zig
@@ -1,0 +1,108 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports script top-level var and function declarations" {
+    const source =
+        \\var badVar = 1;
+        \\function badFn() {}
+        \\let okLet = 2;
+        \\const okConst = 3;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_implicit_globals = true;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_implicit_globals.id));
+    try std.testing.expectEqualStrings(
+        "Implicit global variable declaration.",
+        result.diagnostics[0].message,
+    );
+    try std.testing.expectEqualStrings(
+        "Implicit global function declaration.",
+        result.diagnostics[1].message,
+    );
+}
+
+test "reports lexical declarations when lexicalBindings is enabled" {
+    const source =
+        \\var badVar = 1;
+        \\let badLet = 2;
+        \\const badConst = 3;
+        \\class BadClass {}
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_implicit_globals = true;
+    options.no_implicit_globals_lexical_bindings = true;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_implicit_globals.id));
+    try std.testing.expectEqualStrings(
+        "Implicit global class declaration.",
+        result.diagnostics[3].message,
+    );
+}
+
+test "does not report modules or nested declarations" {
+    const source =
+        \\var moduleVar = 1;
+        \\function moduleFn() {}
+        \\if (moduleVar) {
+        \\  var nested = 1;
+        \\  function nestedFn() {}
+        \\}
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_implicit_globals = true;
+    options.no_implicit_globals_lexical_bindings = true;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    var module_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer module_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(module_result, lint.rules.no_implicit_globals.id));
+
+    const nested_source =
+        \\if (flag) {
+        \\  var nested = 1;
+        \\  function nestedFn() {}
+        \\  let blockLet = 2;
+        \\}
+    ;
+
+    var script_result = try lint.lintSource(std.testing.allocator, nested_source, "fixture.cjs", options);
+    defer script_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(script_result, lint.rules.no_implicit_globals.id));
+}
+
+test "parses lexicalBindings config and can disable the rule" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\", {\"lexicalBindings\": true}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("no-implicit-globals", parsed.value);
+
+    try std.testing.expect(options.no_implicit_globals);
+    try std.testing.expect(options.no_implicit_globals_lexical_bindings);
+
+    try options.setByRuleConfigValue("no-implicit-globals", .{ .string = "off" });
+    try std.testing.expect(!options.no_implicit_globals);
+}


### PR DESCRIPTION
## Summary
- add no-implicit-globals for script top-level var/function declarations
- support lexicalBindings for top-level let/const/class declarations
- wire config parsing, CLI flags, npm rule metadata, docs, and tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check