### PR TITLE
feat: autofix no-useless-return

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -186,7 +186,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration and ESLint template escape handling |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports autofix plus `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
-| [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented |
+| [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented with comment-safe autofix for statement-list returns |
 | [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |

--- a/src/rules/no_useless_return.zig
+++ b/src/rules/no_useless_return.zig
@@ -1,9 +1,10 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-useless-return";
 
@@ -18,14 +19,59 @@ pub fn check(
     if (statement.argument != .null) return;
     if (!isRedundantReturn(tree, index, ctx)) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Unnecessary return statement.",
-        tree.span(index),
-    );
+    const span = tree.span(index);
+    if (hasStatementListParent(tree, ctx) and !hasReturnComment(tree, span)) {
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary return statement.",
+            span,
+            .{ .span = span, .replacement = "" },
+        );
+    } else {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary return statement.",
+            span,
+        );
+    }
+}
+
+fn hasReturnComment(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < span.end and comment.span.end > span.start) return true;
+    }
+
+    const start: usize = @intCast(span.start);
+    const end: usize = @intCast(span.end);
+    if (start > end or end > tree.source.len) return true;
+    if (std.mem.indexOfScalar(u8, tree.source[start..end], ';') != null) return false;
+
+    for (tree.comments) |comment| {
+        if (comment.type != .line or comment.span.start < span.end) continue;
+        const comment_start: usize = @intCast(comment.span.start);
+        if (comment_start > tree.source.len) continue;
+        if (std.mem.indexOfScalar(u8, tree.source[end..comment_start], '\n') == null) return true;
+    }
+    return false;
+}
+
+fn hasStatementListParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    return switch (tree.data(parent)) {
+        .program,
+        .block_statement,
+        .function_body,
+        .static_block,
+        .switch_case,
+        => true,
+        else => false,
+    };
 }
 
 fn isRedundantReturn(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -157,3 +157,51 @@ test "can disable no-useless-return" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_useless_return.id));
 }
+
+test "autofixes redundant returns in statement lists" {
+    const source =
+        \\function first() { work(); return; }
+        \\function second(flag) { if (flag) { return; } }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\function first() { work();  }
+        \\function second(flag) { if (flag) {  } }
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_useless_return.id));
+}
+
+test "does not autofix non-list or commented redundant returns" {
+    const source =
+        \\function first(flag) { if (flag) return; }
+        \\function second() { return/**/; }
+        \\function third() { return// keep
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.no_useless_return.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_useless_return.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- remove redundant `return;` statements when they are direct members of statement lists
- keep diagnostics fixless for single-statement bodies where removal would change syntax
- preserve block and ASI line comments by withholding unsafe fixes
- document autofix support and add public API regression tests

## Why

Deleting a redundant return is safe only when the statement can disappear without leaving an invalid control-flow body and when no attached comment is lost.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -Doptimize=ReleaseFast -j1` (1701 tests)
- `zig build -Doptimize=ReleaseFast -j1`
