### PR TITLE
feat: autofix prefer-object-spread

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -201,7 +201,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented with autofix for global static string and template `parseInt` calls with binary, octal, or hexadecimal radix |
 | [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) | Implemented with autofix |
-| [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Implemented for `Object.assign` calls with a new object literal target |
+| [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread) | Supports accessor-safe, comment-preserving autofix for global `Object.assign` calls with a new object literal target, including single-argument calls |
 | [`prefer-promise-reject-errors`](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) | Supports `allowEmptyReject` configuration |
 | [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) | Reports rethrown built-in errors in `catch` blocks that omit or replace the caught error `cause`, with `requireCatchParameter` support |
 | [`prefer-regex-literals`](https://eslint.org/docs/latest/rules/prefer-regex-literals) | Supports `disallowRedundantWrapping` configuration |

--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -35,19 +35,238 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (isPreferableObjectAssign(ctx.tree, self.symbol_table, call)) {
-            try core.addDiagnostic(
-                self.allocator,
-                self.diagnostics,
-                .warning,
-                id,
-                "Use an object spread instead of Object.assign.",
-                ctx.tree.span(index),
-            );
+            var fixes: std.ArrayList(core.Fix) = .empty;
+            defer fixes.deinit(self.allocator);
+            var replacements: std.ArrayList([]u8) = .empty;
+            defer {
+                for (replacements.items) |replacement| self.allocator.free(replacement);
+                replacements.deinit(self.allocator);
+            }
+
+            if (try buildFixes(self.allocator, &fixes, &replacements, ctx.tree, call, index, ctx.path.parent())) {
+                try core.addDiagnosticWithFixes(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Use an object spread instead of Object.assign.",
+                    ctx.tree.span(index),
+                    fixes.items,
+                );
+            } else {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Use an object spread instead of Object.assign.",
+                    ctx.tree.span(index),
+                );
+            }
         }
 
         return .proceed;
     }
 };
