### PR TITLE
Add prefer-arrow-callback rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -194,6 +194,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
+| [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -258,6 +258,7 @@ const BUILTIN_RULE_IDS = [
   "object-shorthand",
   "one-var",
   "operator-assignment",
+  "prefer-arrow-callback",
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -261,6 +261,7 @@ const BUILTIN_RULE_IDS = [
   "object-shorthand",
   "one-var",
   "operator-assignment",
+  "prefer-arrow-callback",
   "prefer-const",
   "prefer-destructuring",
   "prefer-exponentiation-operator",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2547,6 +2547,9 @@ pub const Options = struct {
     no_use_before_define_allow_named_exports: bool = false,
     no_undef: bool = true,
     no_undef_typeof: bool = false,
+    prefer_arrow_callback: bool = false,
+    prefer_arrow_callback_allow_named_functions: bool = false,
+    prefer_arrow_callback_allow_unbound_this: bool = true,
     prefer_const: bool = true,
     prefer_const_destructuring: PreferConstDestructuring = .any,
     prefer_const_ignore_read_before_assign: bool = true,
@@ -3278,6 +3281,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-promise-executor-return")) {
             self.no_promise_executor_return_allow_void = try noPromiseExecutorReturnAllowVoidFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "prefer-arrow-callback")) {
+            self.prefer_arrow_callback_allow_named_functions = try preferArrowCallbackBoolOptionFromConfig(value, "allowNamedFunctions", false);
+            self.prefer_arrow_callback_allow_unbound_this = try preferArrowCallbackBoolOptionFromConfig(value, "allowUnboundThis", true);
         }
         if (std.mem.eql(u8, cli_name, "prefer-const")) {
             self.prefer_const_destructuring = try preferConstDestructuringFromConfig(value);
@@ -6765,6 +6772,24 @@ pub const Options = struct {
     }
 
     fn preferConstBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const option = config.get(key) orelse return default;
+        return switch (option) {
+            .bool => |enabled| enabled,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn preferArrowCallbackBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
             else => return default,

--- a/src/main.zig
+++ b/src/main.zig
@@ -867,6 +867,14 @@ pub fn main(init: std.process.Init) !void {
             options.no_use_before_define = false;
         } else if (std.mem.eql(u8, arg, "--no-undef=off")) {
             options.no_undef = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-arrow-callback=off")) {
+            options.prefer_arrow_callback = false;
+        } else if (std.mem.eql(u8, arg, "--prefer-arrow-callback=on")) {
+            options.prefer_arrow_callback = true;
+        } else if (std.mem.eql(u8, arg, "--prefer-arrow-callback-allow-named-functions=on")) {
+            options.prefer_arrow_callback_allow_named_functions = true;
+        } else if (std.mem.eql(u8, arg, "--prefer-arrow-callback-allow-unbound-this=off")) {
+            options.prefer_arrow_callback_allow_unbound_this = false;
         } else if (std.mem.eql(u8, arg, "--prefer-const=off")) {
             options.prefer_const = false;
         } else if (std.mem.eql(u8, arg, "--prefer-const-destructuring=all")) {
@@ -2315,6 +2323,10 @@ fn printHelp() void {
         \\  --no-unassigned-vars=off Disable no-unassigned-vars
         \\  --no-use-before-define=off Disable no-use-before-define
         \\  --no-undef=off            Disable no-undef
+        \\  --prefer-arrow-callback=off Disable prefer-arrow-callback
+        \\  --prefer-arrow-callback=on Enable prefer-arrow-callback
+        \\  --prefer-arrow-callback-allow-named-functions=on Allow named function callbacks
+        \\  --prefer-arrow-callback-allow-unbound-this=off Report unbound this callbacks
         \\  --prefer-const=off        Disable prefer-const
         \\  --prefer-const-destructuring=all Require all destructured bindings to be const candidates
         \\  --prefer-exponentiation-operator=off Disable prefer-exponentiation-operator

--- a/src/rules/prefer_arrow_callback.zig
+++ b/src/rules/prefer_arrow_callback.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "prefer-arrow-callback";
+
+pub const Options = struct {
+    allow_named_functions: bool = false,
+    allow_unbound_this: bool = true,
+};
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (function.type != .function_expression) return;
+    if (function.generator) return;
+    if (!isCallback(tree, index, &ctx.path)) return;
+    if (options.allow_named_functions and function.id != .null) return;
+    if (options.allow_unbound_this and !isBoundCallback(tree, index, &ctx.path) and nodeUsesThisOrSuper(tree, function.body)) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        "Expected an arrow function.",
+        tree.span(index),
+    );
+}
+
+fn isCallback(tree: *const ast.Tree, index: ast.NodeIndex, path: *const traverser.NodePath) bool {
+    if (isCallOrNewArgument(tree, index, path.parent())) return true;
+
+    if (!isBindMemberObject(tree, index, path.parent())) return false;
+    const member_index = path.parent() orelse return false;
+    const bind_call_index = path.ancestor(2) orelse return false;
+    if (!isCallCallee(tree, bind_call_index, member_index)) return false;
+
+    return isCallOrNewArgument(tree, bind_call_index, path.ancestor(3));
+}
+
+fn isBoundCallback(tree: *const ast.Tree, index: ast.NodeIndex, path: *const traverser.NodePath) bool {
+    if (!isBindMemberObject(tree, index, path.parent())) return false;
+    const member_index = path.parent() orelse return false;
+    const bind_call_index = path.ancestor(2) orelse return false;
+    return isCallCallee(tree, bind_call_index, member_index);
+}
+
+fn isCallOrNewArgument(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const arguments = switch (tree.data(parent)) {
+        .call_expression => |call| if (call.callee == index) return false else call.arguments,
+        .new_expression => |new| if (new.callee == index) return false else new.arguments,
+        else => return false,
+    };
+    return rangeContains(tree, arguments, index);
+}
+
+fn isCallCallee(tree: *const ast.Tree, call_index: ast.NodeIndex, callee_index: ast.NodeIndex) bool {
+    return switch (tree.data(call_index)) {
+        .call_expression => |call| call.callee == callee_index,
+        else => false,
+    };
+}
+
+fn isBindMemberObject(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const member = switch (tree.data(parent)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member) orelse return false;
+    return member.object == index and std.mem.eql(u8, property, "bind");
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn rangeContains(tree: *const ast.Tree, range: ast.IndexRange, index: ast.NodeIndex) bool {
+    for (tree.extra(range)) |child| {
+        if (child == index) return true;
+    }
+    return false;
+}
+
+fn nodeUsesThisOrSuper(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .this_expression, .super => true,
+        .function, .class => false,
+        .arrow_function_expression => |arrow| nodeUsesThisOrSuper(tree, arrow.body),
+        .function_body => |body| rangeUsesThisOrSuper(tree, body.body),
+        .expression_statement => |statement| nodeUsesThisOrSuper(tree, statement.expression),
+        .return_statement => |statement| nodeUsesThisOrSuper(tree, statement.argument),
+        .block_statement => |block| rangeUsesThisOrSuper(tree, block.body),
+        .parenthesized_expression => |expression| nodeUsesThisOrSuper(tree, expression.expression),
+        .chain_expression => |expression| nodeUsesThisOrSuper(tree, expression.expression),
+        .member_expression => |expression| nodeUsesThisOrSuper(tree, expression.object) or
+            nodeUsesThisOrSuper(tree, expression.property),
+        .call_expression => |expression| nodeUsesThisOrSuper(tree, expression.callee) or
+            rangeUsesThisOrSuper(tree, expression.arguments),
+        .assignment_expression => |expression| nodeUsesThisOrSuper(tree, expression.left) or
+            nodeUsesThisOrSuper(tree, expression.right),
+        .binary_expression => |expression| nodeUsesThisOrSuper(tree, expression.left) or
+            nodeUsesThisOrSuper(tree, expression.right),
+        .logical_expression => |expression| nodeUsesThisOrSuper(tree, expression.left) or
+            nodeUsesThisOrSuper(tree, expression.right),
+        .conditional_expression => |expression| nodeUsesThisOrSuper(tree, expression.@"test") or
+            nodeUsesThisOrSuper(tree, expression.consequent) or
+            nodeUsesThisOrSuper(tree, expression.alternate),
+        .unary_expression => |expression| nodeUsesThisOrSuper(tree, expression.argument),
+        .update_expression => |expression| nodeUsesThisOrSuper(tree, expression.argument),
+        .await_expression => |expression| nodeUsesThisOrSuper(tree, expression.argument),
+        .yield_expression => |expression| nodeUsesThisOrSuper(tree, expression.argument),
+        .sequence_expression => |expression| rangeUsesThisOrSuper(tree, expression.expressions),
+        .array_expression => |expression| rangeUsesThisOrSuper(tree, expression.elements),
+        .object_expression => |expression| rangeUsesThisOrSuper(tree, expression.properties),
+        .object_property => |property| nodeUsesThisOrSuper(tree, property.key) or
+            nodeUsesThisOrSuper(tree, property.value),
+        .spread_element => |element| nodeUsesThisOrSuper(tree, element.argument),
+        else => false,
+    };
+}
+
+fn rangeUsesThisOrSuper(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |child| {
+        if (nodeUsesThisOrSuper(tree, child)) return true;
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -252,6 +252,7 @@ pub const no_with = @import("no_with.zig");
 pub const object_shorthand = @import("object_shorthand.zig");
 pub const one_var = @import("one_var.zig");
 pub const operator_assignment = @import("operator_assignment.zig");
+pub const prefer_arrow_callback = @import("prefer_arrow_callback.zig");
 pub const prefer_const = @import("prefer_const.zig");
 pub const prefer_destructuring = @import("prefer_destructuring.zig");
 pub const prefer_exponentiation_operator = @import("prefer_exponentiation_operator.zig");
@@ -1596,6 +1597,12 @@ const BasicVisitor = struct {
         }
         if (self.options.func_style) {
             try func_style.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, funcStyleOptions(&self.options));
+        }
+        if (self.options.prefer_arrow_callback) {
+            try prefer_arrow_callback.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, .{
+                .allow_named_functions = self.options.prefer_arrow_callback_allow_named_functions,
+                .allow_unbound_this = self.options.prefer_arrow_callback_allow_unbound_this,
+            });
         }
         if (self.options.camelcase) {
             try camelcase.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, camelcaseOptions(&self.options));

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -963,6 +963,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/prefer_arrow_callback.zig");
+}
+
+comptime {
     _ = @import("rules/prefer_const.zig");
 }
 

--- a/tests/rules/prefer_arrow_callback.zig
+++ b/tests/rules/prefer_arrow_callback.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports function expression callbacks" {
+    const source =
+        \\items.map(function (item) {
+        \\  return item.value;
+        \\});
+        \\setTimeout(function () {
+        \\  work();
+        \\}, 0);
+        \\new Promise(function (resolve) {
+        \\  resolve();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.prefer_arrow_callback.id));
+}
+
+test "does not report non-callback function expressions or generators" {
+    const source =
+        \\const handler = function () {
+        \\  return value;
+        \\};
+        \\items.map(function* generator() {
+        \\  yield value;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_arrow_callback.id));
+}
+
+test "supports named callback option" {
+    var options = baseOptions();
+    options.prefer_arrow_callback_allow_named_functions = true;
+
+    const source =
+        \\items.map(function named(item) {
+        \\  return item.value;
+        \\});
+        \\items.map(function (item) {
+        \\  return item.value;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.prefer_arrow_callback.id));
+}
+
+test "supports allowUnboundThis and bound callbacks" {
+    const source =
+        \\items.map(function (item) {
+        \\  return this.format(item);
+        \\});
+        \\items.map(function (item) {
+        \\  return this.format(item);
+        \\}.bind(this));
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer default_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(default_result, lint.rules.prefer_arrow_callback.id));
+
+    var strict_options = baseOptions();
+    strict_options.prefer_arrow_callback_allow_unbound_this = false;
+    var strict_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", strict_options);
+    defer strict_result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(strict_result, lint.rules.prefer_arrow_callback.id));
+}
+
+test "parses prefer-arrow-callback config and can disable" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\", {\"allowNamedFunctions\": true, \"allowUnboundThis\": false}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("prefer-arrow-callback", parsed.value);
+
+    try std.testing.expect(options.prefer_arrow_callback);
+    try std.testing.expect(options.prefer_arrow_callback_allow_named_functions);
+    try std.testing.expect(!options.prefer_arrow_callback_allow_unbound_this);
+
+    try options.setByRuleConfigValue("prefer-arrow-callback", .{ .string = "off" });
+    try std.testing.expect(!options.prefer_arrow_callback);
+}
+
+fn baseOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.prefer_arrow_callback = true;
+    options.prefer_arrow_callback_allow_unbound_this = true;
+    options.no_unassigned_vars = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+    return options;
+}


### PR DESCRIPTION
## Summary
- add prefer-arrow-callback for function expression callbacks passed to call/new expressions
- support allowNamedFunctions and allowUnboundThis migration options, including bound callback handling
- wire config parsing, CLI flags, npm rule metadata, docs, and tests

## Validation
- zig build test --summary all
- zig build test -Doptimize=ReleaseFast -j1 --summary all
- zig build
- node --check npm/utoo-lint/index.js
- node --check npm/utoo-lint/index.cjs
- git diff --check
- git diff --cached --check