### PR TITLE
feat: add autofix foundation

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -132,9 +132,9 @@ npx fishlint eslint --disable-setup --config utoo.json --ext .js,.ts --glob src
 
 The wrapper invokes `utoo-lint` after translating common fishlint eslint flags.
 It forwards `--config`, maps `--glob` values to lint targets, accepts `--ext`
-for compatibility, and ignores fishlint-only setup/debug flags. `--fix` is
-accepted with a warning because `utoo-lint` does not apply fixes yet. It
-discovers `utoo.json`, `utoo-lint.json`, and
+for compatibility, and ignores fishlint-only setup/debug flags. `--fix` applies
+fixes from supported native rules, while `--fix-dry-run` computes fixed output
+without writing files. It discovers `utoo.json`, `utoo-lint.json`, and
 `eslint.config.js`/`eslint.config.mjs`/`eslint.config.cjs`; JavaScript flat
 config files are loaded and materialized as temporary JSON before invoking the
 native binary.

--- a/npm/README.md
+++ b/npm/README.md
@@ -174,8 +174,10 @@ missing explicit and `--glob` targets before invoking native lint. `--quiet`
 and `--quiet=true` filter warnings from compatibility output. Explicit ignored
 file paths emit ESLint-style warnings unless `--no-warn-ignored` or
 `--no-warn-ignored=true` is set.
-Fix controls such as `--fix`, `--fix-dry-run`, and `--fix-type` are accepted
-with a warning because utoo-lint does not apply fixes yet.
+`--fix` and `--fix-dry-run` apply fixes from supported native rules. The Node
+API also composes those fixes with fixes reported by custom rules. `--fix-type`
+remains accepted with a warning but is not implemented yet. Initial native
+autofix coverage includes `no-extra-semi` and `@typescript-eslint/no-extra-semi`.
 Display and reporting controls such as `--color`, `--no-color`, `--stats`,
 `--stats=true`, and `--no-warn-ignored` are accepted for the same reason.
 `--output-file` and `-o` write the native output to the requested report file.

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -417,6 +417,7 @@ const BUILTIN_RULE_IDS = [
   "@typescript-eslint/prefer-namespace-keyword",
   "@typescript-eslint/restrict-plus-operands"
 ];
+const FIXABLE_BUILTIN_RULE_IDS = new Set(["no-extra-semi", "@typescript-eslint/no-extra-semi"]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));
 
 class UtooLint {
@@ -882,12 +883,12 @@ function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (arg === "--fix") {
-      warn("utoo-lint: fishlint --fix is ignored because utoo-lint does not apply fixes yet.");
+      translated.push("--fix");
       index += 1;
       continue;
     }
     if (arg === "--fix-dry-run") {
-      warn("utoo-lint: fishlint --fix-dry-run is ignored because utoo-lint does not apply fixes yet.");
+      translated.push("--fix-dry-run");
       index += 1;
       continue;
     }
@@ -1067,6 +1068,7 @@ function lintFiles(paths, options = {}) {
     if (!resolvedOptions.deferDiagnosticConfigFiltering) {
       report.filePaths = normalizeReportFilePaths(report.filePaths, resolvedOptions);
       report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, resolvedOptions);
+      report.outputs = normalizeReportOutputs(report.outputs, resolvedOptions);
       report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
       report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     }
@@ -1115,6 +1117,10 @@ function lintText(code, options = {}) {
       deferDiagnosticConfigFiltering: true
     });
     report.filePaths = (report.filePaths ?? []).map((filePath) => (filePath === tempFile ? requestedPath : filePath));
+    report.outputs = (report.outputs ?? []).map((fixed) => ({
+      ...fixed,
+      filePath: fixed.filePath === tempFile ? requestedPath : fixed.filePath
+    }));
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,
       filePath: requestedPath
