### PR TITLE
feat: autofix redundant strict directives

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -217,7 +217,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`sort-keys`](https://eslint.org/docs/latest/rules/sort-keys) | Supports object literal key ordering with `asc`/`desc`, `caseSensitive`, `natural`, `minKeys`, and `allowLineSeparatedGroups` |
 | [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting and `ignoreCase` configuration |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration with safe autofix |
-| [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes |
+| [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes with autofix for redundant directives |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |
 | [`unicode-bom`](https://eslint.org/docs/latest/rules/unicode-bom) | Supports `never` and `always` configuration with autofix |
 | [`use-isnan`](https://eslint.org/docs/latest/rules/use-isnan) | Supports `enforceForIndexOf` and `enforceForSwitchCase` configuration |

--- a/src/rules/strict.zig
+++ b/src/rules/strict.zig
@@ -66,8 +66,8 @@ const Visitor = struct {
                 try reportDuplicateDirectives(self.allocator, self.diagnostics, ctx.tree, program.body);
             },
             .function => {},
-            .never => try reportDirectives(self.allocator, self.diagnostics, ctx.tree, program.body, "Strict mode is not permitted."),
-            .module => try reportDirectives(self.allocator, self.diagnostics, ctx.tree, program.body, "'use strict' is unnecessary inside of modules."),
+            .never => try reportDirectives(self.allocator, self.diagnostics, ctx.tree, program.body, "Strict mode is not permitted.", false),
+            .module => try reportDirectives(self.allocator, self.diagnostics, ctx.tree, program.body, "'use strict' is unnecessary inside of modules.", true),
         }
         return .proceed;
     }
@@ -101,7 +101,14 @@ const Visitor = struct {
                     .module => "'use strict' is unnecessary inside of modules.",
                     .function => unreachable,
                 };
-                try reportDirectives(self.allocator, self.diagnostics, ctx.tree, body_range.?, message);
+                try reportDirectives(
+                    self.allocator,
+                    self.diagnostics,
+                    ctx.tree,
+                    body_range.?,
+                    message,
+                    self.mode == .module,
+                );
             }
         }
 
@@ -146,9 +153,21 @@ const Visitor = struct {
                     "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016.",
                 );
             } else if (parent_is_strict) {
-                try addDiagnostic(self.allocator, self.diagnostics, tree, first_directive, "Unnecessary 'use strict' directive.");
+                try addRemovalDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    tree,
+                    first_directive,
+                    "Unnecessary 'use strict' directive.",
+                );
             } else if (self.class_depth > 0) {
-                try addDiagnostic(self.allocator, self.diagnostics, tree, first_directive, "'use strict' is unnecessary inside of classes.");
+                try addRemovalDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    tree,
+                    first_directive,
+                    "'use strict' is unnecessary inside of classes.",
+                );
             }
             try reportDuplicateDirectives(self.allocator, self.diagnostics, tree, body_range.?);
         } else if (parent_is_global and isSimpleParameterList(tree, function.params)) {
@@ -193,10 +212,15 @@ fn reportDirectives(
     tree: *const ast.Tree,
     body: ast.IndexRange,
     message: []const u8,
+    fixable: bool,
 ) Allocator.Error!void {
     for (tree.extra(body)) |statement| {
         if (!isUseStrictDirective(tree, statement)) break;
-        try addDiagnostic(allocator, diagnostics, tree, statement, message);
+        if (fixable) {
+            try addRemovalDiagnostic(allocator, diagnostics, tree, statement, message);
+        } else {
+            try addDiagnostic(allocator, diagnostics, tree, statement, message);
+        }
     }
 }
 
@@ -210,7 +234,7 @@ fn reportDuplicateDirectives(
     for (tree.extra(body)) |statement| {
         if (!isUseStrictDirective(tree, statement)) break;
         if (seen_first) {
-            try addDiagnostic(allocator, diagnostics, tree, statement, "Multiple 'use strict' directives.");
+            try addRemovalDiagnostic(allocator, diagnostics, tree, statement, "Multiple 'use strict' directives.");
         } else {
             seen_first = true;
         }
@@ -255,5 +279,24 @@ fn addDiagnostic(
         id,
         message,
         tree.span(index),
+    );
+}
+
+fn addRemovalDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    message: []const u8,
+) Allocator.Error!void {
+    const span = tree.span(index);
+    try core.addDiagnosticWithFix(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        span,
+        .{ .span = span, .replacement = "" },
     );
 }

--- a/tests/rules/strict.zig
+++ b/tests/rules/strict.zig
@@ -30,6 +30,17 @@ test "reports strict duplicate global directives" {
     try std.testing.expect(hasMessage(result, "Multiple 'use strict' directives."));
 }
 
+test "autofixes duplicate global directives" {
+    const source = "\"use strict\"; \"use strict\"; const value = 1;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.cjs", options(.global));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("\"use strict\";  const value = 1;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.strict.id));
+}
+
 test "reports strict function mode for top-level functions without directives" {
     const source =
         \\function run(value) {
@@ -58,6 +69,31 @@ test "allows strict function mode for function directives" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.strict.id));
 }
 
