### PR TITLE
chore: update yuku to v0.6.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ zig version
 ```
 
 The vendored Yuku `build.zig.zon` currently asks for
-`0.17.0-dev.224+c166c49b1` or newer.
+`0.16.0` or newer. The repository is currently tested with
+`0.17.0-dev.224+c166c49b1`.
 
 Initialize submodules before building:
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const parser = @import("parser");
 const core = @import("core.zig");
+const semantic_compat = @import("semantic_compat.zig");
 
 const ast = parser.ast;
 const Allocator = std.mem.Allocator;
@@ -46,7 +47,8 @@ pub fn lintSourceWithIo(
     const needs_semantic = hasSemanticRules(effective_options);
 
     if (needs_semantic) {
-        var semantic_result = try parser.semantic.analyze(&tree);
+        const semantic_model = try parser.semantic.analyze(&tree);
+        var semantic_result = semantic_compat.Result.init(&tree, semantic_model);
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);

--- a/src/rules/alipay_ant_exhaustive_deps.zig
+++ b/src/rules/alipay_ant_exhaustive_deps.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@alipay/ant/exhaustive-deps";

--- a/src/rules/alipay_ant_no_phantom_dependencies.zig
+++ b/src/rules/alipay_ant_no_phantom_dependencies.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@alipay/ant/no-phantom-dependencies";

--- a/src/rules/alipay_ant_no_spread_params.zig
+++ b/src/rules/alipay_ant_no_spread_params.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@alipay/ant/no-spread-params";

--- a/src/rules/alipay_ant_prefer_click_with_debounce.zig
+++ b/src/rules/alipay_ant_prefer_click_with_debounce.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@alipay/ant/prefer-click-with-debounce";

--- a/src/rules/block_scoped_var.zig
+++ b/src/rules/block_scoped_var.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "block-scoped-var";

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -56,7 +56,7 @@ pub fn runWithOptions(
             .warning,
             id,
             diagnosticMessage(options.mode),
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
         );
     }
 }
@@ -69,9 +69,9 @@ fn diagnosticMessage(mode: Mode) []const u8 {
 }
 
 fn isConsecutiveComment(tree: *const ast.Tree, previous: ast.Comment, current: ast.Comment) bool {
-    if (previous.end > current.start) return false;
+    if (previous.span.end > current.span.start) return false;
 
-    for (tree.source[previous.end..current.start]) |char| {
+    for (tree.source[previous.span.end..current.span.start]) |char| {
         if (!isWhitespace(char)) return false;
     }
     return true;
@@ -85,8 +85,8 @@ fn violatesMode(first: u8, mode: Mode) bool {
 }
 
 fn isInlineComment(tree: *const ast.Tree, comment: ast.Comment) bool {
-    return hasNonWhitespaceBeforeOnLine(tree.source, comment.start) and
-        hasNonWhitespaceAfterOnLine(tree.source, comment.end);
+    return hasNonWhitespaceBeforeOnLine(tree.source, comment.span.start) and
+        hasNonWhitespaceAfterOnLine(tree.source, comment.span.end);
 }
 
 fn hasNonWhitespaceBeforeOnLine(source: []const u8, offset: usize) bool {

--- a/src/rules/default_case.zig
+++ b/src/rules/default_case.zig
@@ -67,7 +67,7 @@ fn hasNoDefaultComment(tree: *const ast.Tree, index: ast.NodeIndex, options: Opt
     const switch_end = tree.span(index).end;
 
     for (tree.comments) |comment| {
-        if (comment.start < last_case_end or comment.end > switch_end) continue;
+        if (comment.span.start < last_case_end or comment.span.end > switch_end) continue;
         const value = std.mem.trim(u8, tree.string(comment.value), &std.ascii.whitespace);
         if (commentMatchesPattern(value, options.comment_pattern)) return true;
     }

--- a/src/rules/eslint_comments_no_restricted_disable.zig
+++ b/src/rules/eslint_comments_no_restricted_disable.zig
@@ -25,7 +25,7 @@ pub fn run(
             .warning,
             id,
             "Disabling 'no-nested-ternary' is not allowed.",
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
         );
     }
 }

--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -6,7 +6,7 @@ const no_eval = @import("no_eval.zig");
 const no_implied_eval = @import("no_implied_eval.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/global_is_checks.zig
+++ b/src/rules/global_is_checks.zig
@@ -5,7 +5,7 @@ const no_global_is_finite = @import("no_global_is_finite.zig");
 const no_global_is_nan = @import("no_global_is_nan.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/import_namespace.zig
+++ b/src/rules/import_namespace.zig
@@ -4,7 +4,7 @@ const core = @import("../core.zig");
 const export_map = @import("import_export_map.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "import/namespace";

--- a/src/rules/import_newline_after_import.zig
+++ b/src/rules/import_newline_after_import.zig
@@ -49,9 +49,9 @@ fn nextLine(tree: *const ast.Tree, import_index: ast.NodeIndex, next_index: ast.
         var first_comment_start: ?u32 = null;
 
         for (tree.comments) |comment| {
-            if (comment.start < import_end or comment.start >= next_start) continue;
-            if (first_comment_start == null or comment.start < first_comment_start.?) {
-                first_comment_start = comment.start;
+            if (comment.span.start < import_end or comment.span.start >= next_start) continue;
+            if (first_comment_start == null or comment.span.start < first_comment_start.?) {
+                first_comment_start = comment.span.start;
             }
         }
 

--- a/src/rules/max_lines.zig
+++ b/src/rules/max_lines.zig
@@ -111,8 +111,8 @@ fn isInsideComment(
     line_end: usize,
 ) bool {
     for (comments) |comment| {
-        const start: usize = comment.start;
-        const end: usize = comment.end;
+        const start: usize = comment.span.start;
+        const end: usize = comment.span.end;
         if (end <= line_start or start >= line_end) continue;
         if (start <= index and index < end) return true;
     }

--- a/src/rules/max_lines_per_function.zig
+++ b/src/rules/max_lines_per_function.zig
@@ -133,8 +133,8 @@ fn isInsideComment(
     line_end: usize,
 ) bool {
     for (comments) |comment| {
-        const start: usize = comment.start;
-        const end: usize = comment.end;
+        const start: usize = comment.span.start;
+        const end: usize = comment.span.end;
         if (end <= line_start or start >= line_end) continue;
         if (start <= index and index < end) return true;
     }

--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -5,7 +5,7 @@ const no_new_native_nonconstructor = @import("no_new_native_nonconstructor.zig")
 const no_obj_calls = @import("no_obj_calls.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/no_alert.zig
+++ b/src/rules/no_alert.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-alert";

--- a/src/rules/no_array_constructor.zig
+++ b/src/rules/no_array_constructor.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-array-constructor";

--- a/src/rules/no_async_promise_executor.zig
+++ b/src/rules/no_async_promise_executor.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-async-promise-executor";

--- a/src/rules/no_buffer_constructor.zig
+++ b/src/rules/no_buffer_constructor.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-buffer-constructor";

--- a/src/rules/no_class_assign.zig
+++ b/src/rules/no_class_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-class-assign";

--- a/src/rules/no_console.zig
+++ b/src/rules/no_console.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-console";

--- a/src/rules/no_const_assign.zig
+++ b/src/rules/no_const_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-const-assign";

--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-eval";

--- a/src/rules/no_ex_assign.zig
+++ b/src/rules/no_ex_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-ex-assign";

--- a/src/rules/no_extend_native.zig
+++ b/src/rules/no_extend_native.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-extend-native";

--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-extra-boolean-cast";

--- a/src/rules/no_fallthrough.zig
+++ b/src/rules/no_fallthrough.zig
@@ -141,7 +141,7 @@ fn hasFallthroughCommentBetween(tree: *const ast.Tree, start: u32, end: u32, opt
     if (start > end) return false;
 
     for (tree.comments) |comment| {
-        if (comment.start < start or comment.end > end) continue;
+        if (comment.span.start < start or comment.span.end > end) continue;
         if (isFallthroughComment(tree.string(comment.value), options.comment_pattern)) return true;
     }
 

--- a/src/rules/no_func_assign.zig
+++ b/src/rules/no_func_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-func-assign";

--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-global-assign";

--- a/src/rules/no_global_is_finite.zig
+++ b/src/rules/no_global_is_finite.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-global-is-finite";

--- a/src/rules/no_global_is_nan.zig
+++ b/src/rules/no_global_is_nan.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-global-is-nan";

--- a/src/rules/no_implied_eval.zig
+++ b/src/rules/no_implied_eval.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-implied-eval";

--- a/src/rules/no_import_assign.zig
+++ b/src/rules/no_import_assign.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-import-assign";

--- a/src/rules/no_inline_comments.zig
+++ b/src/rules/no_inline_comments.zig
@@ -28,8 +28,8 @@ pub fn runWithOptions(
     const source = tree.source;
 
     for (tree.comments) |comment| {
-        const start: usize = comment.start;
-        const end: usize = comment.end;
+        const start: usize = comment.span.start;
+        const end: usize = comment.span.end;
         const line_start = findLineStart(source, start);
         const line_end = findLineEnd(source, start);
 

--- a/src/rules/no_invalid_regexp.zig
+++ b/src/rules/no_invalid_regexp.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-invalid-regexp";

--- a/src/rules/no_irregular_whitespace.zig
+++ b/src/rules/no_irregular_whitespace.zig
@@ -93,7 +93,7 @@ fn startsWith(source: []const u8, bytes: []const u8) bool {
 fn isInsideIgnoredSpan(tree: *const ast.Tree, offset: u32, options: Options) bool {
     if (options.skip_comments) {
         for (tree.comments) |comment| {
-            if (comment.start <= offset and offset < comment.end) return true;
+            if (comment.span.start <= offset and offset < comment.span.end) return true;
         }
     }
 

--- a/src/rules/no_label_var.zig
+++ b/src/rules/no_label_var.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-label-var";
@@ -64,7 +64,7 @@ const Visitor = struct {
 
         try self.labels.append(self.allocator, .{
             .name = ctx.tree.string(label.name),
-            .scope = ctx.scope.currentScopeId(),
+            .scope = ctx.scope.current,
             .node = index,
         });
         return .proceed;

--- a/src/rules/no_loop_func.zig
+++ b/src/rules/no_loop_func.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-loop-func";

--- a/src/rules/no_misleading_character_class.zig
+++ b/src/rules/no_misleading_character_class.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-misleading-character-class";

--- a/src/rules/no_mixed_spaces_and_tabs.zig
+++ b/src/rules/no_mixed_spaces_and_tabs.zig
@@ -78,10 +78,10 @@ fn isIgnoredCommentLine(source: []const u8, comments: []const ast.Comment, line_
     for (comments) |comment| {
         if (comment.type != .block) continue;
 
-        const start_line = lineNumberAtOffset(source, comment.start);
+        const start_line = lineNumberAtOffset(source, comment.span.start);
         if (line_number <= start_line) continue;
 
-        const end_line = lineNumberAtOffset(source, comment.end);
+        const end_line = lineNumberAtOffset(source, comment.span.end);
         if (line_number <= end_line) return true;
     }
 

--- a/src/rules/no_multi_spaces.zig
+++ b/src/rules/no_multi_spaces.zig
@@ -104,11 +104,11 @@ fn checkLine(
 
 fn isBeforeEndOfLineComment(tree: *const ast.Tree, index: usize, line_end: usize) bool {
     for (tree.comments) |comment| {
-        const start: usize = comment.start;
+        const start: usize = comment.span.start;
         if (start != index) continue;
         if (comment.type == .line) return true;
 
-        const end: usize = comment.end;
+        const end: usize = comment.span.end;
         if (end > line_end) return false;
         return isOnlyWhitespace(tree.source[end..line_end]);
     }
@@ -127,7 +127,7 @@ fn collectIgnoredSpans(allocator: Allocator, tree: *const ast.Tree, options: Opt
     errdefer ignored_spans.deinit(allocator);
 
     for (tree.comments) |comment| {
-        try ignored_spans.append(allocator, .{ .start = comment.start, .end = comment.end });
+        try ignored_spans.append(allocator, .{ .start = comment.span.start, .end = comment.span.end });
     }
 
     const data = tree.nodes.items(.data);

--- a/src/rules/no_new_func.zig
+++ b/src/rules/no_new_func.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-new-func";

--- a/src/rules/no_new_native_nonconstructor.zig
+++ b/src/rules/no_new_native_nonconstructor.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-new-native-nonconstructor";

--- a/src/rules/no_new_object.zig
+++ b/src/rules/no_new_object.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-new-object";

--- a/src/rules/no_new_symbol.zig
+++ b/src/rules/no_new_symbol.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-new-symbol";

--- a/src/rules/no_new_wrappers.zig
+++ b/src/rules/no_new_wrappers.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-new-wrappers";

--- a/src/rules/no_obj_calls.zig
+++ b/src/rules/no_obj_calls.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-obj-calls";

--- a/src/rules/no_object_constructor.zig
+++ b/src/rules/no_object_constructor.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-object-constructor";

--- a/src/rules/no_promise_executor_return.zig
+++ b/src/rules/no_promise_executor_return.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-promise-executor-return";

--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-redeclare";

--- a/src/rules/no_regex_spaces.zig
+++ b/src/rules/no_regex_spaces.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-regex-spaces";

--- a/src/rules/no_restricted_globals.zig
+++ b/src/rules/no_restricted_globals.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-restricted-globals";

--- a/src/rules/no_shadow.zig
+++ b/src/rules/no_shadow.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-shadow";

--- a/src/rules/no_trailing_spaces.zig
+++ b/src/rules/no_trailing_spaces.zig
@@ -91,8 +91,8 @@ fn isOnlyTrailingWhitespace(source: []const u8) bool {
 
 fn hasIgnoredCommentOnLine(comments: []const ast.Comment, line_start: usize, line_end: usize) bool {
     for (comments) |comment| {
-        const start: usize = comment.start;
-        const end: usize = comment.end;
+        const start: usize = comment.span.start;
+        const end: usize = comment.span.end;
 
         switch (comment.type) {
             .line => {

--- a/src/rules/no_unassigned_vars.zig
+++ b/src/rules/no_unassigned_vars.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-unassigned-vars";

--- a/src/rules/no_undef.zig
+++ b/src/rules/no_undef.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-undef";

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-unused-vars";

--- a/src/rules/no_use_before_define.zig
+++ b/src/rules/no_use_before_define.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-use-before-define";

--- a/src/rules/no_useless_backreference.zig
+++ b/src/rules/no_useless_backreference.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-useless-backreference";

--- a/src/rules/no_warning_comments.zig
+++ b/src/rules/no_warning_comments.zig
@@ -47,7 +47,7 @@ pub fn runWithOptions(
             diagnostics,
             .warning,
             id,
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
             "Unexpected '{s}' comment.",
             .{match},
         );

--- a/src/rules/object_constructor_checks.zig
+++ b/src/rules/object_constructor_checks.zig
@@ -5,7 +5,7 @@ const no_new_object = @import("no_new_object.zig");
 const no_object_constructor = @import("no_object_constructor.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/prefer_const.zig
+++ b/src/rules/prefer_const.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-const";

--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-exponentiation-operator";

--- a/src/rules/prefer_named_capture_group.zig
+++ b/src/rules/prefer_named_capture_group.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-named-capture-group";

--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-numeric-literals";

--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-object-has-own";

--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-object-spread";

--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-promise-reject-errors";

--- a/src/rules/prefer_regex_literals.zig
+++ b/src/rules/prefer_regex_literals.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "prefer-regex-literals";

--- a/src/rules/preserve_caught_error.zig
+++ b/src/rules/preserve_caught_error.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "preserve-caught-error";

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -6,7 +6,7 @@ const no_promise_executor_return = @import("no_promise_executor_return.zig");
 const prefer_promise_reject_errors = @import("prefer_promise_reject_errors.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/radix.zig
+++ b/src/rules/radix.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "radix";

--- a/src/rules/react_jsx_no_undef.zig
+++ b/src/rules/react_jsx_no_undef.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "react/jsx-no-undef";

--- a/src/rules/reassignment_rules.zig
+++ b/src/rules/reassignment_rules.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 const no_class_assign = @import("no_class_assign.zig");

--- a/src/rules/require_atomic_updates.zig
+++ b/src/rules/require_atomic_updates.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "require-atomic-updates";

--- a/src/rules/require_unicode_regexp.zig
+++ b/src/rules/require_unicode_regexp.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "require-unicode-regexp";

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 const global_call_checks = @import("global_call_checks.zig");

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -41,7 +41,7 @@ pub fn runWithOptions(
             .warning,
             id,
             message(options.style),
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
         );
     }
 }

--- a/src/rules/symbol_checks.zig
+++ b/src/rules/symbol_checks.zig
@@ -5,7 +5,7 @@ const no_new_symbol = @import("no_new_symbol.zig");
 const symbol_description = @import("symbol_description.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub fn run(

--- a/src/rules/symbol_description.zig
+++ b/src/rules/symbol_description.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "symbol-description";

--- a/src/rules/typescript_eslint_ban_ts_comment.zig
+++ b/src/rules/typescript_eslint_ban_ts_comment.zig
@@ -41,7 +41,7 @@ pub fn runWithOptions(
                     diagnostics,
                     .warning,
                     id,
-                    .{ .start = comment.start, .end = comment.end },
+                    .{ .start = comment.span.start, .end = comment.span.end },
                     "Include a description after the \"@ts-{s}\" directive to explain why the @ts-{s} is necessary. The description must be {d} characters or longer.",
                     .{ directive.name, directive.name, options.minimum_description_length },
                 );
@@ -54,7 +54,7 @@ pub fn runWithOptions(
             diagnostics,
             .warning,
             id,
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
             "Do not use \"@ts-{s}\" directives.",
             .{directive.name},
         );

--- a/src/rules/typescript_eslint_ban_tslint_comment.zig
+++ b/src/rules/typescript_eslint_ban_tslint_comment.zig
@@ -22,7 +22,7 @@ pub fn run(
             .@"error",
             id,
             "tslint comment detected.",
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
         );
     }
 }

--- a/src/rules/typescript_eslint_no_loop_func.zig
+++ b/src/rules/typescript_eslint_no_loop_func.zig
@@ -3,7 +3,7 @@ const core = @import("../core.zig");
 const no_loop_func = @import("no_loop_func.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-loop-func";

--- a/src/rules/typescript_eslint_no_redeclare.zig
+++ b/src/rules/typescript_eslint_no_redeclare.zig
@@ -2,7 +2,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 const no_redeclare = @import("no_redeclare.zig");
 
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-redeclare";

--- a/src/rules/typescript_eslint_no_require_imports.zig
+++ b/src/rules/typescript_eslint_no_require_imports.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-require-imports";

--- a/src/rules/typescript_eslint_no_shadow.zig
+++ b/src/rules/typescript_eslint_no_shadow.zig
@@ -2,7 +2,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 const no_shadow = @import("no_shadow.zig");
 
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-shadow";

--- a/src/rules/typescript_eslint_no_unsafe_declaration_merging.zig
+++ b/src/rules/typescript_eslint_no_unsafe_declaration_merging.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-unsafe-declaration-merging";

--- a/src/rules/typescript_eslint_no_unused_vars.zig
+++ b/src/rules/typescript_eslint_no_unused_vars.zig
@@ -2,7 +2,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 const no_unused_vars = @import("no_unused_vars.zig");
 
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-unused-vars";

--- a/src/rules/typescript_eslint_no_use_before_define.zig
+++ b/src/rules/typescript_eslint_no_use_before_define.zig
@@ -2,7 +2,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 const no_use_before_define = @import("no_use_before_define.zig");
 
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = @import("std").mem.Allocator;
 
 pub const id = "@typescript-eslint/no-use-before-define";

--- a/src/rules/typescript_eslint_no_var_requires.zig
+++ b/src/rules/typescript_eslint_no_var_requires.zig
@@ -3,7 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const traverser = parser.traverser;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-var-requires";

--- a/src/rules/typescript_eslint_triple_slash_reference.zig
+++ b/src/rules/typescript_eslint_triple_slash_reference.zig
@@ -38,7 +38,7 @@ pub fn runWithOptions(
             diagnostics,
             .@"error",
             id,
-            .{ .start = comment.start, .end = comment.end },
+            .{ .start = comment.span.start, .end = comment.span.end },
             "Do not use a triple slash reference for {s}, use `import` style instead.",
             .{reference.value},
         );

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -1,0 +1,221 @@
+const std = @import("std");
+const parser = @import("parser");
+
+const ast = parser.ast;
+const yuku_semantic = parser.traverser.semantic;
+
+pub const ScopeTree = struct {
+    scopes: []const yuku_semantic.Scope,
+
+    pub fn init(scopes: yuku_semantic.ScopeTree) ScopeTree {
+        return .{ .scopes = scopes.list };
+    }
+
+    pub inline fn getScope(self: ScopeTree, id: yuku_semantic.ScopeId) yuku_semantic.Scope {
+        return self.scopes[@intFromEnum(id)];
+    }
+};
+
+pub const Reference = struct {
+    name: ast.String,
+    scope: yuku_semantic.ScopeId,
+    node: ast.NodeIndex,
+    kind: Kind,
+
+    pub const Kind = enum(u1) { value, type };
+
+    fn fromYuku(reference: yuku_semantic.Reference) Reference {
+        return .{
+            .name = reference.name,
+            .scope = reference.scope,
+            .node = reference.node,
+            .kind = switch (reference.flags.space) {
+                .type, .namespace => .type,
+                .value, .typeof, .any => .value,
+            },
+        };
+    }
+};
+
+pub const SymbolTable = struct {
+    tree: *const ast.Tree,
+    model: yuku_semantic.Semantic,
+    symbols: []const yuku_semantic.Symbol,
+    references: []const yuku_semantic.Reference,
+
+    pub fn init(tree: *const ast.Tree, model: yuku_semantic.Semantic) SymbolTable {
+        return .{
+            .tree = tree,
+            .model = model,
+            .symbols = model.symbols,
+            .references = model.references,
+        };
+    }
+
+    pub fn resolveAll(_: *SymbolTable, _: ScopeTree) !void {}
+
+    pub inline fn getSymbol(self: SymbolTable, id: yuku_semantic.SymbolId) yuku_semantic.Symbol {
+        return self.model.symbol(id);
+    }
+
+    pub inline fn getReference(self: SymbolTable, id: yuku_semantic.ReferenceId) Reference {
+        return Reference.fromYuku(self.model.reference(id));
+    }
+
+    pub fn iterSymbols(self: SymbolTable) yuku_semantic.Semantic.SymbolIterator {
+        return self.model.iterSymbols();
+    }
+
+    pub fn iterReferences(self: SymbolTable) ReferenceIterator {
+        return .{ .references = self.references };
+    }
+
+    pub fn iterUnresolved(self: SymbolTable) UnresolvedIterator {
+        return .{ .references = self.references };
+    }
+
+    pub fn findInScope(self: SymbolTable, scope: yuku_semantic.ScopeId, name: []const u8) ?yuku_semantic.SymbolId {
+        var bindings = self.model.bindings(scope);
+        while (bindings.next()) |id| {
+            if (std.mem.eql(u8, self.tree.string(self.model.symbol(id).name), name)) return id;
+        }
+        return null;
+    }
+
+    pub fn resolve(
+        self: SymbolTable,
+        _: ScopeTree,
+        scope: yuku_semantic.ScopeId,
+        name: []const u8,
+    ) ?yuku_semantic.SymbolId {
+        return self.model.lookup(scope, name, .any);
+    }
+
+    pub inline fn referenceSymbol(self: SymbolTable, id: yuku_semantic.ReferenceId) yuku_semantic.SymbolId {
+        return self.model.reference(id).symbol;
+    }
+
+    pub inline fn symbolDecls(self: SymbolTable, id: yuku_semantic.SymbolId) []const ast.NodeIndex {
+        return self.model.decls(id);
+    }
+
+    pub fn symbolUses(self: SymbolTable, id: yuku_semantic.SymbolId) UseIterator {
+        return .{ .references = self.references, .ids = self.model.uses(id) };
+    }
+
+    pub inline fn isReferenced(self: SymbolTable, id: yuku_semantic.SymbolId) bool {
+        return self.model.uses(id).len > 0;
+    }
+
+    pub const ReferenceEntry = struct {
+        id: yuku_semantic.ReferenceId,
+        reference: Reference,
+    };
+
+    pub const ReferenceIterator = struct {
+        references: []const yuku_semantic.Reference,
+        index: u32 = 0,
+
+        pub fn next(self: *ReferenceIterator) ?ReferenceEntry {
+            if (self.index >= self.references.len) return null;
+            const index = self.index;
+            self.index += 1;
+            return .{
+                .id = @enumFromInt(index),
+                .reference = Reference.fromYuku(self.references[index]),
+            };
+        }
+    };
+
+    pub const UnresolvedIterator = struct {
+        references: []const yuku_semantic.Reference,
+        index: u32 = 0,
+
+        pub fn next(self: *UnresolvedIterator) ?ReferenceEntry {
+            while (self.index < self.references.len) {
+                const index = self.index;
+                self.index += 1;
+                const reference = self.references[index];
+                if (reference.symbol == .none) {
+                    return .{
+                        .id = @enumFromInt(index),
+                        .reference = Reference.fromYuku(reference),
+                    };
+                }
+            }
+            return null;
+        }
+    };
+
+    pub const UseIterator = struct {
+        references: []const yuku_semantic.Reference,
+        ids: []const yuku_semantic.ReferenceId,
+        index: u32 = 0,
+
+        pub fn next(self: *UseIterator) ?ast.NodeIndex {
+            if (self.index >= self.ids.len) return null;
+            const reference = self.references[@intFromEnum(self.ids[self.index])];
+            self.index += 1;
+            return reference.node;
+        }
+    };
+};
+
+pub const Result = struct {
+    scope_tree: ScopeTree,
+    symbol_table: SymbolTable,
+
+    pub fn init(tree: *const ast.Tree, model: yuku_semantic.Semantic) Result {
+        return .{
+            .scope_tree = ScopeTree.init(model.scopes),
+            .symbol_table = SymbolTable.init(tree, model),
+        };
+    }
+};
+
+const CompatReference = Reference;
+const CompatScopeTree = ScopeTree;
+const CompatSymbolTable = SymbolTable;
+const CompatResult = Result;
+
+/// Transitional facade for rules that still use Yuku's pre-0.6 semantic API.
+/// Traversal types that did not change are forwarded directly to Yuku.
+pub const traverser = struct {
+    pub const Action = parser.traverser.Action;
+    pub const basic = parser.traverser.basic;
+    pub const scoped = parser.traverser.scoped;
+
+    pub const semantic = struct {
+        pub const Ctx = yuku_semantic.Ctx;
+        pub const Scope = yuku_semantic.Scope;
+        pub const ScopeId = yuku_semantic.ScopeId;
+        pub const Symbol = yuku_semantic.Symbol;
+        pub const SymbolId = yuku_semantic.SymbolId;
+        pub const ReferenceId = yuku_semantic.ReferenceId;
+        pub const Reference = CompatReference;
+        pub const ScopeTree = CompatScopeTree;
+        pub const SymbolTable = CompatSymbolTable;
+        pub const Result = CompatResult;
+    };
+};
+
+test "adapts Yuku's space-aware symbol resolution" {
+    var tree = try parser.parse(
+        std.testing.allocator,
+        "type Value = string; { const Value = 1; let item: Value; }",
+        .{ .lang = .ts },
+    );
+    defer tree.deinit();
+
+    const model = try parser.semantic.analyze(&tree);
+    const result = Result.init(&tree, model);
+    var references = result.symbol_table.iterReferences();
+
+    const entry = references.next().?;
+    try std.testing.expectEqualStrings("Value", tree.string(entry.reference.name));
+    try std.testing.expectEqual(Reference.Kind.type, entry.reference.kind);
+    const symbol_id = result.symbol_table.referenceSymbol(entry.id);
+    try std.testing.expect(symbol_id != .none);
+    try std.testing.expect(model.symbol(symbol_id).flags.type_alias);
+    try std.testing.expectEqual(null, references.next());
+}


### PR DESCRIPTION
## What changed

- update the vendored Yuku submodule from `7dd7689` (just after v0.5.8) to `v0.6.1`
- adapt comment spans and scope tracker access to the current parser API
- add a transitional semantic compatibility facade so existing rules consume Yuku's unified, fully resolved `Semantic` model
- add a regression test for type/value-space-aware reference resolution
- refresh the documented Yuku Zig minimum version

## Why

Yuku v0.6.1 includes parser fixes and a redesigned semantic model with space-aware reference resolution. That matters directly to lint rules that distinguish TypeScript type bindings from runtime value bindings.

Release: https://github.com/yuku-toolchain/yuku/releases/tag/v0.6.1

## Impact

The linter now uses Yuku v0.6.1 while keeping the existing rule implementations stable through a small compatibility view. The compatibility layer can be removed incrementally as rules migrate to the new query API.

## Validation

- `zig build test -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- `node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts` (reported the expected 5 diagnostics)
