### PR TITLE
feat: autofix redundant boolean casts

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -85,7 +85,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-ex-assign`](https://eslint.org/docs/latest/rules/no-ex-assign) | Implemented |
 | [`no-extend-native`](https://eslint.org/docs/latest/rules/no-extend-native) | Supports `exceptions` configuration |
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented with side-effect- and comment-safe autofix |
-| [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports `enforceForInnerExpressions` and legacy `enforceForLogicalOperands` configuration |
+| [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports safe autofix, `enforceForInnerExpressions`, and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented with multi-pass autofix for redundant references and label declarations |
 | [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
 | [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase`, common `commentPattern`, and `reportUnusedFallthroughComment` configuration |

--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -16,20 +16,22 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    _: traverser.semantic.SymbolTable,
+    symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
-    try runWithOptions(allocator, diagnostics, tree, .{});
+    try runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
 }
 
 pub fn runWithOptions(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
         .options = options,
     };
 
@@ -39,6 +41,7 @@ pub fn runWithOptions(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 
     pub fn enter_if_statement(
@@ -99,64 +102,235 @@ const Visitor = struct {
         expression: ast.NodeIndex,
     ) Allocator.Error!void {
         const unwrapped = unwrapTransparent(tree, expression);
-        try self.checkBooleanExpression(tree, unwrapped);
+        try self.checkBooleanExpression(tree, unwrapped, .direct);
     }
 
     fn checkBooleanExpression(
         self: *Visitor,
         tree: *const ast.Tree,
         unwrapped: ast.NodeIndex,
+        context: BooleanContext,
     ) Allocator.Error!void {
-        if (isBooleanCall(tree, unwrapped) or isDoubleNegation(tree, unwrapped)) {
-            try core.addDiagnostic(
-                self.allocator,
-                self.diagnostics,
-                .warning,
-                id,
-                "Redundant boolean cast in a boolean context.",
-                tree.span(unwrapped),
-            );
+        if (booleanCall(tree, unwrapped)) |call| {
+            try self.addBooleanCallDiagnostic(tree, unwrapped, call, context);
+        } else if (doubleNegationValue(tree, unwrapped)) |value| {
+            try self.addDoubleNegationDiagnostic(tree, unwrapped, value, context);
         }
 
         switch (tree.data(unwrapped)) {
             .unary_expression => |unary| {
                 if (unary.operator != .logical_not) return;
-                try self.checkBooleanExpression(tree, unwrapTransparent(tree, unary.argument));
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, unary.argument), .{ .unary = unwrapped });
             },
             .logical_expression => |logical| {
                 if (!self.options.enforce_for_inner_expressions) return;
-                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.left));
-                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.right));
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.left), .logical);
+                try self.checkBooleanExpression(tree, unwrapTransparent(tree, logical.right), .logical);
             },
             else => return,
         }
     }
