### PR TITLE
Register eslint-comments no-restricted-disable rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -226,6 +226,12 @@ Each rule links to the corresponding ESLint rule reference.
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Supports `never`, `always`, `onlyEquality`, and `exceptRange` configuration |
 
+## ESLint comments rules
+
+| Rule | Status |
+| --- | --- |
+| [`eslint-comments/no-restricted-disable`](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-restricted-disable.html) | Supports restricted disable comments for configured rules |
+
 ## Import plugin rules
 
 | Rule | Status |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -301,6 +301,7 @@ const BUILTIN_RULE_IDS = [
   "vars-on-top",
   "wrap-iife",
   "yoda",
+  "eslint-comments/no-restricted-disable",
   "import/default",
   "import/export",
   "import/first",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -304,6 +304,7 @@ const BUILTIN_RULE_IDS = [
   "vars-on-top",
   "wrap-iife",
   "yoda",
+  "eslint-comments/no-restricted-disable",
   "import/default",
   "import/export",
   "import/first",


### PR DESCRIPTION
## Summary
- document `eslint-comments/no-restricted-disable` in the rule status table
- add `eslint-comments/no-restricted-disable` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`