### PR TITLE
feat: autofix operator assignments

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -193,7 +193,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
-| [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Implemented |
+| [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Supports `always` and `never` modes with safe autofix |
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |

--- a/src/rules/operator_assignment.zig
+++ b/src/rules/operator_assignment.zig
@@ -40,6 +40,18 @@ pub fn checkWithOptions(
 ) Allocator.Error!void {
     if (options.style == .never) {
         if (!isCompoundAssignmentOperator(expression.operator)) return;
+        if (try neverFix(allocator, tree, expression, index)) |fix| {
+            defer allocator.free(fix.replacement);
+            return core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Assignment operator shorthand is not allowed.",
+                tree.span(index),
+                fix,
+            );
+        }
         return core.addDiagnostic(
             allocator,
             diagnostics,
@@ -52,7 +64,8 @@ pub fn checkWithOptions(
 
     if (expression.operator != .assign) return;
 
-    const binary = switch (tree.data(unwrapTransparent(tree, expression.right))) {
+    const binary_index = unwrapTransparent(tree, expression.right);
+    const binary = switch (tree.data(binary_index)) {
         .binary_expression => |binary| binary,
         else => return,
     };
@@ -64,10 +77,26 @@ pub fn checkWithOptions(
 
     const left = (try referenceFromExpression(arena_allocator, tree, expression.left)) orelse return;
     const right_left = (try referenceFromExpression(arena_allocator, tree, binary.left)) orelse return;
-    if (!referencesEqual(left, right_left)) {
+    const repeats_left = referencesEqual(left, right_left);
+    if (!repeats_left) {
         if (!hasCommutativeAssignmentOperator(binary.operator)) return;
         const right_right = (try referenceFromExpression(arena_allocator, tree, binary.right)) orelse return;
         if (!referencesEqual(left, right_right)) return;
+    }
+
+    if (repeats_left) {
+        if (try alwaysFix(allocator, tree, expression, index, binary, binary_index)) |fix| {
+            defer allocator.free(fix.replacement);
+            return core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Assignment can be replaced with operator assignment.",
+                tree.span(index),
+                fix,
+            );
+        }
     }
 
     try core.addDiagnostic(
@@ -78,6 +107,140 @@ pub fn checkWithOptions(
         "Assignment can be replaced with operator assignment.",
         tree.span(index),
     );
+}
+
+fn neverFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!?core.Fix {
+    if (!canBeFixed(tree, expression.left)) return null;
+    const operator_text = expression.operator.toString();
+    const operator_span = findOperatorSpan(
+        tree,
+        tree.span(expression.left).end,
+        tree.span(expression.right).start,
+        operator_text,
+    ) orelse return null;
+    const assignment_span = tree.span(index);
+    if (hasCommentBetween(tree, assignment_span.start, operator_span.start)) return null;
+
+    const left_text = tree.source[assignment_span.start..operator_span.start];
+    const operator = baseOperator(expression.operator);
+    if (rightNeedsParentheses(tree, expression.right, expression.operator)) {
+        const right_span = tree.span(expression.right);
+        const gap = tree.source[operator_span.end..right_span.start];
+        const right_text = tree.source[right_span.start..right_span.end];
+        return .{
+            .span = assignment_span,
+            .replacement = try std.fmt.allocPrint(
+                allocator,
+                "{s}= {s}{s}{s}({s})",
+                .{ left_text, left_text, operator, gap, right_text },
+            ),
+        };
+    }
+
+    const right_text = tree.source[operator_span.end..assignment_span.end];
+    const separator = if (right_text.len > 0 and tokensNeedSeparation(operator[operator.len - 1], right_text[0])) " " else "";
+    return .{
+        .span = assignment_span,
+        .replacement = try std.fmt.allocPrint(
+            allocator,
+            "{s}= {s}{s}{s}{s}",
+            .{ left_text, left_text, operator, separator, right_text },
+        ),
+    };
+}
+
+fn tokensNeedSeparation(left: u8, right: u8) bool {
+    return (left == '+' and right == '+') or
+        (left == '-' and right == '-') or
+        (left == '/' and (right == '/' or right == '*'));
+}
+
+fn alwaysFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    binary: ast.BinaryExpression,
+    binary_index: ast.NodeIndex,
+) Allocator.Error!?core.Fix {
+    if (!canBeFixed(tree, expression.left) or !canBeFixed(tree, binary.left)) return null;
+
+    const assignment_span = tree.span(index);
+    const equals_span = findOperatorSpan(
+        tree,
+        tree.span(expression.left).end,
+        tree.span(expression.right).start,
+        "=",
+    ) orelse return null;
+    const operator_text = binary.operator.toString();
+    const operator_span = findOperatorSpan(
+        tree,
+        tree.span(binary.left).end,
+        tree.span(binary.right).start,
+        operator_text,
+    ) orelse return null;
+    if (hasCommentBetween(tree, equals_span.end, operator_span.start)) return null;
+
+    const left_text = tree.source[assignment_span.start..equals_span.start];
+    const right_text = try allocAlwaysRightText(
+        allocator,
+        tree,
+        expression.right,
+        binary_index,
+        operator_span.end,
+    );
+    defer allocator.free(right_text);
+    return .{
+        .span = assignment_span,
+        .replacement = try std.fmt.allocPrint(allocator, "{s}{s}={s}", .{ left_text, operator_text, right_text }),
+    };
+}
+
+fn allocAlwaysRightText(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    wrapped_index: ast.NodeIndex,
+    binary_index: ast.NodeIndex,
+    start: u32,
+) Allocator.Error![]u8 {
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+
+    const binary_end = tree.span(binary_index).end;
+    try output.appendSlice(allocator, tree.source[start..binary_end]);
+
+    const wrapped_end = tree.span(wrapped_index).end;
+    var cursor: usize = binary_end;
+    while (cursor < wrapped_end) : (cursor += 1) {
+        if (isTransparentClosingParenthesis(tree, wrapped_index, binary_index, cursor)) continue;
+        try output.append(allocator, tree.source[cursor]);
+    }
+    return output.toOwnedSlice(allocator);
+}
+
+fn isTransparentClosingParenthesis(
+    tree: *const ast.Tree,
+    wrapped_index: ast.NodeIndex,
+    target_index: ast.NodeIndex,
+    offset: usize,
+) bool {
+    var current = wrapped_index;
+    while (current != target_index) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| {
+                if (tree.span(current).end - 1 == offset) return true;
+                current = parenthesized.expression;
+            },
+            .chain_expression => |chain| current = chain.expression,
+            else => return false,
+        }
+    }
+    return false;
 }
 
 fn isCompoundAssignmentOperator(operator: ast.AssignmentOperator) bool {
@@ -96,6 +259,95 @@ fn isCompoundAssignmentOperator(operator: ast.AssignmentOperator) bool {
         .bitwise_and_assign,
         => true,
         else => false,
+    };
+}
+
+fn baseOperator(operator: ast.AssignmentOperator) []const u8 {
+    return switch (operator) {
+        .add_assign => "+",
+        .subtract_assign => "-",
+        .multiply_assign => "*",
+        .divide_assign => "/",
+        .modulo_assign => "%",
+        .exponent_assign => "**",
+        .left_shift_assign => "<<",
+        .right_shift_assign => ">>",
+        .unsigned_right_shift_assign => ">>>",
+        .bitwise_or_assign => "|",
+        .bitwise_xor_assign => "^",
+        .bitwise_and_assign => "&",
+        else => unreachable,
+    };
+}
+
+fn rightNeedsParentheses(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    operator: ast.AssignmentOperator,
+) bool {
+    if (tree.data(index) == .parenthesized_expression) return false;
+    return expressionPrecedence(tree, index) <= assignmentOperatorPrecedence(operator);
+}
+
+fn expressionPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) u8 {
+    return switch (tree.data(index)) {
+        .sequence_expression => 1,
+        .assignment_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .conditional_expression,
+        => 2,
+        .logical_expression => |logical| switch (logical.operator) {
+            .@"or", .nullish_coalescing => 3,
+            .@"and" => 4,
+        },
+        .binary_expression => |binary| binaryOperatorPrecedence(binary.operator),
+        .ts_as_expression, .ts_satisfies_expression => 9,
+        .unary_expression, .await_expression, .ts_type_assertion => 14,
+        .update_expression => 15,
+        .new_expression,
+        .call_expression,
+        .member_expression,
+        .chain_expression,
+        .tagged_template_expression,
+        .import_expression,
+        .ts_non_null_expression,
+        .ts_instantiation_expression,
+        => 17,
+        else => 18,
+    };
+}
+
+fn assignmentOperatorPrecedence(operator: ast.AssignmentOperator) u8 {
+    return switch (operator) {
+        .bitwise_or_assign => 5,
+        .bitwise_xor_assign => 6,
+        .bitwise_and_assign => 7,
+        .left_shift_assign, .right_shift_assign, .unsigned_right_shift_assign => 10,
+        .add_assign, .subtract_assign => 11,
+        .multiply_assign, .divide_assign, .modulo_assign => 12,
+        .exponent_assign => 13,
+        else => unreachable,
+    };
+}
+
+fn binaryOperatorPrecedence(operator: ast.BinaryOperator) u8 {
+    return switch (operator) {
+        .bitwise_or => 5,
+        .bitwise_xor => 6,
+        .bitwise_and => 7,
+        .equal, .not_equal, .strict_equal, .strict_not_equal => 8,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        .in,
+        .instanceof,
+        => 9,
+        .left_shift, .right_shift, .unsigned_right_shift => 10,
+        .add, .subtract => 11,
+        .multiply, .divide, .modulo => 12,
+        .exponent => 13,
     };
 }
 
@@ -187,6 +439,71 @@ fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8
         .private_identifier => |identifier| tree.string(identifier.name),
         else => null,
     };
+}
+
+fn canBeFixed(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const unwrapped = unwrapParentheses(tree, index);
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => true,
+        .member_expression => |member| blk: {
+            const object = unwrapParentheses(tree, member.object);
+            switch (tree.data(object)) {
+                .identifier_reference, .this_expression => {},
+                else => break :blk false,
+            }
+            if (!member.computed) break :blk true;
+            break :blk switch (tree.data(member.property)) {
+                .string_literal, .numeric_literal => true,
+                else => false,
+            };
+        },
+        else => false,
+    };
+}
+
+fn findOperatorSpan(
+    tree: *const ast.Tree,
+    start: u32,
+    end: u32,
+    operator: []const u8,
+) ?ast.Span {
+    var cursor: usize = start;
+    const limit: usize = end;
+    while (cursor + operator.len <= limit) {
+        if (commentContaining(tree, cursor)) |comment| {
+            cursor = comment.span.end;
+            continue;
+        }
+        if (std.mem.eql(u8, tree.source[cursor .. cursor + operator.len], operator)) {
+            return .{ .start = @intCast(cursor), .end = @intCast(cursor + operator.len) };
+        }
+        cursor += 1;
+    }
+    return null;
+}
+
+fn commentContaining(tree: *const ast.Tree, offset: usize) ?ast.Comment {
+    for (tree.comments) |comment| {
+        if (comment.span.start > offset) return null;
+        if (comment.span.start <= offset and offset < comment.span.end) return comment;
+    }
+    return null;
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start >= end) return false;
+        if (comment.span.end > start) return true;
+    }
+    return false;
+}
+
+fn unwrapParentheses(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null and tree.data(current) == .parenthesized_expression) {
+        current = tree.data(current).parenthesized_expression.expression;
+    }
+    return current;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/tests/rules/operator_assignment.zig
+++ b/tests/rules/operator_assignment.zig
@@ -35,6 +35,143 @@ test "reports operator-assignment for assignable binary self updates" {
     try std.testing.expectEqual(@as(usize, 16), helpers.countRule(result, lint.rules.operator_assignment.id));
 }
 
