### PR TITLE
feat: autofix trailing spaces and final newlines

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -20,7 +20,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Supports `allowKeywords` and common `allowPattern` configuration |
-| [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration |
+| [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration with autofix |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, `includeCommonJSModuleExports`, and `considerPropertyDescriptor` configuration |
@@ -161,7 +161,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-ternary`](https://eslint.org/docs/latest/rules/no-ternary) | Implemented |
 | [`no-this-before-super`](https://eslint.org/docs/latest/rules/no-this-before-super) | Implemented |
 | [`no-throw-literal`](https://eslint.org/docs/latest/rules/no-throw-literal) | Implemented |
-| [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Supports `skipBlankLines` and `ignoreComments` configuration |
+| [`no-trailing-spaces`](https://eslint.org/docs/latest/rules/no-trailing-spaces) | Supports `skipBlankLines` and `ignoreComments` configuration with autofix |
 | [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) | Implemented |
 | [`no-undef-init`](https://eslint.org/docs/latest/rules/no-undef-init) | Implemented with safe autofix for `let` bindings |
 | [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars) | Reports read `let`/`var` bindings that have no initializer and no assignment |

--- a/src/rules/eol_last.zig
+++ b/src/rules/eol_last.zig
@@ -36,11 +36,29 @@ pub fn runWithOptions(
     switch (options.style) {
         .always => {
             if (source[source.len - 1] == '\n') return;
-            try addDiagnostic(allocator, diagnostics, source.len - 1, source.len, "Newline required at end of file but not found.");
+            try addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                source.len - 1,
+                source.len,
+                "Newline required at end of file but not found.",
+                source.len,
+                source.len,
+                "\n",
+            );
         },
         .never => {
             const span = finalLinebreakSpan(source) orelse return;
-            try addDiagnostic(allocator, diagnostics, span.start, span.end, "Newline not allowed at end of file.");
+            try addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                span.start,
+                span.end,
+                "Newline not allowed at end of file.",
+                span.start,
+                span.end,
+                "",
+            );
         },
     }
 }
@@ -62,19 +80,26 @@ fn finalLinebreakSpan(source: []const u8) ?Span {
     return null;
 }
 
-fn addDiagnostic(
+fn addDiagnosticWithFix(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     start: usize,
     end: usize,
     message: []const u8,
+    fix_start: usize,
+    fix_end: usize,
+    replacement: []const u8,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         message,
         .{ .start = @intCast(start), .end = @intCast(end) },
+        .{
+            .span = .{ .start = @intCast(fix_start), .end = @intCast(fix_end) },
+            .replacement = replacement,
+        },
     );
 }

--- a/src/rules/no_trailing_spaces.zig
+++ b/src/rules/no_trailing_spaces.zig
@@ -68,13 +68,17 @@ fn addDiagnostic(
     start: usize,
     end: usize,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Trailing spaces not allowed.",
         .{ .start = @intCast(start), .end = @intCast(end) },
+        .{
+            .span = .{ .start = @intCast(start), .end = @intCast(end) },
+            .replacement = "",
+        },
     );
 }
 

--- a/tests/autofix.zig
+++ b/tests/autofix.zig
@@ -66,6 +66,7 @@ test "lintSourceAndFix returns final diagnostics after applying fixes" {
     const source = "const value = 1;;;";
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .typescript_eslint_no_extra_semi = false,

--- a/tests/rules/eol_last.zig
+++ b/tests/rules/eol_last.zig
@@ -98,3 +98,50 @@ test "can disable eol-last" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.eol_last.id));
 }
+
+test "autofixes a missing final linebreak" {
+    var result = try lint.lintSourceAndFix(std.testing.allocator, "const value = 1;", "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = 1;\n", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.eol_last.id));
+}
+
+test "completes a final carriage return as CRLF" {
+    var result = try lint.lintSourceAndFix(std.testing.allocator, "const value = 1;\r", "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = 1;\r\n", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.eol_last.id));
+}
+
+test "autofixes a forbidden final CRLF" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("eol-last", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, "const value = 1;\r\n", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = 1;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.eol_last.id));
+}

--- a/tests/rules/no_extra_semi.zig
+++ b/tests/rules/no_extra_semi.zig
@@ -66,6 +66,7 @@ test "autofixes unnecessary semicolons" {
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .typescript_eslint_no_extra_semi = false,

--- a/tests/rules/no_floating_decimal.zig
+++ b/tests/rules/no_floating_decimal.zig
@@ -61,6 +61,7 @@ test "autofixes leading and trailing decimal points" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -83,6 +84,7 @@ test "autofix separates leading decimals from adjacent keywords" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,

--- a/tests/rules/no_regex_spaces.zig
+++ b/tests/rules/no_regex_spaces.zig
@@ -87,6 +87,7 @@ test "autofixes consecutive spaces in regex literals and constructors" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .prefer_regex_literals = false,
         .no_unused_vars = false,
         .no_undef = false,
@@ -110,6 +111,7 @@ test "autofix preserves the space consumed by a regex quantifier" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -131,6 +133,7 @@ test "does not autofix constructor patterns with escapes or dynamic flags" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .prefer_regex_literals = false,
         .no_unused_vars = false,
         .no_undef = false,

--- a/tests/rules/no_trailing_spaces.zig
+++ b/tests/rules/no_trailing_spaces.zig
@@ -76,3 +76,27 @@ test "can disable no-trailing-spaces" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_trailing_spaces.id));
 }
+
+test "autofixes trailing spaces without changing line endings" {
+    const source =
+        "const first = 1; \n" ++
+        "const second = 2;\t\r\n" ++
+        "  \n" ++
+        "const third = 3;\t";
+    const expected =
+        "const first = 1;\n" ++
+        "const second = 2;\r\n" ++
+        "\n" ++
+        "const third = 3;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_trailing_spaces.id));
+}

--- a/tests/rules/no_undef_init.zig
+++ b/tests/rules/no_undef_init.zig
@@ -62,6 +62,7 @@ test "autofixes undefined initializers for let bindings" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -85,6 +86,7 @@ test "does not report or autofix a shadowed undefined initializer" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -105,6 +107,7 @@ test "does not autofix undefined initializers when syntax must be preserved" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -94,6 +94,7 @@ test "autofixes same-name aliases" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -117,6 +118,7 @@ test "does not autofix aliases when replacement would discard comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,
@@ -137,6 +139,7 @@ test "autofixes parenthesized destructuring aliases to valid shorthand" {
     const source = "({ foo: (foo) } = source);";
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary

- delete whitespace reported by `no-trailing-spaces` while preserving LF and CRLF endings
- make `eol-last` append a missing newline or remove a forbidden final LF/CRLF
- isolate existing autofix tests from the newly fixable default `eol-last` rule
- document both rules as autofix-capable

## Why

Both diagnostics already identify deterministic byte ranges, so the fixes can be exact and semantics-free. Existing autofix tests now disable `eol-last` when their purpose is to verify another rule's output.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- full Zig test suite with a fresh cache (1707 tests)
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
