### PR TITLE
Register jsx-a11y anchor-has-content rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -315,6 +315,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-unresolved",
   "import/no-self-import",
   "jsx-a11y/alt-text",
+  "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -318,6 +318,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-unresolved",
   "import/no-self-import",
   "jsx-a11y/alt-text",
+  "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",


### PR DESCRIPTION
## Summary
- add `jsx-a11y/anchor-has-content` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`