### PR TITLE
feat: autofix prefer-exponentiation-operator

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -197,7 +197,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
-| [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented |
+| [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented with safe autofix |
 | [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented with autofix for global static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented with autofix |

--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -35,6 +35,20 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (isGlobalMathPowCall(ctx.tree, self.symbol_table, call.callee)) {
+            if (try buildFix(self.allocator, ctx.tree, call, index, ctx)) |fix| {
+                defer self.allocator.free(fix.replacement);
+                try core.addDiagnosticWithFix(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Use the exponentiation operator (**) instead of Math.pow.",
+                    ctx.tree.span(index),
+                    fix,
+                );
+                return .proceed;
+            }
+
             try core.addDiagnostic(
                 self.allocator,
                 self.diagnostics,
@@ -48,6 +62,362 @@ const Visitor = struct {
         return .proceed;
     }
 };
+
+fn buildFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
+) Allocator.Error!?core.Fix {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len != 2) return null;
+    if (tree.data(arguments[0]) == .spread_element or tree.data(arguments[1]) == .spread_element) return null;
+    if (hasCommentsInside(tree, tree.span(index))) return null;
+
+    const base = unwrapParentheses(tree, arguments[0]);
+    const exponent = unwrapParentheses(tree, arguments[1]);
+    const base_span = tree.span(base);
+    const exponent_span = tree.span(exponent);
+    const parenthesize_base = doesBaseNeedParens(tree, base);
+    const parenthesize_exponent = expressionPrecedence(tree, exponent) == .lower;
+    const starts_expression_statement = isStartOfExpressionStatement(tree, index, ctx);
+    const parenthesize_all = doesReplacementNeedParens(tree, index, ctx) or
+        (starts_expression_statement and
+            !parenthesize_base and
+            startsStatementSensitiveExpression(tree.source[base_span.start..base_span.end]));
+    const call_span = tree.span(index);
+    const first_replacement_byte = if (parenthesize_all or parenthesize_base)
+        '('
+    else
+        tree.source[base_span.start];
+    const last_replacement_byte = if (parenthesize_all or parenthesize_exponent)
+        ')'
+    else
+        tree.source[exponent_span.end - 1];
+    var prefix: []const u8 = if (needsBoundarySpaceBefore(tree, call_span, first_replacement_byte)) " " else "";
+    if (prefix.len == 0 and
+        starts_expression_statement and
+        !isDirectControlFlowBody(tree, index, ctx) and
+        isContinuationByte(first_replacement_byte) and
+        needsPrecedingSemicolon(tree, call_span.start))
+    {
+        prefix = ";";
+    }
+    const suffix = if (needsBoundarySpaceAfter(tree, call_span, last_replacement_byte)) " " else "";
+    return .{
+        .span = call_span,
+        .replacement = try std.fmt.allocPrint(
+            allocator,
+            "{s}{s}{s}{s}{s}**{s}{s}{s}{s}{s}",
+            .{
+                prefix,
+                if (parenthesize_all) "(" else "",
+                if (parenthesize_base) "(" else "",
+                tree.source[base_span.start..base_span.end],
+                if (parenthesize_base) ")" else "",
+                if (parenthesize_exponent) "(" else "",
+                tree.source[exponent_span.start..exponent_span.end],
+                if (parenthesize_exponent) ")" else "",
+                if (parenthesize_all) ")" else "",
+                suffix,
+            },
+        ),
+    };
+}
+
+fn isDirectControlFlowBody(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
+) bool {
+    const start = tree.span(index).start;
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        if (tree.span(ancestor).start != start) return false;
+        if (tree.data(ancestor) != .expression_statement) continue;
+
+        const parent = ctx.path.ancestor(depth + 1) orelse return false;
+        return switch (tree.data(parent)) {
+            .if_statement => |statement| statement.consequent == ancestor or statement.alternate == ancestor,
+            .for_statement => |statement| statement.body == ancestor,
+            .for_in_statement => |statement| statement.body == ancestor,
+            .for_of_statement => |statement| statement.body == ancestor,
+            .while_statement => |statement| statement.body == ancestor,
+            .do_while_statement => |statement| statement.body == ancestor,
+            .with_statement => |statement| statement.body == ancestor,
+            .labeled_statement => |statement| statement.body == ancestor,
+            else => false,
+        };
+    }
+    return false;
+}
+
+fn isStartOfExpressionStatement(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
+) bool {
+    const start = tree.span(index).start;
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        if (tree.span(ancestor).start != start) return false;
+        if (tree.data(ancestor) == .expression_statement) return true;
+    }
+    return false;
+}
+
+fn startsStatementSensitiveExpression(text: []const u8) bool {
+    if (text.len == 0 or text[0] == '{') return true;
+    return startsWithKeyword(text, "function") or
+        startsWithKeyword(text, "class") or
+        (startsWithKeyword(text, "async") and std.mem.indexOf(u8, text, "function") != null);
+}
+
+fn startsWithKeyword(text: []const u8, keyword: []const u8) bool {
+    if (!std.mem.startsWith(u8, text, keyword)) return false;
+    return text.len == keyword.len or !isIdentifierByte(text[keyword.len]);
+}
+
+fn isContinuationByte(byte: u8) bool {
+    return byte == '(' or byte == '[' or byte == '/' or byte == '`';
+}
+
+fn needsPrecedingSemicolon(tree: *const ast.Tree, offset: u32) bool {
+    const previous = previousSignificantByte(tree, offset) orelse return false;
+    if (std.mem.indexOfAny(u8, tree.source[previous + 1 .. offset], "\r\n") == null) return false;
+
+    const byte = tree.source[previous];
+    if (byte == '}') return closingBraceRequiresSemicolon(tree, previous + 1);
+    if (byte == ';' or byte == '{' or byte == ':') return false;
+    if (isIdentifierByte(byte) and
+        (uninitializedDeclarationEndsAt(tree, previous + 1) or
+            typescriptTypeBoundaryEndsAt(tree, previous + 1))) return false;
+    if ((byte == '\'' or byte == '"') and moduleDeclarationEndsAt(tree, previous + 1)) return false;
+    if (previous > 0) {
+        const pair = tree.source[previous - 1 .. previous + 1];
+        if (std.mem.eql(u8, pair, "=>") or
+            std.mem.eql(u8, pair, "++") or
+            std.mem.eql(u8, pair, "--")) return false;
+    }
+
+    const word = previousWord(tree.source, previous);
+    if (std.mem.eql(u8, word, "break") or
+        std.mem.eql(u8, word, "continue") or
+        std.mem.eql(u8, word, "debugger") or
+        std.mem.eql(u8, word, "do") or
+        std.mem.eql(u8, word, "else") or
+        std.mem.eql(u8, word, "return") or
+        std.mem.eql(u8, word, "yield")) return false;
+
+    return true;
+}
+
+fn typescriptTypeBoundaryEndsAt(tree: *const ast.Tree, end: usize) bool {
+    for (0..tree.nodes.len) |raw_index| {
+        const index: ast.NodeIndex = @enumFromInt(raw_index);
+        if (tree.span(index).end != end) continue;
+        const data = tree.data(index);
+        if (data.isTypeContext()) return true;
+        switch (data) {
+            .ts_type_alias_declaration => return true,
+            .function => |function| if (function.type == .ts_declare_function) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn moduleDeclarationEndsAt(tree: *const ast.Tree, end: usize) bool {
+    for (0..tree.nodes.len) |raw_index| {
+        const index: ast.NodeIndex = @enumFromInt(raw_index);
+        if (tree.span(index).end != end) continue;
+        switch (tree.data(index)) {
+            .import_declaration, .export_named_declaration, .export_all_declaration => return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn uninitializedDeclarationEndsAt(tree: *const ast.Tree, end: usize) bool {
+    for (0..tree.nodes.len) |raw_index| {
+        const index: ast.NodeIndex = @enumFromInt(raw_index);
+        if (tree.span(index).end != end) continue;
+        switch (tree.data(index)) {
+            .variable_declarator => |declarator| if (declarator.init == .null) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn closingBraceRequiresSemicolon(tree: *const ast.Tree, end: usize) bool {
+    for (0..tree.nodes.len) |raw_index| {
+        const index: ast.NodeIndex = @enumFromInt(raw_index);
+        if (tree.span(index).end != end) continue;
+        switch (tree.data(index)) {
+            .object_expression => return true,
+            .function => |function| if (function.type == .function_expression) return true,
+            .class => |class| if (class.type == .class_expression) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn previousSignificantByte(tree: *const ast.Tree, offset: u32) ?usize {
+    var cursor: usize = offset;
+    while (cursor > 0) {
+        while (cursor > 0 and std.ascii.isWhitespace(tree.source[cursor - 1])) cursor -= 1;
+        if (cursor == 0) return null;
+
+        var skipped_comment = false;
+        for (tree.comments) |comment| {
+            if (comment.span.end == cursor) {
+                cursor = comment.span.start;
+                skipped_comment = true;
+                break;
+            }
+            if (comment.span.end > cursor) break;
+        }
+        if (!skipped_comment) return cursor - 1;
+    }
+    return null;
+}
+
+fn previousWord(source: []const u8, end: usize) []const u8 {
+    if (!isIdentifierByte(source[end])) return "";
+    var start = end;
+    while (start > 0 and isIdentifierByte(source[start - 1])) start -= 1;
+    return source[start .. end + 1];
+}
+
+fn needsBoundarySpaceBefore(tree: *const ast.Tree, span: ast.Span, first: u8) bool {
+    if (span.start == 0 or std.ascii.isWhitespace(tree.source[span.start - 1])) return false;
+    if (hasCommentEndingAt(tree, span.start)) return false;
+    return bytesNeedSeparation(tree.source[span.start - 1], first);
+}
+
+fn needsBoundarySpaceAfter(tree: *const ast.Tree, span: ast.Span, last: u8) bool {
+    if (span.end >= tree.source.len or std.ascii.isWhitespace(tree.source[span.end])) return false;
+    if (hasCommentStartingAt(tree, span.end)) return false;
+    return bytesNeedSeparation(last, tree.source[span.end]);
+}
+
+fn hasCommentEndingAt(tree: *const ast.Tree, offset: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end == offset) return true;
+        if (comment.span.end > offset) return false;
+    }
+    return false;
+}
+
+fn hasCommentStartingAt(tree: *const ast.Tree, offset: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start == offset) return true;
+        if (comment.span.start > offset) return false;
+    }
+    return false;
+}
+
+fn bytesNeedSeparation(left: u8, right: u8) bool {
+    if (isIdentifierByte(left) and isIdentifierByte(right)) return true;
+    return switch (left) {
+        '+', '-' => right == left or right == '=',
+        '/' => right == '/' or right == '*' or right == '=',
+        '*' => right == '/' or right == '*' or right == '=',
+        '<', '>' => right == left or right == '=',
+        '&', '|', '^', '%', '!', '=' => right == left or right == '=',
+        '?' => right == '?' or right == '=' or right == '.',
+        '.' => std.ascii.isDigit(right),
+        else => false,
+    };
+}
+
+fn isIdentifierByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
+}
+
+fn doesReplacementNeedParens(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
+) bool {
+    var child = index;
+    var depth: usize = 1;
+    var parent = ctx.path.ancestor(depth) orelse return false;
+
+    if (tree.data(parent) == .chain_expression) {
+        child = parent;
+        depth += 1;
+        parent = ctx.path.ancestor(depth) orelse return false;
+    }
+
+    return switch (tree.data(parent)) {
+        .parenthesized_expression => false,
+        .class => |class| class.super_class == child,
+        .binary_expression => |binary| binary.operator == .exponent and binary.left == child,
+        .unary_expression => |unary| unary.argument == child,
+        .await_expression => |await_expression| await_expression.argument == child,
+        .update_expression => |update| update.argument == child,
+        .member_expression => |member| member.object == child,
+        .call_expression => |call| call.callee == child,
+        .new_expression => |new_expression| new_expression.callee == child,
+        .tagged_template_expression => |tagged| tagged.tag == child,
+        .ts_as_expression => |expression| expression.expression == child,
+        .ts_satisfies_expression => |expression| expression.expression == child,
+        .ts_type_assertion => |expression| expression.expression == child,
+        .ts_non_null_expression => |expression| expression.expression == child,
+        else => false,
+    };
+}
+
+const RelativePrecedence = enum {
+    lower,
+    equal,
+    higher,
+};
+
+fn doesBaseNeedParens(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .await_expression, .unary_expression => true,
+        else => expressionPrecedence(tree, index) != .higher,
+    };
+}
+
+fn expressionPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) RelativePrecedence {
+    return switch (tree.data(index)) {
+        .binary_expression => |binary| if (binary.operator == .exponent) .equal else .lower,
+        .sequence_expression,
+        .arrow_function_expression,
+        .logical_expression,
+        .conditional_expression,
+        .assignment_expression,
+        .yield_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        => .lower,
+        else => .higher,
+    };
+}
+
+fn unwrapParentheses(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (tree.data(current) == .parenthesized_expression) {
+        current = tree.data(current).parenthesized_expression.expression;
+    }
+    return current;
+}
+
+fn hasCommentsInside(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start >= span.end) return false;
+        if (comment.span.start >= span.start and comment.span.end <= span.end) return true;
+    }
+    return false;
+}
 
 fn isGlobalMathPowCall(
     tree: *const ast.Tree,

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -31,6 +31,445 @@ test "reports prefer-exponentiation-operator for Math.pow calls" {
     );
 }
 
+test "autofixes a two-argument Math.pow call" {
+    const source = "const result = Math.pow(base, exponent);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const result = base**exponent;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "does not autofix calls with unsafe arguments or comments" {
+    const source =
+        \\Math.pow();
+        \\Math.pow(base);
+        \\Math.pow(base, exponent, modulus);
+        \\Math.pow(...values);
+        \\Math.pow(base, ...values);
+        \\Math/**/.pow(base, exponent);
+        \\Math.pow(base, /* keep */ exponent);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(
+        @as(usize, 7),
+        helpers.countRule(result.result, lint.rules.prefer_exponentiation_operator.id),
+    );
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_exponentiation_operator.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "preserves outside comments and removes redundant operand parentheses" {
+    const source = "/* before */Math.pow(((base)), ((exponent)))/* after */;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("/* before */base**exponent/* after */;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "parenthesizes Math.pow operands according to exponentiation precedence" {
+    const source =
+        \\Math.pow(a + b, c + d);
+        \\Math.pow(a ** b, c);
+        \\Math.pow(a, b ** c);
+        \\Math.pow(-a, -b);
+        \\Math.pow(a = b, c = d);
+        \\Math.pow((a, b), (c, d));
+        \\Math.pow(() => a, () => b);
+        \\async function run() { return Math.pow(await a, await b); }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\(a + b)**(c + d);
+        \\(a ** b)**c;
+        \\a**b ** c;
+        \\(-a)**-b;
+        \\(a = b)**(c = d);
+        \\(a, b)**(c, d);
+        \\(() => a)**(() => b);
+        \\async function run() { return (await a)**await b; }
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "parenthesizes exponentiation when required by its surrounding expression" {
+    const source =
+        \\+Math.pow(a, b);
+        \\Math.pow(a, b).toString();
+        \\Math.pow(a, b)();
+        \\Math.pow(a, b) ** c;
+        \\a ** Math.pow(b, c);
+        \\consume(Math.pow(a, b));
+        \\object[Math.pow(a, b)];
+        \\[Math.pow(a, b)];
+        \\class C extends Math.pow(a, b) {}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\+(a**b);
+        \\(a**b).toString();
+        \\(a**b)();
+        \\(a**b) ** c;
+        \\a ** b**c;
+        \\consume(a**b);
+        \\object[a**b];
+        \\[a**b];
+        \\class C extends (a**b) {}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "keeps replacement tokens lexically separated from their neighbors" {
+    const source =
+        \\a+Math.pow(++b, c);
+        \\a-Math.pow(--b, c);
+        \\Math.pow(a, b)in object;
+        \\a/Math.pow(/value/, 2);
+        \\a*Math.pow(/value/, 2);
+        \\Math.pow(a, /value/)/divisor;
+        \\a+/**/Math.pow(++b, c)/**/in object;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\a+ ++b**c;
+        \\a- --b**c;
+        \\a**b in object;
+        \\a/ /value/**2;
+        \\a* /value/**2;
+        \\a**/value/ /divisor;
+        \\a+/**/++b**c/**/in object;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "preserves expression statement parsing and automatic semicolon insertion" {
+    const source =
+        \\Math.pow({ value: 2 }.value, 3);
+        \\Math.pow(function () { return 2; }(), 3);
+        \\Math.pow(class { static value = 2 }.value, 3);
+        \\first
+        \\Math.pow(a + b, c);
+        \\second
+        \\Math.pow([a, b].length, c);
+        \\third
+        \\Math.pow(/regex/.source.length, c);
+        \\fourth
+        \\Math.pow(`value`.length, c);
+        \\done;
+        \\Math.pow((a).value, c);
+        \\if (done) {}
+        \\Math.pow((b).value, c);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+        .wrap_iife = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\({ value: 2 }.value**3);
+        \\(function () { return 2; }()**3);
+        \\(class { static value = 2 }.value**3);
+        \\first
+        \\;(a + b)**c;
+        \\second
+        \\;[a, b].length**c;
+        \\third
+        \\;/regex/.source.length**c;
+        \\fourth
+        \\;`value`.length**c;
+        \\done;
+        \\(a).value**c;
+        \\if (done) {}
+        \\(b).value**c;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "does not insert a semicolon before a control-flow body" {
+    const source =
+        \\if (condition)
+        \\  Math.pow([a].length, b);
+        \\while (condition)
+        \\  Math.pow([a].length, b);
+        \\for (; condition;)
+        \\  Math.pow([a].length, b);
+        \\label:
+        \\  Math.pow([a].length, b);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_extra_label = false,
+        .no_undef = false,
+        .no_unused_labels = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (condition)
+        \\  [a].length**b;
+        \\while (condition)
+        \\  [a].length**b;
+        \\for (; condition;)
+        \\  [a].length**b;
+        \\label:
+        \\  [a].length**b;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "autofixes parenthesized computed and optional Math.pow calls" {
+    const source =
+        \\(Math).pow(2, 8);
+        \\Math["pow"](2, 8);
+        \\Math[`pow`](2, 8);
+        \\Math.pow?.(2, 8);
+        \\Math?.pow(2, 8);
+        \\Math?.pow?.(2, 8);
+        \\(Math?.pow)?.(2, 8);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_dot_notation = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\2**8;
+        \\2**8;
+        \\2**8;
+        \\2**8;
+        \\2**8;
+        \\2**8;
+        \\2**8;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "parenthesizes TypeScript assertions in operand and parent positions" {
+    const source =
+        \\const first = Math.pow(base as number, exponent);
+        \\const second = Math.pow(base, exponent as number);
+        \\const third = Math.pow(base, exponent) as number;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const first = (base as number)**exponent;
+        \\const second = base**(exponent as number);
+        \\const third = (base**exponent) as number;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "autofixes nested Math.pow calls across fix iterations" {
+    const source = "Math.pow(Math.pow(a, b), Math.pow(c, d));";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("(a**b)**c**d;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "inserts a semicolon after brace-ending expression statements" {
+    const source =
+        \\let previous = function () {}
+        \\Math.pow(a + b, c);
+        \\previous = {}
+        \\Math.pow([a].length, c);
+        \\previous = class {}
+        \\Math.pow(`value`.length, c);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_empty_function = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\let previous = function () {}
+        \\;(a + b)**c;
+        \\previous = {}
+        \\;[a].length**c;
+        \\previous = class {}
+        \\;`value`.length**c;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "does not insert a semicolon after an uninitialized declaration" {
+    const source =
+        \\let previous
+        \\Math.pow([a].length, b);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\let previous
+        \\[a].length**b;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "does not insert a semicolon after a module declaration" {
+    const source =
+        \\import "first"
+        \\Math.pow([a].length, b);
+        \\export * from "second"
+        \\Math.pow([a].length, b);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.mjs", .{
+        .eol_last = false,
+        .no_undef = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\import "first"
+        \\[a].length**b;
+        \\export * from "second"
+        \\[a].length**b;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
+test "does not insert a semicolon after a TypeScript type boundary" {
+    const source =
+        \\type Value = number
+        \\Math.pow([a].length, b);
+        \\declare function consume(value: Value): void
+        \\Math.pow([a].length, b);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .typescript_eslint_no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\type Value = number
+        \\[a].length**b;
+        \\declare function consume(value: Value): void
+        \\[a].length**b;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_exponentiation_operator.id));
+}
+
 test "does not report prefer-exponentiation-operator for other calls or shadowed Math" {
     const source =
         \\Math.max(base, exponent);


### PR DESCRIPTION
## Summary
- autofix eligible global Math.pow calls to the exponentiation operator
- preserve diagnostics without fixes for wrong arity, spread arguments, or comments inside the call
- preserve operand and parent precedence, right associativity, optional chaining, TypeScript assertions, and nested fix iterations
- prevent token merging and automatic-semicolon-insertion behavior changes

## Why
Math.pow replacement is not a safe text substitution: unary bases, exponentiation associativity, high-precedence parents, adjacent tokens, and semicolonless statement boundaries all require context-aware edits.

## Verification
- zig build test -Doptimize=ReleaseFast -j1 --summary all (1763/1763 passed)
- zig build -Doptimize=ReleaseFast -j1
- zig fmt --check on touched Zig files
- git diff --check