### PR TITLE
ci: use pnpm trusted publishing for npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,9 +223,9 @@ jobs:
       - name: Publish npm packages
         env:
           NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for package_dir in npm/@utoo/lint-*; do
-            pnpm publish "${package_dir}" --access public --provenance --tag "${NPM_TAG}" --no-git-checks
+            pnpm publish "${package_dir}/" --access public --provenance --tag "${NPM_TAG}" --no-git-checks
           done
-          pnpm publish npm/utoo-lint --access public --provenance --tag "${NPM_TAG}" --no-git-checks
+
+          pnpm publish npm/utoo-lint/ --access public --provenance --tag "${NPM_TAG}" --no-git-checks

--- a/npm/README.md
+++ b/npm/README.md
@@ -255,9 +255,10 @@ Publishing order:
 
 ```bash
 for package_dir in npm/@utoo/lint-*; do
-  pnpm publish "${package_dir}" --access public
+  pnpm publish "${package_dir}/" --access public
 done
-pnpm publish npm/utoo-lint --access public
+
+pnpm publish npm/utoo-lint/ --access public
 ```
 
 GitHub Actions stages the native package directories from the release matrix,


### PR DESCRIPTION
## Summary
- Keep npm package publishing on `pnpm publish` using package directories directly.
- Remove `NODE_AUTH_TOKEN` from the release job so npm resolves auth through Trusted Publishing/OIDC.
- Keep native packages publishing before the root `@utoo/lint` package.
- Update the npm README publishing example to match the workflow.

## Root cause
`pnpm publish <dir>` with provenance failed while the workflow was still authenticating through `NPM_TOKEN`. With npm Trusted Publishing enabled for this workflow, the release job should rely on GitHub OIDC (`id-token: write`) instead of an npm automation token, matching how comparable pnpm/native-package projects publish.

## Validation
- `pnpm publish npm/@utoo/lint-linux-x64/ --dry-run --access public --provenance --tag latest --no-git-checks`
- `pnpm publish npm/utoo-lint/ --dry-run --access public --provenance --tag latest --no-git-checks`
- `git diff --check`