### PR TITLE
Register react no-deprecated rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -296,6 +296,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-children-prop`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md) | Supports `allowFunctions` configuration |
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-danger-with-children`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md) | Implemented |
+| [`react/no-deprecated`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-multi-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md) | Supports `ignoreStateless` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -348,6 +348,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-children-prop",
   "react/no-danger",
   "react/no-danger-with-children",
+  "react/no-deprecated",
   "react/no-find-dom-node",
   "react/no-is-mounted",
   "react/no-multi-comp",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -351,6 +351,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-children-prop",
   "react/no-danger",
   "react/no-danger-with-children",
+  "react/no-deprecated",
   "react/no-find-dom-node",
   "react/no-is-mounted",
   "react/no-multi-comp",


### PR DESCRIPTION
## Summary
- document `react/no-deprecated` in the rule status table
- add `react/no-deprecated` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`