### PR TITLE
feat: autofix no-floating-decimal

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -89,7 +89,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented with multi-pass autofix for redundant references and label declarations |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
 | [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase`, common `commentPattern`, and `reportUnusedFallthroughComment` configuration |
-| [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented |
+| [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented with token-safe autofix |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
 | [`no-func-assign`](https://eslint.org/docs/latest/rules/no-func-assign) | Implemented |
 | [`no-global-assign`](https://eslint.org/docs/latest/rules/no-global-assign) | Supports `exceptions` configuration |

--- a/src/rules/no_floating_decimal.zig
+++ b/src/rules/no_floating_decimal.zig
@@ -17,14 +17,55 @@ pub fn check(
     const raw = tree.string(literal.raw);
     if (!hasFloatingDecimal(raw)) return;
 
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    const fix_offset = if (raw[0] == '.') span.start else span.end;
+    const replacement = if (raw[0] == '.' and needsSpaceBeforeLeadingZero(tree.source, span.start)) " 0" else "0";
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "A leading or trailing decimal point should include a digit.",
-        tree.span(index),
+        span,
+        .{
+            .span = .{ .start = fix_offset, .end = fix_offset },
+            .replacement = replacement,
+        },
     );
+}
+
+fn needsSpaceBeforeLeadingZero(source: []const u8, offset: u32) bool {
+    if (offset == 0) return false;
+
+    const previous = source[@as(usize, @intCast(offset)) - 1];
+    return switch (previous) {
+        ' ',
+        '\t',
+        '\r',
+        '\n',
+        '(',
+        '[',
+        '{',
+        ',',
+        ';',
+        ':',
+        '?',
+        '=',
+        '+',
+        '-',
+        '*',
+        '/',
+        '%',
+        '!',
+        '~',
+        '<',
+        '>',
+        '&',
+        '|',
+        '^',
+        => false,
+        else => true,
+    };
 }
 
 fn hasFloatingDecimal(raw: []const u8) bool {

--- a/tests/rules/no_floating_decimal.zig
+++ b/tests/rules/no_floating_decimal.zig
@@ -52,3 +52,47 @@ test "can disable no-floating-decimal" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_floating_decimal.id));
 }
+
+test "autofixes leading and trailing decimal points" {
+    const source =
+        \\const leading = .5;
+        \\const trailing = 2.;
+        \\const negative = -.7;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const leading = 0.5;
+        \\const trailing = 2.0;
+        \\const negative = -0.7;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_floating_decimal.id));
+}
+
+test "autofix separates leading decimals from adjacent keywords" {
+    const source =
+        \\typeof.2;
+        \\for (item of.3);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\typeof 0.2;
+        \\for (item of 0.3);
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_floating_decimal.id));
+}


### PR DESCRIPTION
## Summary

- insert a leading zero for numeric literals such as `.5`
- append a trailing zero for numeric literals such as `2.`
- add whitespace when a leading zero would otherwise merge with an adjacent keyword, including `typeof.2` and `of.2`
- document the rule's autofix support and add public API regression tests

## Why

The edit is normally a zero-width insertion, but keyword-adjacent literals require token-aware spacing to keep the fixed source valid. This PR keeps that boundary local to `no-floating-decimal`.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -Doptimize=ReleaseFast -j1` (1696 tests)
- `zig build -Doptimize=ReleaseFast -j1`
