### PR TITLE
Register max-classes-per-file rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -111,6 +111,7 @@ const BUILTIN_RULE_IDS = [
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",
+  "max-classes-per-file",
   "max-lines",
   "max-lines-per-function",
   "new-cap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -114,6 +114,7 @@ const BUILTIN_RULE_IDS = [
   "init-declarations",
   "linebreak-style",
   "logical-assignment-operators",
+  "max-classes-per-file",
   "max-lines",
   "max-lines-per-function",
   "new-cap",


### PR DESCRIPTION
## Summary
- add `max-classes-per-file` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`