### PR TITLE
feat: autofix arrow-body-style

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -7,7 +7,7 @@ Each rule links to the corresponding ESLint rule reference.
 | --- | --- |
 | [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs) | Supports `setWithoutGet`, `getWithoutSet`, and `enforceForClassMembers` configuration |
 | [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) | Implemented for optional `allowImplicit`, `checkForEach`, and `allowVoid` behavior |
-| [`arrow-body-style`](https://eslint.org/docs/latest/rules/arrow-body-style) | Supports `always`, `as-needed`, `never`, and `requireReturnForObjectLiteral` diagnostics |
+| [`arrow-body-style`](https://eslint.org/docs/latest/rules/arrow-body-style) | Supports `always`, `as-needed`, `never`, and `requireReturnForObjectLiteral` with comment-, precedence-, and ASI-safe autofix |
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`camelcase`](https://eslint.org/docs/latest/rules/camelcase) | Supports declarations, imports, optional property checks, `ignoreDestructuring`, `ignoreImports`, lightweight `allow` patterns, and parses `ignoreGlobals` for migration compatibility |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration with autofix |

--- a/src/rules/arrow_body_style.zig
+++ b/src/rules/arrow_body_style.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "arrow-body-style";
@@ -24,36 +25,246 @@ pub fn checkArrowFunction(
     tree: *const ast.Tree,
     expression: ast.ArrowFunctionExpression,
     index: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
     options: Options,
 ) Allocator.Error!void {
-    if (options.style == .always) {
-        if (expression.expression) {
-            try core.addDiagnostic(
+    if (expression.expression) {
+        const needs_block = options.style == .always or
+            (options.style == .as_needed and
+                options.require_return_for_object_literal and
+                isObjectExpression(tree, expression.body));
+        if (needs_block) {
+            const body_span = tree.span(expression.body);
+            const replacement = try std.fmt.allocPrint(
+                allocator,
+                "{{ return {s}; }}",
+                .{tree.source[body_span.start..body_span.end]},
+            );
+            defer allocator.free(replacement);
+
+            try core.addDiagnosticWithFix(
                 allocator,
                 diagnostics,
                 .warning,
                 id,
                 "Expected block statement surrounding arrow body.",
                 tree.span(index),
+                .{ .span = body_span, .replacement = replacement },
             );
         }
         return;
     }
 
-    if (expression.expression) return;
+    if (options.style == .always) return;
     const returned = singleReturnedExpression(tree, expression.body) orelse return;
     if (options.style == .as_needed and options.require_return_for_object_literal and isObjectExpression(tree, returned)) {
         return;
     }
 
-    try core.addDiagnostic(
+    const message = "Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.";
+    const body_span = tree.span(expression.body);
+    const returned_span = tree.span(returned);
+    if (hasAsiHazard(tree, tree.span(index).end)) {
+        try core.addDiagnostic(allocator, diagnostics, .warning, id, message, body_span);
+        return;
+    }
+
+    if (hasCommentsOutsideReturnedExpression(tree, body_span, returned_span)) {
+        try addCommentPreservingDiagnostic(
+            allocator,
+            diagnostics,
+            tree,
+            message,
+            body_span,
+            returned_span,
+            conciseBodyNeedsParens(tree, returned, index, ctx),
+        );
+        return;
+    }
+
+    if (!conciseBodyNeedsParens(tree, returned, index, ctx)) {
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            body_span,
+            .{
+                .span = body_span,
+                .replacement = tree.source[returned_span.start..returned_span.end],
+            },
+        );
+        return;
+    }
+
+    const replacement = try std.fmt.allocPrint(
+        allocator,
+        "({s})",
+        .{tree.source[returned_span.start..returned_span.end]},
+    );
+    defer allocator.free(replacement);
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
-        "Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.",
-        tree.span(expression.body),
+        message,
+        body_span,
+        .{ .span = body_span, .replacement = replacement },
     );
+}
+
+fn addCommentPreservingDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    message: []const u8,
+    body_span: ast.Span,
+    returned_span: ast.Span,
+    needs_parens: bool,
+) Allocator.Error!void {
+    const opening_brace = findByteOutsideComments(tree, body_span.start, returned_span.start, '{') orelse {
+        try core.addDiagnostic(allocator, diagnostics, .warning, id, message, body_span);
+        return;
+    };
+    const return_start = findSliceOutsideComments(tree, opening_brace + 1, returned_span.start, "return") orelse {
+        try core.addDiagnostic(allocator, diagnostics, .warning, id, message, body_span);
+        return;
+    };
+    const closing_brace = findLastByteOutsideComments(tree, returned_span.end, body_span.end, '}') orelse {
+        try core.addDiagnostic(allocator, diagnostics, .warning, id, message, body_span);
+        return;
+    };
+
+    var fixes: [4]core.Fix = undefined;
+    var fix_count: usize = 0;
+    fixes[fix_count] = .{
+        .span = .{ .start = opening_brace, .end = opening_brace + 1 },
+        .replacement = if (needs_parens) "(" else "",
+    };
+    fix_count += 1;
+    fixes[fix_count] = .{
+        .span = .{ .start = return_start, .end = return_start + @as(u32, "return".len) },
+        .replacement = "",
+    };
+    fix_count += 1;
+    if (findByteOutsideComments(tree, returned_span.end, closing_brace, ';')) |semicolon| {
+        fixes[fix_count] = .{
+            .span = .{ .start = semicolon, .end = semicolon + 1 },
+            .replacement = "",
+        };
+        fix_count += 1;
+    }
+    fixes[fix_count] = .{
+        .span = .{ .start = closing_brace, .end = closing_brace + 1 },
+        .replacement = if (needs_parens) ")" else "",
+    };
+    fix_count += 1;
+
+    try core.addDiagnosticWithFixes(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        body_span,
+        fixes[0..fix_count],
+    );
+}
+
+fn conciseBodyNeedsParens(
+    tree: *const ast.Tree,
+    returned: ast.NodeIndex,
+    arrow: ast.NodeIndex,
+    ctx: *const traverser.basic.Ctx,
+) bool {
+    if (tree.data(returned) == .parenthesized_expression) return false;
+    return switch (tree.data(unwrapTransparent(tree, returned))) {
+        .object_expression, .sequence_expression => true,
+        else => containsInOperator(tree, returned) and isInsideForInitializer(tree, arrow, &ctx.path),
+    };
+}
+
+fn containsInOperator(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    switch (tree.data(index)) {
+        .binary_expression => |expression| {
+            if (expression.operator == .in) return true;
+            return containsInOperator(tree, expression.left) or containsInOperator(tree, expression.right);
+        },
+        inline else => |node| return childrenContainInOperator(tree, @TypeOf(node), node),
+    }
+}
+
+fn childrenContainInOperator(tree: *const ast.Tree, comptime T: type, node: T) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (containsInOperator(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (containsInOperator(tree, child)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+fn isInsideForInitializer(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    path: anytype,
+) bool {
+    var child = index;
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .for_statement => |statement| if (statement.init == child) return true,
+            else => {},
+        }
+        child = ancestor;
+    }
+    return false;
+}
+
+fn hasCommentsOutsideReturnedExpression(tree: *const ast.Tree, body_span: ast.Span, returned_span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= body_span.start) continue;
+        if (comment.span.start >= body_span.end) break;
+        if (comment.span.start < returned_span.start or comment.span.end > returned_span.end) return true;
+    }
+    return false;
+}
+
+fn hasAsiHazard(tree: *const ast.Tree, arrow_end: u32) bool {
+    var offset: usize = arrow_end;
+    while (offset < tree.source.len) {
+        if (std.ascii.isWhitespace(tree.source[offset])) {
+            offset += 1;
+            continue;
+        }
+        if (commentAt(tree, @intCast(offset))) |comment| {
+            offset = comment.span.end;
+            continue;
+        }
+        break;
+    }
+    if (offset == tree.source.len) return false;
+    return switch (tree.source[offset]) {
+        '(', '[', '/', '`', '+', '-' => true,
+        else => false,
+    };
+}
+
+fn commentAt(tree: *const ast.Tree, offset: u32) ?ast.Comment {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= offset) continue;
+        if (comment.span.start > offset) break;
+        return comment;
+    }
+    return null;
 }
 
 fn singleReturnedExpression(tree: *const ast.Tree, body_index: ast.NodeIndex) ?ast.NodeIndex {
@@ -71,6 +282,37 @@ fn singleReturnedExpression(tree: *const ast.Tree, body_index: ast.NodeIndex) ?a
     };
     if (statement.argument == .null) return null;
     return statement.argument;
