### PR TITLE
feat: autofix no-undef-init and no-useless-rename

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -163,7 +163,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-throw-literal`](https://eslint.org/docs/latest/rules/no-throw-literal) | Implemented |
 | [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Supports `skipBlankLines` and `ignoreComments` configuration |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
-| [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented |
+| [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented with safe autofix for `let` bindings |
 | [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars) | Reports read `let`/`var` bindings that have no initializer and no assignment |
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
@@ -185,7 +185,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented for adjacent static string and template literals in concatenation chains |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration and ESLint template escape handling |
-| [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
+| [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports autofix plus `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |

--- a/src/root.zig
+++ b/src/root.zig
@@ -251,6 +251,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_regex_spaces or
         options.no_shadow or
         options.no_unassigned_vars or
+        options.no_undef_init or
         options.no_undef or
         options.react_jsx_no_undef or
         options.no_unused_vars or

--- a/src/rules/no_undef_init.zig
+++ b/src/rules/no_undef_init.zig
@@ -3,15 +3,47 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-undef-init";
 
-pub fn check(
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_variable_declaration(
+        self: *Visitor,
+        declaration: ast.VariableDeclaration,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try check(self.allocator, self.diagnostics, ctx.tree, declaration, self.symbol_table);
+        return .proceed;
+    }
+};
+
+fn check(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     declaration: ast.VariableDeclaration,
+    symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     if (declaration.kind == .@"const") return;
 
@@ -21,25 +53,65 @@ pub fn check(
             else => continue,
         };
 
-        if (!isUndefinedReference(tree, declarator.init)) continue;
+        const reference = undefinedReference(tree, declarator.init) orelse continue;
+        const reference_id = symbol_table.model.referenceOf(reference) orelse continue;
+        if (symbol_table.referenceSymbol(reference_id) != .none) continue;
 
-        try core.addDiagnostic(
-            allocator,
-            diagnostics,
-            .warning,
-            id,
-            "Do not initialize variables to undefined.",
-            tree.span(declarator.init),
-        );
+        const diagnostic_span = tree.span(declarator.init);
+        const binding_span = tree.span(declarator.id);
+        if (declaration.kind == .let and
+            isBindingIdentifier(tree, declarator.id) and
+            !hasCommentBetween(tree, binding_span.end, diagnostic_span.end))
+        {
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Do not initialize variables to undefined.",
+                diagnostic_span,
+                .{
+                    .span = .{
+                        .start = binding_span.end,
+                        .end = diagnostic_span.end,
+                    },
+                    .replacement = "",
+                },
+            );
+        } else {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Do not initialize variables to undefined.",
+                diagnostic_span,
+            );
+        }
     }
 }
 
-fn isUndefinedReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
-    if (index == .null) return false;
-
-    return switch (tree.data(unwrapTransparent(tree, index))) {
-        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+fn isBindingIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .binding_identifier => true,
         else => false,
+    };
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < end and comment.span.end > start) return true;
+    }
+    return false;
+}
+
+fn undefinedReference(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    if (index == .null) return null;
+
+    const unwrapped = unwrapTransparent(tree, index);
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => |identifier| if (std.mem.eql(u8, tree.string(identifier.name), "undefined")) unwrapped else null,
+        else => null,
     };
 }
 

--- a/src/rules/no_useless_rename.zig
+++ b/src/rules/no_useless_rename.zig
@@ -38,7 +38,7 @@ pub fn checkImportSpecifierWithOptions(
     const local = bindingName(tree, specifier.local) orelse return;
     if (!std.mem.eql(u8, imported, local)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, specifier.local);
 }
 
 pub fn checkExportSpecifier(
@@ -66,7 +66,7 @@ pub fn checkExportSpecifierWithOptions(
     const exported = propertyName(tree, specifier.exported) orelse return;
     if (!std.mem.eql(u8, local, exported)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, specifier.local);
 }
 
 pub fn checkObjectPattern(
@@ -97,7 +97,7 @@ pub fn checkObjectPatternWithOptions(
         const value = bindingOrAssignmentName(tree, property.value) orelse continue;
         if (!std.mem.eql(u8, key, value)) continue;
 
-        try addDiagnostic(allocator, diagnostics, tree, property_index);
+        try addDiagnostic(allocator, diagnostics, tree, property_index, property.value);
     }
 }
 
@@ -151,7 +151,7 @@ fn checkAssignmentObjectPattern(
         const value = referenceOrAssignmentName(tree, property.value) orelse continue;
         if (!std.mem.eql(u8, key, value)) continue;
 
-        try addDiagnostic(allocator, diagnostics, tree, property_index);
+        try addDiagnostic(allocator, diagnostics, tree, property_index, property.value);
     }
 }
 