+
+    fn addBooleanCallDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        call: ast.CallExpression,
+        context: BooleanContext,
+    ) Allocator.Error!void {
+        if (!isGlobalBooleanReference(tree, self.symbol_table, call.callee) or
+            call.optional or
+            hasCommentsInside(tree, tree.span(index)))
+        {
+            try self.addDiagnostic(tree, index);
+            return;
+        }
+
+        const arguments = tree.extra(call.arguments);
+        if (arguments.len == 0) {
+            switch (context) {
+                .unary => |parent| {
+                    if (hasCommentsInside(tree, tree.span(parent))) {
+                        try self.addDiagnostic(tree, index);
+                        return;
+                    }
+                    try self.addDiagnosticWithFix(tree, index, tree.span(parent), "true");
+                },
+                else => try self.addDiagnosticWithFix(tree, index, tree.span(index), "false"),
+            }
+            return;
+        }
+
+        if (arguments.len != 1 or tree.data(arguments[0]) == .spread_element) {
+            try self.addDiagnostic(tree, index);
+            return;
+        }
+
+        try self.addReplacementNodeFix(tree, index, tree.span(index), arguments[0], context);
+    }
+
+    fn addDoubleNegationDiagnostic(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        index: ast.NodeIndex,
+        value: ast.NodeIndex,
+        context: BooleanContext,
+    ) Allocator.Error!void {
+        if (hasCommentsInside(tree, tree.span(index))) {
+            try self.addDiagnostic(tree, index);
+            return;
+        }
+
+        try self.addReplacementNodeFix(tree, index, tree.span(index), value, context);
+    }
+
+    fn addReplacementNodeFix(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        diagnostic_index: ast.NodeIndex,
+        fix_span: ast.Span,
+        replacement_index: ast.NodeIndex,
+        context: BooleanContext,
+    ) Allocator.Error!void {
+        const replacement_span = tree.span(replacement_index);
+        const source = tree.source[replacement_span.start..replacement_span.end];
+        if (!replacementNeedsParentheses(tree, replacement_index, context)) {
+            try self.addDiagnosticWithFix(tree, diagnostic_index, fix_span, source);
+            return;
+        }
+
+        const replacement = try std.fmt.allocPrint(self.allocator, "({s})", .{source});
+        defer self.allocator.free(replacement);
+        try self.addDiagnosticWithFix(tree, diagnostic_index, fix_span, replacement);
+    }
+
+    fn addDiagnostic(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Redundant boolean cast in a boolean context.",
+            tree.span(index),
+        );
+    }
+
+    fn addDiagnosticWithFix(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        diagnostic_index: ast.NodeIndex,
+        fix_span: ast.Span,
+        replacement: []const u8,
+    ) Allocator.Error!void {
+        try core.addDiagnosticWithFix(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Redundant boolean cast in a boolean context.",
+            tree.span(diagnostic_index),
+            .{ .span = fix_span, .replacement = replacement },
+        );
+    }
 };
 
-fn isBooleanCall(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+const BooleanContext = union(enum) {
+    direct,
+    unary: ast.NodeIndex,
+    logical,
+};
+
+fn booleanCall(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.CallExpression {
     const call = switch (tree.data(index)) {
         .call_expression => |call| call,
-        else => return false,
+        else => return null,
     };
-
     const callee = unwrapTransparent(tree, call.callee);
-    const name = identifierReferenceName(tree, callee) orelse return false;
-    return std.mem.eql(u8, name, "Boolean");
+    const name = identifierReferenceName(tree, callee) orelse return null;
+    if (!std.mem.eql(u8, name, "Boolean")) return null;
+    return call;
 }
 
-fn isDoubleNegation(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+fn isGlobalBooleanReference(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee_index: ast.NodeIndex,
+) bool {
+    const callee = unwrapTransparent(tree, callee_index);
+    const name = identifierReferenceName(tree, callee) orelse return false;
+    return std.mem.eql(u8, name, "Boolean") and isUnresolvedReference(symbol_table, callee);
+}
+
+fn doubleNegationValue(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
     const outer = switch (tree.data(index)) {
         .unary_expression => |unary| unary,
-        else => return false,
+        else => return null,
     };
-    if (outer.operator != .logical_not) return false;
+    if (outer.operator != .logical_not) return null;
 
     const inner_index = unwrapTransparent(tree, outer.argument);
     const inner = switch (tree.data(inner_index)) {
         .unary_expression => |unary| unary,
-        else => return false,
+        else => return null,
     };
-    return inner.operator == .logical_not;
+    if (inner.operator != .logical_not) return null;
+    return inner.argument;
+}
+
+fn hasCommentsInside(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start >= span.start and comment.span.end <= span.end) return true;
+    }
+    return false;
+}
+
+fn replacementNeedsParentheses(tree: *const ast.Tree, index: ast.NodeIndex, context: BooleanContext) bool {
+    if (tree.data(index) == .parenthesized_expression) return false;
+
+    return switch (context) {
+        .direct => false,
+        .unary => hasLowerThanUnaryPrecedence(tree, index),
+        .logical => hasLogicalOrLowerPrecedence(tree, index),
+    };
+}
+
+fn hasLowerThanUnaryPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .binary_expression,
+        .logical_expression,
+        .conditional_expression,
+        .assignment_expression,
+        .sequence_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        => true,
+        else => false,
+    };
+}
+
+fn hasLogicalOrLowerPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .logical_expression,
+        .conditional_expression,
+        .assignment_expression,
+        .sequence_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        => true,
+        else => false,
+    };
+}
+
+fn isUnresolvedReference(symbol_table: traverser.semantic.SymbolTable, node: ast.NodeIndex) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) return symbol_table.referenceSymbol(entry.id) == .none;
+    }
+    return false;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -899,7 +899,7 @@ pub fn runSemantic(
     }
 
     if (options.no_extra_boolean_cast) {
-        try no_extra_boolean_cast.runWithOptions(allocator, diagnostics, tree, .{
+        try no_extra_boolean_cast.runWithOptions(allocator, diagnostics, tree, semantic_result.symbol_table, .{
             .enforce_for_inner_expressions = options.no_extra_boolean_cast_enforce_for_inner_expressions,
         });
     }

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -130,6 +130,102 @@ test "does not report negated boolean casts outside boolean contexts" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_extra_boolean_cast.id));
 }
 
