### PR TITLE
Register no-unused-private-class-members rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -245,6 +245,7 @@ const BUILTIN_RULE_IDS = [
   "no-unsafe-optional-chaining",
   "no-unused-expressions",
   "no-unused-labels",
+  "no-unused-private-class-members",
   "no-unused-vars",
   "no-use-before-define",
   "no-useless-backreference",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -248,6 +248,7 @@ const BUILTIN_RULE_IDS = [
   "no-unsafe-optional-chaining",
   "no-unused-expressions",
   "no-unused-labels",
+  "no-unused-private-class-members",
   "no-unused-vars",
   "no-use-before-define",
   "no-useless-backreference",


### PR DESCRIPTION
## Summary
- add `no-unused-private-class-members` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`