+
+fn buildFixes(
+    allocator: Allocator,
+    fixes: *std.ArrayList(core.Fix),
+    replacements: *std.ArrayList([]u8),
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+    index: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+) Allocator.Error!bool {
+    const arguments = tree.extra(call.arguments);
+    const call_span = tree.span(index);
+    const first_span = tree.span(arguments[0]);
+    const open_search_start = if (call.type_arguments != .null)
+        tree.span(call.type_arguments).end
+    else
+        tree.span(call.callee).end;
+    const open_paren = findByteOutsideComments(tree, open_search_start, first_span.start, '(') orelse return false;
+    const close_paren = findLastByteOutsideComments(tree, first_span.end, call_span.end, ')') orelse return false;
+    const add_parens = needsParens(tree, index, parent);
+
+    try fixes.append(allocator, .{
+        .span = .{ .start = call_span.start, .end = open_paren },
+        .replacement = "",
+    });
+    try fixes.append(allocator, .{
+        .span = .{ .start = open_paren, .end = open_paren + 1 },
+        .replacement = if (add_parens) "({" else "{",
+    });
+    try fixes.append(allocator, .{
+        .span = .{ .start = close_paren, .end = close_paren + 1 },
+        .replacement = if (add_parens) "})" else "}",
+    });
+
+    var previous_had_properties = false;
+    var previous_had_trailing_comma = false;
+    for (arguments, 0..) |argument, argument_index| {
+        if (argument_index > 0 and (!previous_had_properties or previous_had_trailing_comma)) {
+            const previous_span = tree.span(arguments[argument_index - 1]);
+            const argument_span = tree.span(argument);
+            const comma = findByteOutsideComments(tree, previous_span.end, argument_span.start, ',') orelse return false;
+            try fixes.append(allocator, .{
+                .span = .{ .start = comma, .end = comma + 1 },
+                .replacement = "",
+            });
+        }
+
+        if (objectExpression(tree, argument)) |object_index| {
+            const argument_span = tree.span(argument);
+            const object_span = tree.span(object_index);
+            if (object_span.end <= object_span.start + 1) return false;
+            const left_end = skipWhitespaceForward(tree.source, object_span.start + 1, object_span.end - 1);
+            const right_start = @max(
+                skipWhitespaceBackwardUnlessLineComment(tree, left_end, object_span.end - 1),
+                left_end,
+            );
+
+            try fixes.append(allocator, .{
+                .span = .{ .start = object_span.start, .end = left_end },
+                .replacement = "",
+            });
+            try fixes.append(allocator, .{
+                .span = .{ .start = right_start, .end = object_span.end },
+                .replacement = "",
+            });
+            try appendByteRemovalsOutsideComments(allocator, fixes, tree, argument_span.start, object_span.start, '(');
+            try appendByteRemovalsOutsideComments(allocator, fixes, tree, object_span.end, argument_span.end, ')');
+
+            const object = tree.data(object_index).object_expression;
+            previous_had_properties = object.properties.len > 0;
+            previous_had_trailing_comma = previous_had_properties and
+                hasTrailingComma(tree, object, object_span);
+        } else {
+            const argument_span = tree.span(argument);
+            const argument_source = tree.source[argument_span.start..argument_span.end];
+            const replacement = if (argumentNeedsParens(tree, argument))
+                try std.fmt.allocPrint(allocator, "...({s})", .{argument_source})
+            else
+                try std.fmt.allocPrint(allocator, "...{s}", .{argument_source});
+            replacements.append(allocator, replacement) catch |err| {
+                allocator.free(replacement);
+                return err;
+            };
+            try fixes.append(allocator, .{ .span = argument_span, .replacement = replacement });
+            previous_had_properties = true;
+            previous_had_trailing_comma = false;
+        }
+    }
+
+    return true;
+}
+
+fn needsParens(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return true;
+    return switch (tree.data(parent_index)) {
+        .variable_declarator => |declarator| declarator.init != index,
+        .array_expression,
+        .return_statement,
+        .call_expression,
+        .parenthesized_expression,
+        => false,
+        .object_property => |property| property.value != index,
+        .assignment_expression => |assignment| assignment.left == index,
+        else => true,
+    };
+}
+
+fn argumentNeedsParens(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .assignment_expression, .arrow_function_expression, .conditional_expression => true,
+        else => false,
+    };
+}
+
+fn objectExpression(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    const unwrapped = unwrapTransparent(tree, index);
+    return if (tree.data(unwrapped) == .object_expression) unwrapped else null;
+}
+
+fn hasTrailingComma(tree: *const ast.Tree, object: ast.ObjectExpression, span: ast.Span) bool {
+    const properties = tree.extra(object.properties);
+    if (properties.len == 0) return false;
+    return findByteOutsideComments(tree, tree.span(properties[properties.len - 1]).end, span.end - 1, ',') != null;
+}
+
+fn findByte(source: []const u8, start: u32, end: u32, byte: u8) ?u32 {
+    const relative = std.mem.indexOfScalar(u8, source[start..end], byte) orelse return null;
+    return start + @as(u32, @intCast(relative));
+}
+
+fn findByteOutsideComments(tree: *const ast.Tree, start: u32, end: u32, byte: u8) ?u32 {
+    var search_start = start;
+    while (findByte(tree.source, search_start, end, byte)) |offset| {
+        if (!hasCommentAt(tree, offset)) return offset;
+        search_start = offset + 1;
+    }
+    return null;
+}
+
+fn findLastByteOutsideComments(tree: *const ast.Tree, start: u32, end: u32, byte: u8) ?u32 {
+    var result: ?u32 = null;
+    var search_start = start;
+    while (findByteOutsideComments(tree, search_start, end, byte)) |offset| {
+        result = offset;
+        search_start = offset + 1;
+    }
+    return result;
+}
+
+fn appendByteRemovalsOutsideComments(
+    allocator: Allocator,
+    fixes: *std.ArrayList(core.Fix),
+    tree: *const ast.Tree,
+    start: u32,
+    end: u32,
+    byte: u8,
+) Allocator.Error!void {
+    var search_start = start;
+    while (findByteOutsideComments(tree, search_start, end, byte)) |offset| {
+        try fixes.append(allocator, .{
+            .span = .{ .start = offset, .end = offset + 1 },
+            .replacement = "",
+        });
+        search_start = offset + 1;
+    }
+}
+
+fn hasCommentAt(tree: *const ast.Tree, offset: u32) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= offset) continue;
+        if (comment.span.start > offset) break;
+        return true;
+    }
+    return false;
+}
+
+fn skipWhitespaceForward(source: []const u8, start: u32, end: u32) u32 {
+    var offset = start;
+    while (offset < end and std.ascii.isWhitespace(source[offset])) : (offset += 1) {}
+    return offset;
+}
+
+fn skipWhitespaceBackwardUnlessLineComment(tree: *const ast.Tree, start: u32, end: u32) u32 {
+    for (tree.comments) |comment| {
+        if (comment.type != .line or comment.span.end > end or comment.span.end < start) continue;
+        if (onlyWhitespace(tree.source, comment.span.end, end)) return end;
+    }
+
+    var offset = end;
+    while (offset > start and std.ascii.isWhitespace(tree.source[offset - 1])) : (offset -= 1) {}
+    return offset;
+}
+
+fn onlyWhitespace(source: []const u8, start: u32, end: u32) bool {
+    for (source[start..end]) |byte| {
+        if (!std.ascii.isWhitespace(byte)) return false;
+    }
+    return true;
+}
 
 fn isPreferableObjectAssign(
     tree: *const ast.Tree,
@@ -55,12 +274,28 @@ fn isPreferableObjectAssign(
     call: ast.CallExpression,
 ) bool {
     const arguments = tree.extra(call.arguments);
-    if (arguments.len < 2) return false;
+    if (arguments.len == 0) return false;
     if (!isObjectExpression(tree, arguments[0])) return false;
     for (arguments[1..]) |argument| {
         if (tree.data(argument) == .spread_element) return false;
     }
+    if (arguments.len > 1 and hasArgumentsWithAccessors(tree, arguments)) return false;
     return isGlobalObjectAssign(tree, symbol_table, call.callee);
+}
+
+fn hasArgumentsWithAccessors(tree: *const ast.Tree, arguments: []const ast.NodeIndex) bool {
+    for (arguments) |argument| {
+        const object_index = objectExpression(tree, argument) orelse continue;
+        const properties = tree.extra(tree.data(object_index).object_expression.properties);
+        for (properties) |property_index| {
+            const property = switch (tree.data(property_index)) {
+                .object_property => |property| property,
+                else => continue,
+            };
+            if (property.kind == .get or property.kind == .set) return true;
+        }
+    }
+    return false;
 }
 
 fn isObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/tests/rules/prefer_object_spread.zig
+++ b/tests/rules/prefer_object_spread.zig
@@ -25,6 +25,139 @@ test "reports prefer-object-spread for Object.assign into object literals" {
     try std.testing.expectEqualStrings("Use an object spread instead of Object.assign.", result.diagnostics[0].message);
 }
 
+test "autofixes Object.assign into an object spread" {
+    const source = "const result = Object.assign({}, source);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const result = { ...source};", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofix merges object properties and parenthesizes spread operands" {
+    const source = "Object.assign({ first: 1 }, extra, condition ? yes : no);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("({first: 1, ...extra, ...(condition ? yes : no)});", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofixes single-argument Object.assign calls to object literals" {
+    const source =
+        \\Object.assign({ value: 1 });
+        \\const empty = Object.assign({});
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        \\({value: 1});
+        \\const empty = {};
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofix does not treat a comma in a comment as a trailing comma" {
+    const source = "Object.assign({ first: 1 /* comma, in comment */ }, extra);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("({first: 1 /* comma, in comment */, ...extra});", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofix preserves comments and trailing commas while merging object literals" {
+    const source =
+        \\const value = Object.assign({ first: 1, }, /* keep */ { second: 2 }, extra);
+        \\const multiline = Object.assign({ first: 1 }, {
+        \\  // keep this line
+        \\  second: 2
+        \\});
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        \\const value = {first: 1, /* keep */ second: 2, ...extra};
+        \\const multiline = {first: 1, // keep this line
+        \\  second: 2};
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofix preserves comments around parenthesized object arguments" {
+    const source = "const value = Object.assign((/* before */ { first: 1 } /* after */), extra);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "const value = {/* before */ first: 1 /* after */, ...extra};",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
+test "autofix handles TypeScript type arguments and expression contexts" {
+    const source =
+        \\const object = Object.assign<{}, Record<string, string[]>>({}, getObject());
+        \\const array = [Object.assign({}, source)];
+        \\function make() { return Object.assign({}, source); }
+        \\consume(Object.assign({}, source));
+        \\const arrow = () => Object.assign({}, source);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        \\const object = { ...getObject()};
+        \\const array = [{ ...source}];
+        \\function make() { return { ...source}; }
+        \\consume({ ...source});
+        \\const arrow = () => ({ ...source});
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_object_spread.id));
+}
+
 test "allows non-object targets shadowed Object and spread arguments" {
     const source =
         \\const target = {};
@@ -36,6 +169,8 @@ test "allows non-object targets shadowed Object and spread arguments" {
         \\function local(Object) {
         \\  Object.assign({}, source);
         \\}
+        \\Object.assign({ get value() {} }, source);
+        \\Object.assign({}, { set value(next) {} });
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{


### PR DESCRIPTION
## Summary
- autofix global `Object.assign` calls whose target is a fresh object literal
- merge object-literal properties and spread other arguments while preserving comments, commas, parentheses, and TypeScript type arguments
- support single-argument calls and skip unsafe multi-argument getter/setter cases

## Validation
- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test` (1821 tests)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrappers: `utoo-lint --version`, `eslint --version`