### PR TITLE
feat: autofix prefer-destructuring

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -196,7 +196,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Supports `always` and `never` modes with safe autofix |
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
 | [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
-| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties` |
+| [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties`; autofixes simple same-name object property declarations when comments can be preserved |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented with safe autofix |
 | [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |
 | [`prefer-numeric-literals`](https://eslint.org/docs/latest/rules/prefer-numeric-literals) | Implemented with autofix for global static string and template `parseInt` calls with binary, octal, or hexadecimal radix |

--- a/src/rules/prefer_destructuring.zig
+++ b/src/rules/prefer_destructuring.zig
@@ -44,14 +44,23 @@ pub fn checkVariableDeclarationWithOptions(
         const kind = preferredDestructuringKind(tree, declarator, options) orelse continue;
         if (!allowsVariableDeclarator(options, kind)) continue;
 
-        try core.addDiagnostic(
-            allocator,
-            diagnostics,
-            .warning,
-            id,
-            diagnosticMessage(kind),
-            tree.span(declarator.id),
-        );
+        if (kind == .object) {
+            if (try simpleObjectDestructuringReplacement(allocator, tree, declarator_index, declarator)) |replacement| {
+                defer allocator.free(replacement);
+                try core.addDiagnosticWithFix(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    diagnosticMessage(kind),
+                    tree.span(declarator.id),
+                    .{ .span = tree.span(declarator_index), .replacement = replacement },
+                );
+                continue;
+            }
+        }
+
+        try addDiagnostic(allocator, diagnostics, tree, declarator.id, kind);
     }
 }
 
@@ -76,13 +85,62 @@ pub fn checkAssignmentExpressionWithOptions(
     const kind = preferredAssignmentDestructuringKind(tree, expression, options) orelse return;
     if (!allowsAssignmentExpression(options, kind)) return;
 
+    try addDiagnostic(allocator, diagnostics, tree, expression.left, kind);
+}
+
+fn simpleObjectDestructuringReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declarator_index: ast.NodeIndex,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!?[]u8 {
+    const local_name = bindingIdentifierName(tree, declarator.id) orelse return null;
+    const member = switch (tree.data(declarator.init)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    if (member.computed or member.optional or member.property == .null) return null;
+
+    const property_name = switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => return null,
+    };
+    if (!std.mem.eql(u8, local_name, property_name)) return null;
+    if (tree.data(unwrapTransparent(tree, member.object)) == .super) return null;
+
+    const declarator_span = tree.span(declarator_index);
+    const object_span = tree.span(member.object);
+    if (hasCommentOutsideSpan(tree, declarator_span, object_span)) return null;
+
+    const binding_span = tree.span(declarator.id);
+    const binding_source = tree.source[binding_span.start..binding_span.end];
+    const object_source = tree.source[object_span.start..object_span.end];
+    return try std.fmt.allocPrint(allocator, "{{{s}}} = {s}", .{ binding_source, object_source });
+}
+
+fn hasCommentOutsideSpan(tree: *const ast.Tree, outer: ast.Span, inner: ast.Span) bool {
+    for (tree.comments) |comment| {
+        if (comment.span.end <= outer.start) continue;
+        if (comment.span.start >= outer.end) break;
+        if (comment.span.start < inner.start or comment.span.end > inner.end) return true;
+    }
+    return false;
+}
+
+fn addDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    kind: DestructuringKind,
+) Allocator.Error!void {
     try core.addDiagnostic(
         allocator,
         diagnostics,
         .warning,
         id,
         diagnosticMessage(kind),
-        tree.span(expression.left),
+        tree.span(index),
     );
 }
 

--- a/tests/rules/prefer_destructuring.zig
+++ b/tests/rules/prefer_destructuring.zig
@@ -20,6 +20,78 @@ test "reports prefer-destructuring for object property variable declarators" {
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.prefer_destructuring.id));
 }
 
+test "autofixes simple object property variable declarators" {
+    const source =
+        \\const first = object.first;
+        \\let second = source.second, third = other.third;
+        \\const fromThis = this.fromThis;
+        \\const value = (left || right).value;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .one_var = false,
+        .prefer_const = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const {first} = object;
+        \\let {second} = source, {third} = other;
+        \\const {fromThis} = this;
+        \\const {value} = (left || right);
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_destructuring.id));
+}
+
+test "autofix preserves object comments and refuses unsupported destructuring forms" {
+    const source =
+        \\const kept = (/* inside */ source).kept;
+        \\const blocked /* binding */ = source.blocked;
+        \\const gap = source /* member */ .gap;
+        \\const computed = source["computed"];
+        \\const alias = source.target;
+        \\const wrapped = (source.wrapped);
+        \\assigned = source.assigned;
+        \\const item = list[0];
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .dot_notation = false,
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .prefer_const = false,
+        .prefer_destructuring_enforce_for_renamed_properties = true,
+        .typescript_eslint_dot_notation = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const {kept} = (/* inside */ source);
+        \\const blocked /* binding */ = source.blocked;
+        \\const gap = source /* member */ .gap;
+        \\const computed = source["computed"];
+        \\const alias = source.target;
+        \\const wrapped = (source.wrapped);
+        \\assigned = source.assigned;
+        \\const item = list[0];
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result.result, lint.rules.prefer_destructuring.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_destructuring.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
 test "reports prefer-destructuring for array index variable declarators" {
     const source =
         \\const first = array[0];


### PR DESCRIPTION
## Summary

- autofix simple same-name object property variable declarators into object destructuring
- preserve comments within the source object expression and refuse fixes that could discard comments
- keep computed, array, assignment, renamed, parenthesized-member, and other unsupported forms diagnostic-only

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test --summary all` (1862/1862)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all` (1862/1862)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- native/package CLI `--help` smoke and npm wrapper `--version` smoke