### PR TITLE
fix: align configured rules with ESLint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
         run: ./scripts/package-npm.sh
 
       - name: Verify npm wrapper
-        run: node npm/utoo-lint/bin/utoo-lint.js test/fixtures/bad.ts || test "$?" = "1"
+        run: |
+          node npm/utoo-lint/bin/utoo-lint.js --no-config test/fixtures/bad.ts
+          node npm/utoo-lint/bin/utoo-lint.js --config=npm/utoo-lint/configs/frontend.json test/fixtures/bad.ts && exit 1 || test "$?" = "1"
 
       - name: Test npm package
         run: pnpm --dir npm/utoo-lint test

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ give the binary `utlint.config.json`. Use
 `--config=path/to/utlint.config.json` to select a file explicitly, or
 `--no-config` to disable config discovery. Rule-related CLI options such as
 `--rules` and individual rule toggles are applied after the selected config.
+As in ESLint, a selected config's `rules` map is the complete rule set: rules
+that are not configured are disabled. With no selected config, utoo-lint keeps
+its built-in default rules.
 
 Project-config `files` and `ignores` patterns are relative to the selected
 config file's directory. In a flat config array, those fields determine which
@@ -153,7 +156,7 @@ entries match each file; matching entries are combined in order, with later
 rule values overriding earlier values. The npm CLI, JavaScript API, and
 fishlint compatibility command perform this rule resolution per file.
 
-The raw binary currently applies only `rules` from JSON config. Config-driven
+The raw binary applies only `rules` from JSON config. Config-driven
 `files` and `ignores` filtering and default target selection belong to the
 npm/Node wrapper; pass lint targets explicitly when invoking the raw binary.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ npm/Node wrapper; pass lint targets explicitly when invoking the raw binary.
 
 Rule values may be `off`, `warn`, `error`, `0`, `1`, `2`, booleans, or an
 ESLint-style array whose first item is the severity and later items are native
-rule options.
+rule options. Matching ESLint's CLI behavior, warnings are reported without
+making the command fail; errors return exit status 1. The fishlint-compatible
+CLI can make warnings fail with `--max-warnings`.
 
 To migrate an existing ESLint config into the native utoo format:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,9 @@ migration, but new projects should use a canonical name.
 Use `--config=path/to/utlint.config.json` to select a config explicitly, or
 `--no-config` to ignore local config. Rule-related CLI options such as
 `--rules` and individual rule toggles are applied after the selected config.
+The resolved `rules` map is the complete enabled rule set, matching ESLint's
+configuration model: omitted rules are disabled. If no config is selected,
+utoo-lint uses its built-in default rules.
 
 Project-config `files` and `ignores` patterns are resolved relative to the
 selected config file's directory, including when that config is discovered in
@@ -68,7 +71,7 @@ does not execute or discover TypeScript. It searches for `utlint.config.json`
 and then the legacy JSON names. Use the npm CLI for `utlint.config.ts`; when
 invoking the raw binary directly, use `utlint.config.json`.
 
-The raw binary currently applies only the JSON config's `rules`. Config-driven
+The raw binary applies only the JSON config's `rules`. Config-driven
 `files` and `ignores` filtering, including choosing default lint targets, is an
 npm/Node wrapper feature. Pass lint targets explicitly when invoking the raw
 binary.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,12 @@ The template includes a `$schema` entry for editor validation and a focused set 
 }
 ```
 
-`utoo-lint` treats config severities as ESLint-compatible rule toggles. `off`, `0`, and `false` disable a rule. `warn`, `error`, `on`, `1`, `2`, and `true` enable a rule. ESLint-style arrays are accepted; the first item controls severity, and supported option objects are passed to the native rule implementation.
+`utoo-lint` treats config severities like ESLint. `off`, `0`, and `false`
+disable a rule; `warn`, `warning`, `on`, and `1` report warnings; `error`, `2`,
+and `true` report errors. ESLint-style arrays are accepted; the first item
+controls severity, and supported option objects are passed to the native rule
+implementation. Warnings leave the process exit status at 0, while errors
+return status 1.
 
 ## Rule Names
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -105,7 +105,8 @@ Loading `utlint.config.ts` executes project code. The npm wrapper materializes
 the exported value as JSON for the native binary; the raw binary itself does
 not execute or discover TypeScript. It searches for `utlint.config.json` and
 then the legacy JSON names, so use JSON when invoking it directly. The raw
-binary currently applies only `rules` from that JSON; config-driven `files` and
+binary applies only `rules` from that JSON; omitted rules are disabled, matching
+ESLint's configuration model. Config-driven `files` and
 `ignores` filtering and default target selection are npm/Node wrapper features.
 Pass lint targets explicitly when invoking the raw binary.
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -116,6 +116,10 @@ Rule values support the common ESLint forms:
 - `"warn"`, `"error"`, `1`, `2`, or `true` enable a rule.
 - Arrays such as `["error", { ...options }]` use the first item as severity and pass supported options to the native rule implementation.
 
+As in ESLint, warning diagnostics do not fail the command; error diagnostics
+return exit status 1. The fishlint-compatible CLI also supports
+`--max-warnings` when a warning budget should fail CI.
+
 Rule-related CLI options are applied after the config, so command-line rule
 toggles override configured rule values:
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -104,7 +104,8 @@ the fishlint wrapper and per-file flat config handling.
 `diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
 `column`, `severity`, `message`, and `ruleId`, with disabled per-file rules
 filtered from the diagnostics. `exitCode` is recalculated from the filtered
