### PR TITLE
feat: autofix lonely if statements

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -107,7 +107,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-label-var`](https://eslint.org/docs/latest/rules/no-label-var) | Implemented |
 | [`no-labels`](https://eslint.org/docs/latest/rules/no-labels) | Implemented |
 | [`no-lone-blocks`](https://eslint.org/docs/latest/rules/no-lone-blocks) | Implemented with block-scoped binding exceptions |
-| [`no-lonely-if`](https://eslint.org/docs/latest/rules/no-lonely-if) | Implemented |
+| [`no-lonely-if`](https://eslint.org/docs/latest/rules/no-lonely-if) | Implemented with safe autofix |
 | [`no-loop-func`](https://eslint.org/docs/latest/rules/no-loop-func) | Implemented |
 | [`no-loss-of-precision`](https://eslint.org/docs/latest/rules/no-loss-of-precision) | Implemented |
 | [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Supports `smart-tabs` configuration |

--- a/src/rules/no_lonely_if.zig
+++ b/src/rules/no_lonely_if.zig
@@ -2,7 +2,8 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
-const Allocator = @import("std").mem.Allocator;
+const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 pub const id = "no-lonely-if";
 
@@ -14,17 +15,76 @@ pub fn check(
 ) Allocator.Error!void {
     const lonely_if = lonelyIf(tree, statement) orelse return;
 
-    try core.addDiagnostic(
+    const block_span = tree.span(lonely_if.block);
+    const child_span = tree.span(lonely_if.child);
+    if (hasNonWhitespace(tree.source[block_span.start + 1 .. child_span.start]) or
+        hasNonWhitespace(tree.source[child_span.end .. block_span.end - 1]) or
+        removingBracesChangesAsi(tree, lonely_if))
+    {
+        return core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unexpected if as the only statement in an else block.",
+            child_span,
+        );
+    }
+
+    const prefix = if (block_span.start >= 4 and
+        std.mem.eql(u8, tree.source[block_span.start - 4 .. block_span.start], "else")) " " else "";
+    const replacement = try std.fmt.allocPrint(
+        allocator,
+        "{s}{s}",
+        .{ prefix, tree.source[child_span.start..child_span.end] },
+    );
+    defer allocator.free(replacement);
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Unexpected if as the only statement in an else block.",
-        tree.span(lonely_if),
+        child_span,
+        .{ .span = block_span, .replacement = replacement },
     );
 }
 
-fn lonelyIf(tree: *const ast.Tree, statement: ast.IfStatement) ?ast.NodeIndex {
+fn hasNonWhitespace(source: []const u8) bool {
+    for (source) |byte| {
+        if (!std.ascii.isWhitespace(byte)) return true;
+    }
+    return false;
+}
+
+fn removingBracesChangesAsi(tree: *const ast.Tree, lonely_if: LonelyIf) bool {
+    const statement = tree.data(lonely_if.child).if_statement;
+    if (tree.data(statement.consequent) == .block_statement) return false;
+
+    const consequent_span = tree.span(statement.consequent);
+    if (consequent_span.end > consequent_span.start and tree.source[consequent_span.end - 1] == ';') return false;
+
+    const block_end = tree.span(lonely_if.block).end;
+    const next_offset = nextCodeOffset(tree, block_end) orelse return false;
+    if (std.mem.indexOfAny(u8, tree.source[consequent_span.end..next_offset], "\r\n") == null) return true;
+
+    const next_byte = tree.source[next_offset];
+    if (std.mem.indexOfScalar(u8, "([/+`-", next_byte) != null) return true;
+
+    if (consequent_span.end >= consequent_span.start + 2) {
+        const ending = tree.source[consequent_span.end - 2 .. consequent_span.end];
+        if (std.mem.eql(u8, ending, "++") or std.mem.eql(u8, ending, "--")) return true;
+    }
+    return false;
+}
+
+const LonelyIf = struct {
+    block: ast.NodeIndex,
+    child: ast.NodeIndex,
+};
+
+fn lonelyIf(tree: *const ast.Tree, statement: ast.IfStatement) ?LonelyIf {
     if (statement.alternate == .null) return null;
 
     const block = switch (tree.data(statement.alternate)) {
@@ -34,8 +94,47 @@ fn lonelyIf(tree: *const ast.Tree, statement: ast.IfStatement) ?ast.NodeIndex {
     if (block.body.len != 1) return null;
 
     const child = tree.extra(block.body)[0];
-    return switch (tree.data(child)) {
-        .if_statement => child,
-        else => null,
+    if (tree.data(child) != .if_statement) return null;
+    if (hasUnsafeIf(tree, child) and isFollowedByElse(tree, statement.alternate)) return null;
+    return .{ .block = statement.alternate, .child = child };
+}
+
+fn hasUnsafeIf(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .if_statement => |statement| statement.alternate == .null or hasUnsafeIf(tree, statement.alternate),
+        .for_statement => |statement| hasUnsafeIf(tree, statement.body),
+        .for_in_statement => |statement| hasUnsafeIf(tree, statement.body),
+        .for_of_statement => |statement| hasUnsafeIf(tree, statement.body),
+        .labeled_statement => |statement| hasUnsafeIf(tree, statement.body),
+        .with_statement => |statement| hasUnsafeIf(tree, statement.body),
+        .while_statement => |statement| hasUnsafeIf(tree, statement.body),
+        else => false,
     };
+}
+
+fn isFollowedByElse(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const offset = nextCodeOffset(tree, tree.span(index).end) orelse return false;
+    return offset + "else".len <= tree.source.len and
+        std.mem.eql(u8, tree.source[offset .. offset + "else".len], "else");
+}
+
+fn nextCodeOffset(tree: *const ast.Tree, start: u32) ?usize {
+    var cursor: usize = start;
+    while (cursor < tree.source.len) {
+        if (std.ascii.isWhitespace(tree.source[cursor])) {
+            cursor += 1;
+            continue;
+        }
+        var skipped_comment = false;
+        for (tree.comments) |comment| {
+            if (comment.span.start > cursor) break;
+            if (comment.span.start == cursor) {
+                cursor = comment.span.end;
+                skipped_comment = true;
+                break;
+            }
+        }
+        if (!skipped_comment) return cursor;
+    }
+    return null;
 }

--- a/tests/rules/no_lonely_if.zig
+++ b/tests/rules/no_lonely_if.zig
@@ -24,6 +24,102 @@ test "reports no-lonely-if for if as only else block statement" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_lonely_if.id));
 }
 
