### PR TITLE
feat: autofix yoda comparisons

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -224,7 +224,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`valid-typeof`](https://eslint.org/docs/latest/rules/valid-typeof) | Supports `requireStringLiterals` configuration |
 | [`vars-on-top`](https://eslint.org/docs/latest/rules/vars-on-top) | Implemented |
 | [`wrap-iife`](https://eslint.org/docs/latest/rules/wrap-iife) | Implemented for `outside`, `inside`, and `any` options with autofix |
-| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Supports `never`, `always`, `onlyEquality`, and `exceptRange` configuration |
+| [`yoda`](https://eslint.org/docs/latest/rules/yoda) | Supports `never`, `always`, `onlyEquality`, and `exceptRange` configuration with comment- and token-safe autofix |
 
 ## ESLint comments rules
 

--- a/src/rules/yoda.zig
+++ b/src/rules/yoda.zig
@@ -56,14 +56,148 @@ pub fn checkWithOptions(
     const right_literal = isLiteralLike(tree, expression.right);
     if (hasExpectedYodaStyle(options.style, left_literal, right_literal)) return;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        message(options.style),
-        tree.span(index),
-    );
+    const fix = try buildFix(allocator, tree, expression, index);
+    defer if (fix) |value| allocator.free(value.replacement);
+
+    if (fix) |value| {
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message(options.style),
+            tree.span(index),
+            value,
+        );
+    } else {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message(options.style),
+            tree.span(index),
+        );
+    }
+}
+
+fn buildFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+    index: ast.NodeIndex,
+) Allocator.Error!?core.Fix {
+    const operator_span = findOperatorSpan(tree, expression) orelse return null;
+    const expression_span = tree.span(index);
+    const left_span = tree.span(expression.left);
+    const right_span = tree.span(expression.right);
+    const operator = flippedOperator(expression.operator);
+    const left_text = sourceForRange(tree, expression_span.start, left_span.end);
+    const right_text = sourceForRange(tree, right_span.start, expression_span.end);
+    const before_expression = tree.source[0..@intCast(expression_span.start)];
+    const after_expression = tree.source[@intCast(expression_span.end)..];
+    const prefix = if (needsOperandPrefix(tree, expression.right, before_expression, right_text)) " " else "";
+    const suffix = if (needsOperandSuffix(tree, expression.left, left_text, after_expression)) " " else "";
+
+    return .{
+        .span = expression_span,
+        .replacement = try std.fmt.allocPrint(
+            allocator,
+            "{s}{s}{s}{s}{s}{s}{s}",
+            .{
+                prefix,
+                right_text,
+                sourceForRange(tree, left_span.end, operator_span.start),
+                operator,
+                sourceForRange(tree, operator_span.end, right_span.start),
+                left_text,
+                suffix,
+            },
+        ),
+    };
+}
+
+fn needsOperandPrefix(
+    tree: *const ast.Tree,
+    operand: ast.NodeIndex,
+    before: []const u8,
+    operand_text: []const u8,
+) bool {
+    if (needsTokenSeparator(before, operand_text)) return true;
+    return tree.data(operand) == .regexp_literal and
+        before.len > 0 and
+        isIdentifierByte(before[before.len - 1]);
+}
+
+fn needsOperandSuffix(
+    tree: *const ast.Tree,
+    operand: ast.NodeIndex,
+    operand_text: []const u8,
+    after: []const u8,
+) bool {
+    if (needsTokenSeparator(operand_text, after)) return true;
+    return tree.data(operand) == .regexp_literal and
+        after.len > 0 and
+        isIdentifierByte(after[0]);
+}
+
+fn needsTokenSeparator(left: []const u8, right: []const u8) bool {
+    if (left.len == 0 or right.len == 0) return false;
+    const left_byte = left[left.len - 1];
+    const right_byte = right[0];
+    if (std.ascii.isWhitespace(left_byte) or std.ascii.isWhitespace(right_byte)) return false;
+
+    if (isIdentifierByte(left_byte) and isIdentifierByte(right_byte)) return true;
+    if (left_byte == '+' and right_byte == '+') return true;
+    if (left_byte == '-' and right_byte == '-') return true;
+    return left_byte == '/' and (right_byte == '/' or right_byte == '*');
+}
+
+fn isIdentifierByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
+}
+
+fn findOperatorSpan(tree: *const ast.Tree, expression: ast.BinaryExpression) ?ast.Span {
+    const left_end = tree.span(expression.left).end;
+    const right_start = tree.span(expression.right).start;
+    const operator = expression.operator.toString();
+    const between = sourceForRange(tree, left_end, right_start);
+
+    var search_start: usize = 0;
+    while (std.mem.indexOfPos(u8, between, search_start, operator)) |relative| {
+        const start = left_end + @as(u32, @intCast(relative));
+        const end = start + @as(u32, @intCast(operator.len));
+        if (!hasCommentAt(tree, start)) return .{ .start = start, .end = end };
+        search_start = relative + operator.len;
+    }
+    return null;
+}
+
+fn hasCommentAt(tree: *const ast.Tree, offset: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= offset) continue;
+        if (comment.span.start > offset) break;
+        return true;
+    }
+    return false;
+}
+
+fn flippedOperator(operator: ast.BinaryOperator) []const u8 {
+    return switch (operator) {
+        .equal => "==",
+        .not_equal => "!=",
+        .strict_equal => "===",
+        .strict_not_equal => "!==",
+        .less_than => ">",
+        .less_than_or_equal => ">=",
+        .greater_than => "<",
+        .greater_than_or_equal => "<=",
+        else => unreachable,
+    };
+}
+
+fn sourceForRange(tree: *const ast.Tree, start: u32, end: u32) []const u8 {
+    return tree.source[@intCast(start)..@intCast(end)];
 }
 
 fn hasExpectedYodaStyle(style: Style, left_literal: bool, right_literal: bool) bool {

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -24,6 +24,120 @@ test "reports yoda for literals on the left side" {
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.yoda.id));
 }
 