-diagnostics. The `ESLint` export is an alias for `UtooLint`
+diagnostics: warnings return 0 and errors return 1. The `ESLint` export is an
+alias for `UtooLint`
 and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for
 low-friction replacements. It also provides ESLint-compatible `version`,

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -113,10 +113,12 @@ JSON-serializable object or flat config array. The npm wrapper executes it and
 materializes the result as JSON before invoking the native binary. The raw
 binary does not execute or discover TypeScript; it searches for
 `utlint.config.json` and then the legacy JSON names. Direct native use therefore
-requires a JSON config. The raw binary currently applies only its `rules`;
+requires a JSON config. The raw binary applies only its `rules`;
 config-driven `files` and `ignores` filtering and default target selection are
 npm/Node wrapper features. Pass lint targets explicitly when invoking the raw
-binary.
+binary. As in ESLint, selecting a config disables rules not present in its
+resolved `rules` map. When no config is selected, utoo-lint uses its built-in
+default rules.
 
 Start from the packaged frontend template:
 

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -120,6 +120,10 @@ binary. As in ESLint, selecting a config disables rules not present in its
 resolved `rules` map. When no config is selected, utoo-lint uses its built-in
 default rules.
 
+Rule severities use ESLint's exit behavior: warnings are reported with exit
+status 0, while errors return exit status 1. Use fishlint's `--max-warnings`
+option when warnings should fail CI.
+
 Start from the packaged frontend template:
 
 ```bash

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -164,6 +164,7 @@ if (Array.isArray(selectedConfig.config)) {
 
   const reportWithSeverity = normalizeReportSeverities(grouped.report, ruleResolution, input);
   const reportWithIgnored = appendDiagnostics(reportWithSeverity, ignoredFiltered.diagnostics);
+  const diagnosticCounts = diagnosticCountsFromReport(reportWithIgnored);
   const filteredReport = quiet.enabled ? filterQuietReport(reportWithIgnored) : reportWithIgnored;
   const rewrittenReport = rewriteReportStdinPaths(filteredReport, input);
   if (grouped.stderr) {
@@ -171,12 +172,13 @@ if (Array.isArray(selectedConfig.config)) {
   }
   writeOutput(formatReportOutput(rewrittenReport, nativeValues), output.file);
   cleanupStdinInput(input);
-  process.exit(eslintExitStatusFromCounts(diagnosticCountsFromReport(rewrittenReport), maxWarnings.value));
+  process.exit(eslintExitStatusFromCounts(diagnosticCounts, maxWarnings.value));
 }
 
 const ruleConfig = materializeRuntimeConfig(nativeValues, args, ruleOverrides.rules, selectedConfig);
 const needsReportOutput =
   quiet.enabled ||
+  maxWarnings.value != null ||
   ignoredFiltered.diagnostics.length > 0 ||
   usesJsonWithMetadataFormat(nativeValues) ||
   ruleResolution.configuredRules.size > 0;
@@ -203,10 +205,11 @@ if (needsReportOutput) {
   } else {
     const reportWithSeverity = normalizeReportSeverities(report, ruleResolution, input);
     const reportWithIgnored = appendDiagnostics(reportWithSeverity, ignoredFiltered.diagnostics);
+    const diagnosticCounts = diagnosticCountsFromReport(reportWithIgnored);
     const filteredReport = quiet.enabled ? filterQuietReport(reportWithIgnored) : reportWithIgnored;
     const rewrittenReport = rewriteReportStdinPaths(filteredReport, input);
     writeOutput(formatReportOutput(rewrittenReport, nativeValues), output.file);
-    exitStatus = eslintExitStatusFromCounts(diagnosticCountsFromReport(rewrittenReport), maxWarnings.value);
+    exitStatus = eslintExitStatusFromCounts(diagnosticCounts, maxWarnings.value);
   }
 } else {
   writeOutput(rewriteStdinPath(rawStdout, input), output.file);

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1067,7 +1067,7 @@ function lintFiles(paths, options = {}) {
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
   if (lintPaths.length === 0) {
-    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
@@ -1261,7 +1261,7 @@ function lintText(code, options = {}) {
         files: 0,
         filePaths: [],
         diagnostics,
-        exitCode: diagnostics.length > 0 ? 1 : 0
+        exitCode: exitCodeForDiagnostics(diagnostics)
       };
     }
 
@@ -3642,7 +3642,7 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
-    if (diagnostic.ruleId === "io") {
+    if (diagnostic.ruleId === "io" || diagnostic.ruleId === "parse") {
       return [diagnostic];
     }
 
@@ -3691,7 +3691,7 @@ function hasRuleConfigSource(options = {}, filePath) {
 }
 
 function exitCodeForDiagnostics(diagnostics) {
-  return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
+  return diagnostics?.some((diagnostic) => diagnostic?.severity === "error" || diagnostic?.severity === 2) ? 1 : 0;
 }
 
 function throwOnUnmatchedPatternDiagnostics(report, options = {}) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -11,6 +11,10 @@ export interface LintMessage {
   suggestions?: LintSuggestion[];
 }
 
+export interface LintDiagnostic extends Omit<LintMessage, "severity"> {
+  severity: "warning" | "error";
+}
+
 export interface LintFix {
   range: [number, number];
   text: string;
@@ -37,7 +41,7 @@ export interface LintResult {
 export interface LintReport {
   files: number;
   filePaths: string[];
-  diagnostics: LintMessage[];
+  diagnostics: LintDiagnostic[];
   outputs?: Array<{ filePath: string; output: string }>;
   exitCode: number;
   stderr?: string;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -2903,7 +2903,7 @@ export function lintFiles(paths, options = {}) {
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
   if (lintPaths.length === 0) {
-    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: ignoredDiagnostics.length > 0 ? 1 : 0 };
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
@@ -3097,7 +3097,7 @@ export function lintText(code, options = {}) {
         files: 0,
         filePaths: [],
         diagnostics,
-        exitCode: diagnostics.length > 0 ? 1 : 0
+        exitCode: exitCodeForDiagnostics(diagnostics)
       };
     }
 
@@ -3645,7 +3645,7 @@ function normalizeReportDiagnostics(diagnostics, options = {}) {
     if (!diagnostic?.ruleId) {
       return [diagnostic];
     }
-    if (diagnostic.ruleId === "io") {
+    if (diagnostic.ruleId === "io" || diagnostic.ruleId === "parse") {
       return [diagnostic];
     }
 
@@ -3694,7 +3694,7 @@ function hasRuleConfigSource(options = {}, filePath) {
 }
 
 function exitCodeForDiagnostics(diagnostics) {
-  return (diagnostics?.length ?? 0) > 0 ? 1 : 0;
+  return diagnostics?.some((diagnostic) => diagnostic?.severity === "error" || diagnostic?.severity === 2) ? 1 : 0;
 }
 
 function throwOnUnmatchedPatternDiagnostics(report, options = {}) {

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -49,7 +49,7 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["off", "warn", "error", "on", "0", "1", "2"]
+          "enum": ["off", "warn", "warning", "error", "on", "0", "1", "2"]
         },
         {
           "type": "integer",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { createRequire } from "node:module";
 
-import { ESLint, resolveBinary, runCli } from "../index.js";
+import { ESLint, lintFiles, lintText, resolveBinary, runCli } from "../index.js";
 
 const require = createRequire(import.meta.url);
 const { ESLint: CommonJSESLint, runCli: commonJSRunCli } = require("../index.cjs");
@@ -120,6 +120,46 @@ test("fishlint --rules overrides flat-config off severities", (t) => {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(report.diagnostics.length, 2);
   assert.ok(report.diagnostics.every((diagnostic) => diagnostic.severity === "warning"));
+});
+
+test("fishlint enforces --max-warnings when the native binary exits successfully", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+  const env = { ...process.env, UTOO_LINT_BIN: testBinary() };
+
+  const rejected = spawnSync(
+    process.execPath,
+    [fishlintPath, "eslint", "--no-config", "--max-warnings=0", sourcePath],
+    { cwd: project, env, encoding: "utf8" }
+  );
+  const accepted = spawnSync(
+    process.execPath,
+    [fishlintPath, "eslint", "--no-config", "--max-warnings=1", sourcePath],
+    { cwd: project, env, encoding: "utf8" }
+  );
+
+  assert.equal(rejected.status, 1, rejected.stderr);
+  assert.match(rejected.stderr, /too many warnings/);
+  assert.equal(accepted.status, 0, accepted.stderr);
+});
+
+test("fishlint counts quiet warnings against --max-warnings", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+
+  const result = spawnSync(
+    process.execPath,
+    [fishlintPath, "eslint", "--no-config", "--quiet", "--max-warnings=0", sourcePath],
+    {
+      cwd: project,
+      env: { ...process.env, UTOO_LINT_BIN: testBinary() },
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /too many warnings/);
+  assert.doesNotMatch(result.stdout, /no-debugger/);
 });
 
 test("fishlint groups flat config files by complete rule options", (t) => {
@@ -345,7 +385,7 @@ test("CLI loads utlint.config.ts and --no-config bypasses it", (t) => {
   assert.equal(configured.error, undefined);
   assert.equal(configured.status, 0, configured.stderr);
   assert.equal(unconfigured.error, undefined);
-  assert.equal(unconfigured.status, 1, unconfigured.stderr);
+  assert.equal(unconfigured.status, 0, unconfigured.stderr);
   assert.match(unconfigured.stderr, /no-debugger/);
 });
 
@@ -393,7 +433,7 @@ test("explicit config and --no-config keep last-argument-wins semantics", (t) =>
   );
 
   assert.equal(configLast.status, 0, configLast.stderr);
-  assert.equal(noConfigLast.status, 1, noConfigLast.stderr);
+  assert.equal(noConfigLast.status, 0, noConfigLast.stderr);
 });
 
 test("split -c loads an explicit TypeScript config", (t) => {
@@ -488,6 +528,76 @@ test("raw native binary treats configured rules as the complete rule set", (t) =
 
   assert.equal(result.status, 1, result.stderr);
   assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["error"]);
+});
+
+test("raw native binary reports configured warnings without failing", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"), '{ "rules": { "no-debugger": "warn" } }\n');
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+
+  const result = spawnSync(testBinary(), ["--format=json", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
+});
+
+test("raw native binary applies array and numeric config severities", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+
+  for (const [config, expectedSeverity, expectedStatus] of [
+    ['["warn"]', "warning", 0],
+    ["1", "warning", 0],
+    ['["error"]', "error", 1],
+    ["2", "error", 1]
+  ]) {
+    write(join(project, "utlint.config.json"), `{ "rules": { "no-debugger": ${config} } }\n`);
+    const result = spawnSync(testBinary(), ["--format=json", sourcePath], {
+      cwd: project,
+      encoding: "utf8"
+    });
+    const report = JSON.parse(result.stdout);
+
+    assert.equal(result.status, expectedStatus, result.stderr);
+    assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), [expectedSeverity]);
+  }
+});
+
+test("raw native binary accepts duplicate names in --rules without changing severity", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+
+  const result = spawnSync(
+    testBinary(),
+    ["--no-config", "--rules=no-debugger,no-debugger", "--format=json", sourcePath],
+    { cwd: project, encoding: "utf8" }
+  );
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
+});
+
+test("raw native binary keeps parse errors fatal with an empty rules config", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"));
+  const sourcePath = write(join(project, "index.js"), "const = ;\n");
+
+  const result = spawnSync(testBinary(), ["--format=json", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.ok(report.diagnostics.some((diagnostic) => diagnostic.ruleId === "parse" && diagnostic.severity === "error"));
 });
 
 test("raw native binary enables no rules for an empty config", (t) => {
@@ -516,8 +626,9 @@ test("raw native binary keeps default rules when config discovery is disabled", 
   });
   const report = JSON.parse(result.stdout);
 
-  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
 });
 
 test("ESM API loads an ancestor utlint.config.json", async (t) => {
@@ -643,7 +754,7 @@ test("--rules overrides the selected project config", (t) => {
     encoding: "utf8"
   });
 
-  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.status, 0, result.stderr);
   assert.match(result.stderr, /no-debugger/);
 });
 
@@ -871,8 +982,9 @@ test("CLI --rules enables exactly the requested rules after project config", (t)
   );
   const report = JSON.parse(result.stdout);
 
-  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
   assert.deepEqual(report.outputs, []);
   assert.equal(readFileSync(sourcePath, "utf8"), "debugger;\nconsole.log(1);\nfoo();;\n");
 });
@@ -898,7 +1010,7 @@ test("CLI --rules preserves per-file options for the selected flat-config rule",
     encoding: "utf8"
   });
 
-  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.status, 0, result.stderr);
   assert.doesNotMatch(result.stderr, /src\/index\.ts/);
   assert.match(result.stderr, /test\/index\.ts/);
 });
@@ -976,7 +1088,7 @@ test("ESM and CommonJS apply flat overrideConfig rules per file with project con
   }
 });
 
-test("runCli preserves JSON output after per-file config filtering", (t) => {
+test("ESM and CommonJS runCli preserve warning JSON output without failing", (t) => {
   const project = createProject(t);
   write(
     join(project, "utlint.config.ts"),
@@ -991,17 +1103,59 @@ test("runCli preserves JSON output after per-file config filtering", (t) => {
   const disabledSource = write(join(project, "src", "index.ts"), "debugger;\n");
   const enabledSource = write(join(project, "test", "index.ts"), "debugger;\n");
 
-  const result = runCli(["--json", disabledSource, enabledSource], {
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", disabledSource, enabledSource], {
+      cwd: project,
+      binary: testBinary(),
+      encoding: "utf8"
+    });
+    const report = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(report.diagnostics.length, 1);
+    assert.equal(report.diagnostics[0].severity, "warning");
+    assert.match(report.diagnostics[0].filePath, /test\/index\.ts$/);
+  }
+});
+
+test("ESM and CommonJS keep parse errors fatal when rules are configured", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"));
+  const sourcePath = write(join(project, "index.js"), "const = ;\n");
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", sourcePath], {
+      cwd: project,
+      binary: testBinary(),
+      encoding: "utf8"
+    });
+    const report = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 1, result.stderr);
+    assert.ok(report.diagnostics.some((diagnostic) => diagnostic.ruleId === "parse" && diagnostic.severity === "error"));
+  }
+});
+
+test("ignored-file warnings do not fail lintFiles or lintText", (t) => {
+  const project = createProject(t);
+  const ignoredSource = write(join(project, "ignored.js"), "debugger;\n");
+  const options = {
     cwd: project,
     binary: testBinary(),
-    encoding: "utf8"
-  });
-  const report = JSON.parse(result.stdout);
+    noConfig: true,
+    ignorePatterns: ["ignored.js"]
+  };
 
-  assert.equal(result.status, 1, result.stderr);
-  assert.equal(report.diagnostics.length, 1);
-  assert.equal(report.diagnostics[0].severity, "warning");
-  assert.match(report.diagnostics[0].filePath, /test\/index\.ts$/);
+  for (const execute of [lintFiles, require("../index.cjs").lintFiles]) {
+    const report = execute([ignoredSource], options);
+    assert.equal(report.exitCode, 0);
+    assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
+  }
+  for (const execute of [lintText, require("../index.cjs").lintText]) {
+    const report = execute("debugger;\n", { ...options, filePath: ignoredSource });
+    assert.equal(report.exitCode, 0);
+    assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
+  }
 });
 
 test("runCli keeps --fix writes while filtering project config diagnostics", (t) => {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -475,6 +475,51 @@ test("raw native binary discovers utlint.config.json in an ancestor", (t) => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("raw native binary treats configured rules as the complete rule set", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"), '{ "rules": { "no-debugger": "error" } }\n');
+  const sourcePath = write(join(project, "index.js"), "debugger;\nconst unused = 1;\n");
+
+  const result = spawnSync(testBinary(), ["--format=json", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+});
+
+test("raw native binary enables no rules for an empty config", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"));
+  const sourcePath = write(join(project, "index.js"), "debugger;\nconst unused = 1;\n");
+
+  const result = spawnSync(testBinary(), ["--format=json", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(report.diagnostics, []);
+});
+
+test("raw native binary keeps default rules when config discovery is disabled", (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.json"));
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+
+  const result = spawnSync(testBinary(), ["--no-config", "--format=json", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+});
+
 test("ESM API loads an ancestor utlint.config.json", async (t) => {
   const project = createProject(t);
   write(join(project, "utlint.config.json"), '{ "rules": { "no-debugger": "off" } }\n');

--- a/src/core.zig
+++ b/src/core.zig
@@ -3622,6 +3622,37 @@ pub const Options = struct {
         }
     }
 
+    pub fn severityFromRuleConfigValue(value: std.json.Value) RuleConfigError!?Severity {
+        return switch (value) {
+            .bool => |enabled| if (enabled) .@"error" else null,
+            .integer => |severity| switch (severity) {
+                0 => null,
+                1 => .warning,
+                2 => .@"error",
+                else => error.UnsupportedRuleConfigValue,
+            },
+            .string => |severity| {
+                if (std.ascii.eqlIgnoreCase(severity, "off") or std.mem.eql(u8, severity, "0")) return null;
+                if (std.ascii.eqlIgnoreCase(severity, "warn") or
+                    std.ascii.eqlIgnoreCase(severity, "warning") or
+                    std.ascii.eqlIgnoreCase(severity, "on") or
+                    std.mem.eql(u8, severity, "1"))
+                {
+                    return .warning;
+                }
+                if (std.ascii.eqlIgnoreCase(severity, "error") or std.mem.eql(u8, severity, "2")) {
+                    return .@"error";
+                }
+                return error.UnsupportedRuleConfigValue;
+            },
+            .array => |items| {
+                if (items.items.len == 0) return error.EmptyRuleConfigArray;
+                return severityFromRuleConfigValue(items.items[0]);
+            },
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
     pub const RuleConfigError = error{
         EmptyRuleConfigArray,
         UnknownRule,
@@ -11271,4 +11302,18 @@ test "Options can apply ESLint-style rule config values" {
         Options.RuleConfigError.UnknownRule,
         options.setByRuleConfigValue("unknown-rule", .{ .string = "off" }),
     );
+}
+
+test "Options parses ESLint-style rule severities" {
+    try std.testing.expectEqual(null, try Options.severityFromRuleConfigValue(.{ .string = "off" }));
+    try std.testing.expectEqual(Severity.warning, try Options.severityFromRuleConfigValue(.{ .string = "warn" }));
+    try std.testing.expectEqual(Severity.@"error", try Options.severityFromRuleConfigValue(.{ .string = "error" }));
+    try std.testing.expectEqual(Severity.warning, try Options.severityFromRuleConfigValue(.{ .integer = 1 }));
+    try std.testing.expectEqual(Severity.@"error", try Options.severityFromRuleConfigValue(.{ .integer = 2 }));
+    try std.testing.expectEqual(Severity.@"error", try Options.severityFromRuleConfigValue(.{ .bool = true }));
+
+    var array = std.json.Array.init(std.testing.allocator);
+    defer array.deinit();
+    try array.append(.{ .string = "warn" });
+    try std.testing.expectEqual(Severity.warning, try Options.severityFromRuleConfigValue(.{ .array = array }));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1371,6 +1371,7 @@ fn loadConfigFile(
         },
     };
 
+    options.* = lint.Options.allDisabled();
     const rules_value = root.get("rules") orelse return;
     const rules = switch (rules_value) {
         .object => |object| object,

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,6 +52,7 @@ const JsonOutput = struct {
 };
 
 const JsonOutputList = std.ArrayList(JsonOutput);
+const RuleSeverityMap = std.StringHashMap(lint.Severity);
 
 const JsonReport = struct {
     files: usize,
@@ -64,6 +65,7 @@ const WorkQueue = struct {
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     next_index: std.atomic.Value(usize) = .init(0),
     print_mutex: std.Io.Mutex = .init,
@@ -85,13 +87,18 @@ pub fn main(init: std.process.Init) !void {
     }
 
     var options = lint.Options{};
+    var rule_severities = RuleSeverityMap.init(allocator);
+    defer {
+        clearRuleSeverities(allocator, &rule_severities);
+        rule_severities.deinit();
+    }
     const config = parseConfigArgs(args[1..]);
     if (config.enabled) {
         if (config.path) |path| {
-            try loadConfigFile(allocator, io, path, true, &options);
+            try loadConfigFile(allocator, io, path, true, &options, &rule_severities);
         } else if (try findDefaultConfig(allocator, io)) |path| {
             defer allocator.free(path);
-            try loadConfigFile(allocator, io, path, false, &options);
+            try loadConfigFile(allocator, io, path, false, &options, &rule_severities);
         }
     }
 
@@ -142,7 +149,8 @@ pub fn main(init: std.process.Init) !void {
             };
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
             options = lint.Options.allDisabled();
-            parseEnabledRules(arg["--rules=".len..], &options);
+            clearRuleSeverities(allocator, &rule_severities);
+            try parseEnabledRules(allocator, arg["--rules=".len..], &options, &rule_severities);
         } else if (std.mem.eql(u8, arg, "--accessor-pairs=off")) {
             options.accessor_pairs = false;
         } else if (std.mem.eql(u8, arg, "--accessor-pairs-get-without-set=on")) {
@@ -1243,10 +1251,10 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (output_format == .json) {
-        try lintFilesJson(allocator, io, files.items, options, fix_mode, &stats, &json_diagnostics, &json_outputs);
+        try lintFilesJson(allocator, io, files.items, options, &rule_severities, fix_mode, &stats, &json_diagnostics, &json_outputs);
         try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_outputs.items);
     } else {
-        try lintFiles(allocator, io, files.items, options, fix_mode, thread_count_override, &stats);
+        try lintFiles(allocator, io, files.items, options, &rule_severities, fix_mode, thread_count_override, &stats);
 
         if (fix_mode == .none) {
             std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{ stats.files, stats.diagnostics });
@@ -1259,7 +1267,7 @@ pub fn main(init: std.process.Init) !void {
         }
     }
 
-    if (stats.errors > 0 or stats.diagnostics > 0) {
+    if (stats.errors > 0) {
         std.process.exit(1);
     }
 }
@@ -1347,6 +1355,7 @@ fn loadConfigFile(
     path: []const u8,
     explicit: bool,
     options: *lint.Options,
+    rule_severities: *RuleSeverityMap,
 ) !void {
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_config_file_size)) catch |err| {
         if (explicit) {
@@ -1390,6 +1399,18 @@ fn loadConfigFile(
             );
             std.process.exit(2);
         };
+        const severity = lint.Options.severityFromRuleConfigValue(entry.value_ptr.*) catch |err| {
+            std.debug.print(
+                "utoo-lint: invalid config {s} rule {s}: {s}\n",
+                .{ path, entry.key_ptr.*, @errorName(err) },
+            );
+            std.process.exit(2);
+        };
+        if (severity) |configured_severity| {
+            const owned_rule = try allocator.dupe(u8, entry.key_ptr.*);
+            errdefer allocator.free(owned_rule);
+            try rule_severities.put(owned_rule, configured_severity);
+        }
     }
 }
 
@@ -1426,7 +1447,12 @@ fn collectLintablePaths(
     }
 }
 
-fn parseEnabledRules(value: []const u8, options: *lint.Options) void {
+fn parseEnabledRules(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+    options: *lint.Options,
+    rule_severities: *RuleSeverityMap,
+) !void {
     if (value.len == 0) {
         std.debug.print("utoo-lint: --rules requires a comma-separated rule list\n", .{});
         std.process.exit(2);
@@ -1443,7 +1469,21 @@ fn parseEnabledRules(value: []const u8, options: *lint.Options) void {
             std.debug.print("utoo-lint: unknown rule in --rules: {s}\n", .{rule});
             std.process.exit(2);
         }
+        const owned_rule = try allocator.dupe(u8, rule);
+        errdefer allocator.free(owned_rule);
+        const entry = try rule_severities.getOrPut(owned_rule);
+        if (entry.found_existing) {
+            allocator.free(owned_rule);
+        } else {
+            entry.value_ptr.* = .warning;
+        }
     }
+}
+
+fn clearRuleSeverities(allocator: std.mem.Allocator, rule_severities: *RuleSeverityMap) void {
+    var iter = rule_severities.keyIterator();
+    while (iter.next()) |rule| allocator.free(rule.*);
+    rule_severities.clearRetainingCapacity();
 }
 
 fn parseNoConsoleAllow(value: []const u8, options: *lint.Options) void {
@@ -1777,6 +1817,7 @@ fn lintFiles(
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     thread_count_override: ?usize,
     stats: *Stats,
@@ -1786,7 +1827,7 @@ fn lintFiles(
     const worker_count = @min(files.len, thread_count_override orelse (std.Thread.getCpuCount() catch 1));
     if (worker_count <= 1) {
         for (files) |file| {
-            try lintFile(std.heap.smp_allocator, io, file, options, fix_mode, stats, null);
+            try lintFile(std.heap.smp_allocator, io, file, options, rule_severities, fix_mode, stats, null);
         }
         return;
     }
@@ -1795,6 +1836,7 @@ fn lintFiles(
         .io = io,
         .files = files,
         .options = options,
+        .rule_severities = rule_severities,
         .fix_mode = fix_mode,
     };
 
@@ -1841,13 +1883,14 @@ fn lintFilesJson(
     io: std.Io,
     files: []const []const u8,
     options: lint.Options,
+    rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
     json_outputs: *JsonOutputList,
 ) !void {
     for (files) |file| {
-        try lintFileJson(allocator, io, file, options, fix_mode, stats, json_diagnostics, json_outputs);
+        try lintFileJson(allocator, io, file, options, rule_severities, fix_mode, stats, json_diagnostics, json_outputs);
     }
 }
 
@@ -1861,6 +1904,7 @@ fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
             queue.io,
             queue.files[index],
             queue.options,
+            queue.rule_severities,
             queue.fix_mode,
             &result.stats,
             &queue.print_mutex,
@@ -1876,6 +1920,7 @@ fn lintFileJson(
     io: std.Io,
     path: []const u8,
     options: lint.Options,
+    rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
@@ -1896,7 +1941,7 @@ fn lintFileJson(
     if (fix_mode == .none) {
         var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
         defer result.deinit(allocator);
-        return appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, stats);
+        return appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, rule_severities, stats);
     }
 
     var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
@@ -1910,7 +1955,7 @@ fn lintFileJson(
         try appendJsonOutput(allocator, json_outputs, path, fixed.output);
     }
 
-    try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, stats);
+    try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, rule_severities, stats);
 }
 
 fn lintFile(
@@ -1918,6 +1963,7 @@ fn lintFile(
     io: std.Io,
     path: []const u8,
     options: lint.Options,
+    rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     stats: *Stats,
     print_mutex: ?*std.Io.Mutex,
@@ -1935,7 +1981,7 @@ fn lintFile(
     if (fix_mode == .none) {
         var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
         defer result.deinit(allocator);
-        return printResultDiagnostics(io, print_mutex, path, source, result, stats);
+        return printResultDiagnostics(io, print_mutex, path, source, result, rule_severities, stats);
     }
 
     var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
@@ -1948,7 +1994,7 @@ fn lintFile(
         }
     }
 
-    printResultDiagnostics(io, print_mutex, path, fixed.output, fixed.result, stats);
+    printResultDiagnostics(io, print_mutex, path, fixed.output, fixed.result, rule_severities, stats);
 }
 
 fn printResultDiagnostics(
@@ -1957,21 +2003,23 @@ fn printResultDiagnostics(
     path: []const u8,
     source: []const u8,
     result: lint.Result,
+    rule_severities: *const RuleSeverityMap,
     stats: *Stats,
 ) void {
     for (result.diagnostics) |diagnostic| {
+        const severity = effectiveDiagnosticSeverity(rule_severities, diagnostic);
         const position = lint.offsetToLineColumn(source, diagnostic.span.start);
         printLocked(io, print_mutex, "{s}:{d}:{d}: {s}: {s} [{s}]\n", .{
             path,
             position.line,
             position.column,
-            diagnostic.severity.toString(),
+            severity.toString(),
             diagnostic.message,
             diagnostic.rule_id,
         });
 
         stats.diagnostics += 1;
-        if (diagnostic.severity == .@"error") {
+        if (severity == .@"error") {
             stats.errors += 1;
         }
     }
@@ -2018,9 +2066,11 @@ fn appendJsonResultDiagnostics(
     path: []const u8,
     source: []const u8,
     result: lint.Result,
+    rule_severities: *const RuleSeverityMap,
     stats: *Stats,
 ) !void {
     for (result.diagnostics) |diagnostic| {
+        const severity = effectiveDiagnosticSeverity(rule_severities, diagnostic);
         const position = lint.offsetToLineColumn(source, diagnostic.span.start);
         try appendJsonDiagnostic(
             allocator,
@@ -2028,7 +2078,7 @@ fn appendJsonResultDiagnostics(
             path,
             position.line,
             position.column,
-            diagnostic.severity.toString(),
+            severity.toString(),
             diagnostic.message,
             diagnostic.rule_id,
             source,
@@ -2036,8 +2086,12 @@ fn appendJsonResultDiagnostics(
         );
 
         stats.diagnostics += 1;
-        if (diagnostic.severity == .@"error") stats.errors += 1;
+        if (severity == .@"error") stats.errors += 1;
     }
+}
+
+fn effectiveDiagnosticSeverity(rule_severities: *const RuleSeverityMap, diagnostic: lint.Diagnostic) lint.Severity {
+    return rule_severities.get(diagnostic.rule_id) orelse diagnostic.severity;
 }
 
 fn dupeJsonFixes(allocator: std.mem.Allocator, source: []const u8, fixes: []const lint.Fix) ![]JsonFix {


### PR DESCRIPTION
## What changed

- Treat a selected config's `rules` map as the complete enabled rule set; omitted rules are disabled by default.
- Honor ESLint-style severities in the raw native CLI, ESM wrapper, and CommonJS wrapper:
  - `warn` / `1` report warnings and exit 0.
  - `error` / `2` report errors and exit 1.
- Keep parse and I/O errors fatal.
- Preserve built-in default rules only when no config is selected or `--no-config` is used.
- Keep `--rules` as an explicit warning-level override, including per-file rule options.
- Keep fishlint's `--max-warnings` behavior, including when `--quiet` hides warnings.
- Update schema, TypeScript declarations, docs, and CI verification.

No `onlyConfiguredRules` switch is introduced: the ESLint-style complete rule set is the default whenever a config is selected.

## Why

Direct native JSON config loading previously layered configured rules over every built-in default. That disagreed with the npm/Node entry points and forced projects such as `utoopack-ecosystem-ci` to keep a long `--rules=...` whitelist.

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test` — 62/62 passed
- Raw CLI severity matrix: warn/error, numeric and array forms, parse errors, duplicate `--rules`
- ESM/CommonJS parity, ignored-file warnings, fishlint `--max-warnings` + `--quiet`
- Real `utoopack-ecosystem-ci` config with the candidate binary and no `--rules`: 15 files, 0 diagnostics
