### PR TITLE
feat: autofix logical assignment operators

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -34,7 +34,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`id-match`](https://eslint.org/docs/latest/rules/id-match) | Supports lightweight pattern matching for declarations and import aliases, with `properties`, `classFields`, `onlyDeclarations`, and `ignoreDestructuring` configuration |
 | [`init-declarations`](https://eslint.org/docs/latest/rules/init-declarations) | Supports `always`, `never`, and `ignoreForLoopInit` |
 | [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) | Supports `unix` and `windows` configuration with autofix |
-| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior |
+| [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) | Implemented for `always`, optional `never`, and optional `enforceForIfStatements: true` behavior with comment-, precedence-, and evaluation-safe autofix |
 | [`max-classes-per-file`](https://eslint.org/docs/latest/rules/max-classes-per-file) | Supports `max` and `ignoreExpressions` configuration |
 | [`max-depth`](https://eslint.org/docs/latest/rules/max-depth) | Supports `max`, deprecated `maximum`, function scopes, static blocks, and `else if` chains |
 | [`max-lines`](https://eslint.org/docs/latest/rules/max-lines) | Supports `max`, `skipBlankLines`, and `skipComments` configuration |

--- a/src/rules/logical_assignment_operators.zig
+++ b/src/rules/logical_assignment_operators.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = parser.traverser;
 const Allocator = std.mem.Allocator;
 
 pub const id = "logical-assignment-operators";
@@ -32,7 +33,7 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
-    try checkAssignmentExpressionWithOptions(allocator, diagnostics, tree, expression, index, .{});
+    try checkAssignmentExpressionWithContextAndOptions(allocator, diagnostics, tree, expression, index, null, .{});
 }
 
 pub fn checkAssignmentExpressionWithOptions(
@@ -43,8 +44,20 @@ pub fn checkAssignmentExpressionWithOptions(
     index: ast.NodeIndex,
     options: Options,
 ) Allocator.Error!void {
+    try checkAssignmentExpressionWithContextAndOptions(allocator, diagnostics, tree, expression, index, null, options);
+}
+
+pub fn checkAssignmentExpressionWithContextAndOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    index: ast.NodeIndex,
+    ctx: ?*traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
     if (options.style == .never) {
-        try checkLogicalAssignmentOperator(allocator, diagnostics, tree, expression, index);
+        try checkLogicalAssignmentOperator(allocator, diagnostics, tree, expression, index, ctx);
         return;
     }
 
@@ -63,7 +76,20 @@ pub fn checkAssignmentExpressionWithOptions(
     const right_left = (try referenceFromExpression(arena_allocator, tree, logical.left)) orelse return;
     if (!referencesEqual(left, right_left)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index, logical.operator);
+    const replacement = if (isSafeDirectIdentifier(tree, expression.left, ctx) and !hasCommentInSpan(tree, tree.span(index)))
+        try std.fmt.allocPrint(allocator, "{s} {s}= {s}", .{
+            tree.source[tree.span(expression.left).start..tree.span(expression.left).end],
+            logical.operator.toString(),
+            tree.source[tree.span(logical.right).start..tree.span(logical.right).end],
+        })
+    else
+        null;
+    defer if (replacement) |value| allocator.free(value);
+
+    try addDiagnostic(allocator, diagnostics, tree, index, logical.operator, if (replacement) |value| .{
+        .span = tree.span(index),
+        .replacement = value,
+    } else null);
 }
 
 fn checkLogicalAssignmentOperator(
@@ -72,8 +98,38 @@ fn checkLogicalAssignmentOperator(
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
     index: ast.NodeIndex,
+    ctx: ?*traverser.basic.Ctx,
 ) Allocator.Error!void {
     const operator = logicalOperatorFromAssignment(expression.operator) orelse return;
+    const parenthesize_right = rightNeedsParentheses(tree, expression.right, operator);
+    const replacement = if (isSafeDirectIdentifier(tree, expression.left, ctx) and !hasCommentInSpan(tree, tree.span(index)))
+        try std.fmt.allocPrint(allocator, "{s} = {s} {s} {s}{s}{s}", .{
+            tree.source[tree.span(expression.left).start..tree.span(expression.left).end],
+            tree.source[tree.span(expression.left).start..tree.span(expression.left).end],
+            operator.toString(),
+            if (parenthesize_right) "(" else "",
+            tree.source[tree.span(expression.right).start..tree.span(expression.right).end],
+            if (parenthesize_right) ")" else "",
+        })
+    else
+        null;
+    defer if (replacement) |value| allocator.free(value);
+
+    if (replacement) |value| {
+        const message = try std.fmt.allocPrint(allocator, "Unexpected logical assignment operator `{s}=`.", .{operator.toString()});
+        defer allocator.free(message);
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+            .{ .span = tree.span(index), .replacement = value },
+        );
+        return;
+    }
+
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
@@ -92,6 +148,17 @@ pub fn checkLogicalExpression(
     expression: ast.LogicalExpression,
     index: ast.NodeIndex,
 ) Allocator.Error!void {
+    try checkLogicalExpressionWithContext(allocator, diagnostics, tree, expression, index, null);
+}
+
+pub fn checkLogicalExpressionWithContext(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.LogicalExpression,
+    index: ast.NodeIndex,
+    ctx: ?*traverser.basic.Ctx,
+) Allocator.Error!void {
     const assignment = switch (tree.data(unwrapTransparent(tree, expression.right))) {
         .assignment_expression => |assignment| assignment,
         else => return,
@@ -106,7 +173,23 @@ pub fn checkLogicalExpression(
     const assignment_left = (try referenceFromExpression(arena_allocator, tree, assignment.left)) orelse return;
     if (!referencesEqual(left, assignment_left)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index, expression.operator);
+    const parenthesize = logicalReplacementNeedsParentheses(tree, ctx);
+    const replacement = if (isSafeShortCircuitReference(tree, expression.left, ctx) and !hasCommentInSpan(tree, tree.span(index)))
+        try std.fmt.allocPrint(allocator, "{s}{s} {s}= {s}{s}", .{
+            if (parenthesize) "(" else "",
+            tree.source[tree.span(expression.left).start..tree.span(expression.left).end],
+            expression.operator.toString(),
+            tree.source[tree.span(assignment.right).start..tree.span(assignment.right).end],
+            if (parenthesize) ")" else "",
+        })
+    else
+        null;
+    defer if (replacement) |value| allocator.free(value);
+
+    try addDiagnostic(allocator, diagnostics, tree, index, expression.operator, if (replacement) |value| .{
+        .span = tree.span(index),
+        .replacement = value,
+    } else null);
 }
 
 pub fn checkIfStatement(
@@ -115,6 +198,17 @@ pub fn checkIfStatement(
     tree: *const ast.Tree,
     statement: ast.IfStatement,
     index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkIfStatementWithContext(allocator, diagnostics, tree, statement, index, null);
+}
+
+pub fn checkIfStatementWithContext(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    statement: ast.IfStatement,
+    index: ast.NodeIndex,
+    ctx: ?*traverser.basic.Ctx,
 ) Allocator.Error!void {
     if (statement.alternate != .null) return;
 
@@ -129,7 +223,22 @@ pub fn checkIfStatement(
     const assignment_left = (try referenceFromExpression(arena_allocator, tree, assignment.left)) orelse return;
     if (!referencesEqual(test_reference.reference, assignment_left)) return;
 
-    try addDiagnostic(allocator, diagnostics, tree, index, test_reference.operator);
+    const replacement = if (isSafeShortCircuitReference(tree, assignment.left, ctx) and
+        hasSafeStatementStart(tree, assignment.left) and
+        !hasCommentInSpan(tree, tree.span(index)))
+        try std.fmt.allocPrint(allocator, "{s} {s}= {s};", .{
+            tree.source[tree.span(assignment.left).start..tree.span(assignment.left).end],
+            test_reference.operator.toString(),
+            tree.source[tree.span(assignment.right).start..tree.span(assignment.right).end],
+        })
+    else
+        null;
+    defer if (replacement) |value| allocator.free(value);
+
+    try addDiagnostic(allocator, diagnostics, tree, index, test_reference.operator, if (replacement) |value| .{
+        .span = tree.span(index),
+        .replacement = value,
+    } else null);
 }
 
 const ConditionReference = struct {
@@ -143,7 +252,23 @@ fn addDiagnostic(
     tree: *const ast.Tree,
     index: ast.NodeIndex,
     operator: ast.LogicalOperator,
+    fix: ?core.Fix,
 ) Allocator.Error!void {
+    if (fix) |value| {
+        const message = try std.fmt.allocPrint(allocator, "Assignment can be replaced with `{s}=`.", .{operator.toString()});
+        defer allocator.free(message);
+        try core.addDiagnosticWithFix(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+            value,
+        );
+        return;
+    }
+
     try core.addDiagnosticFmt(
         allocator,
         diagnostics,
@@ -155,12 +280,127 @@ fn addDiagnostic(
     );
 }
 
+fn isSafeDirectIdentifier(tree: *const ast.Tree, index: ast.NodeIndex, ctx: ?*traverser.basic.Ctx) bool {
+    if (ctx == null or isInsideWithStatement(tree, ctx.?)) return false;
+    return tree.data(unwrapTransparent(tree, index)) == .identifier_reference;
+}
+
+fn isSafeShortCircuitReference(tree: *const ast.Tree, index: ast.NodeIndex, ctx: ?*traverser.basic.Ctx) bool {
+    if (isSafeDirectIdentifier(tree, index, ctx)) return true;
+    if (ctx == null or isInsideWithStatement(tree, ctx.?)) return false;
+
+    const member = switch (tree.data(unwrapTransparent(tree, index))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (propertyName(tree, member) == null) return false;
+    return switch (tree.data(unwrapTransparent(tree, member.object))) {
+        .identifier_reference, .this_expression => true,
+        else => false,
+    };
+}
+
+fn isInsideWithStatement(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) bool {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        if (tree.data(ancestor) == .with_statement) return true;
+    }
+    return false;
+}
+
+fn logicalReplacementNeedsParentheses(tree: *const ast.Tree, ctx: ?*traverser.basic.Ctx) bool {
+    const context = ctx orelse return true;
+    const parent = context.path.ancestor(1) orelse return true;
+    return switch (tree.data(parent)) {
+        .expression_statement, .parenthesized_expression => false,
+        else => true,
+    };
+}
+
+fn hasSafeStatementStart(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const span = tree.span(index);
+    if (span.start >= span.end) return false;
+    const first = tree.source[span.start];
+    return first == '_' or first == '$' or std.ascii.isAlphabetic(first) or first >= 0x80;
+}
+
+fn hasCommentInSpan(tree: *const ast.Tree, span: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.start < span.end and comment.span.end > span.start) return true;
+    }
+    return false;
+}
+
 fn logicalOperatorFromAssignment(operator: ast.AssignmentOperator) ?ast.LogicalOperator {
     return switch (operator) {
         .logical_or_assign => .@"or",
         .logical_and_assign => .@"and",
         .nullish_assign => .nullish_coalescing,
         else => null,
+    };
+}
+
+fn rightNeedsParentheses(tree: *const ast.Tree, index: ast.NodeIndex, operator: ast.LogicalOperator) bool {
+    if (tree.data(index) == .parenthesized_expression) return false;
+    const precedence = expressionPrecedence(tree, index);
+    const operator_precedence: u8 = switch (operator) {
+        .@"or", .nullish_coalescing => 3,
+        .@"and" => 4,
+    };
+    if (precedence <= operator_precedence) return true;
+
+    return operator == .nullish_coalescing and switch (tree.data(unwrapTransparent(tree, index))) {
+        .logical_expression => true,
+        else => false,
+    };
+}
+
+fn expressionPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) u8 {
+    return switch (tree.data(index)) {
+        .sequence_expression => 1,
+        .assignment_expression,
+        .arrow_function_expression,
+        .yield_expression,
+        .conditional_expression,
+        => 2,
+        .logical_expression => |logical| switch (logical.operator) {
+            .@"or", .nullish_coalescing => 3,
+            .@"and" => 4,
+        },
+        .binary_expression => |binary| binaryOperatorPrecedence(binary.operator),
+        .ts_as_expression, .ts_satisfies_expression => 9,
+        .unary_expression, .await_expression, .ts_type_assertion => 14,
+        .update_expression => 15,
+        .new_expression,
+        .call_expression,
+        .member_expression,
+        .chain_expression,
+        .tagged_template_expression,
+        .import_expression,
+        .ts_non_null_expression,
+        .ts_instantiation_expression,
+        => 17,
+        else => 18,
+    };
+}
+
+fn binaryOperatorPrecedence(operator: ast.BinaryOperator) u8 {
+    return switch (operator) {
+        .bitwise_or => 5,
+        .bitwise_xor => 6,
+        .bitwise_and => 7,
+        .equal, .not_equal, .strict_equal, .strict_not_equal => 8,
+        .less_than,
+        .less_than_or_equal,
+        .greater_than,
+        .greater_than_or_equal,
+        .in,
+        .instanceof,
+        => 9,
+        .left_shift, .right_shift, .unsigned_right_shift => 10,
+        .add, .subtract => 11,
+        .multiply, .divide, .modulo => 12,
+        .exponent => 13,
     };
 }
 

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1794,7 +1794,7 @@ const BasicVisitor = struct {
             self.options.logical_assignment_operators_style == .always and
             self.options.logical_assignment_operators_enforce_for_if_statements == .yes)
         {
-            try logical_assignment_operators.checkIfStatement(self.allocator, self.diagnostics, ctx.tree, statement, index);
+            try logical_assignment_operators.checkIfStatementWithContext(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
         }
         if (self.options.alipay_ant_prefer_elseif_end_with_else) {
             try alipay_ant_prefer_elseif_end_with_else.check(self.allocator, self.diagnostics, ctx.tree, statement, index, ctx);
@@ -3097,7 +3097,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.logical_assignment_operators) {
-            try logical_assignment_operators.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+            try logical_assignment_operators.checkAssignmentExpressionWithContextAndOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx, .{
                 .style = switch (self.options.logical_assignment_operators_style) {
                     .always => .always,
                     .never => .never,
@@ -3162,7 +3162,7 @@ const BasicVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (self.options.logical_assignment_operators and self.options.logical_assignment_operators_style == .always) {
-            try logical_assignment_operators.checkLogicalExpression(self.allocator, self.diagnostics, ctx.tree, expression, index);
+            try logical_assignment_operators.checkLogicalExpressionWithContext(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx);
         }
         if (self.options.no_constant_binary_expression) {
             try no_constant_binary_expression.checkLogicalExpression(self.allocator, self.diagnostics, ctx.tree, expression);

--- a/tests/rules/logical_assignment_operators.zig
+++ b/tests/rules/logical_assignment_operators.zig
@@ -25,6 +25,58 @@ test "reports logical-assignment-operators for self logical assignments" {
     try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
 }
 
+test "autofixes self logical assignments for identifiers" {
+    const source =
+        \\first = first || fallback;
+        \\second = second && fallback;
+        \\third = third ?? fallback;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first ||= fallback;
+        \\second &&= fallback;
+        \\third ??= fallback;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "does not autofix repeated property access or identifiers inside with" {
+    const source =
+        \\first = first || fallback;
+        \\object.value = object.value || fallback;
+        \\this.ready = this.ready && fallback;
+        \\with (scope) {
+        \\  value = value ?? fallback;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first ||= fallback;
+        \\object.value = object.value || fallback;
+        \\this.ready = this.ready && fallback;
+        \\with (scope) {
+        \\  value = value ?? fallback;
+        \\}
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
 test "reports logical-assignment-operators for short-circuit assignment expressions" {
     const source =
         \\let first;
@@ -46,6 +98,70 @@ test "reports logical-assignment-operators for short-circuit assignment expressi
 
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.logical_assignment_operators.id));
     try std.testing.expectEqualStrings("Assignment can be replaced with `||=`.", result.diagnostics[0].message);
+}
+
+test "autofixes short-circuit assignment expressions for identifiers" {
+    const source =
+        \\first || (first = fallback);
+        \\second && (second = fallback);
+        \\third ?? (third = fallback);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first ||= fallback;
+        \\second &&= fallback;
+        \\third ??= fallback;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "autofixes single property short-circuit expressions but not nested access" {
+    const source =
+        \\object.value || (object.value = fallback);
+        \\this.ready && (this.ready = fallback);
+        \\object.value.current ?? (object.value.current = fallback);
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\object.value ||= fallback;
+        \\this.ready &&= fallback;
+        \\object.value.current ?? (object.value.current = fallback);
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "parenthesizes short-circuit replacements used by a larger logical expression" {
+    const source = "const result = first || (first = fallback) || other;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings("const result = (first ||= fallback) || other;", result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
 }
 
 test "reports logical-assignment-operators for if statements when enabled" {
@@ -71,6 +187,124 @@ test "reports logical-assignment-operators for if statements when enabled" {
     try std.testing.expectEqualStrings("Assignment can be replaced with `&&=`.", result.diagnostics[0].message);
     try std.testing.expectEqualStrings("Assignment can be replaced with `||=`.", result.diagnostics[1].message);
     try std.testing.expectEqualStrings("Assignment can be replaced with `??=`.", result.diagnostics[2].message);
+}
+
+test "autofixes if statements to logical assignments when enabled" {
+    const source =
+        \\if (first) first = fallback;
+        \\if (!second) {
+        \\  second = fallback;
+        \\}
+        \\if (third == null) third = fallback;
+        \\if (null == fourth) {
+        \\  fourth = fallback;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first &&= fallback;
+        \\second ||= fallback;
+        \\third ??= fallback;
+        \\fourth ??= fallback;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "if autofix allows single properties but rejects nested access and with" {
+    const source =
+        \\if (object.value) object.value = fallback;
+        \\if (!this.ready) {
+        \\  this.ready = fallback;
+        \\}
+        \\if (object.value.current) object.value.current = fallback;
+        \\with (scope) {
+        \\  if (value) value = fallback;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
+        .eol_last = false,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\object.value &&= fallback;
+        \\this.ready ||= fallback;
+        \\if (object.value.current) object.value.current = fallback;
+        \\with (scope) {
+        \\  if (value) value = fallback;
+        \\}
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "autofixes without discarding comments" {
+    const source =
+        \\safe = safe || fallback;
+        \\commented = commented /* keep assignment */ || fallback;
+        \\shortValue || (shortValue = /* keep short */ fallback);
+        \\if (condition) {
+        \\  condition = /* keep if */ fallback;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .curly = false,
+        .eol_last = false,
+        .logical_assignment_operators_enforce_for_if_statements = .yes,
+        .no_undef = false,
+        .no_unused_expressions = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\safe ||= fallback;
+        \\commented = commented /* keep assignment */ || fallback;
+        \\shortValue || (shortValue = /* keep short */ fallback);
+        \\if (condition) {
+        \\  condition = /* keep if */ fallback;
+        \\}
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "comment markers inside literals do not suppress autofix" {
+    const source =
+        \\url = url || "https://example.test/path";
+        \\marker = marker || "/* not a comment */";
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\url ||= "https://example.test/path";
+        \\marker ||= "/* not a comment */";
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
 }
 
 test "does not report logical-assignment-operators for if statements by default" {
@@ -146,6 +380,81 @@ test "reports logical-assignment-operators for logical assignments in never mode
     try std.testing.expectEqualStrings("Unexpected logical assignment operator `||=`.", result.diagnostics[0].message);
     try std.testing.expectEqualStrings("Unexpected logical assignment operator `&&=`.", result.diagnostics[1].message);
     try std.testing.expectEqualStrings("Unexpected logical assignment operator `??=`.", result.diagnostics[2].message);
+}
+
+test "autofixes logical assignments in never mode for identifiers" {
+    const source =
+        \\first ||= fallback;
+        \\second &&= fallback;
+        \\third ??= fallback;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .logical_assignment_operators_style = .never,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first = first || fallback;
+        \\second = second && fallback;
+        \\third = third ?? fallback;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "never-mode autofix parenthesizes lower-precedence and mixed logical operands" {
+    const source =
+        \\first &&= condition ? yes : no;
+        \\second ??= fallback || other;
+        \\third ||= fallback ?? other;
+        \\fourth ||= target = fallback;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .logical_assignment_operators_style = .never,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\first = first && (condition ? yes : no);
+        \\second = second ?? (fallback || other);
+        \\third = third || (fallback ?? other);
+        \\fourth = fourth || (target = fallback);
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.logical_assignment_operators.id));
+}
+
+test "never-mode autofix preserves comments and avoids repeated property evaluation" {
+    const source =
+        \\safe ||= fallback;
+        \\commented &&= /* keep */ fallback;
+        \\object.value ??= fallback;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .logical_assignment_operators_style = .never,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\safe = safe || fallback;
+        \\commented &&= /* keep */ fallback;
+        \\object.value ??= fallback;
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result.result, lint.rules.logical_assignment_operators.id));
 }
 
 test "can disable logical-assignment-operators" {


### PR DESCRIPTION
## Summary

- autofix identifier assignments such as `value = value || fallback` and reverse `never`-mode logical assignments
- autofix short-circuit assignment expressions and enabled `if` statement conversions with safety-graded single-property support
- preserve comments, parenthesize lower-precedence and mixed nullish operands, and skip repeated-evaluation or `with`-scope hazards

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test` (1853/1853)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1` (1853/1853)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- packaged `utoo-lint --version` and ESLint wrapper `--version`