### PR TITLE
Register jsx-a11y role-supports-aria-props rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -265,6 +265,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`jsx-a11y/no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md) | Implemented |
 | [`jsx-a11y/no-distracting-elements`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-distracting-elements.md) | Supports `elements` configuration |
 | [`jsx-a11y/role-has-required-aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-has-required-aria-props.md) | Implemented |
+| [`jsx-a11y/role-supports-aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-supports-aria-props.md) | Implemented |
 
 ## Parser diagnostics
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -326,6 +326,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/no-access-key",
   "jsx-a11y/no-distracting-elements",
   "jsx-a11y/role-has-required-aria-props",
+  "jsx-a11y/role-supports-aria-props",
   "react/button-has-type",
   "react/default-props-match-prop-types",
   "react/display-name",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -329,6 +329,7 @@ const BUILTIN_RULE_IDS = [
   "jsx-a11y/no-access-key",
   "jsx-a11y/no-distracting-elements",
   "jsx-a11y/role-has-required-aria-props",
+  "jsx-a11y/role-supports-aria-props",
   "react/button-has-type",
   "react/default-props-match-prop-types",
   "react/display-name",


### PR DESCRIPTION
## Summary
- document `jsx-a11y/role-supports-aria-props` in the rule status table
- add `jsx-a11y/role-supports-aria-props` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`