### PR TITLE
feat: autofix equality and IIFE wrapping

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -21,7 +21,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |
 | [`dot-notation`](https://eslint.org/docs/latest/rules/dot-notation) | Supports autofix plus `allowKeywords` and common `allowPattern` configuration |
 | [`eol-last`](https://eslint.org/docs/latest/rules/eol-last) | Supports `always`, `never`, `unix`, and `windows` configuration with autofix |
-| [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration |
+| [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) | Supports `always`, `allow-null`, and `smart` configuration with safe autofix |
 | [`for-direction`](https://eslint.org/docs/latest/rules/for-direction) | Implemented |
 | [`func-name-matching`](https://eslint.org/docs/latest/rules/func-name-matching) | Supports `always`, `never`, `includeCommonJSModuleExports`, and `considerPropertyDescriptor` configuration |
 | [`func-names`](https://eslint.org/docs/latest/rules/func-names) | Supports `always`, `as-needed`, `never`, and `generators` configuration |
@@ -223,7 +223,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Supports `enforceForIndexOf` and `enforceForSwitchCase` configuration |
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
-| [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options |
+| [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options with autofix |
 | [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Supports `never`, `always`, `onlyEquality`, and `exceptRange` configuration |
 
 ## ESLint comments rules

--- a/src/rules/eqeqeq.zig
+++ b/src/rules/eqeqeq.zig
@@ -37,6 +37,24 @@ pub fn checkWithOptions(
     }
     if (options.style == .smart and isSmartException(tree, expression)) return;
 
+    if (canAutofix(tree, expression)) {
+        if (operatorSpan(tree, expression)) |fix_span| {
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Use strict equality operators.",
+                tree.span(index),
+                .{
+                    .span = fix_span,
+                    .replacement = if (expression.operator == .equal) "===" else "!==",
+                },
+            );
+            return;
+        }
+    }
+
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -45,6 +63,40 @@ pub fn checkWithOptions(
         "Use strict equality operators.",
         tree.span(index),
     );
+}
+
+fn canAutofix(tree: *const ast.Tree, expression: ast.BinaryExpression) bool {
+    if (isTypeofExpression(tree, expression.left) or isTypeofExpression(tree, expression.right)) return true;
+    const left_kind = literalKind(tree, expression.left) orelse return false;
+    const right_kind = literalKind(tree, expression.right) orelse return false;
+    return left_kind == right_kind;
+}
+
+fn operatorSpan(tree: *const ast.Tree, expression: ast.BinaryExpression) ?ast.Span {
+    const operator = if (expression.operator == .equal) "==" else "!=";
+    var cursor: usize = @intCast(tree.span(expression.left).end);
+    const end: usize = @intCast(tree.span(expression.right).start);
+
+    while (cursor + operator.len <= end) {
+        if (commentEndingAfter(tree, cursor)) |comment_end| {
+            cursor = comment_end;
+            continue;
+        }
+        if (std.mem.startsWith(u8, tree.source[cursor..end], operator)) {
+            return .{ .start = @intCast(cursor), .end = @intCast(cursor + operator.len) };
+        }
+        cursor += 1;
+    }
+    return null;
+}
+
+fn commentEndingAfter(tree: *const ast.Tree, offset: usize) ?usize {
+    for (tree.comments) |comment| {
+        const start: usize = @intCast(comment.span.start);
+        const end: usize = @intCast(comment.span.end);
+        if (start <= offset and offset < end) return end;
+    }
+    return null;
 }
 
 fn isSmartException(tree: *const ast.Tree, expression: ast.BinaryExpression) bool {
@@ -86,6 +138,7 @@ fn literalKind(tree: *const ast.Tree, index: ast.NodeIndex) ?LiteralKind {
         .numeric_literal => .number,
         .regexp_literal => .object,
         .string_literal => .string,
+        .template_literal => |literal| if (tree.extra(literal.expressions).len == 0) .string else null,
         else => null,
     };
 }

--- a/src/rules/wrap_iife.zig
+++ b/src/rules/wrap_iife.zig
@@ -1,9 +1,10 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "wrap-iife";
 
@@ -47,7 +48,23 @@ const Visitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        if (isIifeCall(ctx.tree, call) and !isAllowedStyle(ctx.tree, call, index, ctx.path.ancestor(1), self.style)) {
+        const function_index = iifeFunctionIndex(ctx.tree, call) orelse return .proceed;
+        const parent = ctx.path.ancestor(1);
+        if (!isAllowedStyle(ctx.tree, call, index, parent, self.style)) {
+            if (try buildFix(self.allocator, ctx.tree, call, index, function_index, parent, self.style)) |fix| {
+                defer self.allocator.free(fix.replacement);
+                try core.addDiagnosticWithFix(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Wrap an immediate function invocation in parentheses.",
+                    ctx.tree.span(index),
+                    fix,
+                );
+                return .proceed;
+            }
+
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,
@@ -62,6 +79,58 @@ const Visitor = struct {
     }
 };
 
+fn buildFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    function_index: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+    style: Style,
+) Allocator.Error!?core.Fix {
+    const call_is_parenthesized = isParenthesized(tree, index, parent);
+    const function_is_parenthesized = tree.data(call.callee) == .parenthesized_expression;
+
+    if (!call_is_parenthesized and !function_is_parenthesized) {
+        const span = if (style == .inside) tree.span(function_index) else tree.span(index);
+        return .{
+            .span = span,
+            .replacement = try std.fmt.allocPrint(allocator, "({s})", .{tree.source[span.start..span.end]}),
+        };
+    }
+
+    if (style == .outside and function_is_parenthesized) {
+        const callee_span = tree.span(call.callee);
+        const call_span = tree.span(index);
+        if (callee_span.end == 0 or tree.source[callee_span.end - 1] != ')') return null;
+        return .{
+            .span = .{ .start = callee_span.end - 1, .end = call_span.end },
+            .replacement = try std.fmt.allocPrint(
+                allocator,
+                "{s})",
+                .{tree.source[callee_span.end..call_span.end]},
+            ),
+        };
+    }
+
+    if (style == .inside and call_is_parenthesized) {
+        const parent_index = parent orelse return null;
+        const parent_span = tree.span(parent_index);
+        const function_span = tree.span(function_index);
+        if (parent_span.end == 0 or tree.source[parent_span.end - 1] != ')') return null;
+        return .{
+            .span = .{ .start = function_span.end, .end = parent_span.end },
+            .replacement = try std.fmt.allocPrint(
+                allocator,
+                "){s}",
+                .{tree.source[function_span.end .. parent_span.end - 1]},
+            ),
+        };
+    }
+
+    return null;
+}
+
 fn isAllowedStyle(tree: *const ast.Tree, call: ast.CallExpression, index: ast.NodeIndex, parent: ?ast.NodeIndex, style: Style) bool {
     return switch (style) {
         .outside => isParenthesized(tree, index, parent),
@@ -70,10 +139,11 @@ fn isAllowedStyle(tree: *const ast.Tree, call: ast.CallExpression, index: ast.No
     };
 }
 
-fn isIifeCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
-    return switch (tree.data(unwrapTransparent(tree, call.callee))) {
-        .function => |function| function.type == .function_expression,
-        else => false,
+fn iifeFunctionIndex(tree: *const ast.Tree, call: ast.CallExpression) ?ast.NodeIndex {
+    const index = unwrapTransparent(tree, call.callee);
+    return switch (tree.data(index)) {
+        .function => |function| if (function.type == .function_expression) index else null,
+        else => null,
     };
 }
 

--- a/tests/rules/eqeqeq.zig
+++ b/tests/rules/eqeqeq.zig
@@ -19,6 +19,66 @@ test "reports eqeqeq for loose equality operators" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.eqeqeq.id));
 }
 
+test "autofixes loose equality when strict equality preserves semantics" {
+    const source =
+        \\typeof value == "undefined";
+        \\"left" != "right";
+        \\2 == 3;
+        \\`same` == "same";
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\typeof value === "undefined";
+        \\"left" !== "right";
+        \\2 === 3;
+        \\`same` === "same";
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.eqeqeq.id));
+}
+
+test "keeps unsafe loose equality diagnostics unfixed and preserves comments" {
+    const source =
+        \\value == other;
+        \\value != 1;
+        \\value == null;
+        \\typeof value /* marker == */ == "undefined";
+        \\`dynamic ${value}` == `static`;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_eq_null = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\value == other;
+        \\value != 1;
+        \\value == null;
+        \\typeof value /* marker == */ === "undefined";
+        \\`dynamic ${value}` == `static`;
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result.result, lint.rules.eqeqeq.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.eqeqeq.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
 test "supports configured eqeqeq allow-null style" {
     var config = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/rules/wrap_iife.zig
+++ b/tests/rules/wrap_iife.zig
@@ -23,6 +23,35 @@ test "reports wrap-iife for unwrapped and inside-wrapped IIFEs" {
     try std.testing.expectEqualStrings("Wrap an immediate function invocation in parentheses.", result.diagnostics[0].message);
 }
 
+test "autofixes unwrapped and inside-wrapped IIFEs to outside style" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\}();
+        \\const second = (function () {
+        \\  return value;
+        \\})();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const first = (function () {
+        \\  return value;
+        \\}());
+        \\const second = (function () {
+        \\  return value;
+        \\}());
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.wrap_iife.id));
+}
+
 test "allows outside-wrapped IIFEs and non-IIFE calls" {
     const source =
         \\const first = (function () {
@@ -68,6 +97,36 @@ test "supports inside style" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.wrap_iife.id));
 }
 
+test "autofixes unwrapped and outside-wrapped IIFEs to inside style" {
+    const source =
+        \\const first = function () {
+        \\  return value;
+        \\}();
+        \\const second = (function () {
+        \\  return value;
+        \\}());
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .wrap_iife_style = .inside,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const first = (function () {
+        \\  return value;
+        \\})();
+        \\const second = (function () {
+        \\  return value;
+        \\})();
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.wrap_iife.id));
+}
+
 test "supports any style" {
     const source =
         \\const unwrapped = function () {
@@ -90,6 +149,30 @@ test "supports any style" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.wrap_iife.id));
+}
+
+test "autofixes only unwrapped IIFEs in any style" {
+    const source =
+        \\const unwrapped = function () { return value; }();
+        \\const outside = (function () { return value; }());
+        \\const inside = (function () { return value; })();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .wrap_iife_style = .any,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const unwrapped = (function () { return value; }());
+        \\const outside = (function () { return value; }());
+        \\const inside = (function () { return value; })();
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.wrap_iife.id));
 }
 
 test "can disable wrap-iife" {


### PR DESCRIPTION
## Summary
- safely autofix eqeqeq when ESLint considers strict comparison semantics-preserving
- autofix wrap-iife for outside, inside, and any styles
- preserve unsafe eqeqeq findings as diagnostics without automatic edits

## Verification
- zig build test -Doptimize=ReleaseFast -j1 --summary all (1748/1748 passed)
- zig build -Doptimize=ReleaseFast -j1
- zig fmt --check on touched Zig files
- git diff --check