### PR TITLE
feat: autofix unused labels and computed keys

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -176,12 +176,12 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members) | Implemented for private fields, methods, accessors, and static blocks |
 | [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define) | Supports `functions`, `classes`, `variables`, and `allowNamedExports` configuration |
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
-| [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing |
+| [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing and autofix |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreClassWithStaticInitBlock`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
 | [`no-useless-backreference`](https://eslint.org/docs/latest/rules/no-useless-backreference) | Detects nested, forward, disjunctive, and negative-lookaround backreferences in regex literals and static `RegExp` constructors |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |
-| [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior |
+| [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key) | Implemented with optional `enforceForClassMembers` behavior and autofix |
 | [`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat) | Implemented for adjacent static string and template literals in concatenation chains |
 | [`no-useless-constructor`](https://eslint.org/docs/latest/rules/no-useless-constructor) | Implemented |
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration and ESLint template escape handling |

--- a/src/rules/no_unused_labels.zig
+++ b/src/rules/no_unused_labels.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "no-unused-labels";
@@ -13,18 +14,77 @@ pub fn check(
     tree: *const ast.Tree,
     statement: ast.LabeledStatement,
     index: ast.NodeIndex,
+    path: *const traverser.NodePath,
 ) Allocator.Error!void {
     const label_name = labelName(tree, statement.label) orelse return;
     if (containsLabelReference(tree, statement.body, label_name)) return;
 
-    try core.addDiagnostic(
+    const fix_span = ast.Span{
+        .start = tree.span(statement.label).start,
+        .end = tree.span(statement.body).start,
+    };
+    if (!isFixable(tree, statement, path, fix_span)) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unused label.",
+            tree.span(index),
+        );
+        return;
+    }
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Unused label.",
         tree.span(index),
+        .{ .span = fix_span, .replacement = "" },
     );
+}
+
+fn isFixable(
+    tree: *const ast.Tree,
+    statement: ast.LabeledStatement,
+    path: *const traverser.NodePath,
+    fix_span: ast.Span,
+) bool {
+    if (hasCommentBetween(tree, fix_span.start, fix_span.end)) return false;
+    if (!isPotentialDirective(tree, statement.body)) return true;
+
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .labeled_statement => continue,
+            .program, .function_body => return false,
+            else => return true,
+        }
+    }
+    return true;
+}
+
+fn isPotentialDirective(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const expression = switch (tree.data(index)) {
+        .directive => return true,
+        .expression_statement => |statement| statement.expression,
+        else => return false,
+    };
+
+    return switch (tree.data(expression)) {
+        .string_literal => true,
+        .template_literal => |literal| tree.extra(literal.expressions).len == 0,
+        else => false,
+    };
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < end and comment.span.end > start) return true;
+    }
+    return false;
 }
 
 fn labelName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/no_useless_computed_key.zig
+++ b/src/rules/no_useless_computed_key.zig
@@ -22,7 +22,7 @@ pub fn checkObjectExpression(
         if (!isStaticKey(tree, property.key)) continue;
         if (isObjectProtoProperty(tree, property)) continue;
 
-        try addDiagnostic(allocator, diagnostics, tree, property.key);
+        try addDiagnostic(allocator, diagnostics, tree, property.key, property.key);
     }
 }
 
@@ -40,7 +40,7 @@ pub fn checkObjectPattern(
         if (!property.computed) continue;
         if (!isStaticKey(tree, property.key)) continue;
 
-        try addDiagnostic(allocator, diagnostics, tree, property.key);
+        try addDiagnostic(allocator, diagnostics, tree, property.key, property.key);
     }
 }
 
