### PR TITLE
Register react jsx-no-bind rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -329,6 +329,7 @@ const BUILTIN_RULE_IDS = [
   "react/jsx-boolean-value",
   "react/jsx-filename-extension",
   "react/jsx-key",
+  "react/jsx-no-bind",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",
   "react/jsx-no-target-blank",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -332,6 +332,7 @@ const BUILTIN_RULE_IDS = [
   "react/jsx-boolean-value",
   "react/jsx-filename-extension",
   "react/jsx-key",
+  "react/jsx-no-bind",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",
   "react/jsx-no-target-blank",


### PR DESCRIPTION
## Summary
- add `react/jsx-no-bind` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`