### PR TITLE
Register require-unicode-regexp rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -281,6 +281,7 @@ const BUILTIN_RULE_IDS = [
   "radix",
   "require-await",
   "require-atomic-updates",
+  "require-unicode-regexp",
   "require-yield",
   "sort-imports",
   "sort-keys",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -284,6 +284,7 @@ const BUILTIN_RULE_IDS = [
   "radix",
   "require-await",
   "require-atomic-updates",
+  "require-unicode-regexp",
   "require-yield",
   "sort-imports",
   "sort-keys",


### PR DESCRIPTION
## Summary
- add `require-unicode-regexp` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`