### PR TITLE
feat: autofix no-extra-label

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -86,7 +86,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Supports `exceptions` configuration |
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented |
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
-| [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented |
+| [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented with multi-pass autofix for redundant references and label declarations |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
 | [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase`, common `commentPattern`, and `reportUnusedFallthroughComment` configuration |
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |

--- a/src/rules/no_extra_label.zig
+++ b/src/rules/no_extra_label.zig
@@ -18,14 +18,30 @@ pub fn check(
     try reportRedundantLoopLabelReferences(allocator, diagnostics, tree, statement.body, label_name);
     if (containsLabelReference(tree, statement.body, label_name)) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "This label is unnecessary.",
-        tree.span(index),
-    );
+    const fix_span = ast.Span{
+        .start = tree.span(statement.label).start,
+        .end = tree.span(statement.body).start,
+    };
+    if (hasCommentBetween(tree, fix_span.start, fix_span.end)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "This label is unnecessary.",
+            tree.span(index),
+        );
+    } else {
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "This label is unnecessary.",
+            tree.span(index),
+            .{ .span = fix_span, .replacement = "" },
+        );
+    }
 }
 
 fn reportRedundantLoopLabelReferences(
@@ -59,12 +75,12 @@ fn reportRedundantLoopBodyReferences(
     switch (tree.data(index)) {
         .break_statement => |statement| {
             if (sameLabel(tree, statement.label, label_name)) {
-                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, statement.label, label_name);
+                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, index, statement.label, label_name);
             }
         },
         .continue_statement => |statement| {
             if (sameLabel(tree, statement.label, label_name)) {
-                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, statement.label, label_name);
+                try addRedundantReferenceDiagnostic(allocator, diagnostics, tree, index, statement.label, label_name);
             }
         },
         .block_statement => |block| try reportRedundantReferencesInRange(allocator, diagnostics, tree, block.body, label_name),
@@ -115,18 +131,51 @@ fn addRedundantReferenceDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    statement: ast.NodeIndex,
     label: ast.NodeIndex,
     label_name: []const u8,
 ) Allocator.Error!void {
-    try core.addDiagnosticFmt(
+    const statement_span = tree.span(statement);
+    const keyword_end = statement_span.start + switch (tree.data(statement)) {
+        .break_statement => @as(u32, "break".len),
+        .continue_statement => @as(u32, "continue".len),
+        else => return,
+    };
+    const message = try std.fmt.allocPrint(allocator, "This label '{s}' is unnecessary.", .{label_name});
+    defer allocator.free(message);
+    const label_span = tree.span(label);
+
+    if (hasCommentBetween(tree, keyword_end, label_span.end)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            label_span,
+        );
+        return;
+    }
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
-        tree.span(label),
-        "This label '{s}' is unnecessary.",
-        .{label_name},
+        message,
+        label_span,
+        .{
+            .span = .{ .start = keyword_end, .end = label_span.end },
+            .replacement = "",
+        },
     );
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < end and comment.span.end > start) return true;
+    }
+    return false;
 }
 
 fn labelName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/no_extra_label.zig
+++ b/tests/rules/no_extra_label.zig
@@ -138,3 +138,91 @@ test "can disable no-extra-label" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_label.id));
 }
+
+test "autofixes labels without labeled break or continue" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+        \\block: {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\while (ready) {
+        \\  break;
+        \\}
+        \\{
+        \\  call();
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_extra_label.id));
+}
+
+test "autofixes redundant break and continue labels across passes" {
+    const source =
+        \\outer: while (ready) {
+        \\  break outer;
+        \\}
+        \\loop: while (ready) {
+        \\  continue loop;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\while (ready) {
+        \\  break;
+        \\}
+        \\while (ready) {
+        \\  continue;
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_extra_label.id));
+}
+
+test "does not autofix labels when removal would discard comments" {
+    const source =
+        \\outer: while (ready) {
+        \\  break/**/ outer;
+        \\}
+        \\block: /**/ {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_extra_label.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_extra_label.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add autofixes for unnecessary label declarations
- remove redundant labels from `break` and `continue` statements
- let the shared multi-pass fixer remove the now-unused declaration label on the following pass
- withhold fixes whenever the removed range contains comments
- document the rule's autofix coverage and add public API regression tests

## Why

`no-extra-label` reports both redundant control-flow references and labels that have no remaining references. Applying these edits in separate lint passes keeps each diagnostic local and deterministic while still producing the fully simplified source.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -Doptimize=ReleaseFast -j1` (1694 tests)
- `zig build -Doptimize=ReleaseFast -j1`