@@ -1163,6 +1169,10 @@ function buildNativeLintArgs(paths, options) {
 
   if (options.format) {
     cliArgs.push(`--format=${options.format}`);
+  }
+
+  if (options.fix) {
+    cliArgs.push("--fix-dry-run");
   }
 
   if (options.extraArgs) {
@@ -1882,7 +1892,9 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
   if (customRules.length === 0) {
     return results;
   }
-  const sourceCode = createLinterSourceCode(code);
+  let result = results.find((item) => item.filePath === filePath);
+  const effectiveCode = typeof result?.output === "string" ? result.output : code;
+  const sourceCode = createLinterSourceCode(effectiveCode);
   const messages = runCustomLinterRules(customRules, sourceCode, {
     cwd: options.cwd,
     filename: filePath,
@@ -1893,14 +1905,13 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
     return results;
   }
 
-  let result = results.find((item) => item.filePath === filePath);
   if (!result) {
-    result = emptyESLintResult(filePath, code);
+    result = emptyESLintResult(filePath, effectiveCode);
     results.push(result);
   }
   result.messages.push(...filtered.messages);
   result.suppressedMessages.push(...filtered.suppressedMessages);
-  applyResultFixes(result, code, options);
+  applyResultFixes(result, effectiveCode, options);
   finalizeESLintResult(result);
   return results;
 }
@@ -1913,11 +1924,13 @@ function appendCustomLintFileMessages(results, config, options) {
     if (customRules.length === 0) {
       continue;
     }
-    let code;
-    try {
-      code = readFileSync(filePath, "utf8");
-    } catch {
-      continue;
+    let code = result.output;
+    if (typeof code !== "string") {
+      try {
+        code = readFileSync(filePath, "utf8");
+      } catch {
+        continue;
+      }
     }
     const sourceCode = createLinterSourceCode(code);
     const messages = runCustomLinterRules(customRules, sourceCode, {
@@ -3471,6 +3484,14 @@ function reportToESLintResults(report, textOptions = {}) {
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
+  for (const fixed of report.outputs ?? []) {
+    const filePath = textOptions.filePath ?? normalizeESLintFilePath(fixed.filePath, textOptions.cwd);
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    byFile.get(filePath).output = fixed.output;
+  }
+
   if (textOptions.filePath && textOptions.includeEmptyTextResult !== false && !byFile.has(textOptions.filePath)) {
     byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
   }
@@ -3515,6 +3536,13 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
 
 function normalizeReportFilePaths(filePaths, options = {}) {
   return (filePaths ?? []).map((filePath) => normalizeESLintFilePath(filePath, options.cwd));
+}
+
+function normalizeReportOutputs(outputs, options = {}) {
+  return (outputs ?? []).map((fixed) => ({
+    ...fixed,
+    filePath: normalizeESLintFilePath(fixed.filePath, options.cwd)
+  }));
 }
 
 function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
@@ -4035,11 +4063,15 @@ function getErrorResults(results) {
 }
 
 function ruleMetaForRuleId(ruleId) {
-  return {
+  const meta = {
     docs: {
       url: ruleDocsUrl(ruleId)
     }
   };
+  if (FIXABLE_BUILTIN_RULE_IDS.has(ruleId)) {
+    meta.fixable = "code";
+  }
+  return meta;
 }
 
 function createBuiltinRule(ruleId) {
@@ -4114,7 +4146,7 @@ function emptyESLintResult(filePath, source) {
 }
 
 function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
-  return {
+  const message = {
     ruleId: diagnostic.ruleId,
     severity: ruleSeverities?.get(diagnostic.ruleId) ?? (diagnostic.severity === "error" ? 2 : 1),
     message: diagnostic.message,
@@ -4122,6 +4154,14 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
     column: diagnostic.column,
     nodeType: null
   };
+  const fixes = (diagnostic.fixes ?? []).map((fix) => ({
+    range: fix.range,
+    text: fix.text
+  }));
+  if (fixes.length > 0) {
+    message.fix = fixes.length === 1 ? fixes[0] : fixes;
+  }
+  return message;
 }
 
 function finalizeESLintResult(result) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -38,6 +38,7 @@ export interface LintReport {
   files: number;
   filePaths: string[];
   diagnostics: LintMessage[];
+  outputs?: Array<{ filePath: string; output: string }>;
   exitCode: number;
   stderr?: string;
 }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -420,6 +420,7 @@ const BUILTIN_RULE_IDS = [
   "@typescript-eslint/prefer-namespace-keyword",
   "@typescript-eslint/restrict-plus-operands"
 ];
+const FIXABLE_BUILTIN_RULE_IDS = new Set(["no-extra-semi", "@typescript-eslint/no-extra-semi"]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));
 
 export class UtooLint {
@@ -832,7 +833,9 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
   if (customRules.length === 0) {
     return results;
   }
-  const sourceCode = createLinterSourceCode(code);
+  let result = results.find((item) => item.filePath === filePath);
+  const effectiveCode = typeof result?.output === "string" ? result.output : code;
+  const sourceCode = createLinterSourceCode(effectiveCode);
   const messages = runCustomLinterRules(customRules, sourceCode, {
     cwd: options.cwd,
     filename: filePath,
@@ -843,14 +846,13 @@ function appendCustomLintTextMessages(results, code, filePath, config, rules, op
     return results;
   }
 
-  let result = results.find((item) => item.filePath === filePath);
   if (!result) {
-    result = emptyESLintResult(filePath, code);
+    result = emptyESLintResult(filePath, effectiveCode);
     results.push(result);
   }
   result.messages.push(...filtered.messages);
   result.suppressedMessages.push(...filtered.suppressedMessages);
-  applyResultFixes(result, code, options);
+  applyResultFixes(result, effectiveCode, options);
   finalizeESLintResult(result);
   return results;
 }
@@ -863,11 +865,13 @@ function appendCustomLintFileMessages(results, config, options) {
     if (customRules.length === 0) {
       continue;
     }
-    let code;
-    try {
-      code = readFileSync(filePath, "utf8");
-    } catch {
-      continue;
+    let code = result.output;
+    if (typeof code !== "string") {
+      try {
+        code = readFileSync(filePath, "utf8");
+      } catch {
+        continue;
+      }
     }
     const sourceCode = createLinterSourceCode(code);
     const messages = runCustomLinterRules(customRules, sourceCode, {
@@ -2715,12 +2719,12 @@ export function translateFishlintArgs(args = [], options = {}) {
       continue;
     }
     if (arg === "--fix") {
-      warn("utoo-lint: fishlint --fix is ignored because utoo-lint does not apply fixes yet.");
+      translated.push("--fix");
       index += 1;
       continue;
     }
     if (arg === "--fix-dry-run") {
-      warn("utoo-lint: fishlint --fix-dry-run is ignored because utoo-lint does not apply fixes yet.");
+      translated.push("--fix-dry-run");
       index += 1;
       continue;
     }
@@ -2900,6 +2904,7 @@ export function lintFiles(paths, options = {}) {
     if (!resolvedOptions.deferDiagnosticConfigFiltering) {
       report.filePaths = normalizeReportFilePaths(report.filePaths, resolvedOptions);
       report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, resolvedOptions);
+      report.outputs = normalizeReportOutputs(report.outputs, resolvedOptions);
       report.diagnostics = normalizeReportDiagnostics(report.diagnostics, resolvedOptions);
       report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     }
@@ -2948,6 +2953,10 @@ export function lintText(code, options = {}) {
       deferDiagnosticConfigFiltering: true
     });
     report.filePaths = (report.filePaths ?? []).map((filePath) => (filePath === tempFile ? requestedPath : filePath));
+    report.outputs = (report.outputs ?? []).map((fixed) => ({
+      ...fixed,
+      filePath: fixed.filePath === tempFile ? requestedPath : fixed.filePath
+    }));
     report.diagnostics = report.diagnostics.map((diagnostic) => ({
       ...diagnostic,
       filePath: requestedPath
@@ -2996,6 +3005,10 @@ function buildNativeLintArgs(paths, options) {
 
   if (options.format) {
     cliArgs.push(`--format=${options.format}`);
+  }
+
+  if (options.fix) {
+    cliArgs.push("--fix-dry-run");
   }
 
   if (options.extraArgs) {
@@ -3474,6 +3487,14 @@ function reportToESLintResults(report, textOptions = {}) {
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
+  for (const fixed of report.outputs ?? []) {
+    const filePath = textOptions.filePath ?? normalizeESLintFilePath(fixed.filePath, textOptions.cwd);
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    byFile.get(filePath).output = fixed.output;
+  }
+
   if (textOptions.filePath && textOptions.includeEmptyTextResult !== false && !byFile.has(textOptions.filePath)) {
     byFile.set(textOptions.filePath, emptyESLintResult(textOptions.filePath, textOptions.source));
   }
@@ -3518,6 +3539,13 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
 
 function normalizeReportFilePaths(filePaths, options = {}) {
   return (filePaths ?? []).map((filePath) => normalizeESLintFilePath(filePath, options.cwd));
+}
+
+function normalizeReportOutputs(outputs, options = {}) {
+  return (outputs ?? []).map((fixed) => ({
+    ...fixed,
+    filePath: normalizeESLintFilePath(fixed.filePath, options.cwd)
+  }));
 }
 
 function normalizeDiagnosticFilePaths(diagnostics, options = {}) {
@@ -4038,11 +4066,15 @@ function getErrorResults(results) {
 }
 
 function ruleMetaForRuleId(ruleId) {
-  return {
+  const meta = {
     docs: {
       url: ruleDocsUrl(ruleId)
     }
   };
+  if (FIXABLE_BUILTIN_RULE_IDS.has(ruleId)) {
+    meta.fixable = "code";
+  }
+  return meta;
 }
 
 function createBuiltinRule(ruleId) {
@@ -4117,7 +4149,7 @@ function emptyESLintResult(filePath, source) {
 }
 
 function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
-  return {
+  const message = {
     ruleId: diagnostic.ruleId,
     severity: ruleSeverities?.get(diagnostic.ruleId) ?? (diagnostic.severity === "error" ? 2 : 1),
     message: diagnostic.message,
@@ -4125,6 +4157,14 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
     column: diagnostic.column,
     nodeType: null
   };
+  const fixes = (diagnostic.fixes ?? []).map((fix) => ({
+    range: fix.range,
+    text: fix.text
+  }));
+  if (fixes.length > 0) {
+    message.fix = fixes.length === 1 ? fixes[0] : fixes;
+  }
+  return message;
 }
 
 function finalizeESLintResult(result) {

--- a/src/core.zig
+++ b/src/core.zig
@@ -8902,6 +8902,12 @@ pub const Diagnostic = struct {
     message: []const u8,
     span: ast.Span,
     severity: Severity,
+    fixes: []Fix,
+};
+
+pub const Fix = struct {
+    span: ast.Span,
+    replacement: []const u8,
 };
 
 pub const Result = struct {
@@ -8909,7 +8915,7 @@ pub const Result = struct {
 
     pub fn deinit(self: *Result, allocator: Allocator) void {
         for (self.diagnostics) |diagnostic| {
-            allocator.free(diagnostic.message);
+            freeDiagnostic(allocator, diagnostic);
         }
         allocator.free(self.diagnostics);
     }
@@ -8941,14 +8947,58 @@ pub fn addDiagnostic(
     message: []const u8,
     span: ast.Span,
 ) Allocator.Error!void {
+    return addDiagnosticWithFixes(
+        allocator,
+        diagnostics,
+        severity,
+        rule_id,
+        message,
+        span,
+        &.{},
+    );
+}
+
+pub fn addDiagnosticWithFix(
+    allocator: Allocator,
+    diagnostics: *DiagnosticList,
+    severity: Severity,
+    rule_id: []const u8,
+    message: []const u8,
+    span: ast.Span,
+    fix: Fix,
+) Allocator.Error!void {
+    return addDiagnosticWithFixes(
+        allocator,
+        diagnostics,
+        severity,
+        rule_id,
+        message,
+        span,
+        &.{fix},
+    );
+}
+
+pub fn addDiagnosticWithFixes(
+    allocator: Allocator,
+    diagnostics: *DiagnosticList,
+    severity: Severity,
+    rule_id: []const u8,
+    message: []const u8,
+    span: ast.Span,
+    fixes: []const Fix,
+) Allocator.Error!void {
     const owned_message = try allocator.dupe(u8, message);
     errdefer allocator.free(owned_message);
+
+    const owned_fixes = try dupeFixes(allocator, fixes);
+    errdefer freeFixes(allocator, owned_fixes);
 
     try diagnostics.append(allocator, .{
         .rule_id = rule_id,
         .message = owned_message,
         .span = span,
         .severity = severity,
+        .fixes = owned_fixes,
     });
 }
 
@@ -8969,14 +9019,45 @@ pub fn addDiagnosticFmt(
         .message = owned_message,
         .span = span,
         .severity = severity,
+        .fixes = &.{},
     });
 }
 
 pub fn freeDiagnostics(allocator: Allocator, diagnostics: *DiagnosticList) void {
     for (diagnostics.items) |diagnostic| {
-        allocator.free(diagnostic.message);
+        freeDiagnostic(allocator, diagnostic);
     }
     diagnostics.deinit(allocator);
+}
+
+fn dupeFixes(allocator: Allocator, fixes: []const Fix) Allocator.Error![]Fix {
+    if (fixes.len == 0) return &.{};
+
+    const owned = try allocator.alloc(Fix, fixes.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (owned[0..initialized]) |fix| allocator.free(fix.replacement);
+        allocator.free(owned);
+    }
+
+    for (fixes, 0..) |fix, index| {
+        owned[index] = .{
+            .span = fix.span,
+            .replacement = try allocator.dupe(u8, fix.replacement),
+        };
+        initialized += 1;
+    }
+    return owned;
+}
+
+fn freeDiagnostic(allocator: Allocator, diagnostic: Diagnostic) void {
+    allocator.free(diagnostic.message);
+    freeFixes(allocator, diagnostic.fixes);
+}
+
+fn freeFixes(allocator: Allocator, fixes: []Fix) void {
+    for (fixes) |fix| allocator.free(fix.replacement);
+    if (fixes.len > 0) allocator.free(fixes);
 }
 
 pub fn isKnownGlobal(name: []const u8) bool {

--- a/src/fixer.zig
+++ b/src/fixer.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const core = @import("core.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const ApplyResult = struct {
+    output: []u8,
+    applied_diagnostics: usize,
+    fixed: bool,
+
+    pub fn deinit(self: *ApplyResult, allocator: Allocator) void {
+        allocator.free(self.output);
+    }
+};
+
+const Candidate = struct {
+    diagnostic_index: usize,
+    fixes: []const core.Fix,
+    start: u32,
+    end: u32,
+};
+
+const FixRef = struct {
+    diagnostic_index: usize,
+    fix: *const core.Fix,
+};
+
+pub fn apply(
+    allocator: Allocator,
+    source: []const u8,
+    diagnostics: []const core.Diagnostic,
+) Allocator.Error!ApplyResult {
+    var candidates: std.ArrayList(Candidate) = .empty;
+    defer candidates.deinit(allocator);
+
+    for (diagnostics, 0..) |diagnostic, diagnostic_index| {
+        if (diagnostic.fixes.len == 0 or !validFixGroup(source, diagnostic.fixes)) continue;
+
+        var start = diagnostic.fixes[0].span.start;
+        var end = diagnostic.fixes[0].span.end;
+        for (diagnostic.fixes[1..]) |fix| {
+            start = @min(start, fix.span.start);
+            end = @max(end, fix.span.end);
+        }
+        try candidates.append(allocator, .{
+            .diagnostic_index = diagnostic_index,
+            .fixes = diagnostic.fixes,
+            .start = start,
+            .end = end,
+        });
+    }
+
+    std.mem.sort(Candidate, candidates.items, {}, candidateLessThan);
+
+    var accepted: std.ArrayList(FixRef) = .empty;
+    defer accepted.deinit(allocator);
+    var applied_diagnostics: usize = 0;
+
+    for (candidates.items) |candidate| {
+        if (conflictsWithAccepted(candidate.fixes, accepted.items)) continue;
+
+        for (candidate.fixes) |*fix| {
+            try accepted.append(allocator, .{
+                .diagnostic_index = candidate.diagnostic_index,
+                .fix = fix,
+            });
+        }
+        applied_diagnostics += 1;
+    }
+
+    std.mem.sort(FixRef, accepted.items, {}, fixRefLessThan);
+
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+
+    var cursor: usize = 0;
+    for (accepted.items) |entry| {
+        const start: usize = @intCast(entry.fix.span.start);
+        const end: usize = @intCast(entry.fix.span.end);
+        try output.appendSlice(allocator, source[cursor..start]);
+        try output.appendSlice(allocator, entry.fix.replacement);
+        cursor = end;
+    }
+    try output.appendSlice(allocator, source[cursor..]);
+
+    const owned_output = try output.toOwnedSlice(allocator);
+    const fixed = !std.mem.eql(u8, source, owned_output);
+    return .{
+        .output = owned_output,
+        .applied_diagnostics = if (fixed) applied_diagnostics else 0,
+        .fixed = fixed,
+    };
+}
+
+fn validFixGroup(source: []const u8, fixes: []const core.Fix) bool {
+    for (fixes, 0..) |fix, index| {
+        if (fix.span.start > fix.span.end or fix.span.end > source.len) return false;
+
+        for (fixes[index + 1 ..]) |other| {
+            if (fixesConflict(fix, other)) return false;
+        }
+    }
+    return true;
+}
+
+fn conflictsWithAccepted(fixes: []const core.Fix, accepted: []const FixRef) bool {
+    for (fixes) |fix| {
+        for (accepted) |entry| {
+            if (fixesConflict(fix, entry.fix.*)) return true;
+        }
+    }
+    return false;
+}
+
+fn fixesConflict(left: core.Fix, right: core.Fix) bool {
+    if (left.span.start < right.span.end and right.span.start < left.span.end) return true;
+
+    const left_insertion = left.span.start == left.span.end;
+    const right_insertion = right.span.start == right.span.end;
+    if (!left_insertion and !right_insertion) return false;
+
+    return left.span.end == right.span.start or right.span.end == left.span.start;
+}
+
+fn candidateLessThan(_: void, left: Candidate, right: Candidate) bool {
+    if (left.start != right.start) return left.start < right.start;
+    if (left.end != right.end) return left.end < right.end;
+    return left.diagnostic_index < right.diagnostic_index;
+}
+
+fn fixRefLessThan(_: void, left: FixRef, right: FixRef) bool {
+    if (left.fix.span.start != right.fix.span.start) return left.fix.span.start < right.fix.span.start;
+    if (left.fix.span.end != right.fix.span.end) return left.fix.span.end < right.fix.span.end;
+    return left.diagnostic_index < right.diagnostic_index;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,17 +8,30 @@ const Stats = struct {
     files: usize = 0,
     diagnostics: usize = 0,
     errors: usize = 0,
+    fixed: usize = 0,
 
     fn add(self: *Stats, other: Stats) void {
         self.files += other.files;
         self.diagnostics += other.diagnostics;
         self.errors += other.errors;
+        self.fixed += other.fixed;
     }
 };
 
 const OutputFormat = enum {
     text,
     json,
+};
+
+const FixMode = enum {
+    none,
+    write,
+    dry_run,
+};
+
+const JsonFix = struct {
+    range: [2]usize,
+    text: []const u8,
 };
 
 const JsonDiagnostic = struct {
@@ -28,20 +41,30 @@ const JsonDiagnostic = struct {
     severity: []const u8,
     message: []const u8,
     ruleId: []const u8,
+    fixes: []const JsonFix,
 };
 
 const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
+
+const JsonOutput = struct {
+    filePath: []const u8,
+    output: []const u8,
+};
+
+const JsonOutputList = std.ArrayList(JsonOutput);
 
 const JsonReport = struct {
     files: usize,
     filePaths: []const []const u8,
     diagnostics: []const JsonDiagnostic,
+    outputs: []const JsonOutput,
 };
 
 const WorkQueue = struct {
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    fix_mode: FixMode,
     next_index: std.atomic.Value(usize) = .init(0),
     print_mutex: std.Io.Mutex = .init,
 };
@@ -73,6 +96,7 @@ pub fn main(init: std.process.Init) !void {
 
     var thread_count_override: ?usize = null;
     var output_format: OutputFormat = .text;
+    var fix_mode: FixMode = .none;
     var targets: std.ArrayList([]const u8) = .empty;
     defer targets.deinit(allocator);
 
@@ -97,6 +121,18 @@ pub fn main(init: std.process.Init) !void {
             thread_count_override = parsed;
         } else if (std.mem.eql(u8, arg, "--json")) {
             output_format = .json;
+        } else if (std.mem.eql(u8, arg, "--fix")) {
+            if (fix_mode == .dry_run) {
+                std.debug.print("utoo-lint: --fix and --fix-dry-run cannot be used together\n", .{});
+                std.process.exit(2);
+            }
+            fix_mode = .write;
+        } else if (std.mem.eql(u8, arg, "--fix-dry-run")) {
+            if (fix_mode == .write) {
+                std.debug.print("utoo-lint: --fix and --fix-dry-run cannot be used together\n", .{});
+                std.process.exit(2);
+            }
+            fix_mode = .dry_run;
         } else if (std.mem.startsWith(u8, arg, "--format=")) {
             const value = arg["--format=".len..];
             output_format = parseOutputFormat(value) orelse {
@@ -1196,6 +1232,8 @@ pub fn main(init: std.process.Init) !void {
 
     var json_diagnostics: JsonDiagnosticList = .empty;
     defer freeJsonDiagnostics(allocator, &json_diagnostics);
+    var json_outputs: JsonOutputList = .empty;
+    defer freeJsonOutputs(allocator, &json_outputs);
     const json_diagnostics_ptr: ?*JsonDiagnosticList = if (output_format == .json) &json_diagnostics else null;
 
     var stats = Stats{};
@@ -1204,15 +1242,20 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (output_format == .json) {
-        try lintFilesJson(allocator, io, files.items, options, &stats, &json_diagnostics);
-        try writeJsonReport(io, stats, files.items, json_diagnostics.items);
+        try lintFilesJson(allocator, io, files.items, options, fix_mode, &stats, &json_diagnostics, &json_outputs);
+        try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_outputs.items);
     } else {
-        try lintFiles(allocator, io, files.items, options, thread_count_override, &stats);
+        try lintFiles(allocator, io, files.items, options, fix_mode, thread_count_override, &stats);
 
-        std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{
-            stats.files,
-            stats.diagnostics,
-        });
+        if (fix_mode == .none) {
+            std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{ stats.files, stats.diagnostics });
+        } else {
+            std.debug.print("{d} file(s) checked, {d} diagnostic(s), {d} fixed\n", .{
+                stats.files,
+                stats.diagnostics,
+                stats.fixed,
+            });
+        }
     }
 
     if (stats.errors > 0 or stats.diagnostics > 0) {
@@ -1334,7 +1377,7 @@ fn collectLintablePaths(
         if (json_diagnostics) |diagnostics| {
             const message = try std.fmt.allocPrint(allocator, "unable to stat path: {s}", .{@errorName(err)});
             defer allocator.free(message);
-            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io");
+            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{});
         } else {
             std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
         }
@@ -1705,6 +1748,7 @@ fn lintFiles(
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    fix_mode: FixMode,
     thread_count_override: ?usize,
     stats: *Stats,
 ) !void {
@@ -1713,7 +1757,7 @@ fn lintFiles(
     const worker_count = @min(files.len, thread_count_override orelse (std.Thread.getCpuCount() catch 1));
     if (worker_count <= 1) {
         for (files) |file| {
-            try lintFile(std.heap.smp_allocator, io, file, options, stats, null);
+            try lintFile(std.heap.smp_allocator, io, file, options, fix_mode, stats, null);
         }
         return;
     }
@@ -1722,6 +1766,7 @@ fn lintFiles(
         .io = io,
         .files = files,
         .options = options,
+        .fix_mode = fix_mode,
     };
 
     const threads = try allocator.alloc(std.Thread, worker_count);
@@ -1767,11 +1812,13 @@ fn lintFilesJson(
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
+    json_outputs: *JsonOutputList,
 ) !void {
     for (files) |file| {
-        try lintFileJson(allocator, io, file, options, stats, json_diagnostics);
+        try lintFileJson(allocator, io, file, options, fix_mode, stats, json_diagnostics, json_outputs);
     }
 }
 
@@ -1785,6 +1832,7 @@ fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
             queue.io,
             queue.files[index],
             queue.options,
+            queue.fix_mode,
             &result.stats,
             &queue.print_mutex,
         ) catch |err| {
@@ -1799,42 +1847,41 @@ fn lintFileJson(
     io: std.Io,
     path: []const u8,
     options: lint.Options,
+    fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
+    json_outputs: *JsonOutputList,
 ) !void {
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
         defer allocator.free(message);
-        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io");
+        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{});
         stats.errors += 1;
         stats.diagnostics += 1;
         return;
     };
     defer allocator.free(source);
 
-    var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
-    defer result.deinit(allocator);
-
     stats.files += 1;
 
-    for (result.diagnostics) |diagnostic| {
-        const position = lint.offsetToLineColumn(source, diagnostic.span.start);
-        try appendJsonDiagnostic(
-            allocator,
-            json_diagnostics,
-            path,
-            position.line,
-            position.column,
-            diagnostic.severity.toString(),
-            diagnostic.message,
-            diagnostic.rule_id,
-        );
-
-        stats.diagnostics += 1;
-        if (diagnostic.severity == .@"error") {
-            stats.errors += 1;
-        }
+    if (fix_mode == .none) {
+        var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
+        defer result.deinit(allocator);
+        return appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, stats);
     }
+
+    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
+    defer fixed.deinit(allocator);
+
+    if (fixed.fixed) {
+        stats.fixed += fixed.applied_diagnostics;
+        if (fix_mode == .write) {
+            try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = fixed.output });
+        }
+        try appendJsonOutput(allocator, json_outputs, path, fixed.output);
+    }
+
+    try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, stats);
 }
 
 fn lintFile(
@@ -1842,6 +1889,7 @@ fn lintFile(
     io: std.Io,
     path: []const u8,
     options: lint.Options,
+    fix_mode: FixMode,
     stats: *Stats,
     print_mutex: ?*std.Io.Mutex,
 ) !void {
@@ -1853,11 +1901,35 @@ fn lintFile(
     };
     defer allocator.free(source);
 
-    var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
-    defer result.deinit(allocator);
-
     stats.files += 1;
 
+    if (fix_mode == .none) {
+        var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
+        defer result.deinit(allocator);
+        return printResultDiagnostics(io, print_mutex, path, source, result, stats);
+    }
+
+    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
+    defer fixed.deinit(allocator);
+
+    if (fixed.fixed) {
+        stats.fixed += fixed.applied_diagnostics;
+        if (fix_mode == .write) {
+            try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = fixed.output });
+        }
+    }
+
+    printResultDiagnostics(io, print_mutex, path, fixed.output, fixed.result, stats);
+}
+
+fn printResultDiagnostics(
+    io: std.Io,
+    print_mutex: ?*std.Io.Mutex,
+    path: []const u8,
+    source: []const u8,
+    result: lint.Result,
+    stats: *Stats,
+) void {
     for (result.diagnostics) |diagnostic| {
         const position = lint.offsetToLineColumn(source, diagnostic.span.start);
         printLocked(io, print_mutex, "{s}:{d}:{d}: {s}: {s} [{s}]\n", .{
@@ -1885,6 +1957,8 @@ fn appendJsonDiagnostic(
     severity: []const u8,
     message: []const u8,
     rule_id: []const u8,
+    source: []const u8,
+    fixes: []const lint.Fix,
 ) !void {
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
@@ -1895,6 +1969,9 @@ fn appendJsonDiagnostic(
     const owned_rule_id = try allocator.dupe(u8, rule_id);
     errdefer allocator.free(owned_rule_id);
 
+    const owned_fixes = try dupeJsonFixes(allocator, source, fixes);
+    errdefer freeOwnedJsonFixes(allocator, owned_fixes);
+
     try diagnostics.append(allocator, .{
         .filePath = owned_path,
         .line = line,
@@ -1902,7 +1979,77 @@ fn appendJsonDiagnostic(
         .severity = severity,
         .message = owned_message,
         .ruleId = owned_rule_id,
+        .fixes = owned_fixes,
     });
+}
+
+fn appendJsonResultDiagnostics(
+    allocator: std.mem.Allocator,
+    json_diagnostics: *JsonDiagnosticList,
+    path: []const u8,
+    source: []const u8,
+    result: lint.Result,
+    stats: *Stats,
+) !void {
+    for (result.diagnostics) |diagnostic| {
+        const position = lint.offsetToLineColumn(source, diagnostic.span.start);
+        try appendJsonDiagnostic(
+            allocator,
+            json_diagnostics,
+            path,
+            position.line,
+            position.column,
+            diagnostic.severity.toString(),
+            diagnostic.message,
+            diagnostic.rule_id,
+            source,
+            diagnostic.fixes,
+        );
+
+        stats.diagnostics += 1;
+        if (diagnostic.severity == .@"error") stats.errors += 1;
+    }
+}
+
+fn dupeJsonFixes(allocator: std.mem.Allocator, source: []const u8, fixes: []const lint.Fix) ![]JsonFix {
+    if (fixes.len == 0) return &.{};
+
+    const owned = try allocator.alloc(JsonFix, fixes.len);
+    var initialized: usize = 0;
+    errdefer {
+        freeJsonFixes(allocator, owned[0..initialized]);
+        allocator.free(owned);
+    }
+
+    for (fixes, 0..) |fix, index| {
+        owned[index] = .{
+            .range = .{
+                lint.offsetToUtf16Offset(source, fix.span.start),
+                lint.offsetToUtf16Offset(source, fix.span.end),
+            },
+            .text = try allocator.dupe(u8, fix.replacement),
+        };
+        initialized += 1;
+    }
+    return owned;
+}
+
+fn freeJsonFixes(allocator: std.mem.Allocator, fixes: []const JsonFix) void {
+    for (fixes) |fix| allocator.free(fix.text);
+}
+
+fn freeOwnedJsonFixes(allocator: std.mem.Allocator, fixes: []const JsonFix) void {
+    freeJsonFixes(allocator, fixes);
+    if (fixes.len > 0) allocator.free(fixes);
+}
+
+fn appendJsonOutput(allocator: std.mem.Allocator, outputs: *JsonOutputList, path: []const u8, output: []const u8) !void {
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+    const owned_output = try allocator.dupe(u8, output);
+    errdefer allocator.free(owned_output);
+
+    try outputs.append(allocator, .{ .filePath = owned_path, .output = owned_output });
 }
 
 fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosticList) void {
@@ -1910,11 +2057,26 @@ fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosti
         allocator.free(diagnostic.filePath);
         allocator.free(diagnostic.message);
         allocator.free(diagnostic.ruleId);
+        freeOwnedJsonFixes(allocator, diagnostic.fixes);
     }
     diagnostics.deinit(allocator);
 }
 
-fn writeJsonReport(io: std.Io, stats: Stats, file_paths: []const []const u8, diagnostics: []const JsonDiagnostic) !void {
+fn freeJsonOutputs(allocator: std.mem.Allocator, outputs: *JsonOutputList) void {
+    for (outputs.items) |output| {
+        allocator.free(output.filePath);
+        allocator.free(output.output);
+    }
+    outputs.deinit(allocator);
+}
+
+fn writeJsonReport(
+    io: std.Io,
+    stats: Stats,
+    file_paths: []const []const u8,
+    diagnostics: []const JsonDiagnostic,
+    outputs: []const JsonOutput,
+) !void {
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
@@ -1923,6 +2085,7 @@ fn writeJsonReport(io: std.Io, stats: Stats, file_paths: []const []const u8, dia
         .files = stats.files,
         .filePaths = file_paths,
         .diagnostics = diagnostics,
+        .outputs = outputs,
     }, .{}, stdout);
     try stdout.writeByte('\n');
     try stdout.flush();
@@ -1959,6 +2122,8 @@ fn printHelp() void {
         \\  --no-config              Do not read utoo.json or utoo-lint.json
         \\  --format=text|json       Select diagnostic output format
         \\  --json                   Alias for --format=json
+        \\  --fix                    Apply autofixes and write files to disk
+        \\  --fix-dry-run            Apply autofixes without writing files
         \\  --threads=N              Number of worker threads to use
         \\  --rules=a,b,c            Enable only the comma-separated rule list
         \\  --accessor-pairs=off    Disable accessor-pairs

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const parser = @import("parser");
 const core = @import("core.zig");
+const fixer = @import("fixer.zig");
 const semantic_compat = @import("semantic_compat.zig");
 
 const ast = parser.ast;
@@ -9,13 +10,93 @@ const Allocator = std.mem.Allocator;
 pub const Severity = core.Severity;
 pub const Options = core.Options;
 pub const Diagnostic = core.Diagnostic;
+pub const Fix = core.Fix;
 pub const Result = core.Result;
+pub const ApplyFixesResult = fixer.ApplyResult;
+pub const max_autofix_passes = 10;
 pub const SourcePosition = core.SourcePosition;
 pub const NoRestrictedImportEntry = core.NoRestrictedImportEntry;
 pub const NoRestrictedImportKind = core.NoRestrictedImportKind;
 pub const NoRestrictedSyntaxEntry = core.NoRestrictedSyntaxEntry;
 pub const SortImportsMemberSyntax = core.SortImportsMemberSyntax;
 pub const rules = @import("rules/root.zig");
+
+pub fn applyFixes(
+    allocator: Allocator,
+    source: []const u8,
+    diagnostics: []const Diagnostic,
+) Allocator.Error!ApplyFixesResult {
+    return fixer.apply(allocator, source, diagnostics);
+}
+
+pub const LintAndFixResult = struct {
+    output: []u8,
+    result: Result,
+    fixed: bool,
+    passes: usize,
+    applied_diagnostics: usize,
+
+    pub fn deinit(self: *LintAndFixResult, allocator: Allocator) void {
+        allocator.free(self.output);
+        self.result.deinit(allocator);
+    }
+};
+
+pub fn lintSourceAndFix(
+    allocator: Allocator,
+    source: []const u8,
+    path: []const u8,
+    options: Options,
+) Allocator.Error!LintAndFixResult {
+    return lintSourceAndFixWithIo(allocator, null, source, path, options);
+}
+
+pub fn lintSourceAndFixWithIo(
+    allocator: Allocator,
+    io: ?std.Io,
+    source: []const u8,
+    path: []const u8,
+    options: Options,
+) Allocator.Error!LintAndFixResult {
+    var output = try allocator.dupe(u8, source);
+    errdefer allocator.free(output);
+
+    var passes: usize = 0;
+    var applied_diagnostics: usize = 0;
+
+    while (passes < max_autofix_passes) {
+        var result = try lintSourceWithIo(allocator, io, output, path, options);
+        var applied = applyFixes(allocator, output, result.diagnostics) catch |err| {
+            result.deinit(allocator);
+            return err;
+        };
+
+        if (!applied.fixed) {
+            applied.deinit(allocator);
+            return .{
+                .output = output,
+                .result = result,
+                .fixed = passes > 0,
+                .passes = passes,
+                .applied_diagnostics = applied_diagnostics,
+            };
+        }
+
+        result.deinit(allocator);
+        allocator.free(output);
+        output = applied.output;
+        passes += 1;
+        applied_diagnostics += applied.applied_diagnostics;
+    }
+
+    return .{
+        .output = output,
+        .result = try lintSourceWithIo(allocator, io, output, path, options),
+        .fixed = true,
+        .passes = passes,
+        .applied_diagnostics = applied_diagnostics,
+    };
+}
 
 pub fn lintSource(
     allocator: Allocator,
@@ -215,6 +296,26 @@ pub fn offsetToLineColumn(source: []const u8, offset: u32) SourcePosition {
     }
 
     return .{ .line = line, .column = column };
+}
+
+pub fn offsetToUtf16Offset(source: []const u8, offset: u32) usize {
+    const end = @min(@as(usize, @intCast(offset)), source.len);
+    var byte_index: usize = 0;
+    var utf16_offset: usize = 0;
+
+    while (byte_index < end) {
+        const sequence_len = std.unicode.utf8ByteSequenceLength(source[byte_index]) catch 1;
+        if (byte_index + sequence_len > end or byte_index + sequence_len > source.len) {
+            byte_index += 1;
+            utf16_offset += 1;
+            continue;
+        }
+
+        utf16_offset += if (sequence_len == 4) 2 else 1;
+        byte_index += sequence_len;
+    }
+
+    return utf16_offset;
 }
 
 fn appendParserDiagnostics(

--- a/src/rules/no_extra_semi.zig
+++ b/src/rules/no_extra_semi.zig
@@ -17,13 +17,15 @@ pub fn check(
 ) Allocator.Error!void {
     if (isStatementBody(tree, index, ctx)) return;
 
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Unnecessary semicolon.",
-        tree.span(index),
+        span,
+        .{ .span = span, .replacement = "" },
     );
 }
 
@@ -59,13 +61,15 @@ fn reportSemicolonsInRange(
     for (tree.source[start..end], start..) |byte, offset| {
         if (byte != ';') continue;
         const semicolon: u32 = @intCast(offset);
-        try core.addDiagnostic(
+        const span = ast.Span{ .start = semicolon, .end = semicolon + 1 };
+        try core.addDiagnosticWithFix(
             allocator,
             diagnostics,
             .warning,
             id,
             "Unnecessary semicolon.",
-            .{ .start = semicolon, .end = semicolon + 1 },
+            span,
+            .{ .span = span, .replacement = "" },
         );
     }
 }

--- a/src/rules/typescript_eslint_no_extra_semi.zig
+++ b/src/rules/typescript_eslint_no_extra_semi.zig
@@ -17,12 +17,14 @@ pub fn check(
 ) Allocator.Error!void {
     if (no_extra_semi.isStatementBody(tree, index, ctx)) return;
 
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .@"error",
         id,
         "Unnecessary semicolon.",
-        tree.span(index),
+        span,
+        .{ .span = span, .replacement = "" },
     );
 }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1,4 +1,8 @@
 comptime {
+    _ = @import("autofix.zig");
+}
+
+comptime {
     _ = @import("rules/accessor_pairs.zig");
 }
 

--- a/tests/autofix.zig
+++ b/tests/autofix.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+
+test "applies non-overlapping fixes in source order" {
+    const source = "let first = 1;;\nlet second = 2;;\n";
+    var first_fixes = [_]lint.Fix{.{
+        .span = .{ .start = 14, .end = 15 },
+        .replacement = "",
+    }};
+    var second_fixes = [_]lint.Fix{.{
+        .span = .{ .start = 31, .end = 32 },
+        .replacement = "",
+    }};
+    const diagnostics = [_]lint.Diagnostic{
+        diagnostic("first", first_fixes[0..]),
+        diagnostic("second", second_fixes[0..]),
+    };
+
+    var result = try lint.applyFixes(std.testing.allocator, source, &diagnostics);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqual(@as(usize, 2), result.applied_diagnostics);
+    try std.testing.expectEqualStrings("let first = 1;\nlet second = 2;\n", result.output);
+}
+
+test "defers an overlapping diagnostic as one atomic fix group" {
+    const source = "abcdef";
+    var first_fixes = [_]lint.Fix{.{
+        .span = .{ .start = 1, .end = 4 },
+        .replacement = "X",
+    }};
+    var second_fixes = [_]lint.Fix{
+        .{ .span = .{ .start = 0, .end = 1 }, .replacement = "A" },
+        .{ .span = .{ .start = 3, .end = 5 }, .replacement = "Y" },
+    };
+    const diagnostics = [_]lint.Diagnostic{
+        diagnostic("first", first_fixes[0..]),
+        diagnostic("second", second_fixes[0..]),
+    };
+
+    var result = try lint.applyFixes(std.testing.allocator, source, &diagnostics);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.applied_diagnostics);
+    try std.testing.expectEqualStrings("AbcYf", result.output);
+}
+
+test "skips invalid fix ranges" {
+    const source = "value";
+    var fixes = [_]lint.Fix{.{
+        .span = .{ .start = 0, .end = 99 },
+        .replacement = "other",
+    }};
+    const diagnostics = [_]lint.Diagnostic{diagnostic("invalid", fixes[0..])};
+
+    var result = try lint.applyFixes(std.testing.allocator, source, &diagnostics);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqual(@as(usize, 0), result.applied_diagnostics);
+    try std.testing.expectEqualStrings(source, result.output);
+}
+
+test "lintSourceAndFix returns final diagnostics after applying fixes" {
+    const source = "const value = 1;;;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqual(@as(usize, 1), result.passes);
+    try std.testing.expectEqualStrings("const value = 1;", result.output);
+    for (result.result.diagnostics) |diagnostic_item| {
+        try std.testing.expect(!std.mem.eql(u8, diagnostic_item.rule_id, "no-extra-semi"));
+    }
+}
+
+test "converts byte offsets to ESLint UTF-16 offsets" {
+    const source = "a😀中";
+
+    try std.testing.expectEqual(@as(usize, 1), lint.offsetToUtf16Offset(source, 1));
+    try std.testing.expectEqual(@as(usize, 3), lint.offsetToUtf16Offset(source, 5));
+    try std.testing.expectEqual(@as(usize, 4), lint.offsetToUtf16Offset(source, 8));
+}
+
+fn diagnostic(rule_id: []const u8, fixes: []lint.Fix) lint.Diagnostic {
+    return .{
+        .rule_id = rule_id,
+        .message = "message",
+        .span = .{ .start = 0, .end = 1 },
+        .severity = .warning,
+        .fixes = fixes,
+    };
+}

--- a/tests/rules/no_extra_semi.zig
+++ b/tests/rules/no_extra_semi.zig
@@ -58,3 +58,32 @@ test "can disable no-extra-semi" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_semi.id));
 }
+
+test "autofixes unnecessary semicolons" {
+    const source =
+        \\const value = 1;;
+        \\class Example { ; method() {} ; field; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_extra_semi = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_extra_semi.id)) {
+            try std.testing.expectEqual(@as(usize, 1), diagnostic.fixes.len);
+        }
+    }
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        \\const value = 1;
+        \\class Example {  method() {}  field; }
+    , fixed.output);
+}

--- a/tests/rules/typescript_eslint_no_extra_semi.zig
+++ b/tests/rules/typescript_eslint_no_extra_semi.zig
@@ -63,3 +63,19 @@ test "can disable @typescript-eslint/no-extra-semi and fall back to core rule" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_extra_semi.id));
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_extra_semi.id));
 }
+
+test "autofixes @typescript-eslint/no-extra-semi diagnostics" {
+    const source = "const value = 1;;";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("const value = 1;", fixed.output);
+}


### PR DESCRIPTION
## Summary

- add owned text edits to native diagnostics and a deterministic fixer that defers conflicting diagnostic groups
- run lint/fix passes until stable, capped at 10 passes with a final lint result
- support native `--fix` and `--fix-dry-run`, including JSON fixed outputs and UTF-16 ranges for ESLint compatibility
- connect native fixes to the ESM/CJS Node APIs, `Linter#verifyAndFix`, `outputFixes`, and the fishlint compatibility command
- make `no-extra-semi` and `@typescript-eslint/no-extra-semi` the first fixable native rules

## Why

Existing compatibility APIs exposed fix-related surfaces, but native diagnostics could not carry edits and CLI fix flags were ignored. This PR establishes one complete vertical slice so follow-up PRs can add safe fixes rule by rule without changing the execution pipeline again.

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1` (1684 tests)
- `zig build -Doptimize=ReleaseFast -j1`
- ESM and CommonJS Node API smoke tests
- native CLI and fishlint `--fix` integration smoke tests
- Unicode/UTF-16 range coverage
