### PR TITLE
feat: autofix modern builtin calls

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -199,8 +199,8 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
 | [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |
-| [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented for static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
-| [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented |
+| [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented with autofix for global static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
+| [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented with autofix |
 | [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Supports `allowEmptyReject` configuration |
 | [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) | Reports rethrown built-in errors in `catch` blocks that omit or replace the caught error `cause`, with `requireCatchParameter` support |

--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -12,11 +12,12 @@ pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    _: traverser.semantic.SymbolTable,
+    symbol_table: traverser.semantic.SymbolTable,
 ) Allocator.Error!void {
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
     };
 
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -25,6 +26,7 @@ pub fn run(
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -32,14 +34,40 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (preferredLiteralKind(ctx.tree, call)) |kind| {
-            try core.addDiagnostic(
+        if (preferredLiteral(ctx.tree, self.symbol_table, call)) |literal| {
+            const span = ctx.tree.span(index);
+            if (!isValidLiteralValue(literal.value, literal.kind) or hasCommentInside(ctx.tree, span)) {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    diagnosticMessage(literal.kind),
+                    span,
+                );
+                return .proceed;
+            }
+
+            const replacement = try std.fmt.allocPrint(
+                self.allocator,
+                "{s}{s}{s}{s}",
+                .{
+                    if (needsSpaceBefore(ctx.tree.source, span)) " " else "",
+                    literalPrefix(literal.kind),
+                    literal.value,
+                    if (needsSpaceAfter(ctx.tree.source, span)) " " else "",
+                },
+            );
+            defer self.allocator.free(replacement);
+
+            try core.addDiagnosticWithFix(
                 self.allocator,
                 self.diagnostics,
                 .warning,
                 id,
-                diagnosticMessage(kind),
-                ctx.tree.span(index),
+                diagnosticMessage(literal.kind),
+                span,
+                .{ .span = span, .replacement = replacement },
             );
         }
 
@@ -53,18 +81,67 @@ const LiteralKind = enum {
     hexadecimal,
 };
 
-fn preferredLiteralKind(
+const PreferredLiteral = struct {
+    kind: LiteralKind,
+    value: []const u8,
+};
+
+fn preferredLiteral(
     tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
     call: ast.CallExpression,
-) ?LiteralKind {
-    if (!isParseIntCall(tree, call.callee)) return null;
+) ?PreferredLiteral {
+    if (!isParseIntCall(tree, symbol_table, call.callee)) return null;
 
     const arguments = tree.extra(call.arguments);
     if (arguments.len != 2) return null;
 
-    _ = staticStringValue(tree, arguments[0]) orelse return null;
+    const value = staticStringValue(tree, arguments[0]) orelse return null;
     const kind = radixLiteralKind(tree, arguments[1]) orelse return null;
-    return kind;
+    return .{ .kind = kind, .value = value };
+}
+
+fn literalPrefix(kind: LiteralKind) []const u8 {
+    return switch (kind) {
+        .binary => "0b",
+        .octal => "0o",
+        .hexadecimal => "0x",
+    };
+}
+
+fn isValidLiteralValue(value: []const u8, kind: LiteralKind) bool {
+    if (value.len == 0) return false;
+
+    for (value) |byte| {
+        const valid = switch (kind) {
+            .binary => byte == '0' or byte == '1',
+            .octal => byte >= '0' and byte <= '7',
+            .hexadecimal => std.ascii.isHex(byte),
+        };
+        if (!valid) return false;
+    }
+    return true;
+}
+
+fn hasCommentInside(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start >= span.start and comment.span.end <= span.end) return true;
+    }
+    return false;
+}
+
+fn needsSpaceBefore(source: []const u8, span: ast.Span) bool {
+    const start: usize = @intCast(span.start);
+    return start > 0 and isIdentifierPart(source[start - 1]);
+}
+
+fn needsSpaceAfter(source: []const u8, span: ast.Span) bool {
+    const end: usize = @intCast(span.end);
+    return end < source.len and isIdentifierPart(source[end]);
+}
+
+fn isIdentifierPart(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
 }
 
 fn diagnosticMessage(kind: LiteralKind) []const u8 {
@@ -112,11 +189,15 @@ fn radixLiteralKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralKind {
     };
 }
 
-fn isParseIntCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
+fn isParseIntCall(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    callee: ast.NodeIndex,
+) bool {
     const unwrapped = unwrapTransparent(tree, callee);
 
     if (identifierReferenceName(tree, unwrapped)) |name| {
-        return std.mem.eql(u8, name, "parseInt");
+        return std.mem.eql(u8, name, "parseInt") and isUnresolvedReference(symbol_table, unwrapped);
     }
 
     const member = switch (tree.data(unwrapped)) {
@@ -130,7 +211,20 @@ fn isParseIntCall(tree: *const ast.Tree, callee: ast.NodeIndex) bool {
 
     const object = unwrapTransparent(tree, member.object);
     const object_name = identifierReferenceName(tree, object) orelse return false;
-    return std.mem.eql(u8, object_name, "Number");
+    return std.mem.eql(u8, object_name, "Number") and isUnresolvedReference(symbol_table, object);
+}
+
+fn isUnresolvedReference(
+    symbol_table: traverser.semantic.SymbolTable,
+    node: ast.NodeIndex,
+) bool {
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        if (entry.reference.node == node) {
+            return symbol_table.referenceSymbol(entry.id) == .none;
+        }
+    }
+    return false;
 }
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {

--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -36,13 +36,30 @@ const Visitor = struct {
     ) Allocator.Error!traverser.Action {
         if (!isPreferableHasOwn(ctx.tree, self.symbol_table, call)) return .proceed;
 
-        try core.addDiagnostic(
+        const callee_span = ctx.tree.span(call.callee);
+        if (hasCommentInside(ctx.tree, callee_span) or hasOptionalChainInside(ctx.tree.source, callee_span)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+                ctx.tree.span(index),
+            );
+            return .proceed;
+        }
+
+        try core.addDiagnosticWithFix(
             self.allocator,
             self.diagnostics,
             .warning,
             id,
             "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
             ctx.tree.span(index),
+            .{
+                .span = callee_span,
+                .replacement = if (needsSpaceBefore(ctx.tree.source, callee_span)) " Object.hasOwn" else "Object.hasOwn",
+            },
         );
 
         return .proceed;
@@ -96,9 +113,29 @@ fn memberExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.MemberExpr
 
 fn isObjectLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return switch (tree.data(index)) {
-        .object_expression => true,
+        .object_expression => |object| tree.extra(object.properties).len == 0,
         else => false,
     };
+}
+
+fn hasCommentInside(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start >= span.start and comment.span.end <= span.end) return true;
+    }
+    return false;
+}
+
+fn hasOptionalChainInside(source: []const u8, span: ast.Span) bool {
+    return std.mem.indexOf(u8, source[span.start..span.end], "?.") != null;
+}
+
+fn needsSpaceBefore(source: []const u8, span: ast.Span) bool {
+    const start: usize = @intCast(span.start);
+    return start > 0 and isIdentifierPart(source[start - 1]);
+}
+
+fn isIdentifierPart(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
 }
 
 fn propertyNamed(tree: *const ast.Tree, member: ast.MemberExpression, expected: []const u8) bool {

--- a/tests/rules/prefer_numeric_literals.zig
+++ b/tests/rules/prefer_numeric_literals.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
-test "reports prefer-numeric-literals for parseInt calls that can be numeric literals" {
+test "reports prefer-numeric-literals for global parseInt calls that can be numeric literals" {
     const source =
         \\parseInt("101", 2);
         \\parseInt("755", 8);
@@ -33,7 +33,7 @@ test "reports prefer-numeric-literals for parseInt calls that can be numeric lit
     });
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 15), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+    try std.testing.expectEqual(@as(usize, 11), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
     try std.testing.expectEqualStrings("Use a binary literal instead of parseInt().", result.diagnostics[0].message);
 }
 
@@ -55,6 +55,96 @@ test "reports prefer-numeric-literals for static strings even when digits are in
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_numeric_literals.id));
+}
+
+test "autofixes parseInt calls with valid binary octal and hexadecimal digits" {
+    const source =
+        \\parseInt("101", 2);
+        \\parseInt("755", 8);
+        \\Number.parseInt("ff", 16);
+        \\parseInt(`a0`, 16);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\0b101;
+        \\0o755;
+        \\0xff;
+        \\0xa0;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_numeric_literals.id));
+}
+
+test "does not autofix invalid commented or shadowed parseInt calls" {
+    const source =
+        \\parseInt("102", 2);
+        \\parseInt("89", 8);
+        \\parseInt("10px", 16);
+        \\parseInt("", 16);
+        \\parseInt("1_1", 2);
+        \\Number/**/.parseInt("11", 2);
+        \\parseInt("11", /**/2);
+        \\function local(parseInt, Number) {
+        \\  parseInt("101", 2);
+        \\  Number.parseInt("ff", 16);
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result.result, lint.rules.prefer_numeric_literals.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_numeric_literals.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofixes optional parseInt calls without merging adjacent tokens" {
+    const source =
+        \\function* values() {
+        \\  yield(Number).parseInt("11", 2);
+        \\  yield Number.parseInt("17", 8);
+        \\}
+        \\const present = parseInt("A", 16)in object;
+        \\parseInt?.("1F7", 16);
+        \\Number.parseInt?.("ff", 16);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\function* values() {
+        \\  yield 0b11;
+        \\  yield 0o17;
+        \\}
+        \\const present = 0xA in object;
+        \\0x1F7;
+        \\0xff;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_numeric_literals.id));
 }
 
 test "allows parseInt calls without static string and binary octal or hexadecimal radix" {

--- a/tests/rules/prefer_object_has_own.zig
+++ b/tests/rules/prefer_object_has_own.zig
@@ -54,6 +54,78 @@ test "does not report prefer-object-has-own for other calls or shadowed Object" 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.prefer_object_has_own.id));
 }
 
