### PR TITLE
Register jsx-a11y aria-unsupported-elements rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -259,6 +259,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`jsx-a11y/aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md) | Implemented |
 | [`jsx-a11y/aria-proptypes`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-proptypes.md) | Implemented |
 | [`jsx-a11y/aria-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md) | Supports `allowedInvalidRoles` and `ignoreNonDOM` configuration |
+| [`jsx-a11y/aria-unsupported-elements`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md) | Implemented |
 | [`jsx-a11y/iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md) | Implemented |
 | [`jsx-a11y/img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md) | Supports `components` and `words` configuration |
 | [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -320,6 +320,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/aria-props",
   "jsx-a11y/aria-proptypes",
   "jsx-a11y/aria-role",
+  "jsx-a11y/aria-unsupported-elements",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -323,6 +323,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/aria-props",
   "jsx-a11y/aria-proptypes",
   "jsx-a11y/aria-role",
+  "jsx-a11y/aria-unsupported-elements",
   "jsx-a11y/iframe-has-title",
   "jsx-a11y/img-redundant-alt",
   "jsx-a11y/no-access-key",


### PR DESCRIPTION
## Summary
- document `jsx-a11y/aria-unsupported-elements` in the rule status table
- add `jsx-a11y/aria-unsupported-elements` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`