### PR TITLE
feat(node-api): resolve lint targets from config

### DIFF
--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -18,8 +18,10 @@ Run the linter with:
 pnpm exec utoo-lint src
 ```
 
-If no target is provided, `utoo-lint` scans the current directory. It skips
-`.git`, `.zig-cache`, `node_modules`, `vendor`, and `zig-out`.
+If no target is provided, `utoo-lint` uses `files` from `utoo.json` or
+`utoo-lint.json`. When no config file or `files` entry exists, it scans the
+current directory. It skips `.git`, `.zig-cache`, `node_modules`, `vendor`, and
+`zig-out`.
 
 Use a config file:
 
@@ -88,6 +90,10 @@ const report = lintFiles(["src"], {
 
 console.log(report.diagnostics);
 ```
+
+Calling `lintFiles()` without patterns follows the same default target behavior
+as the CLI, so migration scripts usually do not need to expand config `files`
+manually.
 
 CommonJS is supported through `require("@utoo/lint")`.
 

--- a/npm/utoo-lint/bin/utoo-lint.js
+++ b/npm/utoo-lint/bin/utoo-lint.js
@@ -1,22 +1,19 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
 
-import { resolveBinary } from "../lib/binary.js";
+import { runCli } from "../index.js";
 
 if (process.argv[2] === "migrate") {
   const { runMigrate } = await import("./migrate.js");
   process.exit(await runMigrate(process.argv.slice(3)));
 }
 
-let binary;
+let result;
 try {
-  binary = resolveBinary();
+  result = runCli(process.argv.slice(2), { stdio: "inherit" });
 } catch (error) {
   console.error(error.message);
   process.exit(1);
 }