+test "autofixes hasOwnProperty call helpers to Object.hasOwn" {
+    const source =
+        \\Object.prototype.hasOwnProperty.call(object, "key");
+        \\Object.hasOwnProperty.call(object, "key");
+        \\({}).hasOwnProperty.call(object, "key");
+        \\Object["prototype"]["hasOwnProperty"]["call"](object, "key");
+        \\Object.prototype.hasOwnProperty.call?.(object, "key");
+        \\Object.prototype.hasOwnProperty?.call(object, "key");
+        \\Object?.prototype.hasOwnProperty.call(object, "key");
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_prototype_builtins = false,
+        .no_undef = false,
+        .typescript_eslint_dot_notation = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\Object.hasOwn(object, "key");
+        \\Object.hasOwn(object, "key");
+        \\Object.hasOwn(object, "key");
+        \\Object.hasOwn(object, "key");
+        \\Object.hasOwn?.(object, "key");
+        \\Object.prototype.hasOwnProperty?.call(object, "key");
+        \\Object?.prototype.hasOwnProperty.call(object, "key");
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.prefer_object_has_own.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_object_has_own.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofixes Object.hasOwn safely without dropping comments or matching nonempty objects" {
+    const source =
+        \\function check() {
+        \\  return{}.hasOwnProperty.call(object, "key");
+        \\}
+        \\Object/* keep */.prototype.hasOwnProperty.call(object, "key");
+        \\({ value: 1 }).hasOwnProperty.call(object, "key");
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_prototype_builtins = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\function check() {
+        \\  return Object.hasOwn(object, "key");
+        \\}
+        \\Object/* keep */.prototype.hasOwnProperty.call(object, "key");
+        \\({ value: 1 }).hasOwnProperty.call(object, "key");
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.prefer_object_has_own.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_object_has_own.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
 test "can disable prefer-object-has-own" {
     const source = "Object.prototype.hasOwnProperty.call(object, \"key\");\n";
 


### PR DESCRIPTION
## Summary

- autofix `prefer-numeric-literals` to replace safe global `parseInt` calls with binary, octal, or hexadecimal literals
- reject numeric fixes for shadowed globals, invalid digit strings, internal comments, or unsafe token adjacency
- autofix `prefer-object-has-own` by replacing safe helper callees with `Object.hasOwn`
- preserve comments and optional-call semantics, avoid internal optional-chain rewrites, and only match empty object literals
- add end-to-end regression coverage and update rule status documentation

## Why

Both rules are marked fixable by ESLint. The safety checks ensure fixes preserve runtime meaning and always produce tokenizable source.

## Validation

- targeted `prefer-numeric-literals`: 7/7 passed
- targeted `prefer-object-has-own`: 5/5 passed
- full test suite: 1743/1743 passed
- `zig build -fno-incremental -Doptimize=ReleaseFast -j1`
- `zig fmt --check build.zig src tests`
- `git diff --check`