### PR TITLE
feat: autofix dot notation

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -19,7 +19,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
-| [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Supports `allowKeywords` and common `allowPattern` configuration |
+| [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Supports autofix plus `allowKeywords` and common `allowPattern` configuration |
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration with autofix |
 | [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
@@ -335,7 +335,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/) | Implemented for `fields` and `getters` configurations |
 | [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/) | Supports `assertionStyle` plus object/array literal assertion modes |
 | [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) | Implemented for `interface` and `type` configurations |
-| [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented |
+| [`@typescript-eslint/dot-notation`](https://typescript-eslint.io/rules/dot-notation/) | Implemented with autofix through the core rule |
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Supports `accessibility: "no-public"`, `"explicit"`, and `"off"` |
 | [`@typescript-eslint/member-ordering`](https://typescript-eslint.io/rules/member-ordering/) | Implemented for fishlint's default class member ordering |
 | [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |

--- a/src/rules/dot_notation.zig
+++ b/src/rules/dot_notation.zig
@@ -39,15 +39,90 @@ pub fn checkWithOptions(
     if (!options.allow_keywords and isKeyword(property_name)) return;
     if (isAllowedByPattern(property_name, options.allow_pattern)) return;
 
-    try core.addDiagnosticFmt(
+    const span = tree.span(index);
+    const message = try std.fmt.allocPrint(allocator, "['{s}'] is better written in dot notation.", .{property_name});
+    defer allocator.free(message);
+
+    if (wouldDiscardComment(tree, member, span)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            options.severity,
+            options.rule_id,
+            message,
+            span,
+        );
+        return;
+    }
+
+    const prefix = if (member.optional)
+        "?."
+    else if (isDecimalIntegerObject(tree, member.object))
+        " ."
+    else
+        ".";
+    const trailing_space = span.end < tree.source.len and isIdentifierPart(tree.source[span.end]);
+    const replacement = try std.fmt.allocPrint(
+        allocator,
+        "{s}{s}{s}",
+        .{ prefix, property_name, if (trailing_space) " " else "" },
+    );
+    defer allocator.free(replacement);
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         options.severity,
         options.rule_id,
-        tree.span(index),
-        "['{s}'] is better written in dot notation.",
-        .{property_name},
+        message,
+        span,
+        .{
+            .span = .{ .start = tree.span(member.object).end, .end = span.end },
+            .replacement = replacement,
+        },
     );
+}
+
+fn wouldDiscardComment(tree: *const ast.Tree, member: ast.MemberExpression, span: ast.Span) bool {
+    const replaced_start = tree.span(member.object).end;
+    for (tree.comments) |comment| {
+        if (comment.span.start >= replaced_start and comment.span.end <= span.end) return true;
+    }
+    return false;
+}
+
+fn isDecimalIntegerObject(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const literal = switch (tree.data(index)) {
+        .numeric_literal => |literal| literal,
+        else => return false,
+    };
+    if (literal.kind != .decimal) return false;
+
+    const raw = tree.string(literal.raw);
+    if (std.mem.eql(u8, raw, "0")) return true;
+    if (raw.len == 0 or !std.ascii.isDigit(raw[0])) return false;
+
+    if (raw[0] == '0') {
+        var seen_non_octal_digit = false;
+        for (raw[1..]) |char| {
+            if (!std.ascii.isDigit(char)) return false;
+            if (char == '8' or char == '9') seen_non_octal_digit = true;
+        }
+        return seen_non_octal_digit;
+    }
+
+    if (raw[0] < '1' or raw[0] > '9') return false;
+    var previous_underscore = false;
+    for (raw[1..]) |char| {
+        if (char == '_') {
+            if (previous_underscore) return false;
+            previous_underscore = true;
+            continue;
+        }
+        if (!std.ascii.isDigit(char)) return false;
+        previous_underscore = false;
+    }
+    return !previous_underscore;
 }
 
 fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -145,6 +145,60 @@ test "supports common dot-notation allowPattern forms" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.dot_notation.id));
 }
 
+test "autofixes computed properties without changing token boundaries" {
+    const source =
+        \\object["property"];
+        \\object[`template`];
+        \\object?.["optional"];
+        \\1["toString"];
+        \\object["property"]in other;
+    ;
+    const expected =
+        \\object.property;
+        \\object.template;
+        \\object?.optional;
+        \\1 .toString;
+        \\object.property in other;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.dot_notation.id));
+}
+
+test "does not autofix computed properties when comments would be discarded" {
+    const source =
+        \\object[/* keep */ "property"];
+        \\object["property" /* keep */];
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.dot_notation.id));
+}
+
 test "can disable dot-notation" {
     const source =
         \\object["property"];

--- a/tests/rules/typescript_eslint_dot_notation.zig
+++ b/tests/rules/typescript_eslint_dot_notation.zig
@@ -79,6 +79,24 @@ test "allows keyword properties for @typescript-eslint/dot-notation when allowKe
     );
 }
 
+test "autofixes @typescript-eslint/dot-notation diagnostics" {
+    const source = "object[\"property\"];";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("object.property;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.typescript_eslint_dot_notation.id));
+}
+
 test "can disable @typescript-eslint/dot-notation and fall back to core rule" {
     const source =
         \\object["property"];


### PR DESCRIPTION
## Summary

- add safe autofix for computed string and static-template properties in `dot-notation`
- preserve optional chaining and required token spacing around decimal integers and adjacent keywords
- withhold fixes when replacing bracket access would discard comments
- cover the shared `@typescript-eslint/dot-notation` path and document both capabilities

## Why

The rule already identifies static property names that are valid identifiers. Replacing the computed-access suffix is deterministic once optional-chain syntax, decimal-integer ambiguity, adjacent tokens, and comments are handled explicitly.

## Developer impact

`--fix`, `--fix-dry-run`, and `lintSourceAndFix` now convert supported bracket access such as `object["property"]` to `object.property`. Commented bracket access remains diagnostic-only.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- complete test suite: 1722 tests passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`