@@ -183,15 +183,46 @@ fn addDiagnostic(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    replacement_index: ast.NodeIndex,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    const replacement_span = tree.span(replacement_index);
+    if (wouldDiscardComment(tree, span, replacement_span)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Useless rename to the same name.",
+            span,
+        );
+        return;
+    }
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Useless rename to the same name.",
-        tree.span(index),
+        span,
+        .{
+            .span = span,
+            .replacement = tree.source[@intCast(replacement_span.start)..@intCast(replacement_span.end)],
+        },
     );
+}
+
+fn wouldDiscardComment(tree: *const ast.Tree, span: ast.Span, replacement_span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        const inside_span = comment.span.start >= span.start and comment.span.end <= span.end;
+        if (!inside_span) continue;
+
+        const inside_replacement = comment.span.start >= replacement_span.start and
+            comment.span.end <= replacement_span.end;
+        if (!inside_replacement) return true;
+    }
+    return false;
 }
 
 fn bindingOrAssignmentName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1215,6 +1215,10 @@ pub fn runSemantic(
         });
     }
 
+    if (options.no_undef_init) {
+        try no_undef_init.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.react_jsx_no_undef) {
         try react_jsx_no_undef.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
@@ -2843,9 +2847,6 @@ const BasicVisitor = struct {
         }
         if (self.options.vars_on_top) {
             try vars_on_top.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);
-        }
-        if (self.options.no_undef_init) {
-            try no_undef_init.check(self.allocator, self.diagnostics, ctx.tree, declaration);
         }
         if (self.options.no_shadow_restricted_names) {
             try no_shadow_restricted_names.checkVariableDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration);

--- a/tests/rules/no_undef_init.zig
+++ b/tests/rules/no_undef_init.zig
@@ -54,3 +54,69 @@ test "can disable no-undef-init" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_undef_init.id));
 }
+
+test "autofixes undefined initializers for let bindings" {
+    const source =
+        \\let first = undefined;
+        \\let second = (undefined);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\let first;
+        \\let second;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_undef_init.id));
+}
+
+test "does not report or autofix a shadowed undefined initializer" {
+    const source =
+        \\function run(undefined) {
+        \\  let value = undefined;
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_undef_init.id));
+}
+
+test "does not autofix undefined initializers when syntax must be preserved" {
+    const source =
+        \\let first/**/ = undefined;
+        \\let second = /**/undefined;
+        \\var third = undefined;
+        \\let { fourth } = undefined;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result.result, lint.rules.no_undef_init.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_undef_init.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -84,3 +84,66 @@ test "can disable no-useless-rename" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_rename.id));
 }
+
+test "autofixes same-name aliases" {
+    const source =
+        \\import { foo as foo } from "mod";
+        \\export { foo as foo };
+        \\const { bar: bar, baz: baz = fallback } = source;
+        \\({ qux: qux } = source);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\import { foo } from "mod";
+        \\export { foo };
+        \\const { bar, baz = fallback } = source;
+        \\({ qux } = source);
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_useless_rename.id));
+}
+
+test "does not autofix aliases when replacement would discard comments" {
+    const source =
+        \\import { foo /* keep */ as foo } from "mod";
+        \\const { bar: /* keep */ bar } = source;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_useless_rename.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_useless_rename.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofixes parenthesized destructuring aliases to valid shorthand" {
+    const source = "({ foo: (foo) } = source);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("({ foo } = source);", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_useless_rename.id));
+}


### PR DESCRIPTION
## Summary

- add safe autofixes for `no-undef-init` on ordinary `let` bindings
- avoid reporting shadowed `undefined` references and preserve `var`, destructuring, and commented initializers
- autofix same-name import, export, and destructuring aliases for `no-useless-rename`
- withhold rename fixes when replacing the alias would discard comments
- document the new autofix coverage and add public API regression tests

## Why

The autofix pipeline is now available, so these two local, deterministic rules can expose fixes without changing the shared execution path. The implementation follows ESLint's safety boundaries where removing or replacing syntax could alter behavior or lose comments.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -Doptimize=ReleaseFast -j1` (1690 tests)
- `zig build -Doptimize=ReleaseFast -j1`