+test "autofixes redundant Boolean calls and double negations" {
+    const source =
+        \\if (Boolean(value)) { use(value); }
+        \\while (!!value) { break; }
+        \\do { value++; } while (Boolean());
+        \\for (; !!(left || right); value++) { break; }
+        \\const selected = Boolean(value) ? 1 : 2;
+        \\if (!Boolean(value)) { use(value); }
+        \\if (!Boolean()) { use(value); }
+        \\while (!!!value) { break; }
+    ;
+    const expected =
+        \\if (value) { use(value); }
+        \\while (value) { break; }
+        \\do { value++; } while (false);
+        \\for (; (left || right); value++) { break; }
+        \\const selected = value ? 1 : 2;
+        \\if (!value) { use(value); }
+        \\if (true) { use(value); }
+        \\while (!value) { break; }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_extra_boolean_cast.id));
+}
+
+test "autofix preserves precedence for enforced inner expressions" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForInnerExpressions\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-extra-boolean-cast", config.value);
+
+    const source =
+        \\if (foo && Boolean(bar || baz)) { use(bar); }
+        \\if (foo || !!(bar && baz)) { use(bar); }
+        \\if (!Boolean(foo || bar)) { use(bar); }
+    ;
+    const expected =
+        \\if (foo && (bar || baz)) { use(bar); }
+        \\if (foo || (bar && baz)) { use(bar); }
+        \\if (!(foo || bar)) { use(bar); }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_extra_boolean_cast.id));
+}
+
+test "does not autofix unsafe Boolean calls or commented negations" {
+    const source =
+        \\function local(Boolean) {
+        \\  if (Boolean(value)) { use(value); }
+        \\}
+        \\if (Boolean?.(value)) { use(value); }
+        \\if (Boolean(...items)) { use(value); }
+        \\if (Boolean(first, second)) { use(value); }
+        \\if (Boolean(/* keep */ value)) { use(value); }
+        \\if (!/* keep */!value) { use(value); }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result.result, lint.rules.no_extra_boolean_cast.id));
+}
+
 test "can disable no-extra-boolean-cast" {
     const source =
         \\if (Boolean(value)) { use(value); }


### PR DESCRIPTION
## Summary

- add autofix for redundant global `Boolean(...)` calls and double negations in boolean contexts
- convert empty `Boolean()` calls to boolean literals, including `!Boolean()` to `true`
- preserve logical and unary precedence by retaining or adding grouping parentheses
- keep shadowed or optional Boolean calls, spread/multiple arguments, and commented expressions diagnostic-only
- preserve multi-pass behavior for overlapping negations and document the capability

## Why

The rule already identifies casts whose result is immediately coerced to boolean. Safe fixes require distinguishing the global Boolean function, retaining expression precedence, and withholding edits that could discard comments or change optional/local-call behavior.

## Developer impact

`--fix`, `--fix-dry-run`, and `lintSourceAndFix` now simplify supported `Boolean(value)` and `!!value` expressions. Nested negations converge through the existing multi-pass fixer.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- complete test suite: 1730 tests passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`