@@ -56,7 +56,7 @@ pub fn checkMethodDefinition(
     if (isClassConstructorMethod(tree, method)) return;
     if (isStaticPrototypeMember(tree, method.static, method.key)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, method.key);
 }
 
 pub fn checkPropertyDefinition(
@@ -68,25 +68,83 @@ pub fn checkPropertyDefinition(
 ) Allocator.Error!void {
     if (!property.computed) return;
     if (!isStaticKey(tree, property.key)) return;
+    if (isConstructorKey(tree, property.key)) return;
     if (isStaticPrototypeMember(tree, property.static, property.key)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index);
+    try addDiagnostic(allocator, diagnostics, tree, index, property.key);
 }
 
 fn addDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    index: ast.NodeIndex,
+    diagnostic_index: ast.NodeIndex,
+    key_index: ast.NodeIndex,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    const key_span = tree.span(key_index);
+    const fix_span = computedKeyFixSpan(tree, key_span) orelse {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessarily computed property key.",
+            tree.span(diagnostic_index),
+        );
+        return;
+    };
+
+    const key_source = tree.source[key_span.start..key_span.end];
+    var owned_replacement: ?[]u8 = null;
+    defer if (owned_replacement) |replacement| allocator.free(replacement);
+    const replacement = if (needsSpaceBeforeKey(tree, key_index, fix_span)) replacement: {
+        const value = try std.fmt.allocPrint(allocator, " {s}", .{key_source});
+        owned_replacement = value;
+        break :replacement value;
+    } else key_source;
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Unnecessarily computed property key.",
-        tree.span(index),
+        tree.span(diagnostic_index),
+        .{
+            .span = fix_span,
+            .replacement = replacement,
+        },
     );