+}
+
+fn findByteOutsideComments(tree: *const ast.Tree, start: u32, end: u32, byte: u8) ?u32 {
+    var offset = start;
+    while (offset < end) : (offset += 1) {
+        if (tree.source[offset] == byte and !hasCommentAt(tree, offset)) return offset;
+    }
+    return null;
+}
+
+fn findLastByteOutsideComments(tree: *const ast.Tree, start: u32, end: u32, byte: u8) ?u32 {
+    var offset = end;
+    while (offset > start) {
+        offset -= 1;
+        if (tree.source[offset] == byte and !hasCommentAt(tree, offset)) return offset;
+    }
+    return null;
+}
+
+fn findSliceOutsideComments(tree: *const ast.Tree, start: u32, end: u32, needle: []const u8) ?u32 {
+    if (needle.len == 0 or start >= end) return null;
+    var search_start: usize = start;
+    while (std.mem.indexOfPos(u8, tree.source[0..end], search_start, needle)) |offset| {
+        if (!hasCommentAt(tree, @intCast(offset))) return @intCast(offset);
+        search_start = offset + needle.len;
+    }
+    return null;
+}
+
+fn hasCommentAt(tree: *const ast.Tree, offset: u32) bool {
+    return commentAt(tree, offset) != null;
 }
 
 fn isObjectExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -2994,7 +2994,7 @@ const BasicVisitor = struct {
             try max_nested_callbacks.enterArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
         }
         if (self.options.arrow_body_style) {
-            try arrow_body_style.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, index, arrowBodyStyleOptions(&self.options));
+            try arrow_body_style.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx, arrowBodyStyleOptions(&self.options));
         }
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.body, .{

--- a/tests/rules/arrow_body_style.zig
+++ b/tests/rules/arrow_body_style.zig
@@ -32,6 +32,22 @@ test "honors requireReturnForObjectLiteral" {
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.arrow_body_style.id));
 }
 
