### PR TITLE
feat: autofix object-shorthand

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -191,7 +191,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
-| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration |
+| [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration with comment- and semantics-safe autofix |
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Supports `always` and `never` modes with safe autofix |
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |

--- a/src/rules/object_shorthand.zig
+++ b/src/rules/object_shorthand.zig
@@ -42,7 +42,7 @@ pub fn checkWithOptions(
         else
             null;
         if (shorthand_kind == null) return;
-        return addDiagnostic(allocator, diagnostics, tree, index, shorthand_kind.?, options.style);
+        return addDiagnostic(allocator, diagnostics, tree, property, index, shorthand_kind.?, options.style);
     }
 
     if (property.shorthand or property.method) return;
@@ -52,31 +52,281 @@ pub fn checkWithOptions(
     if (options.ignore_constructors and shorthand_kind == .method and isConstructorKey(tree, property.key)) return;
     if (!styleAllowsKind(options.style, shorthand_kind)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index, shorthand_kind, options.style);
+    try addDiagnostic(allocator, diagnostics, tree, property, index, shorthand_kind, options.style);
 }
 
 fn addDiagnostic(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    property: ast.ObjectProperty,
     index: ast.NodeIndex,
     shorthand_kind: ShorthandKind,
     style: core.ObjectShorthandStyle,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    const message = if (style == .never) switch (shorthand_kind) {
+        .property => "Expected property longform.",
+        .method => "Expected method longform.",
+    } else switch (shorthand_kind) {
+        .property => "Expected property shorthand.",
+        .method => "Expected method shorthand.",
+    };
+
+    if (changesProtoSetterSemantics(tree, property)) {
+        try core.addDiagnostic(allocator, diagnostics, .warning, id, message, tree.span(index));
+        return;
+    }
+
+    if (style == .never) {
+        const replacement = switch (shorthand_kind) {
+            .property => try propertyLongformReplacement(allocator, tree, property, index),
+            .method => try methodLongformReplacement(allocator, tree, property, index),
+        };
+        if (replacement) |value| {
+            defer allocator.free(value);
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                message,
+                tree.span(index),
+                .{ .span = tree.span(index), .replacement = value },
+            );
+            return;
+        }
+    }
+
+    if (style != .never and shorthand_kind == .method) {
+        if (try methodShorthandReplacement(allocator, tree, property, index)) |replacement| {
+            defer allocator.free(replacement);
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                message,
+                tree.span(index),
+                .{ .span = tree.span(index), .replacement = replacement },
+            );
+            return;
+        }
+    }
+
+    if (style != .never and shorthand_kind == .property) {
+        const property_span = tree.span(index);
+        const value_span = tree.span(unwrapTransparent(tree, property.value));
+        if (!hasComment(tree.source[property_span.start..value_span.start]) and
+            !hasComment(tree.source[value_span.end..property_span.end]))
+        {
+            try core.addDiagnosticWithFix(
+                allocator,
+                diagnostics,
+                .warning,
+                id,
+                message,
+                property_span,
+                .{
+                    .span = property_span,
+                    .replacement = tree.source[value_span.start..value_span.end],
+                },
+            );
+            return;
+        }
+    }
+
+    try core.addDiagnostic(allocator, diagnostics, .warning, id, message, tree.span(index));
+}
+
+fn hasComment(source: []const u8) bool {
+    return std.mem.indexOf(u8, source, "//") != null or std.mem.indexOf(u8, source, "/*") != null;
+}
+
+fn changesProtoSetterSemantics(tree: *const ast.Tree, property: ast.ObjectProperty) bool {
+    if (property.computed) return false;
+    const name = propertyKeyName(tree, property.key) orelse return false;
+    return std.mem.eql(u8, name, "__proto__");
+}
+
+fn methodShorthandReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+) Allocator.Error!?[]u8 {
+    const value_index = unwrapTransparent(tree, property.value);
+    return switch (tree.data(value_index)) {
+        .function => |function| functionMethodShorthandReplacement(allocator, tree, property, index, function),
+        .arrow_function_expression => |arrow| arrowMethodShorthandReplacement(allocator, tree, property, index, value_index, arrow),
+        else => return null,
+    };
+}
+
+fn functionMethodShorthandReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    function: ast.Function,
+) Allocator.Error!?[]u8 {
+    const key_span = objectKeySourceSpan(tree, property, index) orelse return null;
+    const tail_span = if (function.type_parameters != .null)
+        tree.span(function.type_parameters)
+    else
+        tree.span(function.params);
+    const property_span = tree.span(index);
+    if (hasComment(tree.source[key_span.end..tail_span.start])) return null;
+
+    return try std.fmt.allocPrint(
         allocator,
-        diagnostics,
-        .warning,
-        id,
-        if (style == .never) switch (shorthand_kind) {
-            .property => "Expected property longform.",
-            .method => "Expected method longform.",
-        } else switch (shorthand_kind) {
-            .property => "Expected property shorthand.",
-            .method => "Expected method shorthand.",
+        "{s}{s}{s}{s}",
+        .{
+            if (function.async) "async " else "",
+            if (function.generator) "*" else "",
+            tree.source[key_span.start..key_span.end],
+            tree.source[tail_span.start..property_span.end],
         },
-        tree.span(index),
     );
+}
+
+fn arrowMethodShorthandReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+    arrow_index: ast.NodeIndex,
+    arrow: ast.ArrowFunctionExpression,
+) Allocator.Error!?[]u8 {
+    const key_span = objectKeySourceSpan(tree, property, index) orelse return null;
+    const arrow_span = tree.span(arrow_index);
+    const params_span = tree.span(arrow.params);
+    const body_span = tree.span(arrow.body);
+    const property_span = tree.span(index);
+
+    const arrow_search = tree.source[params_span.end..body_span.start];
+    const arrow_offset = std.mem.lastIndexOf(u8, arrow_search, "=>") orelse return null;
+    const arrow_start: usize = @as(usize, params_span.end) + arrow_offset;
+    if (hasComment(tree.source[key_span.end..arrow_span.start]) or
+        hasComment(tree.source[params_span.start..arrow_start]) or
+        hasComment(tree.source[arrow_start + 2 .. body_span.start]) or
+        hasComment(tree.source[body_span.end..property_span.end])) return null;
+
+    const params_source = tree.source[params_span.start..params_span.end];
+    const params_parenthesized = params_source.len >= 2 and params_source[0] == '(' and params_source[params_source.len - 1] == ')';
+    const type_parameters_source = if (arrow.type_parameters != .null) source: {
+        const type_parameters_span = tree.span(arrow.type_parameters);
+        break :source tree.source[type_parameters_span.start..params_span.start];
+    } else "";
+    const return_type_source = trimRightWhitespace(tree.source[params_span.end..arrow_start]);
+
+    return try std.fmt.allocPrint(
+        allocator,
+        "{s}{s}{s}{s}{s}{s}{s} {s}",
+        .{
+            if (arrow.async) "async " else "",
+            tree.source[key_span.start..key_span.end],
+            type_parameters_source,
+            if (params_parenthesized) "" else "(",
+            params_source,
+            if (params_parenthesized) "" else ")",
+            return_type_source,
+            tree.source[body_span.start..body_span.end],
+        },
+    );
+}
+
+fn trimRightWhitespace(source: []const u8) []const u8 {
+    var end = source.len;
+    while (end > 0 and std.ascii.isWhitespace(source[end - 1])) end -= 1;
+    return source[0..end];
+}
+
+fn propertyLongformReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+) Allocator.Error!?[]u8 {
+    const property_span = tree.span(index);
+    const key_span = tree.span(property.key);
+    if (property_span.start != key_span.start or property_span.end != key_span.end) return null;
+
+    const key_source = tree.source[key_span.start..key_span.end];
+    return try std.fmt.allocPrint(allocator, "{s}: {s}", .{ key_source, key_source });
+}
+
+fn methodLongformReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    property: ast.ObjectProperty,
+    index: ast.NodeIndex,
+) Allocator.Error!?[]u8 {
+    const function = switch (tree.data(unwrapTransparent(tree, property.value))) {
+        .function => |function| function,
+        else => return null,
+    };
+    if (containsSuperReference(tree, function.body)) return null;
+    const key_span = objectKeySourceSpan(tree, property, index) orelse return null;
+    const tail_span = if (function.type_parameters != .null)
+        tree.span(function.type_parameters)
+    else
+        tree.span(function.params);
+    const property_span = tree.span(index);
+    if (hasComment(tree.source[property_span.start..key_span.start]) or
+        hasComment(tree.source[key_span.end..tail_span.start])) return null;
+
+    return try std.fmt.allocPrint(
+        allocator,
+        "{s}: {s}function{s}{s}",
+        .{
+            tree.source[key_span.start..key_span.end],
+            if (function.async) "async " else "",
+            if (function.generator) "*" else "",
+            tree.source[tail_span.start..property_span.end],
+        },
+    );
+}
+
+fn containsSuperReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+
+    switch (tree.data(index)) {
+        .super => return true,
+        .function, .class => return false,
+        inline else => |node| return childrenContainSuperReference(tree, @TypeOf(node), node),
+    }
+}
+
+fn childrenContainSuperReference(tree: *const ast.Tree, comptime T: type, node: T) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.type == ast.NodeIndex) {
+            if (containsSuperReference(tree, @field(node, field.name))) return true;
+        } else if (field.type == ast.IndexRange) {
+            for (tree.extra(@field(node, field.name))) |child| {
+                if (containsSuperReference(tree, child)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+fn objectKeySourceSpan(tree: *const ast.Tree, property: ast.ObjectProperty, index: ast.NodeIndex) ?ast.Span {
+    const key_span = tree.span(property.key);
+    if (!property.computed) return key_span;
+
+    const property_span = tree.span(index);
+    var start: usize = @intCast(key_span.start);
+    while (start > property_span.start and std.ascii.isWhitespace(tree.source[start - 1])) start -= 1;
+    if (start == property_span.start or tree.source[start - 1] != '[') return null;
+    start -= 1;
+
+    var end: usize = @intCast(key_span.end);
+    while (end < property_span.end and std.ascii.isWhitespace(tree.source[end])) end += 1;
+    if (end >= property_span.end or tree.source[end] != ']') return null;
+
+    return .{ .start = @intCast(start), .end = @intCast(end + 1) };
 }
 
 const ShorthandKind = enum {

--- a/tests/rules/object_shorthand.zig
+++ b/tests/rules/object_shorthand.zig
@@ -33,6 +33,225 @@ test "reports object-shorthand for redundant property and method forms" {
     try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.object_shorthand.id));
 }
 
+test "autofixes redundant object properties to shorthand" {
+    const source =
+        \\const foo = 1;
+        \\const quoted = 2;
+        \\const object = { foo: foo, "quoted": quoted };
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const foo = 1;
+        \\const quoted = 2;
+        \\const object = { foo, quoted };
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.object_shorthand.id));
+}
+
+test "autofixes anonymous functions to object methods" {
+    const source =
+        \\const object = {
+        \\  plain: function () { return 1; },
+        \\  asyncValue: async function () { return 2; },
+        \\  generated: function* () { yield 3; },
+        \\  [computed]: function (value) { return value; },
+        \\};
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  plain() { return 1; },
+        \\  async asyncValue() { return 2; },
+        \\  *generated() { yield 3; },
+        \\  [computed](value) { return value; },
+        \\};
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.object_shorthand.id));
+}
+
+test "autofixes shorthand properties and methods to longform" {
+    const source =
+        \\const object = {
+        \\  foo,
+        \\  method(value) { return value; },
+        \\  async asyncMethod() { return 1; },
+        \\  *generated() { yield 2; },
+        \\  [computed]() { return 3; },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  foo: foo,
+        \\  method: function(value) { return value; },
+        \\  asyncMethod: async function() { return 1; },
+        \\  generated: function*() { yield 2; },
+        \\  [computed]: function() { return 3; },
+        \\};
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.object_shorthand.id));
+}
+
+test "autofixes explicit-return arrows to object methods" {
+    const source =
+        \\const object = {
+        \\  plain: value => { return value; },
+        \\  noParams: () => { return 1; },
+        \\  asyncValue: async (value) => { return value; },
+        \\  generic: <T>(value: T): T => { return value; },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"avoidExplicitReturnArrows\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  plain(value) { return value; },
+        \\  noParams() { return 1; },
+        \\  async asyncValue(value) { return value; },
+        \\  generic<T>(value: T): T { return value; },
+        \\};
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.object_shorthand.id));
+}
+
+test "autofixes without discarding comments or changing __proto__ semantics" {
+    const source =
+        \\const object = {
+        \\  safe: safe,
+        \\  preserved: function () { /* keep body */ return 1; },
+        \\  commented: /* keep property */ commented,
+        \\  commentedMethod: /* keep method */ function () { return 2; },
+        \\  commentedArrow: /* keep arrow */ () => { return 3; },
+        \\  __proto__: __proto__,
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"always\",{\"avoidExplicitReturnArrows\":true}]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  safe,
+        \\  preserved() { /* keep body */ return 1; },
+        \\  commented: /* keep property */ commented,
+        \\  commentedMethod: /* keep method */ function () { return 2; },
+        \\  commentedArrow: /* keep arrow */ () => { return 3; },
+        \\  __proto__: __proto__,
+        \\};
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result.result, lint.rules.object_shorthand.id));
+}
+
+test "never mode does not create prototype setters or invalid super references" {
+    const source =
+        \\const object = {
+        \\  safe,
+        \\  __proto__,
+        \\  inherited() { return super.value; },
+        \\};
+    ;
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"never\"]",
+        .{},
+    );
+    defer config.deinit();
+    var options = lint.Options{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    };
+    try options.setByRuleConfigValue("object-shorthand", config.value);
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const object = {
+        \\  safe: safe,
+        \\  __proto__,
+        \\  inherited() { return super.value; },
+        \\};
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.object_shorthand.id));
+}
+
 test "does not report object-shorthand for non-shorthandable properties" {
     const source =
         \\const foo = 1;


### PR DESCRIPTION
## Summary

- autofix redundant properties and function/arrow values to object shorthand
- support reverse longform fixes for `never`, including async, generator, computed, and TypeScript method signatures
- preserve comments and skip fixes that would change `__proto__` setter semantics or invalidate `super` references

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test` (1835/1835)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1` (1835/1835)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- packaged `utoo-lint --version` and ESLint wrapper `--version`