### PR TITLE
Register react jsx-no-undef rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -286,6 +286,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/jsx-no-bind`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) | Supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreRefs`, and `ignoreDOMComponents` configuration |
 | [`react/jsx-no-comment-textnodes`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Implemented |
 | [`react/jsx-no-duplicate-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Implemented with configurable `ignoreCase` behavior |
+| [`react/jsx-no-undef`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md) | Implemented |
 | [`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Supports `allowReferrer`, `enforceDynamicLinks`, `warnOnSpreadAttributes`, `links`, and `forms` configuration |
 | [`react/jsx-pascal-case`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) | Supports `allowAllCaps`, `allowLeadingUnderscore`, `allowNamespace`, and `ignore` configuration |
 | [`react/no-children-prop`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md) | Supports `allowFunctions` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -338,6 +338,7 @@ const BUILTIN_RULE_IDS = [
   "react/jsx-no-bind",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",
+  "react/jsx-no-undef",
   "react/jsx-no-target-blank",
   "react/jsx-pascal-case",
   "react/no-children-prop",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -341,6 +341,7 @@ const BUILTIN_RULE_IDS = [
   "react/jsx-no-bind",
   "react/jsx-no-comment-textnodes",
   "react/jsx-no-duplicate-props",
+  "react/jsx-no-undef",
   "react/jsx-no-target-blank",
   "react/jsx-pascal-case",
   "react/no-children-prop",


### PR DESCRIPTION
## Summary
- document `react/jsx-no-undef` in the rule status table
- add `react/jsx-no-undef` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`