### PR TITLE
docs: clarify TypeScript and JSON configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,25 @@ when a rule or a particular code shape cannot be fixed safely. See
 
 The canonical config names are `utlint.config.ts` and `utlint.config.json`.
 They are two representations of one active config, not layers that are merged.
+
+| Config | Use it when | Supported entry points |
+| --- | --- | --- |
+| `utlint.config.ts` | You want typed authoring, imports, or computed values. | npm CLI, JavaScript API, and fishlint compatibility command |
+| `utlint.config.json` | You want a static, runtime-independent config. | npm CLI, JavaScript API, fishlint compatibility command, and raw native binary |
+
 For the npm/Node entry point, discovery checks each directory before moving to
 its parent, so the nearest config directory wins. Within one directory,
 `utlint.config.ts` takes precedence over `utlint.config.json`. The old
 `utoo.json` and `utoo-lint.json` names remain temporarily supported after the
 canonical names, but are deprecated.
+
+The npm CLI discovers either canonical file automatically. You can also select
+one explicitly:
+
+```bash
+pnpm exec utoo-lint --config=utlint.config.ts src
+pnpm exec utoo-lint --config=utlint.config.json src
+```
 
 Use `utlint.config.json` for a static config that both the npm CLI and raw native
 binary can read:
@@ -142,10 +156,9 @@ JSON-serializable object or flat config array. The npm wrapper executes it,
 materializes the result as JSON, and invokes the native binary. The raw binary
 does not execute or discover TypeScript; it searches for `utlint.config.json`
 and then the legacy JSON names. Invoke the npm CLI for `utlint.config.ts`, or
-give the binary `utlint.config.json`. Use
-`--config=path/to/utlint.config.json` to select a file explicitly, or
-`--no-config` to disable config discovery. Rule-related CLI options such as
-`--rules` and individual rule toggles are applied after the selected config.
+give the binary `utlint.config.json`. Use `--no-config` to disable config
+discovery. Rule-related CLI options such as `--rules` and individual rule
+toggles are applied after the selected config.
 As in ESLint, a selected config's `rules` map is the complete rule set: rules
 that are not configured are disabled. With no selected config, utoo-lint keeps
 its built-in default rules.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,13 @@ The canonical config names are:
 - `utlint.config.json`: a static JSON config readable by both the npm CLI and
   the raw native binary.
 
+Choose the format based on how the config will be used:
+
+| Config | Best for | npm/Node CLI | Raw native binary |
+| --- | --- | --- | --- |
+| `utlint.config.ts` | Type checking while authoring, imports, shared presets, and computed values | Yes | No |
+| `utlint.config.json` | Static configuration, schema validation, and direct native use | Yes | Yes |
+
 These are alternative representations of the same active config. They are not
 implicitly merged. For the npm/Node entry point, discovery is nearest-first:
 all supported names are checked in one directory before the parent directory is
@@ -23,8 +30,20 @@ This means a nearer `utlint.config.json` wins over a more distant
 `utlint.config.ts`. The two legacy JSON names remain temporarily supported for
 migration, but new projects should use a canonical name.
 
-Use `--config=path/to/utlint.config.json` to select a config explicitly, or
-`--no-config` to ignore local config. Rule-related CLI options such as
+The npm CLI discovers either canonical format automatically:
+
+```bash
+npx utoo-lint src
+```
+
+To select a file explicitly, pass either format to `--config`:
+
+```bash
+npx utoo-lint --config=utlint.config.ts src
+npx utoo-lint --config=utlint.config.json src
+```
+
+Use `--no-config` to ignore local config. Rule-related CLI options such as
 `--rules` and individual rule toggles are applied after the selected config.
 The resolved `rules` map is the complete enabled rule set, matching ESLint's
 configuration model: omitted rules are disabled. If no config is selected,
@@ -53,11 +72,12 @@ export default defineConfig({
 ```
 
 `defineConfig()` accepts config objects and flat config arrays and returns a
-flat array. A TypeScript config is trusted executable code: loading it can run
-arbitrary code with the permissions of the Node process. Its default export
-must be a JSON-serializable config object or flat config array. The loader
-transpiles and executes TypeScript syntax; it does not run `tsc` or perform type
-checking.
+flat array. It also provides editor completion and compile-time checking from
+the exported configuration types. A TypeScript config is trusted executable
+code: loading it can run arbitrary code with the permissions of the Node
+process. Its default export must be a JSON-serializable config object or flat
+config array. The loader transpiles and executes TypeScript syntax; it does not
+run `tsc` or perform type checking when linting starts.
 
 For a flat config array, each entry's `files` and `ignores` select the files to
 which that entry applies. Matching entries are combined in array order, so a
@@ -91,6 +111,10 @@ Use `utlint.config.json` for a static, runtime-independent config:
   }
 }
 ```
+
+The optional `$schema` property enables completion and validation in editors
+that support JSON Schema. JSON config cannot contain imports or computed
+values; use `utlint.config.ts` when those are required.
 
 ESLint config files are a migration input, not the recommended long-term
 configuration format. Generate a native config with:

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -64,6 +64,21 @@ lists autofix coverage by rule.
 
 ## Configuration
 
+`utoo-lint` supports two canonical project config formats:
+
+| Config | Use it when | Raw native binary |
+| --- | --- | --- |
+| `utlint.config.ts` | You want typed authoring, imports, or computed values. | No |
+| `utlint.config.json` | You want a static, runtime-independent config. | Yes |
+
+The npm CLI discovers either format automatically. It can also select one
+explicitly:
+
+```bash
+pnpm exec utoo-lint --config=utlint.config.ts src
+pnpm exec utoo-lint --config=utlint.config.json src
+```
+
 For a static config readable by both the npm CLI and raw native binary, create
 `utlint.config.json`:
 


### PR DESCRIPTION
## Summary

- document when to choose `utlint.config.ts` or `utlint.config.json`
- add copy-paste examples for automatic discovery and explicit `--config` selection
- clarify discovery precedence and npm/Node versus raw native binary support
- align the root README, configuration guide, and published npm package README

This follows the TypeScript and JSON config support added in #1034 and makes
the two supported formats easier to discover and compare.

## Test Plan

- `git diff --check`
- verified the documented filenames and precedence against
  `npm/utoo-lint/lib/config-loader.js`
- verified explicit TypeScript config selection and same-directory precedence
  against `npm/utoo-lint/test/config-loading.test.mjs`

Documentation-only change; no runtime behavior changed.
