### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--
+	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
+	Please provide enough information so that others can review your PR.
+	Learn more about contributing: https://github.com/fireairforce/utoo-lint/blob/main/CONTRIBUTING.md
+-->
+
+## Summary
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+
+
+## Test Plan
+
+<!-- What demonstrates that your implementation is correct? -->


### PR DESCRIPTION
## Summary

Add a default pull request template based on `utooland/utoo` so future pull requests consistently document their motivation and validation.

The template links to this repository's contributing guide and omits the upstream automatic-labeling note because this repository does not currently configure that behavior.

## Test Plan

- Confirmed `.github/PULL_REQUEST_TEMPLATE.md` is the only file in the commit.
- Ran `git diff --cached --check` before committing.
- Verified the template contains the `Summary` and `Test Plan` sections.
