### PR TITLE
feat: autofix no-regex-spaces

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -145,7 +145,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-restricted-modules`](https://eslint.org/docs/latest/rules/no-restricted-modules) | Supports restricted CommonJS `require()` sources, `paths`, simple `patterns`, negated patterns, and custom messages |
 | [`no-restricted-properties`](https://eslint.org/docs/latest/rules/no-restricted-properties) | Supports object/property restrictions, destructuring, and `allowObjects`/`allowProperties` configuration |
 | [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) | Supports lightweight AST node selector restrictions with custom messages |
-| [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented |
+| [`no-regex-spaces`](https://eslint.org/docs/latest/rules/no-regex-spaces) | Implemented with safe autofix for literals and static string constructors |
 | [`no-return-assign`](https://eslint.org/docs/latest/rules/no-return-assign) | Implemented for `except-parens` and optional `always` behavior |
 | [`no-return-await`](https://eslint.org/docs/latest/rules/no-return-await) | Implemented for return statements, async arrow expression bodies, and nested tail expressions |
 | [`no-script-url`](https://eslint.org/docs/latest/rules/no-script-url) | Implemented |

--- a/src/rules/no_regex_spaces.zig
+++ b/src/rules/no_regex_spaces.zig
@@ -59,10 +59,27 @@ const Visitor = struct {
         if (arguments.len == 0) return;
         if (!isGlobalRegExpReference(tree, self.symbol_table, callee)) return;
 
-        const pattern = stringLiteralValue(tree, arguments[0]) orelse return;
-        if (!hasConsecutiveSpaces(pattern)) return;
+        const pattern_node = unwrapTransparent(tree, arguments[0]);
+        const literal = switch (tree.data(pattern_node)) {
+            .string_literal => |literal| literal,
+            else => return,
+        };
+        const pattern = tree.string(literal.value);
+        const raw = tree.string(literal.raw);
+        if (raw.len < 2) return;
 
-        try addDiagnostic(self.allocator, self.diagnostics, tree, index);
+        const raw_pattern = raw[1 .. raw.len - 1];
+        if (std.mem.indexOf(u8, raw_pattern, "  ") == null) return;
+        const space_run = firstConsecutiveSpaceRun(pattern) orelse return;
+
+        const has_static_flags = arguments.len < 2 or stringLiteralValue(tree, arguments[1]) != null;
+        const fix_span: ?ast.Span = if (has_static_flags and std.mem.eql(u8, raw_pattern, pattern)) blk: {
+            const pattern_span = tree.span(pattern_node);
+            const start = pattern_span.start + 1 + @as(u32, @intCast(space_run.start));
+            break :blk .{ .start = start, .end = start + @as(u32, @intCast(space_run.len)) };
+        } else null;
+
+        try addDiagnostic(self.allocator, self.diagnostics, tree, index, space_run.len, fix_span);
     }
 };
 
@@ -73,9 +90,18 @@ pub fn check(
     literal: ast.RegExpLiteral,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    if (!hasConsecutiveSpaces(tree.string(literal.pattern))) return;
+    const space_run = firstConsecutiveSpaceRun(tree.string(literal.pattern)) orelse return;
+    const literal_span = tree.span(index);
+    const start = literal_span.start + 1 + @as(u32, @intCast(space_run.start));
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(
+        allocator,
+        diagnostics,
+        tree,
+        index,
+        space_run.len,
+        .{ .start = start, .end = start + @as(u32, @intCast(space_run.len)) },
+    );
 }
 
 fn addDiagnostic(
@@ -83,15 +109,32 @@ fn addDiagnostic(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    space_count: usize,
+    fix_span: ?ast.Span,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Avoid multiple spaces in regular expression literals.",
-        tree.span(index),
-    );
+    if (fix_span) |span| {
+        const replacement = try std.fmt.allocPrint(allocator, " {{{d}}}", .{space_count});
+        defer allocator.free(replacement);
+
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Avoid multiple spaces in regular expression literals.",
+            tree.span(index),
+            .{ .span = span, .replacement = replacement },
+        );
+    } else {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Avoid multiple spaces in regular expression literals.",
+            tree.span(index),
+        );
+    }
 }
 
 fn isGlobalRegExpReference(
@@ -148,38 +191,64 @@ fn isUnresolvedReference(
     return false;
 }
 
-fn hasConsecutiveSpaces(pattern: []const u8) bool {
+const SpaceRun = struct {
+    start: usize,
+    len: usize,
+};
+
+fn firstConsecutiveSpaceRun(pattern: []const u8) ?SpaceRun {
     var in_class = false;
     var escaped = false;
-    var previous_space = false;
+    var run_start: usize = 0;
+    var run_len: usize = 0;
 
-    for (pattern) |char| {
+    for (pattern, 0..) |char, index| {
+        const escaped_char = escaped;
         if (escaped) {
             escaped = false;
-            previous_space = false;
+        } else if (char == '\\') {
+            if (reportableRun(run_start, run_len, char)) |space_run| return space_run;
+            run_len = 0;
+            escaped = true;
             continue;
         }
 
-        switch (char) {
-            '\\' => {
-                escaped = true;
-                previous_space = false;
-            },
-            '[' => {
-                in_class = true;
-                previous_space = false;
-            },
-            ']' => {
-                in_class = false;
-                previous_space = false;
-            },
-            ' ' => {
-                if (!in_class and previous_space) return true;
-                previous_space = !in_class;
-            },
-            else => previous_space = false,
+        if (!escaped_char and char == '[') {
+            if (reportableRun(run_start, run_len, char)) |space_run| return space_run;
+            run_len = 0;
+            in_class = true;
+            continue;
         }
+        if (!escaped_char and char == ']') {
+            run_len = 0;
+            in_class = false;
+            continue;
+        }
+
+        if (!in_class and char == ' ') {
+            if (run_len == 0) run_start = index;
+            run_len += 1;
+            continue;
+        }
+
+        if (!in_class) {
+            if (reportableRun(run_start, run_len, char)) |space_run| return space_run;
+        }
+        run_len = 0;
     }
 
-    return false;
+    return reportableRun(run_start, run_len, null);
+}
+
+fn reportableRun(start: usize, len: usize, next: ?u8) ?SpaceRun {
+    const count = if (next != null and isQuantifierStart(next.?)) len -| 1 else len;
+    if (count < 2) return null;
+    return .{ .start = start, .len = count };
+}
+
+fn isQuantifierStart(char: u8) bool {
+    return switch (char) {
+        '+', '*', '{', '?' => true,
+        else => false,
+    };
 }

--- a/tests/rules/no_regex_spaces.zig
+++ b/tests/rules/no_regex_spaces.zig
@@ -78,3 +78,72 @@ test "can disable no-regex-spaces" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_regex_spaces.id));
 }
+
+test "autofixes consecutive spaces in regex literals and constructors" {
+    const source =
+        \\const first = /foo  bar/;
+        \\const second = RegExp("foo   bar");
+        \\const third = new RegExp('end    ');
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .prefer_regex_literals = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const first = /foo {2}bar/;
+        \\const second = RegExp("foo {3}bar");
+        \\const third = new RegExp('end {4}');
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_regex_spaces.id));
+}
+
+test "autofix preserves the space consumed by a regex quantifier" {
+    const source =
+        \\const valid = /  +/;
+        \\const fixed = /bar   {3}baz/;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const valid = /  +/;
+        \\const fixed = /bar {2} {3}baz/;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_regex_spaces.id));
+}
+
+test "does not autofix constructor patterns with escapes or dynamic flags" {
+    const source =
+        \\const escaped = new RegExp("\\d  ");
+        \\const dynamic = RegExp("foo  bar", flags);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .prefer_regex_literals = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_regex_spaces.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_regex_spaces.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace the first redundant run of regex spaces with an explicit `{N}` quantifier
- support regex literals and global `RegExp` call/new expressions with static string patterns
- preserve the final space when it is consumed by an existing quantifier
- report without a fix when constructor strings contain escapes or flags are dynamic
- document the autofix coverage and add public API regression tests

## Why

Regex space runs map directly to source only when the pattern text is static and unescaped. This PR keeps fixes limited to those cases while preserving existing diagnostics for patterns that cannot be rewritten safely.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -Doptimize=ReleaseFast -j1` (1699 tests)
- `zig build -Doptimize=ReleaseFast -j1`
