### PR TITLE
feat: autofix capitalized comments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -10,7 +10,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`arrow-body-style`](https://eslint.org/docs/latest/rules/arrow-body-style) | Supports `always`, `as-needed`, `never`, and `requireReturnForObjectLiteral` diagnostics |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`camelcase`](https://eslint.org/docs/latest/rules/camelcase) | Supports declarations, imports, optional property checks, `ignoreDestructuring`, `ignoreImports`, lightweight `allow` patterns, and parses `ignoreGlobals` for migration compatibility |
-| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration |
+| [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration with autofix |
 | [`complexity`](https://eslint.org/docs/latest/rules/complexity) | Supports `max`, deprecated `maximum`, `classic` and `modified` variants, functions, arrow functions, and static blocks |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`consistent-this`](https://eslint.org/docs/latest/rules/consistent-this) | Supports configured aliases for direct `this` captures and same-scope deferred assignment checks |

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -44,19 +44,29 @@ pub fn runWithOptions(
         if (options.ignore_inline_comments and isInlineComment(tree, comment)) continue;
         if (options.ignore_consecutive_comments and consecutive) continue;
 
-        const value = trimLeftDecorations(tree.string(comment.value));
+        const raw_value = tree.string(comment.value);
+        const value = trimLeftDecorations(raw_value);
         if (isIgnoredComment(value)) continue;
 
-        const first = firstAsciiLetter(value) orelse continue;
-        if (!violatesMode(first, options.mode)) continue;
+        const first = firstAsciiLetter(raw_value) orelse continue;
+        if (!violatesMode(first.char, options.mode)) continue;
 
-        try core.addDiagnostic(
+        var replacement = [_]u8{switch (options.mode) {
+            .always => std.ascii.toUpper(first.char),
+            .never => std.ascii.toLower(first.char),
+        }};
+        const fix_start = comment.value.start + @as(u32, @intCast(first.offset));
+        try core.addDiagnosticWithFix(
             allocator,
             diagnostics,
             .warning,
             id,
             diagnosticMessage(options.mode),
             .{ .start = comment.span.start, .end = comment.span.end },
+            .{
+                .span = .{ .start = fix_start, .end = fix_start + 1 },
+                .replacement = replacement[0..],
+            },
         );
     }
 }
@@ -146,11 +156,16 @@ fn startsWithAnyIgnoreCase(value: []const u8, prefixes: []const []const u8) bool
     return false;
 }
 
-fn firstAsciiLetter(value: []const u8) ?u8 {
+const AsciiLetter = struct {
+    char: u8,
+    offset: usize,
+};
+
+fn firstAsciiLetter(value: []const u8) ?AsciiLetter {
     var index: usize = 0;
     while (index < value.len) : (index += 1) {
         const char = value[index];
-        if (std.ascii.isAlphabetic(char)) return char;
+        if (std.ascii.isAlphabetic(char)) return .{ .char = char, .offset = index };
         if (std.ascii.isDigit(char)) return null;
         if (char == '_' or char == '$') return null;
     }

--- a/tests/rules/capitalized_comments.zig
+++ b/tests/rules/capitalized_comments.zig
@@ -20,6 +20,58 @@ test "reports capitalized-comments for comments starting with lowercase words" {
     try std.testing.expectEqualStrings("Comments should start with an uppercase character.", result.diagnostics[0].message);
 }
 
+test "autofixes lowercase comment starts in always mode" {
+    const source =
+        \\// lowercase line comment
+        \\/* lowercase block comment */
+        \\/*
+        \\ * (decorated block comment)
+        \\ */
+    ;
+    const expected =
+        \\// Lowercase line comment
+        \\/* Lowercase block comment */
+        \\/*
+        \\ * (Decorated block comment)
+        \\ */
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.capitalized_comments.id));
+}
+
+test "composes with spaced-comment fixes at the same comment boundary" {
+    const source =
+        \\//lowercase line comment
+        \\/*lowercase block comment */
+        \\/**lowercase jsdoc comment */
+    ;
+    const expected =
+        \\// Lowercase line comment
+        \\/* Lowercase block comment */
+        \\/** Lowercase jsdoc comment */
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.capitalized_comments.id));
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.spaced_comment.id));
+}
+
 test "allows uppercase, numeric, symbolic, directives, urls, and empty comments" {
     const source =
         \\// Uppercase line comment
@@ -64,6 +116,52 @@ test "reports capitalized-comments for uppercase starts in never mode" {
 
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.capitalized_comments.id));
     try std.testing.expectEqualStrings("Comments should not start with an uppercase character.", result.diagnostics[0].message);
