### PR TITLE
build: update yuku to v0.8.0

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -131,11 +131,11 @@ pub fn lintSourceWithIo(
         const semantic_model = try parser.semantic.analyze(&tree);
         var semantic_result = semantic_compat.Result.init(&tree, semantic_model);
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
-        try appendParserDiagnostics(allocator, &diagnostics, &tree);
+        try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
         try rules.runSemantic(allocator, &diagnostics, &tree, io, path, semantic_result, effective_options);
     } else {
-        try appendParserDiagnostics(allocator, &diagnostics, &tree);
+        try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
     }
 
@@ -323,8 +323,11 @@ fn appendParserDiagnostics(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    options: Options,
 ) Allocator.Error!void {
     for (tree.diagnostics.items) |diagnostic| {
+        if (reactNoUnescapedEntitiesCoversParserDiagnostic(tree, diagnostic, options)) continue;
+
         try core.addDiagnostic(
             allocator,
             diagnostics,
@@ -334,4 +337,24 @@ fn appendParserDiagnostics(
             diagnostic.span,
         );
     }
+}
+
+fn reactNoUnescapedEntitiesCoversParserDiagnostic(
+    tree: *const ast.Tree,
+    diagnostic: ast.Diagnostic,
+    options: Options,
+) bool {
+    if (!options.react_no_unescaped_entities) return false;
+
+    const offset: usize = @intCast(diagnostic.span.start);
+    if (offset >= tree.source.len) return false;
+
+    const byte = tree.source[offset];
+    return switch (byte) {
+        '>' => options.react_no_unescaped_entities_forbid_gt and
+            std.mem.eql(u8, diagnostic.message, "Unexpected '>' in JSX text"),
+        '}' => options.react_no_unescaped_entities_forbid_closing_brace and
+            std.mem.eql(u8, diagnostic.message, "Unexpected '}' in JSX text"),
+        else => false,
+    };
 }

--- a/src/rules/no_redeclare.zig
+++ b/src/rules/no_redeclare.zig
@@ -110,7 +110,7 @@ fn isBuiltinGlobalRedeclaration(
     options: Options,
 ) bool {
     return options.builtin_globals and
-        tree.source_type == .script and
+        tree.source_type != .module and
         symbol.scope == .root and
         core.isKnownGlobal(name);
 }

--- a/src/rules/react_no_unescaped_entities.zig
+++ b/src/rules/react_no_unescaped_entities.zig
@@ -21,7 +21,101 @@ pub fn check(
     index: ast.NodeIndex,
     options: Options,
 ) Allocator.Error!void {
-    const span = tree.span(index);
+    try checkSpan(allocator, diagnostics, tree, tree.span(index), options);
+}
+
+pub fn checkElement(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    element: ast.JSXElement,
+    options: Options,
+) Allocator.Error!void {
+    if (element.closing_element == .null) return;
+
+    try checkChildren(
+        allocator,
+        diagnostics,
+        tree,
+        tree.span(element.opening_element).end,
+        tree.span(element.closing_element).start,
+        element.children,
+        options,
+    );
+}
+
+pub fn checkFragment(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    fragment: ast.JSXFragment,
+    options: Options,
+) Allocator.Error!void {
+    try checkChildren(
+        allocator,
+        diagnostics,
+        tree,
+        tree.span(fragment.opening_fragment).end,
+        tree.span(fragment.closing_fragment).start,
+        fragment.children,
+        options,
+    );
+}
+
+fn checkChildren(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    content_start: u32,
+    content_end: u32,
+    children: ast.IndexRange,
+    options: Options,
+) Allocator.Error!void {
+    if (content_start > content_end) return;
+
+    const gap_options = Options{
+        .forbid_gt = options.forbid_gt,
+        .forbid_double_quote = false,
+        .forbid_single_quote = false,
+        .forbid_closing_brace = options.forbid_closing_brace,
+    };
+    var cursor = content_start;
+
+    for (tree.extra(children)) |child| {
+        const child_span = tree.span(child);
+        if (cursor < child_span.start) {
+            try checkSpan(
+                allocator,
+                diagnostics,
+                tree,
+                .{ .start = cursor, .end = child_span.start },
+                gap_options,
+            );
+        }
+        if (tree.data(child) == .jsx_text) {
+            try checkSpan(allocator, diagnostics, tree, child_span, options);
+        }
+        cursor = @max(cursor, child_span.end);
+    }
+
+    if (cursor < content_end) {
+        try checkSpan(
+            allocator,
+            diagnostics,
+            tree,
+            .{ .start = cursor, .end = content_end },
+            gap_options,
+        );
+    }
+}
+
+fn checkSpan(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    span: ast.Span,
+    options: Options,
+) Allocator.Error!void {
     const source = sourceSlice(tree, span) orelse return;
 
     for (source, 0..) |byte, offset| {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -3693,6 +3693,20 @@ const BasicVisitor = struct {
                 .allow_functions = self.options.react_no_children_prop_allow_functions,
             });
         }
+        if (self.options.react_no_unescaped_entities) {
+            try react_no_unescaped_entities.checkElement(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                element,
+                .{
+                    .forbid_gt = self.options.react_no_unescaped_entities_forbid_gt,
+                    .forbid_double_quote = self.options.react_no_unescaped_entities_forbid_double_quote,
+                    .forbid_single_quote = self.options.react_no_unescaped_entities_forbid_single_quote,
+                    .forbid_closing_brace = self.options.react_no_unescaped_entities_forbid_closing_brace,
+                },
+            );
+        }
         if (self.options.react_jsx_filename_extension) {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
                 .extensions = self.options.react_jsx_filename_extension_extensions,
@@ -3741,10 +3755,24 @@ const BasicVisitor = struct {
 
     pub fn enter_jsx_fragment(
         self: *BasicVisitor,
-        _: ast.JSXFragment,
+        fragment: ast.JSXFragment,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.react_no_unescaped_entities) {
+            try react_no_unescaped_entities.checkFragment(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                fragment,
+                .{
+                    .forbid_gt = self.options.react_no_unescaped_entities_forbid_gt,
+                    .forbid_double_quote = self.options.react_no_unescaped_entities_forbid_double_quote,
+                    .forbid_single_quote = self.options.react_no_unescaped_entities_forbid_single_quote,
+                    .forbid_closing_brace = self.options.react_no_unescaped_entities_forbid_closing_brace,
+                },
+            );
+        }
         if (self.options.react_jsx_filename_extension) {
             try react_jsx_filename_extension.check(self.allocator, self.diagnostics, ctx.tree, self.file_path, index, &self.react_jsx_filename_extension_state, .{
                 .extensions = self.options.react_jsx_filename_extension_extensions,
@@ -3850,14 +3878,6 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.react_jsx_no_comment_textnodes) {
             try react_jsx_no_comment_textnodes.check(self.allocator, self.diagnostics, ctx.tree, text, index);
-        }
-        if (self.options.react_no_unescaped_entities) {
-            try react_no_unescaped_entities.check(self.allocator, self.diagnostics, ctx.tree, index, .{
-                .forbid_gt = self.options.react_no_unescaped_entities_forbid_gt,
-                .forbid_double_quote = self.options.react_no_unescaped_entities_forbid_double_quote,
-                .forbid_single_quote = self.options.react_no_unescaped_entities_forbid_single_quote,
-                .forbid_closing_brace = self.options.react_no_unescaped_entities_forbid_closing_brace,
-            });
         }
         return .proceed;
     }


### PR DESCRIPTION
## Summary

- Update the vendored Yuku submodule from `v0.6.3` (`9153d418`) to `v0.8.0` (`214f50c8`).
- Treat Yuku's new `commonjs` source type like scripts for built-in global redeclaration checks.
- Preserve `react/no-unescaped-entities` coverage for bare `>` and `}` after Yuku began consuming those characters as parser errors.
- Suppress duplicate parser diagnostics only when the configured lint rule emits the equivalent diagnostic.

## Why

Yuku 0.8 includes parser correctness, semantic analysis, security, and FFI performance updates. The upgrade also introduces two observable API/AST behavior changes that require compatibility handling in utoo-lint.

## Root cause

Yuku now returns `SourceType.commonjs` for `.cjs` and `.cts`, while utoo-lint's built-in global check only accepted `SourceType.script`. Yuku also removes bare `>` and `}` from `JSXText` spans and reports them as parser errors, so scanning only `JSXText` nodes missed the lint diagnostics and produced duplicate parser output.

## Impact

CommonJS built-in global redeclarations and JSX unescaped-entity reporting retain their existing utoo-lint behavior while using Yuku 0.8. No CLI or configuration changes are required.

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1` — 1868 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- npm wrapper smoke test against `test/fixtures/bad.ts`
- `git diff --check`
