### PR TITLE
feat: autofix one-var

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -192,7 +192,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |
 | [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) | Supports `always`, `methods`, `properties`, `never`, `avoidQuotes`, `ignoreConstructors`, and `avoidExplicitReturnArrows` configuration with comment- and semantics-safe autofix |
-| [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration |
+| [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration with comment- and context-safe autofix |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Supports `always` and `never` modes with safe autofix |
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |

--- a/src/rules/one_var.zig
+++ b/src/rules/one_var.zig
@@ -1,9 +1,10 @@
+const std = @import("std");
 const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
 const traverser = parser.traverser;
-const Allocator = @import("std").mem.Allocator;
+const Allocator = std.mem.Allocator;
 
 pub const id = "one-var";
 
@@ -37,6 +38,27 @@ pub fn checkWithOptions(
     if (declaration.declarators.len < 2) return;
     if (isForStatementInit(tree, index, ctx)) return;
 
+    var fixes: std.ArrayList(core.Fix) = .empty;
+    defer fixes.deinit(allocator);
+    var replacements: std.ArrayList([]u8) = .empty;
+    defer {
+        for (replacements.items) |replacement| allocator.free(replacement);
+        replacements.deinit(allocator);
+    }
+
+    if (isStatementListContext(tree, ctx) and try buildSplitFixes(allocator, &fixes, &replacements, tree, declaration, ctx)) {
+        try core.addDiagnosticWithFixes(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Split variable declarations into multiple statements.",
+            tree.span(index),
+            fixes.items,
+        );
+        return;
+    }
+
     try core.addDiagnostic(
         allocator,
         diagnostics,
@@ -45,6 +67,108 @@ pub fn checkWithOptions(
         "Split variable declarations into multiple statements.",
         tree.span(index),
     );
+}
+
+fn buildSplitFixes(
+    allocator: Allocator,
+    fixes: *std.ArrayList(core.Fix),
+    replacements: *std.ArrayList([]u8),
+    tree: *const ast.Tree,
+    declaration: ast.VariableDeclaration,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!bool {
+    const declarators = tree.extra(declaration.declarators);
+    const exported = isExportedDeclaration(tree, ctx);
+    for (declarators[0 .. declarators.len - 1], declarators[1..]) |current, next| {
+        const current_span = tree.span(current);
+        const next_span = tree.span(next);
+        const comma = findSeparatorComma(tree.source, current_span.end, next_span.start) orelse return false;
+        const tail = tree.source[comma + 1 .. next_span.start];
+        const preserve_tail = hasComment(tail) or containsLineTerminator(tail);
+        const replacement = if (preserve_tail)
+            try std.fmt.allocPrint(allocator, ";{s}{s}{s}{s} ", .{
+                tail,
+                if (exported) "export " else "",
+                if (declaration.declare) "declare " else "",
+                declaration.kind.toString(),
+            })
+        else
+            try std.fmt.allocPrint(allocator, "; {s}{s}{s} ", .{
+                if (exported) "export " else "",
+                if (declaration.declare) "declare " else "",
+                declaration.kind.toString(),
+            });
+        replacements.append(allocator, replacement) catch |err| {
+            allocator.free(replacement);
+            return err;
+        };
+
+        try fixes.append(allocator, .{
+            .span = .{ .start = comma, .end = next_span.start },
+            .replacement = replacement,
+        });
+    }
+    return fixes.items.len == declarators.len - 1;
+}
+
+fn isExportedDeclaration(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    const parent = ctx.path.ancestor(1) orelse return false;
+    return tree.data(parent) == .export_named_declaration;
+}
+
+fn findSeparatorComma(source: []const u8, start: u32, end: u32) ?u32 {
+    var index: usize = @intCast(start);
+    const limit: usize = @intCast(end);
+
+    while (index < limit) {
+        if (source[index] == ',') return @intCast(index);
+        if (source[index] == '/' and index + 1 < limit) {
+            if (source[index + 1] == '/') {
+                index += 2;
+                while (index < limit and source[index] != '\n' and source[index] != '\r') index += 1;
+                continue;
+            }
+            if (source[index + 1] == '*') {
+                index += 2;
+                while (index + 1 < limit and !(source[index] == '*' and source[index + 1] == '/')) index += 1;
+                if (index + 1 >= limit) return null;
+                index += 2;
+                continue;
+            }
+        }
+        if (!std.ascii.isWhitespace(source[index])) return null;
+        index += 1;
+    }
+    return null;
+}
+
+fn hasComment(source: []const u8) bool {
+    return std.mem.indexOf(u8, source, "//") != null or std.mem.indexOf(u8, source, "/*") != null;
+}
+
+fn containsLineTerminator(source: []const u8) bool {
+    for (source) |char| {
+        if (char == '\n' or char == '\r') return true;
+    }
+    return false;
+}
+
+fn isStatementListContext(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var parent = ctx.path.ancestor(1) orelse return false;
+    if (tree.data(parent) == .export_named_declaration) {
+        parent = ctx.path.ancestor(2) orelse return false;
+    }
+
+    return switch (tree.data(parent)) {
+        .program,
+        .function_body,
+        .block_statement,
+        .static_block,
+        .switch_case,
+        .ts_module_block,
+        => true,
+        else => false,
+    };
 }
 
 fn shouldCheckKind(kind: ast.VariableKind, options: Options) bool {

--- a/tests/rules/one_var.zig
+++ b/tests/rules/one_var.zig
@@ -17,6 +17,151 @@ test "reports one-var for combined variable declarations" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.one_var.id));
 }
 
+test "autofixes combined variable declarations into separate statements" {
+    const source =
+        \\var first = 1, second = 2;
+        \\let third = 3, fourth = 4;
+        \\const fifth = 5, sixth = 6;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\var first = 1; var second = 2;
+        \\let third = 3; let fourth = 4;
+        \\const fifth = 5; const sixth = 6;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.one_var.id));
+}
+
+test "autofixes multiline declarations without discarding comments" {
+    const source =
+        \\var first = 1, // keep second
+        \\    second = 2, /* keep third */ third = 3;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\var first = 1; // keep second
+        \\    var second = 2; /* keep third */ var third = 3;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.one_var.id));
+}
+
+test "autofixes exported and ambient declarations with their modifiers" {
+    const source =
+        \\export const first = 1, second = 2;
+        \\declare let third: number, fourth: string;
+        \\export declare const fifth: number, sixth: string;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", .{
+        .eol_last = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\export const first = 1; export const second = 2;
+        \\declare let third: number; declare let fourth: string;
+        \\export declare const fifth: number; export declare const sixth: string;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.one_var.id));
+}
+
+test "autofixes using and await using declarations" {
+    const source =
+        \\async function cleanup() {
+        \\  using first = acquire(), second = acquire();
+        \\  await using third = acquireAsync(), fourth = acquireAsync();
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\async function cleanup() {
+        \\  using first = acquire(); using second = acquire();
+        \\  await using third = acquireAsync(); await using fourth = acquireAsync();
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.one_var.id));
+}
+
+test "does not autofix declarations outside statement lists" {
+    const source =
+        \\if (ready) var first = 1, second = 2;
+        \\if (ready) { var third = 3, fourth = 4; }
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (ready) var first = 1, second = 2;
+        \\if (ready) { var third = 3; var fourth = 4; }
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.one_var.id));
+}
+
+test "autofixes destructuring declarations in switch cases without adding a final semicolon" {
+    const source =
+        \\switch (kind) {
+        \\  case "value":
+        \\    let { first } = source, [second] = values
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_case_declarations = false,
+        .no_fallthrough = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\switch (kind) {
+        \\  case "value":
+        \\    let { first } = source; let [second] = values
+        \\}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.one_var.id));
+}
+
 test "does not report one-var for separate declarations or for loop init" {
     const source =
         \\let first = 1;


### PR DESCRIPTION
## Summary

- autofix `one-var` never-mode diagnostics by splitting combined declarators into independent statements
- preserve multiline layout, comments, exports, ambient modifiers, and `using` / `await using` declaration kinds
- avoid autofixing declarations outside statement-list contexts where splitting would produce invalid syntax

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test` (1841/1841)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1` (1841/1841)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- packaged `utoo-lint --version` and ESLint wrapper `--version`