### PR TITLE
Register react default-props-match-prop-types rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -323,6 +323,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/no-access-key",
   "jsx-a11y/no-distracting-elements",
   "react/button-has-type",
+  "react/default-props-match-prop-types",
   "react/jsx-boolean-value",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -326,6 +326,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/no-access-key",
   "jsx-a11y/no-distracting-elements",
   "react/button-has-type",
+  "react/default-props-match-prop-types",
   "react/jsx-boolean-value",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",


### PR DESCRIPTION
## Summary
- add `react/default-props-match-prop-types` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`