+}
+
+test "autofixes uppercase comment starts in never mode" {
+    const source =
+        \\// Uppercase line comment
+        \\/* (Uppercase block comment) */
+    ;
+    const expected =
+        \\// uppercase line comment
+        \\/* (uppercase block comment) */
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments_mode = .never,
+        .eol_last = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.capitalized_comments.id));
+}
+
+test "does not autofix comments excluded by ignore options" {
+    const source =
+        \\const first = call(/* lowercase inline block */ value);
+        \\// First comment starts a group
+        \\// second consecutive line comment
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments_ignore_inline_comments = .yes,
+        .capitalized_comments_ignore_consecutive_comments = .yes,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .spaced_comment = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.capitalized_comments.id));
 }
 
 test "ignores only inline comments when ignoreInlineComments is enabled" {

--- a/tests/rules/dot_notation.zig
+++ b/tests/rules/dot_notation.zig
@@ -184,6 +184,7 @@ test "does not autofix computed properties when comments would be discarded" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .no_unused_expressions = false,

--- a/tests/rules/eqeqeq.zig
+++ b/tests/rules/eqeqeq.zig
@@ -55,6 +55,7 @@ test "keeps unsafe loose equality diagnostics unfixed and preserves comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_eq_null = false,
         .no_undef = false,

--- a/tests/rules/no_array_constructor.zig
+++ b/tests/rules/no_array_constructor.zig
@@ -64,6 +64,7 @@ test "autofixes Array constructors while preserving argument text" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_console = false,
         .no_unused_vars = false,
@@ -88,6 +89,7 @@ test "does not autofix Array constructors with unsafe call or comment boundaries
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_console = false,
         .no_unused_expressions = false,

--- a/tests/rules/no_confusing_arrow.zig
+++ b/tests/rules/no_confusing_arrow.zig
@@ -71,6 +71,7 @@ test "autofixes confusing arrow bodies when parentheses are allowed" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,

--- a/tests/rules/no_extra_bind.zig
+++ b/tests/rules/no_extra_bind.zig
@@ -152,6 +152,7 @@ test "does not autofix bind calls with effects, spreads, or comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,

--- a/tests/rules/no_extra_boolean_cast.zig
+++ b/tests/rules/no_extra_boolean_cast.zig
@@ -214,6 +214,7 @@ test "does not autofix unsafe Boolean calls or commented negations" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,

--- a/tests/rules/no_multi_spaces.zig
+++ b/tests/rules/no_multi_spaces.zig
@@ -183,6 +183,7 @@ test "autofixes reported runs of multiple spaces" {
         "const second = 2; // comment\n";
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .no_inline_comments = false,
         .no_unused_vars = false,
         .no_undef = false,

--- a/tests/rules/no_useless_computed_key.zig
+++ b/tests/rules/no_useless_computed_key.zig
@@ -90,6 +90,7 @@ test "autofixes safe computed keys without discarding comments or merging numeri
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_floating_decimal = false,
         .no_unused_vars = false,

--- a/tests/rules/no_useless_rename.zig
+++ b/tests/rules/no_useless_rename.zig
@@ -118,6 +118,7 @@ test "does not autofix aliases when replacement would discard comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -190,6 +190,7 @@ test "does not autofix non-list or commented redundant returns" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -59,6 +59,7 @@ test "does not autofix calls with unsafe arguments or comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .typescript_eslint_no_unused_expressions = false,
@@ -83,6 +84,7 @@ test "preserves outside comments and removes redundant operand parentheses" {
     const source = "/* before */Math.pow(((base)), ((exponent)))/* after */;";
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_undef = false,
         .typescript_eslint_no_unused_expressions = false,

--- a/tests/rules/prefer_object_has_own.zig
+++ b/tests/rules/prefer_object_has_own.zig
@@ -102,6 +102,7 @@ test "autofixes Object.hasOwn safely without dropping comments or matching nonem
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_prototype_builtins = false,
         .no_undef = false,

--- a/tests/rules/spaced_comment.zig
+++ b/tests/rules/spaced_comment.zig
@@ -157,6 +157,7 @@ test "autofixes missing spaces after comment markers" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_inline_comments = false,
         .no_tabs = false,
@@ -181,6 +182,7 @@ test "autofixes spaces and tabs disallowed after comment markers" {
         "/**jsdoc comment */";
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .spaced_comment_style = .never,
         .no_inline_comments = false,
@@ -202,6 +204,7 @@ test "does not autofix a disallowed newline after a block comment marker" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .spaced_comment_style = .never,
         .no_unused_vars = false,

--- a/tests/rules/typescript_eslint_no_array_constructor.zig
+++ b/tests/rules/typescript_eslint_no_array_constructor.zig
@@ -92,6 +92,7 @@ test "typescript autofix preserves ASI and constructor header comments" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .capitalized_comments = false,
         .eol_last = false,
         .no_unused_expressions = false,
         .typescript_eslint_no_unused_expressions = false,


### PR DESCRIPTION
## Summary

- attach single-character fixes to `capitalized-comments` diagnostics in `always` and `never` modes
- preserve ignored inline/consecutive comments and compose with `spaced-comment` fixes
- isolate unrelated autofix tests from the newly fixable default rule and document support

## Test plan

- `zig fmt --check build.zig src tests`
- `zig build test` (1767/1767)
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrapper smoke test