### PR TITLE
Register no-use-before-define rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -243,6 +243,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",
+  "no-use-before-define",
   "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -246,6 +246,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",
+  "no-use-before-define",
   "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",


### PR DESCRIPTION
## Summary
- add `no-use-before-define` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`