### PR TITLE
feat: autofix no-unneeded-ternary

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -167,7 +167,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars) | Reports read `let`/`var` bindings that have no initializer and no assignment |
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
-| [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Implemented |
+| [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Supports `defaultAssignment` with precedence-, side-effect-, and comment-safe autofix |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unreachable-loop`](https://eslint.org/docs/latest/rules/no-unreachable-loop) | Supports loop body exit detection and `ignore` configuration |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |

--- a/src/rules/no_unneeded_ternary.zig
+++ b/src/rules/no_unneeded_ternary.zig
@@ -30,27 +30,223 @@ pub fn checkWithOptions(
     options: Options,
 ) Allocator.Error!void {
     if (isUnneededBooleanTernary(tree, expression)) {
-        try core.addDiagnostic(
-            allocator,
-            diagnostics,
-            .warning,
-            id,
-            "Unnecessary use of boolean literals in conditional expression.",
-            tree.span(index),
-        );
+        const replacement = try booleanTernaryReplacement(allocator, tree, expression, index);
+        defer if (replacement) |value| allocator.free(value);
+
+        if (replacement) |value| {
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unnecessary use of boolean literals in conditional expression.",
+                tree.span(index),
+                .{ .span = tree.span(index), .replacement = value },
+            );
+        } else {
+            try core.addDiagnostic(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                "Unnecessary use of boolean literals in conditional expression.",
+                tree.span(index),
+            );
+        }
         return;
     }
 
     if (options.default_assignment or !isDefaultAssignment(tree, expression)) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Unnecessary use of conditional expression for default assignment.",
-        tree.span(index),
-    );
+    const replacement = try defaultAssignmentReplacement(allocator, tree, expression);
+    defer if (replacement) |value| allocator.free(value);
+
+    if (replacement) |value| {
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary use of conditional expression for default assignment.",
+            tree.span(index),
+            .{ .span = tree.span(index), .replacement = value },
+        );
+    } else {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Unnecessary use of conditional expression for default assignment.",
+            tree.span(index),
+        );
+    }
+}
+
+fn booleanTernaryReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!?[]u8 {
+    const consequent = booleanLiteralValue(tree, expression.consequent).?;
+    const alternate = booleanLiteralValue(tree, expression.alternate).?;
+    const expression_span = tree.span(index);
+
+    if (consequent == alternate) {
+        if (identifierReferenceName(tree, expression.@"test") == null or hasCommentInside(tree, expression_span)) return null;
+        return @as(?[]u8, try allocator.dupe(u8, if (consequent) "true" else "false"));
+    }
+
+    const test_span = tree.span(expression.@"test");
+    if (hasCommentBetween(tree, test_span.end, expression_span.end)) return null;
+
+    if (alternate) return @as(?[]u8, try invertExpression(allocator, tree, expression.@"test"));
+    if (isBooleanExpression(tree, expression.@"test")) {
+        return @as(?[]u8, try allocator.dupe(u8, sourceForSpan(tree, test_span)));
+    }
+
+    const inverted = try invertExpression(allocator, tree, expression.@"test");
+    defer allocator.free(inverted);
+    return @as(?[]u8, try std.fmt.allocPrint(allocator, "!{s}", .{inverted}));
+}
+
+fn defaultAssignmentReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.ConditionalExpression,
+) Allocator.Error!?[]u8 {
+    const test_span = tree.span(expression.@"test");
+    const alternate_span = tree.span(expression.alternate);
+    if (hasCommentBetween(tree, test_span.end, alternate_span.start)) return null;
+
+    const test_text = sourceForSpan(tree, test_span);
+    const alternate_text = sourceForSpan(tree, alternate_span);
+    if (alternateNeedsParentheses(tree, expression.alternate)) {
+        return @as(?[]u8, try std.fmt.allocPrint(allocator, "{s} || ({s})", .{ test_text, alternate_text }));
+    }
+    return @as(?[]u8, try std.fmt.allocPrint(allocator, "{s} || {s}", .{ test_text, alternate_text }));
+}
+
+fn invertExpression(allocator: Allocator, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error![]u8 {
+    const span = tree.span(index);
+    if (tree.data(index) == .binary_expression) {
+        const binary = tree.data(index).binary_expression;
+        if (inverseOperator(binary.operator)) |inverse| {
+            const left_span = tree.span(binary.left);
+            const right_span = tree.span(binary.right);
+            if (!hasCommentBetween(tree, left_span.end, right_span.start)) {
+                const between = sourceForRange(tree, left_span.end, right_span.start);
+                const operator = binary.operator.toString();
+                if (std.mem.indexOf(u8, between, operator)) |relative_start| {
+                    const operator_start = left_span.end + @as(u32, @intCast(relative_start));
+                    const operator_end = operator_start + @as(u32, @intCast(operator.len));
+                    return std.fmt.allocPrint(
+                        allocator,
+                        "{s}{s}{s}",
+                        .{
+                            sourceForRange(tree, span.start, operator_start),
+                            inverse,
+                            sourceForRange(tree, operator_end, span.end),
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    const text = sourceForSpan(tree, span);
+    if (unaryNegationNeedsParentheses(tree, index)) {
+        return std.fmt.allocPrint(allocator, "!({s})", .{text});
+    }
+    return std.fmt.allocPrint(allocator, "!{s}", .{text});
+}
+
+fn inverseOperator(operator: ast.BinaryOperator) ?[]const u8 {
+    return switch (operator) {
+        .equal => "!=",
+        .not_equal => "==",
+        .strict_equal => "!==",
+        .strict_not_equal => "===",
+        else => null,
+    };
+}
+
+fn isBooleanExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binary_expression => |binary| switch (binary.operator) {
+            .equal,
+            .not_equal,
+            .strict_equal,
+            .strict_not_equal,
+            .less_than,
+            .less_than_or_equal,
+            .greater_than,
+            .greater_than_or_equal,
+            .in,
+            .instanceof,
+            => true,
+            else => false,
+        },
+        .unary_expression => |unary| unary.operator == .logical_not,
+        else => false,
+    };
+}
+
+fn unaryNegationNeedsParentheses(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (tree.data(index) == .parenthesized_expression) return false;
+    return switch (tree.data(index)) {
+        .sequence_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .assignment_expression,
+        .conditional_expression,
+        .logical_expression,
+        .binary_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        => true,
+        else => false,
+    };
+}
+
+fn alternateNeedsParentheses(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (tree.data(index) == .parenthesized_expression) return false;
+    return switch (tree.data(index)) {
+        .sequence_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .assignment_expression,
+        .conditional_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        => true,
+        .logical_expression => |logical| logical.operator == .nullish_coalescing,
+        else => false,
+    };
+}
+
+fn hasCommentInside(tree: *const ast.Tree, span: ast.Span) bool {
+    return hasCommentBetween(tree, span.start, span.end);
+}
+
+fn hasCommentBetween(tree: *const ast.Tree, start: u32, end: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= start) continue;
+        if (comment.span.start >= end) break;
+        return true;
+    }
+    return false;
+}
+
+fn sourceForSpan(tree: *const ast.Tree, span: ast.Span) []const u8 {
+    return sourceForRange(tree, span.start, span.end);
+}
+
+fn sourceForRange(tree: *const ast.Tree, start: u32, end: u32) []const u8 {
+    return tree.source[@intCast(start)..@intCast(end)];
 }
 
 fn isUnneededBooleanTernary(tree: *const ast.Tree, expression: ast.ConditionalExpression) bool {

--- a/tests/rules/no_unneeded_ternary.zig
+++ b/tests/rules/no_unneeded_ternary.zig
@@ -69,6 +69,173 @@ test "supports configured no-unneeded-ternary defaultAssignment false" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unneeded_ternary.id));
 }
 
+test "autofixes unnecessary boolean ternaries" {
+    const source =
+        \\const first = value ? true : false;
+        \\const second = value ? false : true;
+        \\const third = value === 1 ? false : true;
+        \\const fourth = value >= 1 ? true : false;
+        \\const fifth = !value ? true : false;
+        \\const sixth = value ? false : false;
+    ;
+    const expected =
+        \\const first = !!value;
+        \\const second = !value;
+        \\const third = value !== 1;
+        \\const fourth = value >= 1;
+        \\const fifth = !value;
+        \\const sixth = false;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "autofix preserves precedence while negating boolean ternaries" {
+    const source =
+        \\const first = left + right ? false : true;
+        \\const second = load() ? false : true;
+        \\const third = value instanceof Type ? false : true;
+        \\const fourth = value != 1 ? false : true;
+        \\const fifth = (left || right) ? true : false;
+    ;
+    const expected =
+        \\const first = !(left + right);
+        \\const second = !load();
+        \\const third = !(value instanceof Type);
+        \\const fourth = value == 1;
+        \\const fifth = !!(left || right);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .eqeqeq = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "autofixes configured default assignments" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"defaultAssignment\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-unneeded-ternary", config.value);
+
+    const source =
+        \\const first = value ? value : fallback;
+        \\const second = value ? value : ready ? yes : no;
+        \\const third = value ? value : item => item;
+        \\const fourth = value ? value : left ?? right;
+        \\const fifth = ((value)) ? (((value))) : (((fallback)));
+    ;
+    const expected =
+        \\const first = value || fallback;
+        \\const second = value || (ready ? yes : no);
+        \\const third = value || (item => item);
+        \\const fourth = value || (left ?? right);
+        \\const fifth = ((value)) || (((fallback)));
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "autofix preserves TypeScript expression grouping" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"defaultAssignment\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-unneeded-ternary", config.value);
+
+    const source =
+        \\const first = (value as unknown) ? false : true;
+        \\const second = value ? value : fallback as unknown;
+    ;
+    const expected =
+        \\const first = !(value as unknown);
+        \\const second = value || (fallback as unknown);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_unneeded_ternary.id));
+}
+
+test "does not autofix side-effectful equal branches or discard comments" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"defaultAssignment\":false}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("no-unneeded-ternary", config.value);
+
+    const source =
+        \\const first = load() ? false : false;
+        \\const second = value ? /* keep */ true : false;
+        \\const third = value ? value /* keep */ : fallback;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.no_unneeded_ternary.id));
+}
+
 test "can disable no-unneeded-ternary" {
     const source =
         \\const value = enabled ? true : false;


### PR DESCRIPTION
## Summary
- autofix boolean-literal ternaries with safe negation and operator inversion
- autofix `defaultAssignment: false` cases to `||` while preserving precedence and TypeScript grouping
- skip fixes that would drop comments or remove side effects

## Testing
- `zig fmt --check build.zig src tests`
- `zig build test`
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- `node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts || test "$?" = "1"`