+test "autofixes concise object bodies when requireReturnForObjectLiteral is enabled" {
+    const source = "const object = () => ({ value: true });";
+
+    var options = baseOptions();
+    options.arrow_body_style_require_return_for_object_literal = true;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "const object = () => { return ({ value: true }); };",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
 test "reports concise bodies in always mode" {
     const source =
         \\const bad = () => value;
@@ -48,6 +64,93 @@ test "reports concise bodies in always mode" {
     try std.testing.expect(hasMessage(result, "Expected block statement surrounding arrow body."));
 }
 
+test "autofixes concise arrow bodies to blocks in always mode" {
+    const source =
+        \\const value = () => source;
+        \\const object = () => ({ value: true });
+    ;
+
+    var options = baseOptions();
+    options.arrow_body_style_style = .always;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const value = () => { return source; };
+        \\const object = () => { return ({ value: true }); };
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
+test "autofixes a single return block to a concise body" {
+    const source = "const value = () => { return source; };";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const value = () => source;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
+test "autofix parenthesizes object and sequence concise bodies" {
+    const source =
+        \\const object = () => { return { value: true }; };
+        \\const sequence = () => { return first(), second; };
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        \\const object = () => ({ value: true });
+        \\const sequence = () => (first(), second);
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
+test "autofix preserves comments around a returned expression" {
+    const source = "const value = /* a */ () /* b */ => /* c */ { /* d */ return /* e */ source /* f */; /* g */ } /* h */;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "const value = /* a */ () /* b */ => /* c */  /* d */  /* e */ source /* f */ /* g */  /* h */;",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
+test "autofix parenthesizes in expressions used in for initializers" {
+    const source = "for (const predicate = () => { return key in object; }; ; ) use(predicate);";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "for (const predicate = () => (key in object); ; ) use(predicate);",
+        result.output,
+    );
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
+test "does not autofix a concise body when removing braces creates an ASI hazard" {
+    const source =
+        \\const value = () => { return source }
+        \\(1).toString();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", baseOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.fixed);
+    try std.testing.expectEqualStrings(source, result.output);
+    try std.testing.expect(helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
+}
+
 test "never mode reports returned object literals too" {
     const source =
         \\const bad = () => { return { value: true }; };
@@ -61,6 +164,20 @@ test "never mode reports returned object literals too" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.arrow_body_style.id));
+}
+
+test "never mode autofixes single-return blocks regardless of the object option" {
+    const source = "const value = () => { return { value: true }; };";
+
+    var options = baseOptions();
+    options.arrow_body_style_style = .never;
+    options.arrow_body_style_require_return_for_object_literal = true;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("const value = () => ({ value: true });", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.arrow_body_style.id));
 }
 
 test "parses arrow-body-style config" {


### PR DESCRIPTION
## Summary
- autofix concise arrow bodies to block returns in `always` mode
- autofix single-return blocks to concise bodies in `as-needed` and `never` modes
- preserve comments and add required parentheses for object, sequence, and `in` expressions in `for` initializers
- skip unsafe brace removal across ASI-sensitive token boundaries
- enforce and autofix concise object bodies when `requireReturnForObjectLiteral` is enabled

## Validation
- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test` (1829 tests)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrappers: `utoo-lint --version`, `eslint --version`