### PR TITLE
Register react void-dom-elements-no-children rule

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -315,6 +315,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`react/require-render-return`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-render-return.md) | Implemented |
 | [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | Supports `component` and `html` configuration |
 | [`react/style-prop-object`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md) | Implemented |
+| [`react/void-dom-elements-no-children`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md) | Implemented |
 
 ## React Hooks rules
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -367,6 +367,7 @@ const BUILTIN_RULE_IDS = [
   "react/require-render-return",
   "react/self-closing-comp",
   "react/style-prop-object",
+  "react/void-dom-elements-no-children",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -370,6 +370,7 @@ const BUILTIN_RULE_IDS = [
   "react/require-render-return",
   "react/self-closing-comp",
   "react/style-prop-object",
+  "react/void-dom-elements-no-children",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",


### PR DESCRIPTION
## Summary
- document `react/void-dom-elements-no-children` in the rule status table
- add `react/void-dom-elements-no-children` to the npm package builtin rule list
- keep the ESM and CommonJS entrypoints in sync

## Validation
- `zig build test --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build`
- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `git diff --check`
- `git diff --cached --check`