### PR TITLE
Register jsx-a11y aria-role rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -317,6 +317,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/alt-text",
   "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
+  "jsx-a11y/aria-role",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -320,6 +320,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/alt-text",
   "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
+  "jsx-a11y/aria-role",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",


### PR DESCRIPTION
## Summary
- add `jsx-a11y/aria-role` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`