+test "autofixes a simple binary self update" {
+    const source = "value = value + amount;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("value += amount;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "autofixes safe left-repeat operators and preserves right-hand text" {
+    const source =
+        \\value = value - amount;
+        \\value = value * amount;
+        \\value = value / amount;
+        \\value = value % amount;
+        \\value = value ** amount;
+        \\value = value << amount;
+        \\value = value >> amount;
+        \\value = value >>> amount;
+        \\value = value | mask;
+        \\value = value ^ mask;
+        \\value = value & mask;
+        \\obj.count = obj.count + amount;
+        \\this.total = this.total - amount;
+        \\obj["count"] = obj["count"] | mask;
+        \\obj[0] = obj[0] & mask;
+        \\value = (value + amount);
+        \\value = value + (amount);
+    ;
+    const expected =
+        \\value -= amount;
+        \\value *= amount;
+        \\value /= amount;
+        \\value %= amount;
+        \\value **= amount;
+        \\value <<= amount;
+        \\value >>= amount;
+        \\value >>>= amount;
+        \\value |= mask;
+        \\value ^= mask;
+        \\value &= mask;
+        \\obj.count += amount;
+        \\this.total -= amount;
+        \\obj["count"] |= mask;
+        \\obj[0] &= mask;
+        \\value += amount;
+        \\value += (amount);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .dot_notation = false,
+        .eol_last = false,
+        .no_bitwise = false,
+        .no_undef = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "does not autofix unsafe always-mode diagnostics" {
+    const source =
+        \\value = amount * value;
+        \\obj.deep.count = obj.deep.count + amount;
+        \\obj[key] = obj[key] + amount;
+        \\value = /* keep */ value + amount;
+        \\value = value /* keep */ + amount;
+        \\(obj?.count).total = (obj?.count).total + amount;
+        \\obj.count = obj?.count + amount;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(
+        @as(usize, 7),
+        helpers.countRule(result.result, lint.rules.operator_assignment.id),
+    );
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.operator_assignment.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "always-mode autofix preserves comments outside the removed reference" {
+    const source = "obj/* left */.count/* equals */= obj.count +/* right */ amount;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        "obj/* left */.count/* equals */+=/* right */ amount;",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "always-mode autofix preserves trailing comments inside redundant parentheses" {
+    const source = "value = ((value + amount /* keep */) /* outer */);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("value += amount /* keep */ /* outer */;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
 test "does not report operator-assignment when shorthand would change the expression" {
     const source =
         \\let value = 1;
@@ -97,6 +234,234 @@ test "reports operator-assignment for shorthand when configured never" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 12), helpers.countRule(result, lint.rules.operator_assignment.id));
+}
+
+test "autofixes simple shorthand in never mode" {
+    const source = "value += amount;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("value = value + amount;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "never-mode autofix expands supported shorthand references" {
+    const source =
+        \\value -= amount;
+        \\value *= amount;
+        \\value /= amount;
+        \\value %= amount;
+        \\value **= amount;
+        \\value <<= amount;
+        \\value >>= amount;
+        \\value >>>= amount;
+        \\value |= mask;
+        \\value ^= mask;
+        \\value &= mask;
+        \\obj.count += amount;
+        \\this.total -= amount;
+        \\obj["count"] |= mask;
+        \\obj[0] &= mask;
+        \\value &&= amount;
+        \\value ||= amount;
+        \\value ??= amount;
+    ;
+    const expected =
+        \\value = value - amount;
+        \\value = value * amount;
+        \\value = value / amount;
+        \\value = value % amount;
+        \\value = value ** amount;
+        \\value = value << amount;
+        \\value = value >> amount;
+        \\value = value >>> amount;
+        \\value = value | mask;
+        \\value = value ^ mask;
+        \\value = value & mask;
+        \\obj.count = obj.count + amount;
+        \\this.total = this.total - amount;
+        \\obj["count"] = obj["count"] | mask;
+        \\obj[0] = obj[0] & mask;
+        \\value &&= amount;
+        \\value ||= amount;
+        \\value ??= amount;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .dot_notation = false,
+        .eol_last = false,
+        .no_bitwise = false,
+        .no_undef = false,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "never-mode autofix preserves right-hand precedence" {
+    const source =
+        \\value *= amount + 1;
+        \\value -= amount - offset;
+        \\value += amount + suffix;
+        \\value += amount = 1;
+        \\value *= (amount + 1);
+        \\value += amount * scale;
+        \\value **= amount ** exponent;
+    ;
+    const expected =
+        \\value = value * (amount + 1);
+        \\value = value - (amount - offset);
+        \\value = value + (amount + suffix);
+        \\value = value + (amount = 1);
+        \\value = value * (amount + 1);
+        \\value = value + amount * scale;
+        \\value = value ** (amount ** exponent);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .eol_last = false,
+        .no_multi_assign = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "never-mode autofix keeps replacement tokens separated" {
+    const source =
+        \\value+=-amount;
+        \\value+=+amount;
+        \\value-=--count;
+        \\value/=/**/amount;
+        \\value/=// keep
+        \\amount;
+        \\value/=/pattern/;
+        \\value+=/**/+amount;
+        \\value+= +amount;
+    ;
+    const expected =
+        \\value= value+-amount;
+        \\value= value+ +amount;
+        \\value= value- --count;
+        \\value= value/ /**/amount;
+        \\value= value/ // keep
+        \\amount;
+        \\value= value/ /pattern/;
+        \\value= value+/**/+amount;
+        \\value= value+ +amount;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "never-mode autofix preserves comments after the operator" {
+    const source =
+        \\value +=/* keep */ amount;
+        \\value +=// keep
+        \\ amount;
+    ;
+    const expected =
+        \\value = value +/* keep */ amount;
+        \\value = value +// keep
+        \\ amount;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
+}
+
+test "does not autofix never-mode references that would be duplicated unsafely" {
+    const source =
+        \\value/* keep */+= amount;
+        \\obj/* keep */.count += amount;
+        \\(/* keep */value) += amount;
+        \\obj.deep.count += amount;
+        \\obj[key] += amount;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(
+        @as(usize, 5),
+        helpers.countRule(result.result, lint.rules.operator_assignment.id),
+    );
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.operator_assignment.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "never-mode autofix preserves parentheses and comments outside the assignment" {
+    const source =
+        \\(/* outside */value += amount);
+        \\(obj.count) ^= mask;
+    ;
+    const expected =
+        \\(/* outside */value = value + amount);
+        \\(obj.count) = (obj.count) ^ mask;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .operator_assignment_style = .never,
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_bitwise = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.operator_assignment.id));
 }
 
 test "can disable operator-assignment" {


### PR DESCRIPTION
## Summary

- autofix safe repeated-reference assignments in `always` mode across all supported operators
- expand compound assignments in `never` mode while preserving expression precedence
- preserve comments, transparent-parenthesis trivia, spacing, regex/comment boundaries, and token adjacency
- leave reversed commutative expressions, dynamic/nested references, optional chains, and comment-duplication cases unfixed
- document safe autofix support

## Test plan

- `zig fmt --check build.zig src tests`
- `zig build test` (1786/1786)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrapper smoke test