### PR TITLE
feat: autofix ambiguous expressions

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -53,7 +53,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-caller`](https://eslint.org/docs/latest/rules/no-caller) | Implemented |
 | [`no-case-declarations`](https://eslint.org/docs/latest/rules/no-case-declarations) | Implemented |
 | [`no-class-assign`](https://eslint.org/docs/latest/rules/no-class-assign) | Implemented |
-| [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow) | Implemented for `allowParens: true` and `allowParens: false` |
+| [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow) | Supports `allowParens` with autofix when parentheses are allowed |
 | [`no-comma-operator`](https://eslint.org/docs/latest/rules/no-comma-operator) | Implemented |
 | [`no-compare-neg-zero`](https://eslint.org/docs/latest/rules/no-compare-neg-zero) | Implemented |
 | [`no-cond-assign`](https://eslint.org/docs/latest/rules/no-cond-assign) | Implemented |
@@ -66,7 +66,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-control-regex`](https://eslint.org/docs/latest/rules/no-control-regex) | Implemented |
 | [`no-debugger`](https://eslint.org/docs/latest/rules/no-debugger) | Implemented |
 | [`no-delete-var`](https://eslint.org/docs/latest/rules/no-delete-var) | Implemented |
-| [`no-div-regex`](https://eslint.org/docs/latest/rules/no-div-regex) | Implemented |
+| [`no-div-regex`](https://eslint.org/docs/latest/rules/no-div-regex) | Implemented with autofix |
 | [`no-dupe-args`](https://eslint.org/docs/latest/rules/no-dupe-args) | Implemented |
 | [`no-dupe-class-members`](https://eslint.org/docs/latest/rules/no-dupe-class-members) | Implemented |
 | [`no-dupe-else-if`](https://eslint.org/docs/latest/rules/no-dupe-else-if) | Implemented |

--- a/src/rules/no_confusing_arrow.zig
+++ b/src/rules/no_confusing_arrow.zig
@@ -1,8 +1,9 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-confusing-arrow";
 
@@ -30,13 +31,34 @@ pub fn checkWithOptions(
 
     if (!isConfusingBody(tree, expression.body, options.allow_parens)) return;
 
-    try core.addDiagnostic(
+    const span = tree.span(expression.body);
+    if (!options.allow_parens) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Arrow function used ambiguously with a conditional expression.",
+            span,
+        );
+        return;
+    }
+
+    const replacement = try std.fmt.allocPrint(
+        allocator,
+        "({s})",
+        .{tree.source[span.start..span.end]},
+    );
+    defer allocator.free(replacement);
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Arrow function used ambiguously with a conditional expression.",
-        tree.span(expression.body),
+        span,
+        .{ .span = span, .replacement = replacement },
     );
 }
 

--- a/src/rules/no_div_regex.zig
+++ b/src/rules/no_div_regex.zig
@@ -16,12 +16,17 @@ pub fn check(
     const pattern = tree.string(literal.pattern);
     if (pattern.len == 0 or pattern[0] != '=') return;
 
-    try core.addDiagnostic(
+    const span = tree.span(index);
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "A regular expression literal can be confused with '/='.",
-        tree.span(index),
+        span,
+        .{
+            .span = .{ .start = span.start + 1, .end = span.start + 2 },
+            .replacement = "[=]",
+        },
     );
 }

--- a/tests/rules/no_confusing_arrow.zig
+++ b/tests/rules/no_confusing_arrow.zig
@@ -60,6 +60,47 @@ test "reports parenthesized conditional expression bodies when allowParens is fa
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_confusing_arrow.id));
 }
 
+test "autofixes confusing arrow bodies when parentheses are allowed" {
+    const source =
+        \\const first = value => value ? firstValue : secondValue;
+        \\const second = value => value /* keep */ ? firstValue : secondValue;
+    ;
+    const expected =
+        \\const first = value => (value ? firstValue : secondValue);
+        \\const second = value => (value /* keep */ ? firstValue : secondValue);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_confusing_arrow.id));
+}
+
+test "does not autofix confusing arrows when allowParens is false" {
+    const source =
+        \\const first = value => value ? firstValue : secondValue;
+        \\const second = value => (value ? firstValue : secondValue);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_confusing_arrow_allow_parens = .no,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_confusing_arrow.id));
+}
+
 test "can disable no-confusing-arrow" {
     const source = "const first = value => value ? firstValue : secondValue;\n";
 

--- a/tests/rules/no_div_regex.zig
+++ b/tests/rules/no_div_regex.zig
@@ -36,6 +36,33 @@ test "does not report no-div-regex for ordinary regex literals" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_div_regex.id));
 }
 
+test "autofixes regex literals that can be confused with division assignment" {
+    const source =
+        \\function value() {
+        \\  return /=foo/;
+        \\}
+        \\const pattern = /=bar/u;
+    ;
+    const expected =
+        \\function value() {
+        \\  return /[=]foo/;
+        \\}
+        \\const pattern = /[=]bar/u;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_div_regex.id));
+}
+
 test "can disable no-div-regex" {
     const source =
         \\const pattern = /=foo/;


### PR DESCRIPTION
## Summary

- autofix `no-div-regex` by replacing the ambiguous leading `=` with `[=]`
- autofix `no-confusing-arrow` by parenthesizing conditional bodies when `allowParens` is enabled
- preserve body comments and leave `allowParens: false` diagnostics unfixed
- add focused tests and update rule status documentation

## Why

Both fixes are deterministic, localized source edits that match ESLint behavior.

## Validation

- `zig test -fno-incremental -OReleaseFast ...`: 1733/1733 passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
- `zig fmt --check build.zig src tests`
- `git diff --check`