### PR TITLE
ci: fix npm publish package paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for package_dir in npm/@utoo/lint-*; do
-            pnpm --dir "${package_dir}" publish --access public --provenance --tag "${NPM_TAG}" --no-git-checks
+            pnpm publish "${package_dir}" --access public --provenance --tag "${NPM_TAG}" --no-git-checks
           done
-          pnpm --dir npm/utoo-lint publish --access public --provenance --tag "${NPM_TAG}" --no-git-checks
+          pnpm publish npm/utoo-lint --access public --provenance --tag "${NPM_TAG}" --no-git-checks

--- a/npm/README.md
+++ b/npm/README.md
@@ -255,9 +255,9 @@ Publishing order:
 
 ```bash
 for package_dir in npm/@utoo/lint-*; do
-  pnpm --dir "${package_dir}" publish --access public
+  pnpm publish "${package_dir}" --access public
 done
-pnpm --dir npm/utoo-lint publish --access public
+pnpm publish npm/utoo-lint --access public
 ```
 
 GitHub Actions stages the native package directories from the release matrix,


### PR DESCRIPTION
## Summary
- Publish npm packages by passing each package directory as the explicit `pnpm publish` package spec.
- Update the npm README publishing example to match the workflow.

## Root cause
`pnpm --dir <package> publish ...` no longer forwards a package spec to the underlying `npm publish` invocation in this setup, so npm exits with `EUSAGE` and prints `npm publish <package-spec>`.

## Validation
- `pnpm publish npm/@utoo/lint-linux-x64 --dry-run --access public --provenance --tag latest --no-git-checks`
- `pnpm publish npm/utoo-lint --dry-run --access public --provenance --tag latest --no-git-checks`