### PR TITLE
feat: autofix comments and constructor parens

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -43,7 +43,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`max-params`](https://eslint.org/docs/latest/rules/max-params) | Supports `max`, deprecated `maximum`, and `countThis` configuration |
 | [`max-statements`](https://eslint.org/docs/latest/rules/max-statements) | Supports `max`, deprecated `maximum`, `ignoreTopLevelFunctions`, and static block isolation |
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
-| [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented |
+| [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented with nested-expression-safe autofix |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |
 | [`no-array-constructor`](https://eslint.org/docs/latest/rules/no-array-constructor) | Implemented |
 | [`no-async-promise-executor`](https://eslint.org/docs/latest/rules/no-async-promise-executor) | Implemented |
@@ -216,7 +216,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) | Supports declaration/member sorting, `ignoreCase`, `ignoreDeclarationSort`, `ignoreMemberSort`, `allowSeparatedGroups`, and `memberSyntaxSortOrder` |
 | [`sort-keys`](https://eslint.org/docs/latest/rules/sort-keys) | Supports object literal key ordering with `asc`/`desc`, `caseSensitive`, `natural`, `minKeys`, and `allowLineSeparatedGroups` |
 | [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting and `ignoreCase` configuration |
-| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration |
+| [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration with safe autofix |
 | [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration with autofix |

--- a/src/rules/new_parens.zig
+++ b/src/rules/new_parens.zig
@@ -14,20 +14,24 @@ pub fn check(
     index: ast.NodeIndex,
 ) Allocator.Error!void {
     if (expression.arguments.len != 0) return;
-    if (hasTrailingParen(tree, index)) return;
+    if (hasOwnParens(tree, index, expression.callee)) return;
 
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Missing '()' invoking a constructor.",
-        tree.span(index),
+        span,
+        .{ .span = .{ .start = span.end, .end = span.end }, .replacement = "()" },
     );
 }
 
-fn hasTrailingParen(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn hasOwnParens(tree: *const ast.Tree, index: ast.NodeIndex, callee_index: ast.NodeIndex) bool {
     const span = tree.span(index);
+    if (tree.span(callee_index).end >= span.end) return false;
+
     const start: usize = @intCast(span.start);
     const end: usize = @intCast(span.end);
     if (start >= end or end > tree.source.len) return false;

--- a/src/rules/spaced_comment.zig
+++ b/src/rules/spaced_comment.zig
@@ -35,15 +35,52 @@ pub fn runWithOptions(
     for (tree.comments) |comment| {
         if (hasExpectedSpacing(tree, comment, options)) continue;
 
+        const diagnostic_span: ast.Span = .{ .start = comment.span.start, .end = comment.span.end };
+        if (fixForComment(tree, comment, options)) |fix| {
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                message(options.style),
+                diagnostic_span,
+                fix,
+            );
+            continue;
+        }
+
         try core.addDiagnostic(
             allocator,
             diagnostics,
             .warning,
             id,
             message(options.style),
-            .{ .start = comment.span.start, .end = comment.span.end },
+            diagnostic_span,
         );
     }
+}
+
+fn fixForComment(tree: *const ast.Tree, comment: ast.Comment, options: Options) ?core.Fix {
+    const value = tree.string(comment.value);
+    const spacing_index = spacingIndex(value, comment.type);
+    const spacing_start = comment.span.start + 2 + @as(u32, @intCast(spacing_index));
+
+    if (options.style == .always) {
+        if (spacing_start > comment.span.end) return null;
+        return .{ .span = .{ .start = spacing_start, .end = spacing_start }, .replacement = " " };
+    }
+    if (spacing_index >= value.len or !isSpaceOrTab(value[spacing_index])) return null;
+
+    var spacing_end = spacing_index + 1;
+    while (spacing_end < value.len and isSpaceOrTab(value[spacing_end])) : (spacing_end += 1) {}
+
+    return .{
+        .span = .{
+            .start = spacing_start,
+            .end = comment.span.start + 2 + @as(u32, @intCast(spacing_end)),
+        },
+        .replacement = "",
+    };
 }
 
 fn hasExpectedSpacing(tree: *const ast.Tree, comment: ast.Comment, options: Options) bool {
@@ -93,4 +130,8 @@ fn matchesRepeatedException(value: []const u8, exception: []const u8) bool {
 
 fn isWhitespace(char: u8) bool {
     return char == ' ' or char == '\t' or char == '\r' or char == '\n';
+}
+
+fn isSpaceOrTab(char: u8) bool {
+    return char == ' ' or char == '\t';
 }

--- a/tests/rules/new_parens.zig
+++ b/tests/rules/new_parens.zig
@@ -49,3 +49,40 @@ test "can disable new-parens" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.new_parens.id));
 }
+
+test "autofixes constructors missing parentheses" {
+    const source =
+        \\const first = new Widget;
+        \\const second = new namespace.Widget;
+    ;
+    const expected =
+        \\const first = new Widget();
+        \\const second = new namespace.Widget();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.new_parens.id));
+}
+
+test "autofixes each constructor in a nested new expression" {
+    const source = "const value = new new Widget;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = new new Widget()();", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.new_parens.id));
+}

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -141,3 +141,80 @@ test "can disable spaced-comment" {
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.spaced_comment.id));
 }
+
+test "autofixes missing spaces after comment markers" {
+    const source =
+        \\//line comment
+        \\/*block comment */
+        \\/**jsdoc comment */
+        \\const value = 1; //inline comment
+    ;
+    const expected =
+        \\// line comment
+        \\/* block comment */
+        \\/** jsdoc comment */
+        \\const value = 1; // inline comment
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_inline_comments = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.spaced_comment.id));
+}
+
+test "autofixes spaces and tabs disallowed after comment markers" {
+    const source =
+        "//   line comment\n" ++
+        "/*\tblock comment */\n" ++
+        "/**  jsdoc comment */";
+    const expected =
+        "//line comment\n" ++
+        "/*block comment */\n" ++
+        "/**jsdoc comment */";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .spaced_comment_style = .never,
+        .no_inline_comments = false,
+        .no_tabs = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.spaced_comment.id));
+}
+
+test "does not autofix a disallowed newline after a block comment marker" {
+    const source =
+        \\/*
+        \\line comment */
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .spaced_comment_style = .never,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.spaced_comment.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.spaced_comment.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add safe `always` and `never` autofixes for `spaced-comment`
- preserve multi-line block comments by withholding fixes when removing a newline would join lines
- add autofix for missing empty constructor parentheses in `new-parens`
- distinguish a nested constructor's own parentheses from its callee's parentheses
- document both autofix capabilities and add public API regression coverage

## Why

Both rules already report deterministic syntax locations. Comment spacing can be changed with a single insertion or a bounded space/tab deletion, while constructor parentheses can be inserted at the end of the exact `new` expression.

## Developer impact

`--fix`, `--fix-dry-run`, and `lintSourceAndFix` now normalize supported comment markers and no-argument constructor calls. Nested expressions such as `new new Widget` converge safely over multiple fix passes.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- complete test suite: 1719 tests passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
