### PR TITLE
Register jsx-a11y no-distracting-elements rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -321,6 +321,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",
+  "jsx-a11y/no-distracting-elements",
   "react/jsx-boolean-value",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -324,6 +324,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",
+  "jsx-a11y/no-distracting-elements",
   "react/jsx-boolean-value",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",


### PR DESCRIPTION
## Summary
- add `jsx-a11y/no-distracting-elements` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`