+test "autofixes a lonely if into an else-if chain" {
+    const source =
+        \\if (first) {
+        \\  runFirst();
+        \\} else {
+        \\  if (second) {
+        \\    runSecond();
+        \\  }
+        \\}
+    ;
+    const expected =
+        \\if (first) {
+        \\  runFirst();
+        \\} else if (second) {
+        \\    runSecond();
+        \\  }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_else_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_lonely_if.id));
+}
+
+test "autofix preserves comments outside the else block and inside the child if" {
+    const source =
+        \\if (first) {
+        \\  runFirst();
+        \\} else /* outer */ {
+        \\  if /* inner */ (second) {
+        \\    runSecond();
+        \\  }
+        \\}
+    ;
+    const expected =
+        \\if (first) {
+        \\  runFirst();
+        \\} else /* outer */ if /* inner */ (second) {
+        \\    runSecond();
+        \\  }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_else_return = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_lonely_if.id));
+}
+
+test "does not autofix comments between the else braces and child if" {
+    const source =
+        \\if (first) {} else {
+        \\  /* keep before */ if (second) {}
+        \\}
+        \\if (third) {} else {
+        \\  if (fourth) {} /* keep after */
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.no_lonely_if.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_lonely_if.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
 test "does not report no-lonely-if when else block has multiple statements" {
     const source =
         \\if (first) {
@@ -44,6 +140,91 @@ test "does not report no-lonely-if when else block has multiple statements" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lonely_if.id));
+}
+
+test "does not report when else braces prevent a dangling else" {
+    const source = "if (outer) if (first) {} else { if (second) {} } else {}";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_lonely_if.id));
+}
+
+test "does not autofix when removing braces could change ASI semantics" {
+    const source =
+        \\if (first) {} else { if (second) run() } follow();
+        \\if (third) {} else {
+        \\  if (fourth) run()
+        \\}
+        \\[1, 2, 3].forEach(run);
+        \\if (fifth) {} else {
+        \\  if (sixth) count++
+        \\}
+        \\use(count);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.no_lonely_if.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_lonely_if.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofixes ASI-sensitive shapes when consequents have semicolons" {
+    const source =
+        \\if (first) {} else{ if (second) run(); } follow();
+        \\if (third) {} else {
+        \\  if (fourth) run();
+        \\}
+        \\[1, 2, 3].forEach(run);
+        \\if (fifth) {} else {
+        \\  if (sixth) count++;
+        \\}
+        \\use(count);
+    ;
+    const expected =
+        \\if (first) {} else if (second) run(); follow();
+        \\if (third) {} else if (fourth) run();
+        \\[1, 2, 3].forEach(run);
+        \\if (fifth) {} else if (sixth) count++;
+        \\use(count);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_empty = false,
+        .no_empty_block_statements = false,
+        .no_plusplus = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_lonely_if.id));
 }
 
 test "can disable no-lonely-if" {


### PR DESCRIPTION
## Summary

- flatten a sole `if` inside an `else` block into an `else if` chain
- preserve comments outside the removed braces and inside the child `if`
- leave diagnostics unfixed when brace-adjacent comments would be lost
- avoid dangling-else and automatic-semicolon-insertion semantic changes
- add spacing for compact `else{` forms and document autofix support

## Test plan

- `zig fmt --check build.zig src tests`
- `zig build test` (1792/1792)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrapper smoke test