### PR TITLE
Register jsx-a11y aria-proptypes rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -257,6 +257,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`jsx-a11y/alt-text`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md) | Supports `elements` and element component mapping configuration |
 | [`jsx-a11y/anchor-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md) | Supports `components` configuration |
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
+| [`jsx-a11y/aria-proptypes`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-proptypes.md) | Implemented |
 | [`jsx-a11y/aria-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md) | Supports `allowedInvalidRoles` and `ignoreNonDOM` configuration |
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
 | [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -318,6 +318,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/alt-text",
   "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
+  "jsx-a11y/aria-proptypes",
   "jsx-a11y/aria-role",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -321,6 +321,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/alt-text",
   "jsx-a11y/anchor-has-content",
   "jsx-a11y/aria-props",
+  "jsx-a11y/aria-proptypes",
   "jsx-a11y/aria-role",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",


### PR DESCRIPTION
## Summary
- document `jsx-a11y/aria-proptypes` in the rule status table
- add `jsx-a11y/aria-proptypes` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`