### PR TITLE
feat: autofix curly

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -15,7 +15,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`consistent-this`](https://eslint.org/docs/latest/rules/consistent-this) | Supports configured aliases for direct `this` captures and same-scope deferred assignment checks |
 | [`constructor-super`](https://eslint.org/docs/latest/rules/constructor-super) | Implemented |
-| [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, `multi`, and `multi-or-nest` configuration |
+| [`curly`](https://eslint.org/docs/latest/rules/curly) | Supports `all`, `multi-line`, `multi`, and `multi-or-nest` configuration; autofixes stable block additions/removals while preserving comments and refusing ASI or dangling-`else` hazards |
 | [`default-case`](https://eslint.org/docs/latest/rules/default-case) | Implemented with common `commentPattern` behavior |
 | [`default-case-last`](https://eslint.org/docs/latest/rules/default-case-last) | Implemented |
 | [`default-param-last`](https://eslint.org/docs/latest/rules/default-param-last) | Implemented |

--- a/src/rules/curly.zig
+++ b/src/rules/curly.zig
@@ -27,12 +27,19 @@ pub fn checkIfStatementWithOptions(
     statement: ast.IfStatement,
     options: Options,
 ) Allocator.Error!void {
-    try checkBodyWithOptions(allocator, diagnostics, tree, statement.consequent, options);
+    try checkBodyWithContext(
+        allocator,
+        diagnostics,
+        tree,
+        statement.consequent,
+        options,
+        statement.alternate != .null,
+    );
 
     if (statement.alternate == .null) return;
     if (tree.data(statement.alternate) == .if_statement) return;
 
-    try checkBodyWithOptions(allocator, diagnostics, tree, statement.alternate, options);
+    try checkBodyWithContext(allocator, diagnostics, tree, statement.alternate, options, false);
 }
 
 pub fn checkBody(
@@ -51,20 +58,45 @@ pub fn checkBodyWithOptions(
     body: ast.NodeIndex,
     options: Options,
 ) Allocator.Error!void {
+    return checkBodyWithContext(allocator, diagnostics, tree, body, options, false);
+}
+
+fn checkBodyWithContext(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+    options: Options,
+    protect_dangling_else: bool,
+) Allocator.Error!void {
     if (body == .null) return;
     switch (tree.data(body)) {
         .block_statement => |block| {
             if (options.style != .multi and options.style != .multi_or_nest) return;
             if (!isUnnecessaryBlock(tree, block, options.style)) return;
 
-            try core.addDiagnostic(
-                allocator,
-                diagnostics,
-                .warning,
-                id,
-                "Unnecessary block statement.",
-                tree.span(body),
-            );
+            if (try unnecessaryBlockReplacement(allocator, tree, body, block, protect_dangling_else)) |replacement| {
+                defer allocator.free(replacement);
+                const span = tree.span(body);
+                try core.addDiagnosticWithFix(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Unnecessary block statement.",
+                    span,
+                    .{ .span = span, .replacement = replacement },
+                );
+            } else {
+                try core.addDiagnostic(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    "Unnecessary block statement.",
+                    tree.span(body),
+                );
+            }
             return;
         },
         else => {},
@@ -85,7 +117,113 @@ pub fn checkBodyWithOptions(
         diagnostics,
         tree,
         body,
+        switch (options.style) {
+            .all, .multi_line => true,
+            .multi => false,
+            .multi_or_nest => isControlStatement(tree, body),
+        },
     );
+}
+
+fn unnecessaryBlockReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    body: ast.NodeIndex,
+    block: ast.BlockStatement,
+    protect_dangling_else: bool,
+) Allocator.Error!?[]u8 {
+    const statements = tree.extra(block.body);
+    const statement = statements[0];
+
+    if (protect_dangling_else) {
+        switch (tree.data(statement)) {
+            .if_statement => |nested| if (nested.alternate == .null) return null,
+            else => {},
+        }
+    }
+
+    const block_span = tree.span(body);
+    if (block_span.end <= block_span.start + 1 or
+        tree.source[block_span.start] != '{' or
+        tree.source[block_span.end - 1] != '}') return null;
+    if (!isSafeWithoutBlock(tree, tree.span(statement), block_span)) return null;
+
+    const inner = tree.source[block_span.start + 1 .. block_span.end - 1];
+    const prefix = if (needsLeadingSpace(tree.source, block_span.start, inner)) " " else "";
+    const suffix = if (needsTrailingSpace(tree.source, block_span.end, inner)) " " else "";
+    return try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ prefix, inner, suffix });
+}
+
+fn isSafeWithoutBlock(tree: *const ast.Tree, statement_span: ast.Span, block_span: ast.Span) bool {
+    if (previousCodeOffset(tree, statement_span.end, statement_span.start)) |offset| {
+        if (tree.source[offset] == ';') return true;
+    }
+
+    const next = nextCodeOffset(tree, block_span.end) orelse return true;
+    if (!containsLineTerminator(tree.source[block_span.end..next])) return false;
+
+    return switch (tree.source[next]) {
+        '(', '[', '/', '`', '+', '-' => false,
+        else => true,
+    };
+}
+
+fn nextCodeOffset(tree: *const ast.Tree, start: u32) ?usize {
+    var cursor: usize = start;
+    while (cursor < tree.source.len) {
+        if (std.ascii.isWhitespace(tree.source[cursor])) {
+            cursor += 1;
+            continue;
+        }
+        if (commentAt(tree, @intCast(cursor))) |comment| {
+            cursor = comment.span.end;
+            continue;
+        }
+        return cursor;
+    }
+    return null;
+}
+
+fn previousCodeOffset(tree: *const ast.Tree, end: u32, start: u32) ?usize {
+    var cursor: usize = end;
+    while (cursor > start) {
+        while (cursor > start and std.ascii.isWhitespace(tree.source[cursor - 1])) cursor -= 1;
+        if (cursor == start) return null;
+
+        var skipped_comment = false;
+        for (tree.comments) |comment| {
+            if (comment.span.end != cursor or comment.span.start < start) continue;
+            cursor = comment.span.start;
+            skipped_comment = true;
+            break;
+        }
+        if (skipped_comment) continue;
+        return cursor - 1;
+    }
+    return null;
+}
+
+fn commentAt(tree: *const ast.Tree, offset: u32) ?ast.Comment {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= offset) continue;
+        if (comment.span.start > offset) break;
+        return comment;
+    }
+    return null;
+}
+
+fn needsLeadingSpace(source: []const u8, block_start: u32, inner: []const u8) bool {
+    return block_start > 0 and inner.len > 0 and
+        isIdentifierByte(source[block_start - 1]) and isIdentifierByte(inner[0]);
+}
+
+fn needsTrailingSpace(source: []const u8, block_end: u32, inner: []const u8) bool {
+    return block_end < source.len and inner.len > 0 and
+        isIdentifierByte(inner[inner.len - 1]) and isIdentifierByte(source[block_end]);
+}
+
+fn isIdentifierByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$';
 }
 
 fn addExpectedBlockDiagnostic(
@@ -93,14 +231,32 @@ fn addExpectedBlockDiagnostic(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     body: ast.NodeIndex,
+    allow_fix: bool,
 ) Allocator.Error!void {
-    try core.addDiagnostic(
+    const span = tree.span(body);
+    if (!allow_fix) {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Expected a block statement.",
+            span,
+        );
+        return;
+    }
+
+    const replacement = try std.fmt.allocPrint(allocator, "{{{s}}}", .{tree.source[span.start..span.end]});
+    defer allocator.free(replacement);
+
+    try core.addDiagnosticWithFix(
         allocator,
         diagnostics,
         .warning,
         id,
         "Expected a block statement.",
-        tree.span(body),
+        span,
+        .{ .span = span, .replacement = replacement },
     );
 }
 

--- a/tests/rules/curly.zig
+++ b/tests/rules/curly.zig
@@ -25,6 +25,244 @@ test "reports curly for control statements without block bodies" {
     try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, lint.rules.curly.id));
 }
 
+test "autofixes control statement bodies with block statements" {
+    const source =
+        \\if (ready) run();
+        \\else stop();
+        \\while (ready) run();
+        \\do run(); while (ready);
+        \\for (let i = 0; i < 3; i++) run();
+        \\for (const key in object) run();
+        \\for (const item of items) run();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (ready) {run();}
+        \\else {stop();}
+        \\while (ready) {run();}
+        \\do {run();} while (ready);
+        \\for (let i = 0; i < 3; i++) {run();}
+        \\for (const key in object) {run();}
+        \\for (const item of items) {run();}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.curly.id));
+}
+
+test "autofix preserves comments around bodies when adding block statements" {
+    const source =
+        \\if (ready) /* before */ run(); // after
+        \\while (ready)
+        \\  /* keep */ run();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (ready) /* before */ {run();} // after
+        \\while (ready)
+        \\  /* keep */ {run();}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.curly.id));
+}
+
+test "autofixes unnecessary blocks for multi style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.capitalized_comments = false;
+    options.eol_last = false;
+    options.no_for_in = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (ready) {run();}
+        \\else{stop();}
+        \\while (ready) {/* keep */ run();}
+        \\do{run();}while (ready);
+        \\for (let i = 0; i < 3; i++) {run();}
+        \\for (const key in object) {run();}
+        \\for (const item of items) {run();}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (ready) run();
+        \\else stop();
+        \\while (ready) /* keep */ run();
+        \\do run();while (ready);
+        \\for (let i = 0; i < 3; i++) run();
+        \\for (const key in object) run();
+        \\for (const item of items) run();
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.curly.id));
+}
+
+test "autofix refuses unsafe multi block removal" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_expressions = false;
+    options.typescript_eslint_no_unused_expressions = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (safe) {run();}
+        \\if (sameLine) {run()} follow();
+        \\if (asiHazard) {run()}
+        \\[1, 2, 3].forEach(run);
+        \\if (outer) {if (inner) run();} else {stop();}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (safe) run();
+        \\if (sameLine) {run()} follow();
+        \\if (asiHazard) {run()}
+        \\[1, 2, 3].forEach(run);
+        \\if (outer) {if (inner) run();} else stop();
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.curly.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.curly.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofix keeps nested control statements for multi-or-nest style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-or-nest\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (ready) {run();}
+        \\if (ready) {if (nested) run();}
+        \\while (ready) {for (;;) stop();}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (ready) run();
+        \\if (ready) {if (nested) run();}
+        \\while (ready) {for (;;) stop();}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.curly.id));
+}
+
+test "autofix refuses configured block additions that would not converge" {
+    var multi_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi\"]",
+        .{},
+    );
+    defer multi_config.deinit();
+
+    var multi_options = lint.Options{};
+    try multi_options.setByRuleConfigValue("curly", multi_config.value);
+    multi_options.eol_last = false;
+    multi_options.no_undef = false;
+    multi_options.no_unused_vars = false;
+    multi_options.parser_semantic_errors = false;
+
+    const multi_source =
+        \\if (ready)
+        \\  run();
+    ;
+    var multi_result = try lint.lintSourceAndFix(std.testing.allocator, multi_source, "fixture.js", multi_options);
+    defer multi_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!multi_result.fixed);
+    try std.testing.expectEqualStrings(multi_source, multi_result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(multi_result.result, lint.rules.curly.id));
+    try std.testing.expectEqual(@as(usize, 0), multi_result.result.diagnostics[0].fixes.len);
+
+    var nested_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-or-nest\"]",
+        .{},
+    );
+    defer nested_config.deinit();
+
+    var nested_options = multi_options;
+    try nested_options.setByRuleConfigValue("curly", nested_config.value);
+
+    const nested_source =
+        \\if (simple)
+        \\  run();
+        \\if (outer) if (inner) run();
+    ;
+    var nested_result = try lint.lintSourceAndFix(std.testing.allocator, nested_source, "fixture.js", nested_options);
+    defer nested_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(nested_result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (simple)
+        \\  run();
+        \\if (outer) {if (inner) run();}
+    , nested_result.output);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(nested_result.result, lint.rules.curly.id));
+    try std.testing.expectEqual(@as(usize, 0), nested_result.result.diagnostics[0].fixes.len);
+}
+
 test "does not report curly for block bodies or else-if chains" {
     const source =
         \\if (ready) { run(); }
@@ -88,6 +326,40 @@ test "supports configured curly multi-line style" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.curly.id));
+}
+
+test "autofixes configured curly multi-line style" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",\"multi-line\"]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("curly", config.value);
+    options.eol_last = false;
+    options.no_undef = false;
+    options.no_unused_vars = false;
+    options.parser_semantic_errors = false;
+
+    const source =
+        \\if (singleLine) run();
+        \\if (multiLine)
+        \\  run();
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\if (singleLine) run();
+        \\if (multiLine)
+        \\  {run();}
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.curly.id));
 }
 
 test "supports configured curly multi style" {

--- a/tests/rules/no_array_constructor.zig
+++ b/tests/rules/no_array_constructor.zig
@@ -121,6 +121,7 @@ test "autofix inserts an ASI guard only in statement lists" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .no_console = false,
         .no_unused_expressions = false,

--- a/tests/rules/no_floating_decimal.zig
+++ b/tests/rules/no_floating_decimal.zig
@@ -84,6 +84,7 @@ test "autofix separates leading decimals from adjacent keywords" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,

--- a/tests/rules/no_lonely_if.zig
+++ b/tests/rules/no_lonely_if.zig
@@ -171,6 +171,7 @@ test "does not autofix when removing braces could change ASI semantics" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .no_empty = false,
         .no_empty_block_statements = false,
@@ -212,6 +213,7 @@ test "autofixes ASI-sensitive shapes when consequents have semicolons" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .no_empty = false,
         .no_empty_block_statements = false,

--- a/tests/rules/no_useless_return.zig
+++ b/tests/rules/no_useless_return.zig
@@ -191,6 +191,7 @@ test "does not autofix non-list or commented redundant returns" {
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .capitalized_comments = false,
+        .curly = false,
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,

--- a/tests/rules/prefer_exponentiation_operator.zig
+++ b/tests/rules/prefer_exponentiation_operator.zig
@@ -265,6 +265,7 @@ test "does not insert a semicolon before a control-flow body" {
     ;
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .curly = false,
         .eol_last = false,
         .no_extra_label = false,
         .no_undef = false,

--- a/tests/rules/yoda.zig
+++ b/tests/rules/yoda.zig
@@ -68,6 +68,7 @@ test "autofix preserves comments, spacing, and parenthesized operands" {
 
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .capitalized_comments = false,
+        .curly = false,
         .eqeqeq = false,
         .eol_last = false,
         .no_empty_block_statements = false,


### PR DESCRIPTION
## Summary

- add public `lintSourceAndFix` support for `curly` block insertion and safe block removal
- preserve comments and spacing while refusing ASI, dangling-else, and non-converging configured rewrites
- isolate existing rule-specific autofix tests from the newly fixable default `curly` rule

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test --summary all` (1860/1860)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all` (1860/1860)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- native/package CLI `--help` smoke and npm wrapper `--version` smoke