### PR TITLE
Register react prefer-es6-class rule

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -344,6 +344,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-unescaped-entities",
   "react/no-unknown-property",
   "react/no-unused-prop-types",
+  "react/prefer-es6-class",
   "react/prop-types",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -347,6 +347,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-unescaped-entities",
   "react/no-unknown-property",
   "react/no-unused-prop-types",
+  "react/prefer-es6-class",
   "react/prop-types",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",


### PR DESCRIPTION
## Summary
- add `react/prefer-es6-class` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`