### PR TITLE
Add no-restricted-modules rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -142,6 +142,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-restricted-exports`](https://eslint.org/docs/latest/rules/no-restricted-exports) | Supports `restrictedNamedExports` and `restrictDefaultExports` |
 | [`no-restricted-globals`](https://eslint.org/docs/latest/rules/no-restricted-globals) | Supports direct global restrictions, custom messages, and optional global object checks |
 | [`no-restricted-imports`](https://eslint.org/docs/latest/rules/no-restricted-imports) | Supports restricted `paths`, simple `patterns`, custom messages, import name allow/deny lists, type-only allowances, and re-export checks |
+| [`no-restricted-modules`](https://eslint.org/docs/latest/rules/no-restricted-modules) | Supports restricted CommonJS `require()` sources, `paths`, simple `patterns`, negated patterns, and custom messages |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) | Supports lightweight AST node selector restrictions with custom messages |
 | [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -212,6 +212,7 @@ const BUILTIN_RULE_IDS = [
   "no-restricted-exports",
   "no-restricted-globals",
   "no-restricted-imports",
+  "no-restricted-modules",
   "no-restricted-syntax",
   "no-regex-spaces",
   "no-return-assign",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -215,6 +215,7 @@ const BUILTIN_RULE_IDS = [
   "no-restricted-exports",
   "no-restricted-globals",
   "no-restricted-imports",
+  "no-restricted-modules",
   "no-restricted-syntax",
   "no-regex-spaces",
   "no-return-assign",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1304,6 +1304,8 @@ pub const NoRestrictedImports = struct {
     }
 };
 
+pub const NoRestrictedModules = NoRestrictedImports;
+
 pub const max_no_unused_vars_ignore_pattern_len = 256;
 
 pub const NoUnusedVarsIgnorePatternError = error{
@@ -2416,6 +2418,8 @@ pub const Options = struct {
     no_restricted_globals_entries: NoRestrictedGlobals = .{},
     no_restricted_imports: bool = false,
     no_restricted_imports_entries: NoRestrictedImports = .{},
+    no_restricted_modules: bool = false,
+    no_restricted_modules_entries: NoRestrictedModules = .{},
     no_restricted_properties: bool = true,
     no_restricted_properties_entries: NoRestrictedProperties = .{},
     no_restricted_syntax: bool = false,
@@ -3210,6 +3214,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-imports")) {
             self.no_restricted_imports_entries = try noRestrictedImportsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-restricted-modules")) {
+            self.no_restricted_modules_entries = try noRestrictedModulesFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "no-restricted-properties")) {
             self.no_restricted_properties_entries = try noRestrictedPropertiesFromConfig(value);
@@ -4573,6 +4580,10 @@ pub const Options = struct {
         }
 
         return result;
+    }
+
+    fn noRestrictedModulesFromConfig(value: std.json.Value) RuleConfigError!NoRestrictedModules {
+        return try noRestrictedImportsFromConfig(value);
     }
 
     fn appendNoRestrictedImportConfigItems(

--- a/src/main.zig
+++ b/src/main.zig
@@ -608,6 +608,14 @@ pub fn main(init: std.process.Init) !void {
             appendNoRestrictedImportName(arg["--no-restricted-imports-name=".len..], &options, .path);
         } else if (std.mem.startsWith(u8, arg, "--no-restricted-imports-pattern=")) {
             appendNoRestrictedImportName(arg["--no-restricted-imports-pattern=".len..], &options, .pattern);
+        } else if (std.mem.eql(u8, arg, "--no-restricted-modules=off")) {
+            options.no_restricted_modules = false;
+        } else if (std.mem.eql(u8, arg, "--no-restricted-modules=on")) {
+            options.no_restricted_modules = true;
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-modules-name=")) {
+            appendNoRestrictedModuleName(arg["--no-restricted-modules-name=".len..], &options, .path);
+        } else if (std.mem.startsWith(u8, arg, "--no-restricted-modules-pattern=")) {
+            appendNoRestrictedModuleName(arg["--no-restricted-modules-pattern=".len..], &options, .pattern);
         } else if (std.mem.eql(u8, arg, "--no-restricted-properties=off")) {
             options.no_restricted_properties = false;
         } else if (std.mem.eql(u8, arg, "--no-restricted-syntax=off")) {
@@ -1472,6 +1480,15 @@ fn appendNoRestrictedImportName(value: []const u8, options: *lint.Options, kind:
     options.no_restricted_imports = true;
 }
 
+fn appendNoRestrictedModuleName(value: []const u8, options: *lint.Options, kind: lint.NoRestrictedImportKind) void {
+    var entry = lint.NoRestrictedImportEntry{ .kind = kind };
+    if (!entry.setSource(value) or !options.no_restricted_modules_entries.append(entry)) {
+        std.debug.print("utoo-lint: invalid no-restricted-modules value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.no_restricted_modules = true;
+}
+
 fn appendNoRestrictedSyntaxSelector(value: []const u8, options: *lint.Options) void {
     var entry = lint.NoRestrictedSyntaxEntry{};
     if (!entry.setSelector(value) or !options.no_restricted_syntax_entries.append(entry)) {
@@ -2217,6 +2234,10 @@ fn printHelp() void {
         \\  --no-restricted-imports=on Enable no-restricted-imports
         \\  --no-restricted-imports-name=NAME Restrict an import source
         \\  --no-restricted-imports-pattern=PATTERN Restrict import sources matching a simple * pattern
+        \\  --no-restricted-modules=off Disable no-restricted-modules
+        \\  --no-restricted-modules=on Enable no-restricted-modules
+        \\  --no-restricted-modules-name=NAME Restrict a require() source
+        \\  --no-restricted-modules-pattern=PATTERN Restrict require() sources matching a simple * pattern
         \\  --no-restricted-properties=off Disable no-restricted-properties
         \\  --no-restricted-syntax=off Disable no-restricted-syntax
         \\  --no-restricted-syntax=on Enable no-restricted-syntax

--- a/src/rules/no_restricted_modules.zig
+++ b/src/rules/no_restricted_modules.zig
@@ -1,0 +1,158 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-restricted-modules";
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    restrictions: core.NoRestrictedModules,
+) Allocator.Error!void {
+    if (restrictions.count == 0) return;
+    if (!isRequireCallee(tree, call.callee)) return;
+
+    const source = firstStaticStringArgument(tree, call.arguments) orelse return;
+    const entry = matchingRestriction(&restrictions, source) orelse return;
+
+    try reportModule(allocator, diagnostics, tree, index, source, entry);
+}
+
+fn isRequireCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "require"),
+        else => false,
+    };
+}
+
+fn firstStaticStringArgument(tree: *const ast.Tree, arguments: ast.IndexRange) ?[]const u8 {
+    if (arguments.len == 0) return null;
+
+    return switch (tree.data(unwrapTransparent(tree, tree.extra(arguments)[0]))) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn matchingRestriction(restrictions: *const core.NoRestrictedModules, source: []const u8) ?*const core.NoRestrictedImportEntry {
+    var matched_pattern: ?*const core.NoRestrictedImportEntry = null;
+
+    for (0..restrictions.count) |restriction_index| {
+        const entry = restrictions.at(restriction_index);
+        const pattern = entry.source();
+
+        switch (entry.kind) {
+            .path => {
+                if (std.mem.eql(u8, pattern, source)) return entry;
+            },
+            .pattern => {
+                if (std.mem.startsWith(u8, pattern, "!")) {
+                    if (wildcardMatches(pattern[1..], source)) matched_pattern = null;
+                } else if (wildcardMatches(pattern, source)) {
+                    matched_pattern = entry;
+                }
+            },
+        }
+    }
+
+    return matched_pattern;
+}
+
+fn wildcardMatches(pattern: []const u8, source: []const u8) bool {
+    if (pattern.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, pattern, '*') == null) {
+        return std.mem.eql(u8, pattern, source);
+    }
+
+    var source_index: usize = 0;
+    var part_index: usize = 0;
+    var parts = std.mem.splitScalar(u8, pattern, '*');
+    while (parts.next()) |part| : (part_index += 1) {
+        if (part.len == 0) continue;
+
+        if (part_index == 0 and pattern[0] != '*') {
+            if (!std.mem.startsWith(u8, source, part)) return false;
+            source_index = part.len;
+            continue;
+        }
+
+        const found = std.mem.indexOf(u8, source[source_index..], part) orelse return false;
+        source_index += found + part.len;
+    }
+
+    if (pattern[pattern.len - 1] != '*') {
+        var last_parts = std.mem.splitScalar(u8, pattern, '*');
+        var last: []const u8 = "";
+        while (last_parts.next()) |part| {
+            if (part.len > 0) last = part;
+        }
+        return std.mem.endsWith(u8, source, last);
+    }
+
+    return true;
+}
+
+fn reportModule(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    node: ast.NodeIndex,
+    source: []const u8,
+    entry: *const core.NoRestrictedImportEntry,
+) Allocator.Error!void {
+    if (entry.message()) |message| {
+        try core.addDiagnosticFmt(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            tree.span(node),
+            "'{s}' module is restricted from being used. {s}",
+            .{ source, message },
+        );
+        return;
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(node),
+        "'{s}' module is restricted from being used.",
+        .{source},
+    );
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -200,6 +200,7 @@ pub const no_redeclare = @import("no_redeclare.zig");
 pub const no_restricted_exports = @import("no_restricted_exports.zig");
 pub const no_restricted_globals = @import("no_restricted_globals.zig");
 pub const no_restricted_imports = @import("no_restricted_imports.zig");
+pub const no_restricted_modules = @import("no_restricted_modules.zig");
 pub const no_restricted_properties = @import("no_restricted_properties.zig");
 pub const no_restricted_syntax = @import("no_restricted_syntax.zig");
 pub const no_regex_spaces = @import("no_regex_spaces.zig");
@@ -3339,6 +3340,9 @@ const BasicVisitor = struct {
         }
         if (self.options.no_process_exit) {
             try no_process_exit.check(self.allocator, self.diagnostics, ctx.tree, call, index);
+        }
+        if (self.options.no_restricted_modules) {
+            try no_restricted_modules.check(self.allocator, self.diagnostics, ctx.tree, call, index, self.options.no_restricted_modules_entries);
         }
         if (self.options.use_isnan) {
             try use_isnan.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, self.useIsnanOptions());

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -739,6 +739,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_restricted_modules.zig");
+}
+
+comptime {
     _ = @import("rules/no_restricted_properties.zig");
 }
 

--- a/tests/rules/no_restricted_modules.zig
+++ b/tests/rules/no_restricted_modules.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports no-restricted-modules for restricted require sources" {
+    const source =
+        \\const fs = require("fs");
+        \\const path = (require)("path");
+        \\const ok = require("ok");
+    ;
+
+    const options = try optionsWithConfig("[\"error\", \"fs\", \"path\"]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_modules.id));
+}
+
+test "reports object path restrictions with custom messages" {
+    const source =
+        \\const fs = require("fs");
+        \\const path = require("path");
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\", {\"name\":\"fs\", \"message\":\"Use graceful-fs instead.\"}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_restricted_modules.id));
+    try std.testing.expect(hasMessage(result, "Use graceful-fs instead."));
+}
+
+test "reports patterns and honors negated patterns" {
+    const source =
+        \\const privateApi = require("private/api");
+        \\const allowed = require("private/allowed");
+        \\const nested = require("secret/nested/value");
+    ;
+
+    const options = try optionsWithConfig(
+        "[\"error\", {\"patterns\":[\"private/*\", \"!private/allowed\", \"secret/*\"]}]",
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_restricted_modules.id));
+}
+
+test "ignores dynamic require arguments and non-require calls" {
+    const source =
+        \\const fs = customRequire("fs");
+        \\const dynamic = require(name);
+        \\const templated = require(`pkg-${name}`);
+        \\const staticTemplate = require(`fs`);
+    ;
+
+    const options = try optionsWithConfig("[\"error\", \"fs\"]");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_restricted_modules.id));
+}
+
+test "can disable no-restricted-modules" {
+    const source =
+        \\const fs = require("fs");
+    ;
+
+    var options = try optionsWithConfig("[\"error\", \"fs\"]");
+    options.no_restricted_modules = false;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_restricted_modules.id));
+}
+
+test "parses paths and patterns config" {
+    const options = try optionsWithConfig(
+        "[\"error\", {\"paths\":[{\"name\":\"fs\", \"message\":\"Use safe-fs.\"}], \"patterns\":[\"private/*\"]}]",
+    );
+
+    try std.testing.expect(options.no_restricted_modules);
+    try std.testing.expectEqual(@as(usize, 2), options.no_restricted_modules_entries.count);
+    try std.testing.expectEqualStrings("fs", options.no_restricted_modules_entries.at(0).source());
+    try std.testing.expectEqualStrings("Use safe-fs.", options.no_restricted_modules_entries.at(0).message().?);
+    try std.testing.expectEqualStrings("private/*", options.no_restricted_modules_entries.at(1).source());
+}
+
+fn optionsWithConfig(config: []const u8) !lint.Options {
+    var options = baseOptions();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue("no-restricted-modules", parsed.value);
+    return options;
+}
+
+fn baseOptions() lint.Options {
+    return .{
+        .no_undef = false,
+        .no_unassigned_vars = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_restricted_modules.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add no-restricted-modules for static CommonJS require() calls
- support string entries, paths, simple patterns, negated patterns, and custom messages
- wire config parsing, CLI flags, npm rule metadata, docs, and tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check