+test "autofixes directives inherited from a strict parent function" {
+    const source = "function outer() { \"use strict\"; return function inner() { \"use strict\"; return 1; }; }";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.cjs", options(.function));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        "function outer() { \"use strict\"; return function inner() {  return 1; }; }",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.strict.id));
+}
+
+test "autofixes directives inside classes" {
+    const source = "class Example { method() { \"use strict\"; return 1; } }";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.cjs", options(.function));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("class Example { method() {  return 1; } }", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.strict.id));
+}
+
 test "reports strict never mode and module directives" {
     const source =
         \\"use strict";
@@ -71,6 +107,71 @@ test "reports strict never mode and module directives" {
     var module_result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", options(.safe));
     defer module_result.deinit(std.testing.allocator);
     try std.testing.expect(hasMessage(module_result, "'use strict' is unnecessary inside of modules."));
+}
+
+test "autofixes unnecessary module directives" {
+    const source = "\"use strict\"; export function run() { \"use strict\"; return 1; }";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.mjs", options(.safe));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(" export function run() {  return 1; }", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.strict.id));
+}
+
+test "autofix preserves comments around removed directives" {
+    const source = "/* before */ \"use strict\"; /* after */ export const value = 1;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.mjs", options(.safe));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("/* before */  /* after */ export const value = 1;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.strict.id));
+}
+
+test "does not autofix diagnostics that could change strict-mode semantics" {
+    const Case = struct {
+        source: []const u8,
+        mode: StrictMode,
+    };
+    const cases = [_]Case{
+        .{ .source = "\"use strict\"; call();", .mode = .never },
+        .{ .source = "call();", .mode = .global },
+        .{ .source = "function run() {}", .mode = .function },
+        .{ .source = "function run(value = 1) { \"use strict\"; return value; }", .mode = .function },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSourceAndFix(std.testing.allocator, case.source, "fixture.cjs", options(case.mode));
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.fixed);
+        try std.testing.expectEqualStrings(case.source, result.output);
+        try std.testing.expect(helpers.hasRule(result.result, lint.rules.strict.id));
+        for (result.result.diagnostics) |diagnostic| {
+            if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.strict.id)) {
+                try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+            }
+        }
+    }
+}
+
+test "autofixes only duplicate directives with non-simple parameters" {
+    const source = "function run(value = 1) { \"use strict\"; \"use strict\"; return value; }";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.cjs", options(.function));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        "function run(value = 1) { \"use strict\";  return value; }",
+        result.output,
+    );
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.strict.id));
+    try std.testing.expect(hasMessage(result.result, "non-simple parameter list"));
+    try std.testing.expectEqual(@as(usize, 0), result.result.diagnostics[0].fixes.len);
 }
 
 test "parses strict config mode" {
@@ -93,7 +194,10 @@ fn options(mode: StrictMode) lint.Options {
 
 fn baseOptions() lint.Options {
     return .{
+        .capitalized_comments = false,
+        .eol_last = false,
         .no_empty_block_statements = false,
+        .no_multi_spaces = false,
         .no_undef = false,
         .no_unused_vars = false,
         .parser_semantic_errors = false,


### PR DESCRIPTION
## Summary

- remove duplicate `use strict` directives in global and function modes
- remove directives made redundant by modules, strict parent functions, or class bodies
- leave missing, `never`, `global`, and non-simple-parameter diagnostics unfixed when changing them could alter semantics
- preserve surrounding comments and document the safe autofix boundary

## Test plan

- `zig fmt --check build.zig src tests`
- `zig build test` (1774/1774)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrapper smoke test