### PR TITLE
feat: autofix array constructors

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -45,7 +45,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`new-cap`](https://eslint.org/docs/latest/rules/new-cap) | Supports `newIsCap`, `capIsNew`, `properties`, exception names, and exception patterns |
 | [`new-parens`](https://eslint.org/docs/latest/rules/new-parens) | Implemented with nested-expression-safe autofix |
 | [`no-alert`](https://eslint.org/docs/latest/rules/no-alert) | Implemented with global `this`, `window`, and `globalThis` detection |
-| [`no-array-constructor`](https://eslint.org/docs/latest/rules/no-array-constructor) | Implemented |
+| [`no-array-constructor`](https://eslint.org/docs/latest/rules/no-array-constructor) | Implemented with argument-preserving, ASI-safe autofix |
 | [`no-async-promise-executor`](https://eslint.org/docs/latest/rules/no-async-promise-executor) | Implemented |
 | [`no-await-in-loop`](https://eslint.org/docs/latest/rules/no-await-in-loop) | Implemented |
 | [`no-bitwise`](https://eslint.org/docs/latest/rules/no-bitwise) | Implemented |
@@ -339,7 +339,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/explicit-member-accessibility`](https://typescript-eslint.io/rules/explicit-member-accessibility/) | Supports `accessibility: "no-public"`, `"explicit"`, and `"off"` |
 | [`@typescript-eslint/member-ordering`](https://typescript-eslint.io/rules/member-ordering/) | Implemented for fishlint's default class member ordering |
 | [`@typescript-eslint/method-signature-style`](https://typescript-eslint.io/rules/method-signature-style/) | Implemented for fishlint's `property` configuration |
-| [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented |
+| [`@typescript-eslint/no-array-constructor`](https://typescript-eslint.io/rules/no-array-constructor/) | Implemented with argument-preserving, ASI-safe autofix |
 | [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/) | Implemented |
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Supports base `allow` kinds plus `private-constructors`, `protected-constructors`, `decoratedFunctions`, and `overrideMethods` configuration |

--- a/src/rules/array_constructor_fix.zig
+++ b/src/rules/array_constructor_fix.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const Policy = struct {
+    allow_optional: bool = false,
+    minimum_non_spread_when_nonempty: usize = 2,
+};
+
+pub fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    callee: ast.NodeIndex,
+    arguments: ast.IndexRange,
+    optional: bool,
+    prefix_semicolon: bool,
+    policy: Policy,
+    severity: core.Severity,
+    rule_id: []const u8,
+    message: []const u8,
+) Allocator.Error!void {
+    const span = tree.span(index);
+    if (!canAutofix(tree, span, callee, arguments, optional, policy)) {
+        try core.addDiagnostic(allocator, diagnostics, severity, rule_id, message, span);
+        return;
+    }
+
+    const arguments_text = argumentsText(tree, span, callee);
+    const replacement = try std.fmt.allocPrint(
+        allocator,
+        "{s}[{s}]",
+        .{ if (prefix_semicolon) ";" else "", arguments_text },
+    );
+    defer allocator.free(replacement);
+
+    try core.addDiagnosticWithFix(
+        allocator,
+        diagnostics,
+        severity,
+        rule_id,
+        message,
+        span,
+        .{ .span = span, .replacement = replacement },
+    );
+}
+
+pub fn needsAsiGuard(tree: *const ast.Tree, index: ast.NodeIndex, path: anytype) bool {
+    const start = tree.span(index).start;
+    var depth: usize = 1;
+
+    while (path.ancestor(depth)) |ancestor_index| : (depth += 1) {
+        if (tree.span(ancestor_index).start != start) return false;
+        if (tree.data(ancestor_index) != .expression_statement) continue;
+
+        const parent_index = path.ancestor(depth + 1) orelse return false;
+        if (!isStatementList(tree, parent_index)) return false;
+        return needsGuardAfterPreviousToken(tree, start);
+    }
+
+    return false;
+}
+
+fn canAutofix(
+    tree: *const ast.Tree,
+    span: ast.Span,
+    callee: ast.NodeIndex,
+    arguments: ast.IndexRange,
+    optional: bool,
+    policy: Policy,
+) bool {
+    if (optional and !policy.allow_optional) return false;
+    if (arguments.len > 0 and nonSpreadCount(tree, arguments) < policy.minimum_non_spread_when_nonempty) return false;
+
+    const opening_parenthesis = openingParenthesis(tree, span, callee);
+    const header_end = opening_parenthesis orelse span.end;
+    for (tree.comments) |comment| {
+        if (comment.span.start >= span.start and comment.span.end <= header_end) return false;
+    }
+
+    return true;
+}
+
+fn nonSpreadCount(tree: *const ast.Tree, arguments: ast.IndexRange) usize {
+    var count: usize = 0;
+    for (tree.extra(arguments)) |argument| {
+        if (tree.data(argument) != .spread_element) count += 1;
+    }
+    return count;
+}
+
+fn argumentsText(tree: *const ast.Tree, span: ast.Span, callee: ast.NodeIndex) []const u8 {
+    if (span.end == 0 or tree.source[span.end - 1] != ')') return "";
+    const opening = openingParenthesis(tree, span, callee) orelse return "";
+    return tree.source[opening + 1 .. span.end - 1];
+}
+
+fn openingParenthesis(tree: *const ast.Tree, span: ast.Span, callee: ast.NodeIndex) ?u32 {
+    const search_start = tree.span(callee).end;
+    if (search_start >= span.end) return null;
+    const offset = std.mem.indexOfScalar(u8, tree.source[search_start..span.end], '(') orelse return null;
+    return search_start + @as(u32, @intCast(offset));
+}
+
+fn isStatementList(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .program,
+        .function_body,
+        .block_statement,
+        .static_block,
+        .switch_case,
+        => true,
+        else => false,
+    };
+}
+
+fn needsGuardAfterPreviousToken(tree: *const ast.Tree, start: u32) bool {
+    const previous = previousSignificantByte(tree, start) orelse return false;
+    const char = tree.source[previous];
+    if (char == ';' or char == '{' or char == ':') return false;
+
+    if (previous > 0) {
+        const pair = tree.source[previous - 1 .. previous + 1];
+        if (std.mem.eql(u8, pair, "++") or
+            std.mem.eql(u8, pair, "--") or
+            std.mem.eql(u8, pair, "=>")) return false;
+    }
+
+    return true;
+}
+
+fn previousSignificantByte(tree: *const ast.Tree, start: u32) ?usize {
+    var cursor: usize = start;
+
+    while (cursor > 0) {
+        while (cursor > 0 and std.ascii.isWhitespace(tree.source[cursor - 1])) cursor -= 1;
+        if (cursor == 0) return null;
+
+        var skipped_comment = false;
+        for (tree.comments) |comment| {
+            if (comment.span.end != cursor) continue;
+            cursor = comment.span.start;
+            skipped_comment = true;
+            break;
+        }
+        if (skipped_comment) continue;
+
+        return cursor - 1;
+    }
+
+    return null;
+}

--- a/src/rules/no_array_constructor.zig
+++ b/src/rules/no_array_constructor.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const array_constructor_fix = @import("array_constructor_fix.zig");
 const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
@@ -34,8 +35,8 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isDisallowedArrayConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments)) {
-            try addDiagnostic(self, ctx.tree, index);
+        if (expression.type_arguments == .null and isDisallowedArrayConstructor(ctx.tree, self.symbol_table, expression.callee, expression.arguments)) {
+            try addDiagnostic(self, ctx.tree, index, expression.callee, expression.arguments, false, &ctx.path);
         }
 
         return .proceed;
@@ -47,21 +48,35 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isDisallowedArrayConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments)) {
-            try addDiagnostic(self, ctx.tree, index);
+        if (call.type_arguments == .null and isDisallowedArrayConstructor(ctx.tree, self.symbol_table, call.callee, call.arguments)) {
+            try addDiagnostic(self, ctx.tree, index, call.callee, call.arguments, call.optional, &ctx.path);
         }
 
         return .proceed;
     }
 
-    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
-        try core.addDiagnostic(
+    fn addDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        callee: ast.NodeIndex,
+        arguments: ast.IndexRange,
+        optional: bool,
+        path: anytype,
+    ) Allocator.Error!void {
+        try array_constructor_fix.addDiagnostic(
             self.allocator,
             self.diagnostics,
+            tree,
+            index,
+            callee,
+            arguments,
+            optional,
+            array_constructor_fix.needsAsiGuard(tree, index, path),
+            .{},
             .warning,
             id,
             "Use an array literal instead of the Array constructor.",
-            tree.span(index),
         );
     }
 };

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3457,7 +3457,7 @@ const BasicVisitor = struct {
             try typescript_eslint_no_extra_non_null_assertion.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
         if (self.options.typescript_eslint_no_array_constructor) {
-            try typescript_eslint_no_array_constructor.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index);
+            try typescript_eslint_no_array_constructor.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call, index, ctx);
         }
         if (self.options.complexity) {
             complexity.countCallExpression(&self.complexity_state, call);
@@ -3506,7 +3506,7 @@ const BasicVisitor = struct {
             try new_parens.check(self.allocator, self.diagnostics, ctx.tree, expression, index);
         }
         if (self.options.typescript_eslint_no_array_constructor) {
-            try typescript_eslint_no_array_constructor.checkNewExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try typescript_eslint_no_array_constructor.checkNewExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_array_constructor.zig
+++ b/src/rules/typescript_eslint_no_array_constructor.zig
@@ -3,6 +3,8 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const array_constructor_fix = @import("array_constructor_fix.zig");
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "@typescript-eslint/no-array-constructor";
@@ -13,12 +15,13 @@ pub fn checkCallExpression(
     tree: *const ast.Tree,
     call: ast.CallExpression,
     index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
     if (call.arguments.len == 1) return;
     if (call.type_arguments != .null) return;
     if (!isArrayIdentifier(tree, call.callee)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, call.callee, call.arguments, call.optional, &ctx.path);
 }
 
 pub fn checkNewExpression(
@@ -27,12 +30,13 @@ pub fn checkNewExpression(
     tree: *const ast.Tree,
     expression: ast.NewExpression,
     index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
     if (expression.arguments.len == 1) return;
     if (expression.type_arguments != .null) return;
     if (!isArrayIdentifier(tree, expression.callee)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, expression.callee, expression.arguments, false, &ctx.path);
 }
 
 fn addDiagnostic(
@@ -40,14 +44,27 @@ fn addDiagnostic(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     index: ast.NodeIndex,
+    callee: ast.NodeIndex,
+    arguments: ast.IndexRange,
+    optional: bool,
+    path: anytype,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    try array_constructor_fix.addDiagnostic(
         allocator,
         diagnostics,
+        tree,
+        index,
+        callee,
+        arguments,
+        optional,
+        array_constructor_fix.needsAsiGuard(tree, index, path),
+        .{
+            .allow_optional = true,
+            .minimum_non_spread_when_nonempty = 0,
+        },
         .@"error",
         id,
         "The array literal notation [] is preferable.",
-        tree.span(index),
     );
 }
 

--- a/tests/rules/no_array_constructor.zig
+++ b/tests/rules/no_array_constructor.zig
@@ -45,6 +45,96 @@ test "does not report no-array-constructor for single non-spread argument or sha
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_array_constructor.id));
 }
 
+test "autofixes Array constructors while preserving argument text" {
+    const source =
+        \\const a = Array();
+        \\const b = new Array();
+        \\const c = Array(1, 2);
+        \\const d = new Array("a", "b");
+        \\const e = Array(first, ...rest, last);
+        \\const f = Array(1, /* keep */ 2);
+    ;
+    const expected =
+        \\const a = [];
+        \\const b = [];
+        \\const c = [1, 2];
+        \\const d = ["a", "b"];
+        \\const e = [first, ...rest, last];
+        \\const f = [1, /* keep */ 2];
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_console = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_array_constructor.id));
+}
+
+test "does not autofix Array constructors with unsafe call or comment boundaries" {
+    const source =
+        \\Array?.();
+        \\Array(...items);
+        \\Array(...items, last);
+        \\new /* keep */ Array(1, 2);
+        \\Array /* keep */ (1, 2);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_console = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result.result, lint.rules.no_array_constructor.id));
+}
+
+test "autofix inserts an ASI guard only in statement lists" {
+    const source =
+        \\previous()
+        \\Array()
+        \\if (condition)
+        \\  Array()
+    ;
+    const expected =
+        \\previous()
+        \\;[]
+        \\if (condition)
+        \\  []
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_console = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .typescript_eslint_no_array_constructor = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_array_constructor.id));
+}
+
 test "can disable no-array-constructor" {
     const source =
         \\const a = Array();

--- a/tests/rules/typescript_eslint_no_array_constructor.zig
+++ b/tests/rules/typescript_eslint_no_array_constructor.zig
@@ -52,6 +52,60 @@ test "does not report @typescript-eslint/no-array-constructor for single argumen
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_array_constructor.id));
 }
 
+test "autofixes @typescript-eslint/no-array-constructor diagnostics" {
+    const source =
+        \\const a = Array();
+        \\const b = new Array(1, 2);
+        \\Array?.();
+    ;
+    const expected =
+        \\const a = [];
+        \\const b = [1, 2];
+        \\[];
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.typescript_eslint_no_array_constructor.id));
+}
+
+test "typescript autofix preserves ASI and constructor header comments" {
+    const source =
+        \\previous()
+        \\Array()
+        \\new /* keep */ Array(1, 2)
+    ;
+    const expected =
+        \\previous()
+        \\;[]
+        \\new /* keep */ Array(1, 2)
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_unused_expressions = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.typescript_eslint_no_array_constructor.id));
+}
+
 test "can disable @typescript-eslint/no-array-constructor and fall back to core rule" {
     const source =
         \\const a = Array();


### PR DESCRIPTION
## Summary

- add argument-preserving autofix for core and TypeScript `no-array-constructor`
- share constructor slicing, comment protection, and ASI handling across both rules
- preserve comments inside argument lists while withholding fixes that would discard constructor-header comments
- keep core optional calls and spread cases with fewer than two ordinary arguments diagnostic-only
- document both autofix capabilities and add public API regression coverage

## Why

Both rules already identify constructor forms that prefer array literals. The fix can safely reuse the exact source between the call parentheses, provided sparse-array semantics, optional calls, comments, and statement-boundary parsing are handled explicitly.

## Developer impact

`--fix`, `--fix-dry-run`, and `lintSourceAndFix` now convert supported `Array()` and `new Array(a, b)` expressions to array literals. When a leading `[` could continue the preceding expression, the fixer inserts an ASI guard semicolon.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- complete test suite: 1727 tests passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`