+test "autofixes literals onto the expected comparison side" {
+    const source =
+        \\if ("red" === color) {}
+        \\if (0 < count) {}
+        \\if (true !== enabled) {}
+        \\if (-1 >= value) {}
+    ;
+    const expected =
+        \\if (color === "red") {}
+        \\if (count > 0) {}
+        \\if (enabled !== true) {}
+        \\if (value <= -1) {}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
+}
+
+test "autofix preserves comments, spacing, and parenthesized operands" {
+    const source =
+        \\if ( /* a */ 0 /* b */ < /* c */ value /* d */ ) {}
+        \\if (0 /* < decoy */ < value) {}
+        \\while (0 === (current = next));
+    ;
+    const expected =
+        \\if ( /* a */ value /* b */ > /* c */ 0 /* d */ ) {}
+        \\if (value /* < decoy */ > 0) {}
+        \\while ((current = next) === 0);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
+}
+
+test "autofix separates moved operands from adjacent outer tokens" {
+    const source =
+        \\const inside = 0 < lookup()in values;
+        \\const typed = 1 > current++instanceof Number;
+        \\const matched = /x/ < lookup()in values;
+    ;
+    const expected =
+        \\const inside = lookup() > 0 in values;
+        \\const typed = current++ < 1 instanceof Number;
+        \\const matched = lookup() > /x/ in values;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
+}
+
+test "autofix protects moved operands adjacent to yield" {
+    const source =
+        \\function* run() {
+        \\  yield(1) < value;
+        \\  yield(1) < ++value;
+        \\  yield(1) < (value);
+        \\}
+    ;
+    const expected =
+        \\function* run() {
+        \\  yield value > (1);
+        \\  yield++value > (1);
+        \\  yield(value) > (1);
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
+}
+
 test "does not report yoda when literals are on the right side or both sides" {
     const source =
         \\if (color === "red") {}
@@ -69,6 +183,35 @@ test "reports yoda always when literals are on the right side" {
 
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.yoda.id));
     try std.testing.expectEqualStrings("Expected literal to be on the left side of comparison.", result.diagnostics[0].message);
+}
+
+test "autofixes comparisons configured for yoda always" {
+    const source =
+        \\if (color == "red") {}
+        \\if (count > 0) {}
+        \\if (value <= -1) {}
+    ;
+    const expected =
+        \\if ("red" == color) {}
+        \\if (0 < count) {}
+        \\if (-1 >= value) {}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .yoda_style = .always,
+        .eqeqeq = false,
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
 }
 
 test "allows yoda always when literals are on the left side or both sides" {
@@ -126,6 +269,41 @@ test "supports configured yoda onlyEquality option" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.yoda.id));
 }
 
+test "autofix respects configured yoda onlyEquality" {
+    const source =
+        \\if ("red" === color) {}
+        \\if (0 < count) {}
+    ;
+    const expected =
+        \\if (color === "red") {}
+        \\if (0 < count) {}
+    ;
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\",{\"onlyEquality\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("yoda", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
+}
+
 test "supports configured yoda exceptRange option" {
     const source =
         \\if (0 <= age && age < 18) {}
@@ -155,6 +333,41 @@ test "supports configured yoda exceptRange option" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.yoda.id));
+}
+
+test "autofix respects configured yoda exceptRange" {
+    const source =
+        \\if (0 <= age && age < 18) {}
+        \\if (0 < count) {}
+    ;
+    const expected =
+        \\if (0 <= age && age < 18) {}
+        \\if (count > 0) {}
+    ;
+
+    var options = lint.Options{
+        .eol_last = false,
+        .no_empty_block_statements = false,
+        .no_constant_condition = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\",{\"exceptRange\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue("yoda", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.yoda.id));
 }
 
 test "can disable yoda" {


### PR DESCRIPTION
## Summary
- autofix Yoda comparisons by swapping operand source text and flipping relational operators
- preserve comments, spacing, parentheses, negative literals, templates, and regular expressions
- protect moved operands from adjacent `yield`, `in`, and `instanceof` tokens
- honor `always`, `never`, `onlyEquality`, and `exceptRange` behavior

## Testing
- `zig fmt --check build.zig src tests`
- `zig build test`
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- `node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts || test "$?" = "1"`