### PR TITLE
feat: autofix no-extra-bind

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -84,7 +84,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-eval`](https://eslint.org/docs/latest/rules/no-eval) | Supports `allowIndirect` configuration |
 | [`no-ex-assign`](https://eslint.org/docs/latest/rules/no-ex-assign) | Implemented |
 | [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Supports `exceptions` configuration |
-| [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented |
+| [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented with side-effect- and comment-safe autofix |
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented with multi-pass autofix for redundant references and label declarations |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |

--- a/src/rules/no_extra_bind.zig
+++ b/src/rules/no_extra_bind.zig
@@ -14,7 +14,8 @@ pub fn check(
     call: ast.CallExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    const callee_member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+    const member_index = unwrapTransparent(tree, call.callee);
+    const callee_member = switch (tree.data(member_index)) {
         .member_expression => |member| member,
         else => return,
     };
@@ -32,6 +33,19 @@ pub fn check(
     };
     if (!is_extra) return;
 
+    if (bindFixes(tree, call, index, callee_member, member_index)) |fixes| {
+        try core.addDiagnosticWithFixes(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "The function binding is unnecessary.",
+            tree.span(index),
+            &fixes,
+        );
+        return;
+    }
+
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -40,6 +54,67 @@ pub fn check(
         "The function binding is unnecessary.",
         tree.span(index),
     );
+}
+
+fn bindFixes(
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    call_index: ast.NodeIndex,
+    member: ast.MemberExpression,
+    member_index: ast.NodeIndex,
+) ?[2]core.Fix {
+    if (!argumentsCanBeDiscarded(tree, call.arguments)) return null;
+
+    const object_span = tree.span(member.object);
+    const member_span = tree.span(member_index);
+    const callee_span = tree.span(call.callee);
+    const call_span = tree.span(call_index);
+
+    if (object_span.end >= member_span.end or
+        member_span.end > callee_span.end or
+        callee_span.end >= call_span.end)
+    {
+        return null;
+    }
+    if (hasCommentBetween(tree, object_span.end, call_span.end)) return null;
+
+    return .{
+        .{
+            .span = .{ .start = object_span.end, .end = member_span.end },
+            .replacement = "",
+        },
+        .{
+            .span = .{ .start = callee_span.end, .end = call_span.end },
+            .replacement = "",
+        },
+    };
+}
+
+fn argumentsCanBeDiscarded(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    const arguments = tree.extra(range);
+    if (arguments.len == 0) return true;
+    if (arguments.len != 1) return false;
+
+    return switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+        .identifier_reference,
+        .this_expression,
+        .function,
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .regexp_literal,
+        => true,
+        else => false,
+    };
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < end and comment.span.end > start) return true;
+    }
+    return false;
 }
 
 fn functionUsesThis(tree: *const ast.Tree, function: ast.Function) bool {

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -114,3 +114,57 @@ test "can disable no-extra-bind" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_bind.id));
 }
+
+test "autofixes unnecessary bind calls without losing parentheses" {
+    const source =
+        \\const first = function () { return value; }.bind(context);
+        \\const second = (() => value)[`bind`](null);
+        \\const third = (function () { return value; }.bind)(undefined);
+        \\const fourth = (() => value)?.bind?.(this);
+        \\const fifth = function () { return value; }.bind();
+    ;
+    const expected =
+        \\const first = function () { return value; };
+        \\const second = (() => value);
+        \\const third = (function () { return value; });
+        \\const fourth = (() => value);
+        \\const fifth = function () { return value; };
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_extra_bind.id));
+}
+
+test "does not autofix bind calls with effects, spreads, or comments" {
+    const source =
+        \\const first = function () { return value; }.bind(getContext());
+        \\const second = (() => value).bind(...contexts);
+        \\const third = function () { return value; }./* keep */bind(context);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.no_extra_bind.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_extra_bind.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- remove unnecessary `.bind(...)` calls with a two-range atomic fix
- preserve parentheses around function expressions and wrapped member access
- withhold fixes for effectful or spread arguments and comment-bearing removal ranges
- document autofix support and add public API regression tests

## Why

Removing `.bind(...)` is safe only when discarding its argument cannot drop observable work and the edit does not erase comments. Separate removal ranges preserve syntax such as `(function () {}.bind)(context)`.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test -fno-incremental -Doptimize=ReleaseFast -j1`
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
