### PR TITLE
docs: add license and security policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ It currently has some performance advantages compared with other lint tools:
 
 This repo is a working scaffold, not a production linter yet.
 
+- License: [MIT](LICENSE)
+- Security: See the [security policy](SECURITY.md) to report vulnerabilities
+  privately.
+
 Useful docs:
 
 - [Rule status](docs/rule-status.md) lists implemented rules and their ESLint

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to `main` first. The latest `0.x` release is the
+supported release line; older releases should not be assumed to receive
+security fixes.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately before public disclosure.
+
+- Prefer a [private GitHub security advisory](https://github.com/fireairforce/utoo-lint/security/advisories/new).
+- If private reporting is unavailable, contact a maintainer through a
+  non-public channel instead of opening a public issue with exploit details.
+
+Please include:
+
+- the affected package, version, or commit
+- the affected operating system and architecture, when relevant
+- reproduction steps or a minimal proof of concept
+- the expected impact and any known mitigations
+
+The maintainers will coordinate validation, remediation, and disclosure with
+the reporter.
+
+## Security-Relevant Controls
+
+The project treats the following as security-relevant controls:
+
+- JavaScript, TypeScript, and configuration files are treated as untrusted input
+- the Yuku parser dependency is pinned as a Git submodule
+- autofix file writes require explicit opt-in and provide a dry-run mode
+- release artifacts include checksums, and npm releases use provenance

--- a/npm/@utoo/lint-darwin-arm64/LICENSE
+++ b/npm/@utoo/lint-darwin-arm64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/@utoo/lint-darwin-x64/LICENSE
+++ b/npm/@utoo/lint-darwin-x64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/@utoo/lint-linux-arm64/LICENSE
+++ b/npm/@utoo/lint-linux-arm64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/@utoo/lint-linux-x64/LICENSE
+++ b/npm/@utoo/lint-linux-x64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/@utoo/lint-win32-x64/LICENSE
+++ b/npm/@utoo/lint-win32-x64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/utoo-lint/LICENSE
+++ b/npm/utoo-lint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- add a security policy covering supported versions, private vulnerability reporting, and security-relevant controls
- link the MIT license and security policy from the README
- include the MIT license text in the main npm package and all platform packages

## Why

The repository already declares MIT licensing, but nested npm packages did not include the license text in their published contents. A repository security policy also gives reporters a private disclosure path and documents the supported release line.

## Validation

- `git diff --check origin/main...HEAD`
- verified all package license files match the root `LICENSE`
- ran `pnpm pack --dry-run --json` for `@utoo/lint` and all five platform packages; each includes `LICENSE`