-
-const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
 
 if (result.error) {
   console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -465,7 +465,7 @@ class UtooLint {
     this.options = { ...options };
   }
 
-  async lintFiles(patterns = ["."], options = {}) {
+  async lintFiles(patterns, options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
@@ -667,6 +667,152 @@ function run(args = [], options = {}) {
     encoding: options.encoding ?? "utf8",
     input: options.input,
     stdio: options.stdio
+  });
+}
+
+const UTOO_LINT_CLI_VALUE_FLAGS = new Set(["--config", "-c", "--format", "-f", "--rules", "--threads"]);
+
+function parseUtooLintCliArgs(args = []) {
+  const values = normalizeStringArray(args, "args");
+  const passthroughArgs = [];
+  const targets = [];
+  const options = {};
+  let help = false;
+  let versionFlag = false;
+
+  for (let index = 0; index < values.length; index += 1) {
+    const arg = values[index];
+    if (arg === "--") {
+      targets.push(...values.slice(index + 1));
+      break;
+    }
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg === "--version" || arg === "-v") {
+      versionFlag = true;
+      continue;
+    }
+    if (UTOO_LINT_CLI_VALUE_FLAGS.has(arg)) {
+      const value = values[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: ${arg} requires a value`);
+      }
+      appendCliOption(passthroughArgs, options, arg, value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      appendCliOption(passthroughArgs, options, "--config", arg.slice("--config=".length));
+      continue;
+    }
+    if (arg.startsWith("--format=")) {
+      appendCliOption(passthroughArgs, options, "--format", arg.slice("--format=".length));
+      continue;
+    }
+    if (arg.startsWith("--rules=")) {
+      appendCliOption(passthroughArgs, options, "--rules", arg.slice("--rules=".length));
+      continue;
+    }
+    if (arg.startsWith("--threads=")) {
+      appendCliOption(passthroughArgs, options, "--threads", arg.slice("--threads=".length));
+      continue;
+    }
+    if (arg === "--no-config") {
+      options.noConfig = true;
+      delete options.config;
+      continue;
+    }
+    if (arg === "--json") {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    targets.push(arg);
+  }
+
+  return { help, options, passthroughArgs, targets, version: versionFlag };
+}
+
+function appendCliOption(passthroughArgs, options, flag, value) {
+  if (value == null || value === "") {
+    throw new Error(`utoo-lint: ${flag} requires a value`);
+  }
+  switch (flag) {
+    case "--config":
+    case "-c":
+      options.config = value;
+      delete options.noConfig;
+      return;
+    case "--format":
+    case "-f":
+      options.format = value;
+      return;
+    case "--rules":
+      options.rules = value;
+      return;
+    case "--threads":
+      options.threads = value;
+      return;
+    default:
+      passthroughArgs.push(`${flag}=${value}`);
+  }
+}
+
+function completedRunResult(status, stdout, stderr, options = {}) {
+  const inherited = options.stdio === "inherit";
+  if (inherited) {
+    if (stdout) {
+      process.stdout.write(stdout);
+    }
+    if (stderr) {
+      process.stderr.write(stderr);
+    }
+  }
+  return {
+    status,
+    signal: null,
+    error: undefined,
+    stdout: inherited ? null : stdout,
+    stderr: inherited ? null : stderr,
+    output: [null, inherited ? null : stdout, inherited ? null : stderr],
+    pid: 0
+  };
+}
+
+function runCli(args = [], options = {}) {
+  const parsed = parseUtooLintCliArgs(args);
+  if (parsed.version) {
+    return completedRunResult(0, `v${version}\n`, "", options);
+  }
+  if (parsed.help) {
+    return run(parsed.passthroughArgs, options);
+  }
+
+  const cliOptions = {
+    ...options,
+    ...parsed.options
+  };
+  const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
+  const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, cliOptions);
+  const lintPaths = filteredLintPaths(targets, cliOptions);
+  if (lintPaths.length === 0) {
+    return completedRunResult(ignoredDiagnostics.length > 0 ? 1 : 0, "", "", options);
+  }
+
+  return withTemporaryConfig(cliOptions, (resolvedOptions) => {
+    const cliArgs = buildRunCliArgs(lintPaths, resolvedOptions, parsed.passthroughArgs);
+    return run(cliArgs, {
+      ...resolvedOptions,
+      stdio: options.stdio,
+      encoding: options.encoding,
+      input: options.input
+    });
   });
 }
 
@@ -882,14 +1028,15 @@ function booleanFlagValue(arg) {
   return true;
 }
 
-function lintFiles(paths = ["."], options = {}) {
-  return withTemporaryConfig(options, (resolvedOptions) => {
-    const ignoredDiagnostics = ignoredLintPathDiagnostics(paths, resolvedOptions);
-    const lintPaths = filteredLintPaths(paths, resolvedOptions);
-    if (lintPaths.length === 0) {
-      return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
-    }
+function lintFiles(paths, options = {}) {
+  const targets = lintTargetsForInput(paths, options);
+  const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
+  const lintPaths = filteredLintPaths(targets, options);
+  if (lintPaths.length === 0) {
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
+  }
 
+  return withTemporaryConfig(options, (resolvedOptions) => {
     const cliArgs = buildLintArgs(lintPaths, resolvedOptions);
     const result = run(cliArgs, { ...resolvedOptions, stdio: undefined, encoding: "utf8" });
 
@@ -981,6 +1128,21 @@ function lintText(code, options = {}) {
 }
 
 function buildLintArgs(paths, options) {
+  return buildNativeLintArgs(paths, {
+    ...options,
+    format: "json",
+    extraArgs: options.extraArgs
+  });
+}
+
+function buildRunCliArgs(paths, options, passthroughArgs) {
+  return buildNativeLintArgs(paths, {
+    ...options,
+    extraArgs: passthroughArgs
+  });
+}
+
+function buildNativeLintArgs(paths, options) {
   const cliArgs = [];
 
   if (options.config) {
@@ -999,7 +1161,9 @@ function buildLintArgs(paths, options) {
     cliArgs.push(`--threads=${options.threads}`);
   }
 
-  cliArgs.push("--format=json");
+  if (options.format) {
+    cliArgs.push(`--format=${options.format}`);
+  }
 
   if (options.extraArgs) {
     cliArgs.push(...normalizeStringArray(options.extraArgs, "extraArgs"));
@@ -1206,6 +1370,37 @@ function configDataFromFileConfig(options, filePath) {
   return configDataFromConfig(config, filePath, options.cwd);
 }
 
+function lintTargetsForInput(paths, options = {}) {
+  if (paths == null) {
+    return defaultLintTargets(options);
+  }
+  return normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
+}
+
+function defaultLintTargets(options = {}) {
+  if (options.noConfig) {
+    return ["."];
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return ["."];
+  }
+
+  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd));
+  return targets.length > 0 ? targets : ["."];
+}
+
+function filePatternsFromConfig(config) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => filePatternsFromConfig(entry));
+  }
+  return normalizeConfigPatterns(config.files);
+}
+
 function configAppliesToFile(config, filePath, cwd) {
   if (!filePath) {
     return true;
@@ -1229,6 +1424,9 @@ function normalizeConfigPatterns(patterns) {
   return values.flatMap((value) => {
     if (typeof value === "string") {
       return [value];
+    }
+    if (Array.isArray(value)) {
+      return normalizeConfigPatterns(value);
     }
     return [];
   });
@@ -3741,6 +3939,9 @@ function matchesIgnorePattern(target, pattern) {
 }
 
 function matchesConfigFilePattern(target, pattern) {
+  if (!hasGlobSyntax(pattern)) {
+    return target === pattern || target.startsWith(`${pattern}/`) || target.endsWith(`/${pattern}`);
+  }
   const expression = new RegExp(`^${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
@@ -4107,6 +4308,7 @@ module.exports = {
   platformPackageName,
   resolveBinary,
   run,
+  runCli,
   runFishlint,
   translateFishlintArgs,
   version

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -82,6 +82,7 @@ export interface LintOptions {
   env?: Record<string, string | undefined>;
   threads?: number;
   rules?: string[] | string;
+  format?: "text" | "json" | string;
   config?: string;
   configFile?: string;
   noConfig?: boolean;
@@ -309,6 +310,7 @@ export function loadESLint(options?: { useFlatConfig?: boolean; cwd?: string }):
 export function lintFiles(patterns?: string | string[], options?: LintOptions): LintReport;
 export function lintText(code: string, options?: TextLintOptions): LintReport;
 export function run(args?: string[], options?: LintOptions): unknown;
+export function runCli(args?: string[], options?: LintOptions): unknown;
 export function runFishlint(args?: string[], options?: LintOptions): unknown;
 export function translateFishlintArgs(args?: string[], options?: { command?: string; warn?: (message: string) => void }): string[];
 export function resolveBinary(options?: { env?: Record<string, string | undefined>; platform?: string; arch?: string }): string;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -468,7 +468,7 @@ export class UtooLint {
     this.options = { ...options };
   }
 
-  async lintFiles(patterns = ["."], options = {}) {
+  async lintFiles(patterns, options = {}) {
     const mergedOptions = mergeLintOptions(this.options, options);
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
@@ -2503,6 +2503,152 @@ export function run(args = [], options = {}) {
   });
 }
 
+const UTOO_LINT_CLI_VALUE_FLAGS = new Set(["--config", "-c", "--format", "-f", "--rules", "--threads"]);
+
+function parseUtooLintCliArgs(args = []) {
+  const values = normalizeStringArray(args, "args");
+  const passthroughArgs = [];
+  const targets = [];
+  const options = {};
+  let help = false;
+  let versionFlag = false;
+
+  for (let index = 0; index < values.length; index += 1) {
+    const arg = values[index];
+    if (arg === "--") {
+      targets.push(...values.slice(index + 1));
+      break;
+    }
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg === "--version" || arg === "-v") {
+      versionFlag = true;
+      continue;
+    }
+    if (UTOO_LINT_CLI_VALUE_FLAGS.has(arg)) {
+      const value = values[index + 1];
+      if (!value) {
+        throw new Error(`utoo-lint: ${arg} requires a value`);
+      }
+      appendCliOption(passthroughArgs, options, arg, value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      appendCliOption(passthroughArgs, options, "--config", arg.slice("--config=".length));
+      continue;
+    }
+    if (arg.startsWith("--format=")) {
+      appendCliOption(passthroughArgs, options, "--format", arg.slice("--format=".length));
+      continue;
+    }
+    if (arg.startsWith("--rules=")) {
+      appendCliOption(passthroughArgs, options, "--rules", arg.slice("--rules=".length));
+      continue;
+    }
+    if (arg.startsWith("--threads=")) {
+      appendCliOption(passthroughArgs, options, "--threads", arg.slice("--threads=".length));
+      continue;
+    }
+    if (arg === "--no-config") {
+      options.noConfig = true;
+      delete options.config;
+      continue;
+    }
+    if (arg === "--json") {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    targets.push(arg);
+  }
+
+  return { help, options, passthroughArgs, targets, version: versionFlag };
+}
+
+function appendCliOption(passthroughArgs, options, flag, value) {
+  if (value == null || value === "") {
+    throw new Error(`utoo-lint: ${flag} requires a value`);
+  }
+  switch (flag) {
+    case "--config":
+    case "-c":
+      options.config = value;
+      delete options.noConfig;
+      return;
+    case "--format":
+    case "-f":
+      options.format = value;
+      return;
+    case "--rules":
+      options.rules = value;
+      return;
+    case "--threads":
+      options.threads = value;
+      return;
+    default:
+      passthroughArgs.push(`${flag}=${value}`);
+  }
+}
+
+function completedRunResult(status, stdout, stderr, options = {}) {
+  const inherited = options.stdio === "inherit";
+  if (inherited) {
+    if (stdout) {
+      process.stdout.write(stdout);
+    }
+    if (stderr) {
+      process.stderr.write(stderr);
+    }
+  }
+  return {
+    status,
+    signal: null,
+    error: undefined,
+    stdout: inherited ? null : stdout,
+    stderr: inherited ? null : stderr,
+    output: [null, inherited ? null : stdout, inherited ? null : stderr],
+    pid: 0
+  };
+}
+
+export function runCli(args = [], options = {}) {
+  const parsed = parseUtooLintCliArgs(args);
+  if (parsed.version) {
+    return completedRunResult(0, `v${version}\n`, "", options);
+  }
+  if (parsed.help) {
+    return run(parsed.passthroughArgs, options);
+  }
+
+  const cliOptions = {
+    ...options,
+    ...parsed.options
+  };
+  const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
+  const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, cliOptions);
+  const lintPaths = filteredLintPaths(targets, cliOptions);
+  if (lintPaths.length === 0) {
+    return completedRunResult(ignoredDiagnostics.length > 0 ? 1 : 0, "", "", options);
+  }
+
+  return withTemporaryConfig(cliOptions, (resolvedOptions) => {
+    const cliArgs = buildRunCliArgs(lintPaths, resolvedOptions, parsed.passthroughArgs);
+    return run(cliArgs, {
+      ...resolvedOptions,
+      stdio: options.stdio,
+      encoding: options.encoding,
+      input: options.input
+    });
+  });
+}
+
 export function runFishlint(args = [], options = {}) {
   const cliArgs = normalizeStringArray(args, "args");
   const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
@@ -2715,14 +2861,15 @@ function booleanFlagValue(arg) {
   return true;
 }
 
-export function lintFiles(paths = ["."], options = {}) {
-  return withTemporaryConfig(options, (resolvedOptions) => {
-    const ignoredDiagnostics = ignoredLintPathDiagnostics(paths, resolvedOptions);
-    const lintPaths = filteredLintPaths(paths, resolvedOptions);
-    if (lintPaths.length === 0) {
-      return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
-    }
+export function lintFiles(paths, options = {}) {
+  const targets = lintTargetsForInput(paths, options);
+  const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
+  const lintPaths = filteredLintPaths(targets, options);
+  if (lintPaths.length === 0) {
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
+  }
 
+  return withTemporaryConfig(options, (resolvedOptions) => {
     const cliArgs = buildLintArgs(lintPaths, resolvedOptions);
     const result = run(cliArgs, { ...resolvedOptions, stdio: undefined, encoding: "utf8" });
 
@@ -2814,6 +2961,21 @@ export function lintText(code, options = {}) {
 }
 
 function buildLintArgs(paths, options) {
+  return buildNativeLintArgs(paths, {
+    ...options,
+    format: "json",
+    extraArgs: options.extraArgs
+  });
+}
+
+function buildRunCliArgs(paths, options, passthroughArgs) {
+  return buildNativeLintArgs(paths, {
+    ...options,
+    extraArgs: passthroughArgs
+  });
+}
+
+function buildNativeLintArgs(paths, options) {
   const cliArgs = [];
 
   if (options.config) {
@@ -2832,7 +2994,9 @@ function buildLintArgs(paths, options) {
     cliArgs.push(`--threads=${options.threads}`);
   }
 
-  cliArgs.push("--format=json");
+  if (options.format) {
+    cliArgs.push(`--format=${options.format}`);
+  }
 
   if (options.extraArgs) {
     cliArgs.push(...normalizeStringArray(options.extraArgs, "extraArgs"));
@@ -3039,6 +3203,37 @@ function configDataFromFileConfig(options, filePath) {
   return configDataFromConfig(config, filePath, options.cwd);
 }
 
+function lintTargetsForInput(paths, options = {}) {
+  if (paths == null) {
+    return defaultLintTargets(options);
+  }
+  return normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
+}
+
+function defaultLintTargets(options = {}) {
+  if (options.noConfig) {
+    return ["."];
+  }
+
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return ["."];
+  }
+
+  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd));
+  return targets.length > 0 ? targets : ["."];
+}
+
+function filePatternsFromConfig(config) {
+  if (!config) {
+    return [];
+  }
+  if (Array.isArray(config)) {
+    return config.flatMap((entry) => filePatternsFromConfig(entry));
+  }
+  return normalizeConfigPatterns(config.files);
+}
+
 function configAppliesToFile(config, filePath, cwd) {
   if (!filePath) {
     return true;
@@ -3062,6 +3257,9 @@ function normalizeConfigPatterns(patterns) {
   return values.flatMap((value) => {
     if (typeof value === "string") {
       return [value];
+    }
+    if (Array.isArray(value)) {
+      return normalizeConfigPatterns(value);
     }
     return [];
   });
@@ -3744,6 +3942,9 @@ function matchesIgnorePattern(target, pattern) {
 }
 
 function matchesConfigFilePattern(target, pattern) {
+  if (!hasGlobSyntax(pattern)) {
+    return target === pattern || target.startsWith(`${pattern}/`) || target.endsWith(`/${pattern}`);
+  }
   const expression = new RegExp(`^${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }

--- a/npm/utoo-lint/lib/binary.cjs
+++ b/npm/utoo-lint/lib/binary.cjs
@@ -1,4 +1,4 @@
-const { existsSync } = require("node:fs");
+const { chmodSync, existsSync, statSync } = require("node:fs");
 const { join } = require("node:path");
 
 const here = __dirname;
@@ -26,7 +26,7 @@ function resolveBinary(options = {}) {
 
   if (env.UTOO_LINT_BIN) {
     if (existsSync(env.UTOO_LINT_BIN)) {
-      return env.UTOO_LINT_BIN;
+      return ensureExecutable(env.UTOO_LINT_BIN, platform);
     }
     throw new Error(`utoo-lint: UTOO_LINT_BIN does not exist: ${env.UTOO_LINT_BIN}`);
   }
@@ -47,7 +47,7 @@ function resolveBinary(options = {}) {
     try {
       const resolved = candidate();
       if (existsSync(resolved)) {
-        return resolved;
+        return ensureExecutable(resolved, platform);
       }
     } catch {}
   }
@@ -56,6 +56,21 @@ function resolveBinary(options = {}) {
     `utoo-lint: missing native package ${packageName}. ` +
       "Run `./scripts/package-npm.sh` from the repository root, or install the matching optional dependency."
   );
+}
+
+function ensureExecutable(path, platform) {
+  if (platform === "win32") {
+    return path;
+  }
+  try {
+    const mode = statSync(path).mode;
+    if ((mode & 0o111) === 0) {
+      chmodSync(path, mode | 0o755);
+    }
+  } catch {
+    // Let spawn surface the actual filesystem error if chmod is not permitted.
+  }
+  return path;
 }
 
 module.exports = {

--- a/npm/utoo-lint/lib/binary.js
+++ b/npm/utoo-lint/lib/binary.js
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { chmodSync, existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -29,7 +29,7 @@ export function resolveBinary(options = {}) {
 
   if (env.UTOO_LINT_BIN) {
     if (existsSync(env.UTOO_LINT_BIN)) {
-      return env.UTOO_LINT_BIN;
+      return ensureExecutable(env.UTOO_LINT_BIN, platform);
     }
     throw new Error(`utoo-lint: UTOO_LINT_BIN does not exist: ${env.UTOO_LINT_BIN}`);
   }
@@ -50,7 +50,7 @@ export function resolveBinary(options = {}) {
     try {
       const resolved = candidate();
       if (existsSync(resolved)) {
-        return resolved;
+        return ensureExecutable(resolved, platform);
       }
     } catch {}
   }
@@ -59,4 +59,19 @@ export function resolveBinary(options = {}) {
     `utoo-lint: missing native package ${packageName}. ` +
       "Run `./scripts/package-npm.sh` from the repository root, or install the matching optional dependency."
   );
+}
+
+function ensureExecutable(path, platform) {
+  if (platform === "win32") {
+    return path;
+  }
+  try {
+    const mode = statSync(path).mode;
+    if ((mode & 0o111) === 0) {
+      chmodSync(path, mode | 0o755);
+    }
+  } catch {
+    // Let spawn surface the actual filesystem error if chmod is not permitted.
+  }
+  return path;
 }


### PR DESCRIPTION
## Summary

- route the `utoo-lint` bin through a higher-level Node API instead of spawning the native binary directly
- default CLI/API target resolution to `utoo.json` / `utoo-lint.json` `files`, falling back to `.` when absent
- normalize common split CLI flags like `--config utoo.json` and `--format json`
- preserve native lint execution while expanding directories/globs and applying ignores in Node
- make binary resolution repair missing executable bits before spawning

## Validation

- `node --check npm/utoo-lint/index.js`
- `node --check npm/utoo-lint/index.cjs`
- `node --check npm/utoo-lint/bin/utoo-lint.js`
- temporary fixture: `lintFiles(undefined, { cwd })` reads `utoo.json.files`
- temporary fixture: `runCli(['--config', 'utoo.json', '--format', 'json'], { cwd })` reports expected diagnostics
- simulated non-executable native binary and verified `resolveBinary()` restores executable permissions