### PR TITLE
feat: autofix file whitespace rules

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -33,7 +33,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`id-length`](https://eslint.org/docs/latest/rules/id-length) | Supports `min`, `max`, `exceptions`, common `exceptionPatterns`, and `properties` for bindings, imports, functions, and class/object properties |
 | [`id-match`](https://eslint.org/docs/latest/rules/id-match) | Supports lightweight pattern matching for declarations and import aliases, with `properties`, `classFields`, `onlyDeclarations`, and `ignoreDestructuring` configuration |
 | [`init-declarations`](https://eslint.org/docs/latest/rules/init-declarations) | Supports `always`, `never`, and `ignoreForLoopInit` |
-| [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration |
+| [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration with autofix |
 | [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
 | [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
@@ -113,9 +113,9 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Supports `smart-tabs` configuration |
 | [`no-misleading-character-class`](https://eslint.org/docs/latest/rules/no-misleading-character-class) | Implemented |
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Supports `ignoreNonDeclaration` configuration and class field initializers |
-| [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Supports `ignoreEOLComments` and common `exceptions` configuration |
+| [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) | Supports `ignoreEOLComments` and common `exceptions` configuration with autofix |
 | [`no-multi-str`](https://eslint.org/docs/latest/rules/no-multi-str) | Implemented |
-| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max`, `maxBOF`, and `maxEOF` behavior |
+| [`no-multiple-empty-lines`](https://eslint.org/docs/latest/rules/no-multiple-empty-lines) | Implemented with optional `max`, `maxBOF`, and `maxEOF` behavior and autofix |
 | [`no-negated-condition`](https://eslint.org/docs/latest/rules/no-negated-condition) | Implemented |
 | [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) | Implemented |
 | [`no-new`](https://eslint.org/docs/latest/rules/no-new) | Implemented |
@@ -219,7 +219,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
 | [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
-| [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration |
+| [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration with autofix |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Supports `enforceForIndexOf` and `enforceForSwitchCase` configuration |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |

--- a/src/rules/linebreak_style.zig
+++ b/src/rules/linebreak_style.zig
@@ -35,13 +35,15 @@ pub fn runWithOptions(
 
     while (findLinebreak(source, index)) |linebreak| {
         if (!linebreakMatchesStyle(linebreak, options.style)) {
-            try core.addDiagnostic(
+            const span: ast.Span = .{ .start = @intCast(linebreak.start), .end = @intCast(linebreak.end) };
+            try core.addDiagnosticWithFix(
                 allocator,
                 diagnostics,
                 .warning,
                 id,
                 messageForStyle(options.style),
-                .{ .start = @intCast(linebreak.start), .end = @intCast(linebreak.end) },
+                span,
+                .{ .span = span, .replacement = linebreakForStyle(options.style) },
             );
         }
 
@@ -82,5 +84,12 @@ fn messageForStyle(style: Style) []const u8 {
     return switch (style) {
         .unix => "Expected linebreaks to be 'LF' but found 'CRLF'.",
         .windows => "Expected linebreaks to be 'CRLF' but found 'LF'.",
+    };
+}
+
+fn linebreakForStyle(style: Style) []const u8 {
+    return switch (style) {
+        .unix => "\n",
+        .windows => "\r\n",
     };
 }

--- a/src/rules/no_multi_spaces.zig
+++ b/src/rules/no_multi_spaces.zig
@@ -90,13 +90,15 @@ fn checkLine(
         if (index - start > 1) {
             if (options.ignore_eol_comments == .yes and isBeforeEndOfLineComment(tree, index, line_end)) continue;
 
-            try core.addDiagnostic(
+            const span: ast.Span = .{ .start = @intCast(start), .end = @intCast(index) };
+            try core.addDiagnosticWithFix(
                 allocator,
                 diagnostics,
                 .warning,
                 id,
                 "Multiple spaces found before.",
-                .{ .start = @intCast(start), .end = @intCast(index) },
+                span,
+                .{ .span = span, .replacement = " " },
             );
         }
     }

--- a/src/rules/no_multiple_empty_lines.zig
+++ b/src/rules/no_multiple_empty_lines.zig
@@ -43,14 +43,13 @@ pub fn runWithOptions(
             else
                 options.max;
             if (empty_lines > max) {
-                try core.addDiagnosticFmt(
+                try addDiagnosticWithFix(
                     allocator,
                     diagnostics,
-                    .warning,
-                    id,
-                    .{ .start = @intCast(line_start), .end = @intCast(line_end) },
-                    "More than {d} blank lines not allowed.",
-                    .{max},
+                    line_start,
+                    line_end,
+                    nextLineStart(source, line_end),
+                    max,
                 );
             }
         } else {
@@ -59,11 +58,41 @@ pub fn runWithOptions(
 
         if (line_end >= source.len) break;
 
-        line_start = line_end + 1;
-        if (source[line_end] == '\r' and line_start < source.len and source[line_start] == '\n') {
-            line_start += 1;
-        }
+        line_start = nextLineStart(source, line_end);
     }
+}
+
+fn addDiagnosticWithFix(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    line_start: usize,
+    line_end: usize,
+    removal_end: usize,
+    max: usize,
+) Allocator.Error!void {
+    const message = try std.fmt.allocPrint(allocator, "More than {d} blank lines not allowed.", .{max});
+    defer allocator.free(message);
+
+    try core.addDiagnosticWithFix(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        .{ .start = @intCast(line_start), .end = @intCast(line_end) },
+        .{
+            .span = .{ .start = @intCast(line_start), .end = @intCast(removal_end) },
+            .replacement = "",
+        },
+    );
+}
+
+fn nextLineStart(source: []const u8, line_end: usize) usize {
+    if (line_end >= source.len) return source.len;
+
+    var start = line_end + 1;
+    if (source[line_end] == '\r' and start < source.len and source[start] == '\n') start += 1;
+    return start;
 }
 
 fn isLeadingEmptyLine(source: []const u8, line_start: usize) bool {

--- a/src/rules/unicode_bom.zig
+++ b/src/rules/unicode_bom.zig
@@ -36,28 +36,27 @@ pub fn runWithOptions(
     switch (options.style) {
         .never => {
             if (!has_bom) return;
-            try addDiagnostic(allocator, diagnostics, 0, bom.len, "Unexpected Unicode BOM (Byte Order Mark).");
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unexpected Unicode BOM (Byte Order Mark).",
+                .{ .start = 0, .end = bom.len },
+                .{ .span = .{ .start = 0, .end = bom.len }, .replacement = "" },
+            );
         },
         .always => {
             if (has_bom) return;
-            try addDiagnostic(allocator, diagnostics, 0, @min(tree.source.len, 1), "Expected Unicode BOM (Byte Order Mark).");
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Expected Unicode BOM (Byte Order Mark).",
+                .{ .start = 0, .end = @intCast(@min(tree.source.len, 1)) },
+                .{ .span = .{ .start = 0, .end = 0 }, .replacement = bom },
+            );
         },
     }
-}
-
-fn addDiagnostic(
-    allocator: Allocator,
-    diagnostics: *core.DiagnosticList,
-    start: usize,
-    end: usize,
-    message: []const u8,
-) Allocator.Error!void {
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        message,
-        .{ .start = @intCast(start), .end = @intCast(end) },
-    );
 }

--- a/tests/rules/eol_last.zig
+++ b/tests/rules/eol_last.zig
@@ -113,6 +113,7 @@ test "autofixes a missing final linebreak" {
 
 test "completes a final carriage return as CRLF" {
     var result = try lint.lintSourceAndFix(std.testing.allocator, "const value = 1;\r", "fixture.js", .{
+        .linebreak_style = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/linebreak_style.zig
+++ b/tests/rules/linebreak_style.zig
@@ -76,3 +76,54 @@ test "can disable linebreak-style" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.linebreak_style.id));
 }
+
+test "autofixes CRLF linebreaks to Unix LF" {
+    const source =
+        "const first = 1;\r\n" ++
+        "const second = 2;\r\n";
+    const expected =
+        "const first = 1;\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.linebreak_style.id));
+}
+
+test "autofixes LF linebreaks to Windows CRLF" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"windows\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("linebreak-style", config.value);
+
+    const source =
+        "const first = 1;\n" ++
+        "const second = 2;\r\n" ++
+        "const third = 3;\n";
+    const expected =
+        "const first = 1;\r\n" ++
+        "const second = 2;\r\n" ++
+        "const third = 3;\r\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.linebreak_style.id));
+}

--- a/tests/rules/no_multi_spaces.zig
+++ b/tests/rules/no_multi_spaces.zig
@@ -171,3 +171,26 @@ test "can disable no-multi-spaces" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multi_spaces.id));
 }
+
+test "autofixes reported runs of multiple spaces" {
+    const source =
+        "const first =  1;\n" ++
+        "if (foo   === bar) {}\n" ++
+        "const second = 2;  // comment\n";
+    const expected =
+        "const first = 1;\n" ++
+        "if (foo === bar) {}\n" ++
+        "const second = 2; // comment\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_inline_comments = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_multi_spaces.id));
+}

--- a/tests/rules/no_multiple_empty_lines.zig
+++ b/tests/rules/no_multiple_empty_lines.zig
@@ -143,3 +143,50 @@ test "can disable no-multiple-empty-lines" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_multiple_empty_lines.id));
 }
+
+test "autofixes excess blank lines between statements" {
+    const source =
+        "const first = 1;\n" ++
+        "\n" ++
+        "\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+    const expected =
+        "const first = 1;\n" ++
+        "\n" ++
+        "\n" ++
+        "const second = 2;\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_multiple_empty_lines.id));
+}
+
+test "autofixes CRLF blank lines at the beginning and end of a file" {
+    const source =
+        "\r\n" ++
+        "\r\n" ++
+        "const value = 1;\r\n" ++
+        "\r\n" ++
+        "\r\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .linebreak_style_style = .windows,
+        .no_multiple_empty_lines_max_bof = 0,
+        .no_multiple_empty_lines_max_eof = 0,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = 1;\r\n", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_multiple_empty_lines.id));
+}

--- a/tests/rules/no_trailing_spaces.zig
+++ b/tests/rules/no_trailing_spaces.zig
@@ -91,6 +91,7 @@ test "autofixes trailing spaces without changing line endings" {
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
+        .linebreak_style = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -166,6 +166,7 @@ test "autofixes redundant returns in statement lists" {
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
+        .no_multi_spaces = false,
         .no_undef = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,

--- a/tests/rules/unicode_bom.zig
+++ b/tests/rules/unicode_bom.zig
@@ -88,3 +88,40 @@ test "can disable unicode-bom" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.unicode_bom.id));
 }
+
+test "autofixes a forbidden Unicode BOM" {
+    const source = "\xEF\xBB\xBFconst value = 1;\n";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = 1;\n", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.unicode_bom.id));
+}
+
+test "autofixes a missing required Unicode BOM" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("unicode-bom", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, "const value = 1;\n", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("\xEF\xBB\xBFconst value = 1;\n", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.unicode_bom.id));
+}


### PR DESCRIPTION
## Summary

- add bidirectional autofix for `unicode-bom` (`always` and `never`)
- normalize `linebreak-style` violations to LF or CRLF
- collapse reported `no-multi-spaces` ranges to one space
- remove complete excess lines for `no-multiple-empty-lines`, including BOF, EOF, and CRLF cases
- isolate older autofix tests from newly fixable layout rules

## Why

These four layout rules already identify deterministic byte ranges. Attaching whitespace-only fixes makes `--fix`, `--fix-dry-run`, and `lintSourceAndFix` useful for file-wide normalization without changing JavaScript semantics.

## Developer impact

Configured files can now be normalized for BOM presence, line-ending style, repeated spaces, and excess blank lines in the same multi-pass autofix run. Existing ignore and exception options continue to control whether diagnostics—and therefore fixes—are emitted.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- complete test suite: 1714 tests passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
