### PR TITLE
Register no-unsafe-optional-chaining rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -241,6 +241,7 @@ const BUILTIN_RULE_IDS = [
   "no-unreachable",
   "no-unsafe-finally",
   "no-unsafe-negation",
+  "no-unsafe-optional-chaining",
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -244,6 +244,7 @@ const BUILTIN_RULE_IDS = [
   "no-unreachable",
   "no-unsafe-finally",
   "no-unsafe-negation",
+  "no-unsafe-optional-chaining",
   "no-unused-expressions",
   "no-unused-labels",
   "no-unused-vars",


### PR DESCRIPTION
## Summary
- add `no-unsafe-optional-chaining` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`