### PR TITLE
feat: autofix sort-vars

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -215,7 +215,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`require-yield`](https://eslint.org/docs/latest/rules/require-yield) | Implemented |
 | [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) | Supports declaration/member sorting, `ignoreCase`, `ignoreDeclarationSort`, `ignoreMemberSort`, `allowSeparatedGroups`, and `memberSyntaxSortOrder` |
 | [`sort-keys`](https://eslint.org/docs/latest/rules/sort-keys) | Supports object literal key ordering with `asc`/`desc`, `caseSensitive`, `natural`, `minKeys`, and `allowLineSeparatedGroups` |
-| [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting and `ignoreCase` configuration |
+| [`sort-vars`](https://eslint.org/docs/latest/rules/sort-vars) | Supports same-declaration identifier sorting, `ignoreCase`, and formatting-preserving autofix for literal initializers |
 | [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) | Supports `always`, `never`, `markers`, and `exceptions` configuration with safe autofix |
 | [`strict`](https://eslint.org/docs/latest/rules/strict) | Supports `safe`, `global`, `function`, and `never` modes with autofix for redundant directives |
 | [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description) | Implemented |

--- a/src/rules/sort_vars.zig
+++ b/src/rules/sort_vars.zig
@@ -19,6 +19,7 @@ pub fn checkVariableDeclaration(
     options: Options,
 ) Allocator.Error!void {
     var previous_name: ?[]const u8 = null;
+    var fix_considered = false;
 
     for (tree.extra(declaration.declarators)) |declarator_index| {
         const declarator = switch (tree.data(declarator_index)) {
@@ -29,20 +30,132 @@ pub fn checkVariableDeclaration(
 
         if (previous_name) |previous| {
             if (compareNames(name, previous, options.ignore_case) < 0) {
-                try core.addDiagnostic(
-                    allocator,
-                    diagnostics,
-                    .warning,
-                    id,
-                    "Variables within the same declaration block should be sorted alphabetically.",
-                    tree.span(declarator.id),
-                );
+                const fix = if (!fix_considered) fix: {
+                    fix_considered = true;
+                    break :fix try buildFix(allocator, tree, declaration, options);
+                } else null;
+                defer if (fix) |value| allocator.free(value.replacement);
+
+                if (fix) |value| {
+                    try core.addDiagnosticWithFix(
+                        allocator,
+                        diagnostics,
+                        .warning,
+                        id,
+                        "Variables within the same declaration block should be sorted alphabetically.",
+                        tree.span(declarator.id),
+                        value,
+                    );
+                } else {
+                    try core.addDiagnostic(
+                        allocator,
+                        diagnostics,
+                        .warning,
+                        id,
+                        "Variables within the same declaration block should be sorted alphabetically.",
+                        tree.span(declarator.id),
+                    );
+                }
                 continue;
             }
         }
 
         previous_name = name;
     }
+}
+
+fn buildFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    options: Options,
+) Allocator.Error!?core.Fix {
+    var declarators: std.ArrayList(ast.NodeIndex) = .empty;
+    defer declarators.deinit(allocator);
+
+    for (tree.extra(declaration.declarators)) |index| {
+        const declarator = switch (tree.data(index)) {
+            .variable_declarator => |value| value,
+            else => continue,
+        };
+        if (bindingIdentifierName(tree, declarator.id) == null) continue;
+        if (declarator.init != .null and !isLiteralInitializer(tree, declarator.init)) return null;
+        try declarators.append(allocator, index);
+    }
+    if (declarators.items.len < 2) return null;
+
+    const sorted = try allocator.dupe(ast.NodeIndex, declarators.items);
+    defer allocator.free(sorted);
+    stableSortDeclarators(tree, sorted, options.ignore_case);
+
+    var replacement: std.ArrayList(u8) = .empty;
+    errdefer replacement.deinit(allocator);
+
+    for (sorted, 0..) |index, sorted_index| {
+        const span = tree.span(index);
+        try replacement.appendSlice(allocator, sourceForSpan(tree, span));
+
+        if (sorted_index + 1 < sorted.len) {
+            const original_span = tree.span(declarators.items[sorted_index]);
+            const next_original_span = tree.span(declarators.items[sorted_index + 1]);
+            try replacement.appendSlice(
+                allocator,
+                tree.source[@intCast(original_span.end)..@intCast(next_original_span.start)],
+            );
+        }
+    }
+
+    return .{
+        .span = .{
+            .start = tree.span(declarators.items[0]).start,
+            .end = tree.span(declarators.items[declarators.items.len - 1]).end,
+        },
+        .replacement = try replacement.toOwnedSlice(allocator),
+    };
+}
+
+fn stableSortDeclarators(tree: *const ast.Tree, declarators: []ast.NodeIndex, ignore_case: bool) void {
+    var index: usize = 1;
+    while (index < declarators.len) : (index += 1) {
+        const current = declarators[index];
+        const current_name = declaratorName(tree, current);
+        var insertion = index;
+        while (insertion > 0 and compareNames(current_name, declaratorName(tree, declarators[insertion - 1]), ignore_case) < 0) {
+            declarators[insertion] = declarators[insertion - 1];
+            insertion -= 1;
+        }
+        declarators[insertion] = current;
+    }
+}
+
+fn declaratorName(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const declarator = tree.data(index).variable_declarator;
+    return bindingIdentifierName(tree, declarator.id).?;
+}
+
+fn isLiteralInitializer(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapParentheses(tree, index))) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .regexp_literal,
+        => true,
+        else => false,
+    };
+}
+
+fn unwrapParentheses(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (tree.data(current) == .parenthesized_expression) {
+        current = tree.data(current).parenthesized_expression.expression;
+    }
+    return current;
+}
+
+fn sourceForSpan(tree: *const ast.Tree, span: ast.Span) []const u8 {
+    return tree.source[@intCast(span.start)..@intCast(span.end)];
 }
 
 fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/tests/rules/sort_vars.zig
+++ b/tests/rules/sort_vars.zig
@@ -43,6 +43,84 @@ test "supports ignoreCase" {
     try std.testing.expect(helpers.hasRule(insensitive_result, lint.rules.sort_vars.id));
 }
 
+test "autofixes identifier declarators into alphabetical order" {
+    const source =
+        \\let beta = 2, alpha = 1, charlie = 3;
+        \\let charlie = 3, delta = 4, alpha = 1, beta = 2;
+    ;
+    const expected =
+        \\let alpha = 1, beta = 2, charlie = 3;
+        \\let alpha = 1, beta = 2, charlie = 3, delta = 4;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.sort_vars.id));
+}
+
+test "autofix preserves declaration formatting and destructuring positions" {
+    const source =
+        \\var delta,
+        \\    alpha = 1,
+        \\    [middle] = values,
+        \\    beta = 2;
+    ;
+    const expected =
+        \\var alpha = 1,
+        \\    beta = 2,
+        \\    [middle] = values,
+        \\    delta;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.sort_vars.id));
+}
+
+test "does not autofix declarations with non-literal identifier initializers" {
+    const source =
+        \\let beta = 1, alpha = compute();
+        \\let delta = 4, charlie = delta;
+        \\let zebra = 0, apple = `${zebra}`;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.sort_vars.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.sort_vars.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofix supports ignoreCase and preserves comments around literal declarations" {
+    const source =
+        \\let Bravo = /b/ /* keep */, /* between */ alpha = (1);
+    ;
+    const expected =
+        \\let alpha = (1) /* keep */, /* between */ Bravo = /b/;
+    ;
+
+    var options = baseOptions();
+    options.sort_vars_ignore_case = true;
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.sort_vars.id));
+}
+
 test "ignores destructuring declarators and can disable rule" {
     const source =
         \\let z, { a } = value, y;
@@ -61,6 +139,8 @@ test "ignores destructuring declarators and can disable rule" {
 
 fn baseOptions() lint.Options {
     return .{
+        .capitalized_comments = false,
+        .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
         .one_var = false,


### PR DESCRIPTION
## Summary
- autofix sortable identifier declarators across an entire variable declaration
- preserve original whitespace, line breaks, comments, and destructuring positions
- keep `ignoreCase` ordering stable and skip fixes when an identifier initializer is not a literal

## Testing
- `zig fmt --check build.zig src tests`
- `zig build test`
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- `node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts || test "$?" = "1"`