### PR TITLE
Register react no-this-in-sfc rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -303,6 +303,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/no-redundant-should-component-update`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |
+| [`react/no-this-in-sfc`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md) | Implemented |
 | [`react/no-unescaped-entities`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) | Supports `forbid` configuration |
 | [`react/no-unknown-property`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md) | Supports `ignore` and `requireDataLowercase` configuration |
 | [`react/no-unused-prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) | Supports `skipShapeProps`, `ignore`, and `customValidators` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -355,6 +355,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-redundant-should-component-update",
   "react/no-render-return-value",
   "react/no-string-refs",
+  "react/no-this-in-sfc",
   "react/no-unescaped-entities",
   "react/no-unknown-property",
   "react/no-unused-prop-types",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -358,6 +358,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-redundant-should-component-update",
   "react/no-render-return-value",
   "react/no-string-refs",
+  "react/no-this-in-sfc",
   "react/no-unescaped-entities",
   "react/no-unknown-property",
   "react/no-unused-prop-types",


### PR DESCRIPTION
## Summary
- document `react/no-this-in-sfc` in the rule status table
- add `react/no-this-in-sfc` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`