### PR TITLE
feat: autofix prefer-const

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -195,7 +195,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`one-var`](https://eslint.org/docs/latest/rules/one-var) | Supports string `never` and per-kind `var`/`let`/`const` `never` configuration with comment- and context-safe autofix |
 | [`operator-assignment`](https://eslint.org/docs/latest/rules/operator-assignment) | Supports `always` and `never` modes with safe autofix |
 | [`prefer-arrow-callback`](https://eslint.org/docs/latest/rules/prefer-arrow-callback) | Supports callback function expressions plus `allowNamedFunctions` and `allowUnboundThis` configuration |
-| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration |
+| [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) | Supports `destructuring` and `ignoreReadBeforeAssign` configuration; autofixes `let` declarations only when every binding can safely become `const` |
 | [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring) | Supports object/array variable declarator and assignment expression configuration plus `enforceForRenamedProperties`; autofixes simple same-name object property declarations when comments can be preserved |
 | [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) | Implemented with safe autofix |
 | [`prefer-named-capture-group`](https://eslint.org/docs/latest/rules/prefer-named-capture-group) | Detects unnamed capture groups in regex literals and static `RegExp` constructors |

--- a/src/rules/prefer_const.zig
+++ b/src/rules/prefer_const.zig
@@ -25,6 +25,7 @@ pub const Options = struct {
 
 const Candidate = struct {
     node: ast.NodeIndex,
+    declaration: ast.NodeIndex,
     name: []const u8,
     initialized: bool = true,
     reassigned: bool = false,
@@ -98,28 +99,38 @@ pub fn runWithOptions(
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
 
+    var fixed_declarations = std.AutoHashMap(ast.NodeIndex, bool).init(allocator);
+    defer fixed_declarations.deinit();
+
     var candidate_iter = candidates.iterator();
     while (candidate_iter.next()) |entry| {
         const candidate = entry.value_ptr.*;
-        if (candidate.reassigned) continue;
-        const report_node = if (candidate.initialized) candidate.node else report_node: {
-            if (candidate.assignment_count != 1) continue;
-            if (options.ignore_read_before_assign and candidate.read_before_assignment) continue;
-            break :report_node candidate.first_assignment_node;
-        };
-        if (candidate.destructuring_group) |group_id| {
-            if (options.destructuring == .all and (destructuring_groups.get(group_id) orelse false)) continue;
+        const report_node = candidateReportNode(candidate, &destructuring_groups, options) orelse continue;
+
+        const can_fix = candidate.initialized and
+            !fixed_declarations.contains(candidate.declaration) and
+            declarationCanFix(tree, candidate.declaration, &decl_symbols, &candidates, &destructuring_groups, options);
+        if (can_fix) {
+            if (try declarationReplacement(allocator, tree, candidate.declaration)) |replacement| {
+                defer allocator.free(replacement);
+                const message = try std.fmt.allocPrint(allocator, "'{s}' is never reassigned. Use 'const' instead.", .{candidate.name});
+                defer allocator.free(message);
+                const declaration_span = tree.span(candidate.declaration);
+                try core.addDiagnosticWithFix(
+                    allocator,
+                    diagnostics,
+                    .warning,
+                    id,
+                    message,
+                    tree.span(report_node),
+                    .{ .span = declaration_span, .replacement = replacement },
+                );
+                try fixed_declarations.put(candidate.declaration, true);
+                continue;
+            }
         }
 
-        try core.addDiagnosticFmt(
-            allocator,
-            diagnostics,
-            .warning,
-            id,
-            tree.span(report_node),
-            "'{s}' is never reassigned. Use 'const' instead.",
-            .{candidate.name},
-        );
+        try addCandidateDiagnostic(allocator, diagnostics, tree, candidate, report_node);
     }
 }
 
@@ -135,7 +146,7 @@ const Visitor = struct {
     pub fn enter_variable_declaration(
         self: *Visitor,
         declaration: ast.VariableDeclaration,
-        _: ast.NodeIndex,
+        index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (declaration.kind != .let) return .proceed;
@@ -153,7 +164,7 @@ const Visitor = struct {
                 break :group group_id;
             } else null;
 
-            try self.collectCandidate(ctx.tree, declarator.id, group, declarator.init != .null);
+            try self.collectCandidate(ctx.tree, declarator.id, index, group, declarator.init != .null);
         }
 
         return .proceed;
@@ -219,7 +230,7 @@ const Visitor = struct {
                 break :group group_id;
             } else null;
 
-            try self.collectCandidate(tree, declarator.id, group, true);
+            try self.collectCandidate(tree, declarator.id, index, group, true);
         }
     }
 
@@ -245,6 +256,7 @@ const Visitor = struct {
         self: *Visitor,
         tree: *const ast.Tree,
         index: ast.NodeIndex,
+        declaration: ast.NodeIndex,
         group: ?usize,
         initialized: bool,
     ) Allocator.Error!void {
@@ -260,18 +272,19 @@ const Visitor = struct {
                 }
                 try self.candidates.put(symbol_id, .{
                     .node = index,
+                    .declaration = declaration,
                     .name = tree.string(identifier.name),
                     .initialized = initialized,
                     .destructuring_group = group,
                 });
             },
-            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left, group, initialized),
-            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument, group, initialized),
+            .assignment_pattern => |pattern| try self.collectCandidate(tree, pattern.left, declaration, group, initialized),
+            .binding_rest_element => |element| try self.collectCandidate(tree, element.argument, declaration, group, initialized),
             .array_pattern => |pattern| {
                 for (tree.extra(pattern.elements)) |element| {
-                    try self.collectCandidate(tree, element, group, initialized);
+                    try self.collectCandidate(tree, element, declaration, group, initialized);
                 }
-                try self.collectCandidate(tree, pattern.rest, group, initialized);
+                try self.collectCandidate(tree, pattern.rest, declaration, group, initialized);
             },
             .object_pattern => |pattern| {
                 for (tree.extra(pattern.properties)) |property_index| {
@@ -279,9 +292,9 @@ const Visitor = struct {
                         .binding_property => |property| property,
                         else => continue,
                     };
-                    try self.collectCandidate(tree, property.value, group, initialized);
+                    try self.collectCandidate(tree, property.value, declaration, group, initialized);
                 }
-                try self.collectCandidate(tree, pattern.rest, group, initialized);
+                try self.collectCandidate(tree, pattern.rest, declaration, group, initialized);
             },
             else => {},
         }
@@ -340,6 +353,178 @@ const Visitor = struct {
         }
     }
 };
+
+fn candidateReportNode(
+    candidate: Candidate,
+    destructuring_groups: *const DestructuringGroupMap,
+    options: Options,
+) ?ast.NodeIndex {
+    if (candidate.reassigned) return null;
+    const report_node = if (candidate.initialized) candidate.node else report_node: {
+        if (candidate.assignment_count != 1) return null;
+        if (options.ignore_read_before_assign and candidate.read_before_assignment) return null;
+        break :report_node candidate.first_assignment_node;
+    };
+    if (candidate.destructuring_group) |group_id| {
+        if (options.destructuring == .all and (destructuring_groups.get(group_id) orelse false)) return null;
+    }
+    return report_node;
+}
+
+fn declarationCanFix(
+    tree: *const ast.Tree,
+    declaration_index: ast.NodeIndex,
+    decl_symbols: *const DeclSymbolMap,
+    candidates: *const std.AutoHashMap(SymbolId, Candidate),
+    destructuring_groups: *const DestructuringGroupMap,
+    options: Options,
+) bool {
+    const declaration = switch (tree.data(declaration_index)) {
+        .variable_declaration => |declaration| declaration,
+        else => return false,
+    };
+    if (declaration.kind != .let or declaration.declarators.len == 0) return false;
+
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |declarator| declarator,
+            else => return false,
+        };
+        if (!patternCanFix(
+            tree,
+            declarator.id,
+            declaration_index,
+            decl_symbols,
+            candidates,
+            destructuring_groups,
+            options,
+        )) return false;
+    }
+    return true;
+}
+
+fn patternCanFix(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    declaration_index: ast.NodeIndex,
+    decl_symbols: *const DeclSymbolMap,
+    candidates: *const std.AutoHashMap(SymbolId, Candidate),
+    destructuring_groups: *const DestructuringGroupMap,
+    options: Options,
+) bool {
+    if (index == .null) return true;
+
+    return switch (tree.data(index)) {
+        .binding_identifier => binding: {
+            const symbol_id = decl_symbols.get(index) orelse break :binding false;
+            const candidate = candidates.get(symbol_id) orelse break :binding false;
+            break :binding candidate.declaration == declaration_index and
+                candidate.initialized and
+                candidateReportNode(candidate, destructuring_groups, options) != null;
+        },
+        .assignment_pattern => |pattern| patternCanFix(
+            tree,
+            pattern.left,
+            declaration_index,
+            decl_symbols,
+            candidates,
+            destructuring_groups,
+            options,
+        ),
+        .binding_rest_element => |element| patternCanFix(
+            tree,
+            element.argument,
+            declaration_index,
+            decl_symbols,
+            candidates,
+            destructuring_groups,
+            options,
+        ),
+        .array_pattern => |pattern| pattern: {
+            for (tree.extra(pattern.elements)) |element| {
+                if (!patternCanFix(
+                    tree,
+                    element,
+                    declaration_index,
+                    decl_symbols,
+                    candidates,
+                    destructuring_groups,
+                    options,
+                )) break :pattern false;
+            }
+            break :pattern patternCanFix(
+                tree,
+                pattern.rest,
+                declaration_index,
+                decl_symbols,
+                candidates,
+                destructuring_groups,
+                options,
+            );
+        },
+        .object_pattern => |pattern| pattern: {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |property| property,
+                    else => break :pattern false,
+                };
+                if (!patternCanFix(
+                    tree,
+                    property.value,
+                    declaration_index,
+                    decl_symbols,
+                    candidates,
+                    destructuring_groups,
+                    options,
+                )) break :pattern false;
+            }
+            break :pattern patternCanFix(
+                tree,
+                pattern.rest,
+                declaration_index,
+                decl_symbols,
+                candidates,
+                destructuring_groups,
+                options,
+            );
+        },
+        else => false,
+    };
+}
+
+fn declarationReplacement(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    declaration_index: ast.NodeIndex,
+) Allocator.Error!?[]u8 {
+    const span = tree.span(declaration_index);
+    if (span.end < span.start + "let".len or
+        !std.mem.eql(u8, tree.source[span.start .. span.start + "let".len], "let")) return null;
+
+    return try std.fmt.allocPrint(
+        allocator,
+        "const{s}",
+        .{tree.source[span.start + "let".len .. span.end]},
+    );
+}
+
+fn addCandidateDiagnostic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    candidate: Candidate,
+    report_node: ast.NodeIndex,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(report_node),
+        "'{s}' is never reassigned. Use 'const' instead.",
+        .{candidate.name},
+    );
+}
 
 fn isReadBeforeFirstAssignment(tree: *const ast.Tree, index: ast.NodeIndex, candidate: Candidate) bool {
     if (candidate.assignment_count == 0) return true;

--- a/tests/rules/no_undef_init.zig
+++ b/tests/rules/no_undef_init.zig
@@ -65,6 +65,7 @@ test "autofixes undefined initializers for let bindings" {
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -89,6 +90,7 @@ test "does not report or autofix a shadowed undefined initializer" {
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -110,6 +112,7 @@ test "does not autofix undefined initializers when syntax must be preserved" {
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/one_var.zig
+++ b/tests/rules/one_var.zig
@@ -27,6 +27,7 @@ test "autofixes combined variable declarations into separate statements" {
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
         .no_unused_vars = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -148,6 +149,7 @@ test "autofixes destructuring declarations in switch cases without adding a fina
         .no_fallthrough = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/prefer_const.zig
+++ b/tests/rules/prefer_const.zig
@@ -24,6 +24,115 @@ test "reports prefer-const for initialized let declarations that are never reass
     try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.prefer_const.id));
 }
 
+test "autofixes fully const-compatible let declarations" {
+    const source =
+        \\let a = 1;
+        \\let b = 2, c = 3;
+        \\let { d, e } = obj;
+        \\for (let key in obj) {
+        \\  console.log(key);
+        \\}
+        \\for (let value of list) {
+        \\  console.log(value);
+        \\}
+        \\let/* keep */ f = 4;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .capitalized_comments = false,
+        .eol_last = false,
+        .no_console = false,
+        .no_for_in = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .one_var = false,
+        .prefer_destructuring = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const a = 1;
+        \\const b = 2, c = 3;
+        \\const { d, e } = obj;
+        \\for (const key in obj) {
+        \\  console.log(key);
+        \\}
+        \\for (const value of list) {
+        \\  console.log(value);
+        \\}
+        \\const/* keep */ f = 4;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_const.id));
+}
+
+test "autofix refuses partially compatible or delayed let declarations" {
+    const source =
+        \\let safe = 1;
+        \\let stable = 1, changed = 2;
+        \\changed++;
+        \\let delayed;
+        \\delayed = 1;
+        \\let { left, right } = obj;
+        \\right = 2;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_plusplus = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .one_var = false,
+        .prefer_destructuring = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const safe = 1;
+        \\let stable = 1, changed = 2;
+        \\changed++;
+        \\let delayed;
+        \\delayed = 1;
+        \\let { left, right } = obj;
+        \\right = 2;
+    , result.output);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result.result, lint.rules.prefer_const.id));
+    for (result.result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.prefer_const.id)) {
+            try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        }
+    }
+}
+
+test "autofixes destructuring only when all bindings qualify in all mode" {
+    const source =
+        \\let { a, b } = first;
+        \\let { c, d } = second;
+        \\d = 2;
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .prefer_const_destructuring = .all,
+        .prefer_destructuring = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(
+        \\const { a, b } = first;
+        \\let { c, d } = second;
+        \\d = 2;
+    , result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.prefer_const.id));
+}
+
 test "does not report prefer-const for reassigned let bindings or read-before-assign declarations by default" {
     const source =
         \\let a = 1;

--- a/tests/rules/sort_vars.zig
+++ b/tests/rules/sort_vars.zig
@@ -144,6 +144,7 @@ fn baseOptions() lint.Options {
         .no_undef = false,
         .no_unused_vars = false,
         .one_var = false,
+        .prefer_const = false,
         .parser_semantic_errors = false,
         .sort_vars = true,
     };


### PR DESCRIPTION
## Summary

- autofix `let` declarations only when every binding can safely become `const`
- reuse semantic candidate/reassignment analysis across simple, multi-declarator, destructuring, for-in, and for-of declarations
- preserve comments by replacing the complete declaration and keep partial or delayed-assignment cases diagnostic-only
- isolate existing rule-specific autofix tests from the newly fixable default `prefer-const` rule

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test --summary all` (1865/1865)
- `zig build`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all` (1865/1865)
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- native/package CLI `--help` smoke and npm wrapper `--version` smoke