+}
+
+fn computedKeyFixSpan(tree: *const ast.Tree, key_span: ast.Span) ?ast.Span {
+    const source = tree.source;
+    var start: usize = @intCast(key_span.start);
+    while (start > 0 and std.ascii.isWhitespace(source[start - 1])) start -= 1;
+    if (start == 0 or source[start - 1] != '[') return null;
+    const left_bracket = start - 1;
+
+    var end: usize = @intCast(key_span.end);
+    while (end < source.len and std.ascii.isWhitespace(source[end])) end += 1;
+    if (end >= source.len or source[end] != ']') return null;
+
+    return .{ .start = @intCast(left_bracket), .end = @intCast(end + 1) };
+}
+
+fn needsSpaceBeforeKey(tree: *const ast.Tree, key_index: ast.NodeIndex, fix_span: ast.Span) bool {
+    if (tree.data(key_index) != .numeric_literal) return false;
+
+    const key_span = tree.span(key_index);
+    const key_source = tree.source[key_span.start..key_span.end];
+    if (key_source.len == 0 or key_source[0] == '.') return false;
+
+    const start: usize = @intCast(fix_span.start);
+    if (start == 0) return false;
+    return isIdentifierPart(tree.source[start - 1]);
+}
+
+fn isIdentifierPart(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
 }
 
 fn isStaticKey(tree: *const ast.Tree, index: ast.NodeIndex) bool {
@@ -105,7 +163,11 @@ fn isObjectProtoProperty(tree: *const ast.Tree, property: ast.ObjectProperty) bo
 
 fn isClassConstructorMethod(tree: *const ast.Tree, method: ast.MethodDefinition) bool {
     if (method.static or method.kind != .method) return false;
-    return keyName(tree, method.key) != null and std.mem.eql(u8, keyName(tree, method.key).?, "constructor");
+    return isConstructorKey(tree, method.key);
+}
+
+fn isConstructorKey(tree: *const ast.Tree, key: ast.NodeIndex) bool {
+    return keyName(tree, key) != null and std.mem.eql(u8, keyName(tree, key).?, "constructor");
 }
 
 fn isStaticPrototypeMember(tree: *const ast.Tree, is_static: bool, key: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2638,7 +2638,7 @@ const BasicVisitor = struct {
             try no_extra_label.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
         }
         if (self.options.no_unused_labels) {
-            try no_unused_labels.check(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try no_unused_labels.check(self.allocator, self.diagnostics, ctx.tree, statement, index, &ctx.path);
         }
         if (self.options.no_labels) {
             try no_labels.checkLabeledStatementWithOptions(self.allocator, self.diagnostics, ctx.tree, statement, index, self.noLabelsOptions());

--- a/tests/rules/no_unused_labels.zig
+++ b/tests/rules/no_unused_labels.zig
@@ -91,6 +91,85 @@ test "does not count references to shadowed nested labels" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unused_labels.id));
 }
 
+test "autofixes labels without labeled break or continue" {
+    const source =
+        \\outer: while (ready) {
+        \\  break;
+        \\}
+        \\block: {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\while (ready) {
+        \\  break;
+        \\}
+        \\{
+        \\  call();
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_unused_labels.id));
+}
+
+test "does not autofix unused labels when removal would discard comments or create directives" {
+    const source =
+        \\topLevel: "use strict";
+        \\function example() {
+        \\  functionBody: `directive`;
+        \\}
+        \\commented: /**/ {
+        \\  call();
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.no_unused_labels.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_unused_labels.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "only removes outer labels when nested removal could create a directive" {
+    const source = "outer: inner: \"use strict\";";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_labels = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("inner: \"use strict\";", result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.no_unused_labels.id));
+    try std.testing.expectEqual(@as(usize, 0), result.result.diagnostics[0].fixes.len);
+}
+
 test "can disable no-unused-labels" {
     const source =
         \\outer: while (ready) {

--- a/tests/rules/no_useless_computed_key.zig
+++ b/tests/rules/no_useless_computed_key.zig
@@ -23,6 +23,106 @@ test "reports no-useless-computed-key for object and pattern literal keys" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.no_useless_computed_key.id));
 }
 
+test "autofixes literal computed keys in objects, patterns, and classes" {
+    const source =
+        \\const object = {
+        \\  ["name"]: value,
+        \\  [0]: value,
+        \\  ["method"]() {},
+        \\};
+        \\const { ["name"]: name, [0]: zero } = object;
+        \\class Example {
+        \\  ["method"]() {}
+        \\  get ["value"]() {
+        \\    return value;
+        \\  }
+        \\  ["field"] = value;
+        \\  static ["name"]() {}
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_function = false,
+        .no_unused_vars = false,
+        .no_useless_rename = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  "name": value,
+        \\  0: value,
+        \\  "method"() {},
+        \\};
+        \\const { "name": name, 0: zero } = object;
+        \\class Example {
+        \\  "method"() {}
+        \\  get "value"() {
+        \\    return value;
+        \\  }
+        \\  "field" = value;
+        \\  static "name"() {}
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_useless_computed_key.id));
+}
+
+test "autofixes safe computed keys without discarding comments or merging numeric keys" {
+    const source =
+        \\const object = {
+        \\  [ "spaced" ]: value,
+        \\  [/* keep */ "before"]: value,
+        \\  ["after" /* keep */]: value,
+        \\  get[2]() {
+        \\    return value;
+        \\  },
+        \\  get[.2]() {
+        \\    return value;
+        \\  },
+        \\};
+        \\class Example {
+        \\  static[3] = value;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_floating_decimal = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  "spaced": value,
+        \\  [/* keep */ "before"]: value,
+        \\  ["after" /* keep */]: value,
+        \\  get 2() {
+        \\    return value;
+        \\  },
+        \\  get.2() {
+        \\    return value;
+        \\  },
+        \\};
+        \\class Example {
+        \\  static 3 = value;
+        \\}
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_useless_computed_key.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_useless_computed_key.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
 test "reports no-useless-computed-key for class members with literal keys" {
     const source =
         \\class Example {
@@ -79,6 +179,9 @@ test "does not report no-useless-computed-key for dynamic keys or semantic excep
         \\class Example {
         \\  ["constructor"]() {}
         \\  static ["prototype"]() {}
+        \\  ["constructor"];
+        \\  static ["constructor"];
+        \\  static ["prototype"];
         \\  [name]() {}
         \\}
     ;


### PR DESCRIPTION
## Summary

- autofix `no-unused-labels` by removing unused label prefixes
- avoid fixes that would discard comments or turn string expressions into directives
- autofix `no-useless-computed-key` across objects, patterns, methods, and class fields
- preserve comments, whitespace-sensitive token boundaries, and class `constructor`/`prototype` semantic exceptions
- update rule status documentation and add end-to-end regression coverage

## Why

Both rules are marked fixable by ESLint. These implementations follow the same safety boundaries so applying fixes does not lose comments, merge tokens, or create invalid/directive syntax.

## Validation

- targeted `no-unused-labels`: 8/8 passed
- targeted `no-useless-computed-key`: 7/7 passed
- full test suite: 1738/1738 passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
- `zig fmt --check build.zig src tests`
- `git diff --check`