### PR TITLE
docs: document autofix usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Use machine-readable output:
 utoo-lint --format=json src
 ```
 
+### Autofix
+
+Apply safe fixes from all enabled rules that support autofix:
+
+```bash
+pnpm exec utoo-lint --fix src
+```
+
+Preview the result without changing files:
+
+```bash
+pnpm exec utoo-lint --fix-dry-run --format=json src
+```
+
+`--fix` writes fixed source back to disk. `--fix-dry-run` never writes files;
+with JSON output, changed sources are returned in the `outputs` array. Fixes run
+until the source is stable, subject to a safety pass limit. Diagnostics remain
+when a rule or a particular code shape cannot be fixed safely. See
+[Rule status](docs/rule-status.md) for per-rule autofix coverage.
+
 ## Configuration
 
 By default, `utoo-lint` reads `utoo.json` or `utoo-lint.json` from the current
@@ -109,6 +129,14 @@ const report = lintFiles(["src"], {
   config: "utoo.json",
   rules: ["no-debugger"]
 });
+```
+
+Set `fix: true` to compute fixed output without writing files:
+
+```js
+const report = lintFiles(["src"], { fix: true });
+
+console.log(report.outputs);
 ```
 
 ## Architecture

--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -2,6 +2,8 @@
 
 This document tracks the ESLint-compatible rules currently implemented by `utoo-lint`.
 Each rule links to the corresponding ESLint rule reference.
+Autofix is called out where it is available; unsafe code shapes remain diagnostics
+instead of being rewritten.
 
 | Rule | Status |
 | --- | --- |
@@ -87,7 +89,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`no-extra-bind`](https://eslint.org/docs/latest/rules/no-extra-bind) | Implemented with side-effect- and comment-safe autofix |
 | [`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) | Supports safe autofix, `enforceForInnerExpressions`, and legacy `enforceForLogicalOperands` configuration |
 | [`no-extra-label`](https://eslint.org/docs/latest/rules/no-extra-label) | Implemented with multi-pass autofix for redundant references and label declarations |
-| [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented |
+| [`no-extra-semi`](https://eslint.org/docs/latest/rules/no-extra-semi) | Implemented with autofix |
 | [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) | Supports `allowEmptyCase`, common `commentPattern`, and `reportUnusedFallthroughComment` configuration |
 | [`no-floating-decimal`](https://eslint.org/docs/latest/rules/no-floating-decimal) | Implemented with token-safe autofix |
 | [`no-for-in`](https://eslint.org/docs/latest/rules/no-for-in) | Implemented |
@@ -345,7 +347,7 @@ Each rule links to the corresponding ESLint rule reference.
 | [`@typescript-eslint/no-empty-function`](https://typescript-eslint.io/rules/no-empty-function/) | Supports base `allow` kinds plus `private-constructors`, `protected-constructors`, `decoratedFunctions`, and `overrideMethods` configuration |
 | [`@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/) | Supports `allowSingleExtends` configuration |
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
-| [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented |
+| [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented with autofix |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
 | [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports `allowAsThisParameter` and boolean/string-list `allowInGenericTypeArguments` configuration |

--- a/npm/README.md
+++ b/npm/README.md
@@ -176,8 +176,8 @@ file paths emit ESLint-style warnings unless `--no-warn-ignored` or
 `--no-warn-ignored=true` is set.
 `--fix` and `--fix-dry-run` apply fixes from supported native rules. The Node
 API also composes those fixes with fixes reported by custom rules. `--fix-type`
-remains accepted with a warning but is not implemented yet. Initial native
-autofix coverage includes `no-extra-semi` and `@typescript-eslint/no-extra-semi`.
+remains accepted with a warning but is not implemented yet. Native autofix
+coverage is tracked per rule in [the rule status](../docs/rule-status.md).
 Display and reporting controls such as `--color`, `--no-color`, `--stats`,
 `--stats=true`, and `--no-warn-ignored` are accepted for the same reason.
 `--output-file` and `-o` write the native output to the requested report file.

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -41,6 +41,27 @@ Use machine-readable output:
 pnpm exec utoo-lint --format=json src
 ```
 
+## Autofix
+
+Apply safe fixes from all enabled rules that support autofix:
+
+```bash
+pnpm exec utoo-lint --fix src
+```
+
+Preview the result without changing files:
+
+```bash
+pnpm exec utoo-lint --fix-dry-run --format=json src
+```
+
+`--fix` writes fixed source back to disk. `--fix-dry-run` never writes files;
+with JSON output, changed sources are returned in the `outputs` array. Fixes run
+until the source is stable, subject to a safety pass limit. Diagnostics remain
+when a rule or a particular code shape cannot be fixed safely. The current
+[rule status](https://github.com/fireairforce/utoo-lint/blob/main/docs/rule-status.md)
+lists autofix coverage by rule.
+
 ## Configuration
 
 Create a `utoo.json` file:
@@ -96,6 +117,19 @@ as the CLI, so migration scripts usually do not need to expand config `files`
 manually.
 
 CommonJS is supported through `require("@utoo/lint")`.
+
+Set `fix: true` to compute fixed output through the JavaScript API. Raw
+`lintFiles()` and `lintText()` reports expose changed sources in `outputs`
+without writing them. The ESLint-compatible API follows the usual two-step
+flow:
+
+```js
+import { ESLint } from "@utoo/lint";
+
+const eslint = new ESLint({ fix: true });
+const results = await eslint.lintFiles(["src"]);
+await ESLint.outputFixes(results);
+```
 
 ## Binary Resolution
 


### PR DESCRIPTION
## Summary

- document `--fix` and `--fix-dry-run` in the repository and published package READMEs
- explain dry-run JSON outputs, multi-pass behavior, and safe-fix boundaries
- document JavaScript API fix output and ESLint-compatible `outputFixes()` usage
- replace stale initial-coverage wording and complete rule-status autofix labels

## Why

Autofix is now broadly implemented, but the primary README still omits how to use it and the npm packaging README describes only the initial two-rule coverage.

## Validation

- `git diff --check`
- verified Markdown code fences are balanced
- verified documented CLI and JavaScript API surfaces exist in the implementation