### PR TITLE
perf: cache executable configs per lint run

### DIFF
--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -484,7 +484,7 @@ class UtooLint {
   }
 
   async lintFiles(patterns, options = {}) {
-    const mergedOptions = mergeLintOptions(this.options, options);
+    const mergedOptions = withConfigCache(mergeLintOptions(this.options, options));
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
     const nativeOptions = lintOptionsWithoutCustomRules(mergedOptions, customRuleFilterMap);
@@ -504,7 +504,7 @@ class UtooLint {
       throw new TypeError("code must be a string");
     }
 
-    const mergedOptions = mergeLintOptions(this.options, options);
+    const mergedOptions = withConfigCache(mergeLintOptions(this.options, options));
     const filePath = normalizeESLintFilePath(textFilePathForOptions(options, "<text>"), mergedOptions.cwd);
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleMap = customRuleMapForConfig(customRuleConfig, new Map(), filePath, mergedOptions.cwd);
@@ -528,7 +528,7 @@ class UtooLint {
   }
 
   async calculateConfigForFile(filePath) {
-    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(withConfigCache(eslintConstructorOptions(this.options)), filePath);
   }
 
   async findConfigFile(filePath) {
@@ -610,7 +610,7 @@ class CLIEngine {
   }
 
   executeOnFiles(patterns) {
-    const mergedOptions = eslintConstructorOptions(this.options);
+    const mergedOptions = withConfigCache(eslintConstructorOptions(this.options));
     const report = lintFiles(patterns, mergedOptions);
     throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
@@ -630,10 +630,10 @@ class CLIEngine {
       typeof filePathOrOptions === "object" && filePathOrOptions !== null
         ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
         : filePathOrOptions;
-    const mergedOptions = {
+    const mergedOptions = withConfigCache({
       ...eslintConstructorOptions(this.options),
       ...textOptions
-    };
+    });
     const report = lintText(code, {
       ...mergedOptions,
       filePath
@@ -670,7 +670,7 @@ class CLIEngine {
   }
 
   getConfigForFile(filePath) {
-    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(withConfigCache(eslintConstructorOptions(this.options)), filePath);
   }
 }
 
@@ -812,12 +812,12 @@ function runCli(args = [], options = {}) {
     return run(parsed.passthroughArgs, options);
   }
 
-  const cliOptions = {
+  const cliOptions = withConfigCache({
     ...options,
     ...parsed.options,
     extraArgs: parsed.passthroughArgs,
     preserveNativeDefaults: Boolean(parsed.options.noConfig)
-  };
+  });
   const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
   const report = lintFiles(targets, cliOptions);
   report.diagnostics = normalizeReportDiagnostics(report.diagnostics, cliOptions);
@@ -1063,6 +1063,7 @@ function booleanFlagValue(arg) {
 }
 
 function lintFiles(paths, options = {}) {
+  options = withConfigCache(options);
   const targets = lintTargetsForInput(paths, options);
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
@@ -1241,6 +1242,7 @@ function mergeNativeReports(reports) {
 }
 
 function lintText(code, options = {}) {
+  options = withConfigCache(options);
   if (typeof code !== "string") {
     throw new TypeError("code must be a string");
   }
@@ -1307,7 +1309,7 @@ function buildNativeLintArgs(paths, options) {
   if (!options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
     const configForRuleSelection = options.noConfig
       ? undefined
-      : options.config ? readConfig(options.config, options.cwd) : undefined;
+      : options.config ? readConfig(options.config, options.cwd, options.configCache) : undefined;
     const enabledRules = enabledRuleNamesFromConfigs(
       configForRuleSelection,
       options.baseConfig,
@@ -1351,6 +1353,12 @@ function mergeLintOptions(base, override) {
     ...eslintConstructorOptions(base),
     ...override
   };
+}
+
+function withConfigCache(options) {
+  // Executable configs are otherwise re-evaluated at every per-file lookup.
+  // Keep the cache on the options object so one public invocation shares it.
+  return options.configCache ? options : { ...options, configCache: new Map() };
 }
 
 function eslintConstructorOptions(options) {
@@ -1525,7 +1533,7 @@ function rulesFromFileConfig(options, filePath) {
     return {};
   }
 
-  const config = readConfig(configPath, options.cwd);
+  const config = readConfig(configPath, options.cwd, options.configCache);
   return rulesFromConfig(config, filePath, dirname(configPath));
 }
 
@@ -1539,7 +1547,7 @@ function configDataFromFileConfig(options, filePath) {
     return {};
   }
 
-  const config = readConfig(configPath, options.cwd);
+  const config = readConfig(configPath, options.cwd, options.configCache);
   return configDataFromConfig(config, filePath, dirname(configPath));
 }
 
@@ -1560,7 +1568,7 @@ function defaultLintTargets(options = {}) {
     return ["."];
   }
 
-  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd));
+  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache));
   return targets.length > 0
     ? targets.map((target) => resolveConfigPattern(target, dirname(configPath)))
     : ["."];
@@ -1652,7 +1660,9 @@ function configPathFromDirectory(directory) {
 function withTemporaryConfig(options, callback) {
   const fileConfigPath = !options.noConfig ? configPathForOptions(options) : undefined;
   const shouldMaterializeFileConfig = Boolean(fileConfigPath);
-  const fileConfig = shouldMaterializeFileConfig ? readConfig(fileConfigPath, options.cwd) : undefined;
+  const fileConfig = shouldMaterializeFileConfig
+    ? readConfig(fileConfigPath, options.cwd, options.configCache)
+    : undefined;
   const configs = [options.baseConfig, fileConfig, options.overrideConfig];
   const rules = shouldMaterializeFileConfig
     ? materializedRulesFromConfigs(...configs)
@@ -4012,7 +4022,7 @@ function ignorePatternsFromFileConfig(options, filePath) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  return ignorePatternsFromConfig(readConfig(configPath, options.cwd)).map((pattern) =>
+  return ignorePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache)).map((pattern) =>
     rebaseConfigPattern(pattern, dirname(configPath), cwd)
   );
 }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -487,7 +487,7 @@ export class UtooLint {
   }
 
   async lintFiles(patterns, options = {}) {
-    const mergedOptions = mergeLintOptions(this.options, options);
+    const mergedOptions = withConfigCache(mergeLintOptions(this.options, options));
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleFilterMap = customRuleMapForConfig(customRuleConfig, new Map());
     const nativeOptions = lintOptionsWithoutCustomRules(mergedOptions, customRuleFilterMap);
@@ -507,7 +507,7 @@ export class UtooLint {
       throw new TypeError("code must be a string");
     }
 
-    const mergedOptions = mergeLintOptions(this.options, options);
+    const mergedOptions = withConfigCache(mergeLintOptions(this.options, options));
     const filePath = normalizeESLintFilePath(textFilePathForOptions(options, "<text>"), mergedOptions.cwd);
     const customRuleConfig = [mergedOptions.baseConfig, mergedOptions.overrideConfig].filter(Boolean);
     const customRuleMap = customRuleMapForConfig(customRuleConfig, new Map(), filePath, mergedOptions.cwd);
@@ -531,7 +531,7 @@ export class UtooLint {
   }
 
   async calculateConfigForFile(filePath) {
-    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(withConfigCache(eslintConstructorOptions(this.options)), filePath);
   }
 
   async findConfigFile(filePath) {
@@ -2446,7 +2446,7 @@ export class CLIEngine {
   }
 
   executeOnFiles(patterns) {
-    const mergedOptions = eslintConstructorOptions(this.options);
+    const mergedOptions = withConfigCache(eslintConstructorOptions(this.options));
     const report = lintFiles(patterns, mergedOptions);
     throwOnUnmatchedPatternDiagnostics(report, mergedOptions);
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
@@ -2466,10 +2466,10 @@ export class CLIEngine {
       typeof filePathOrOptions === "object" && filePathOrOptions !== null
         ? filePathOrOptions.filePath ?? filePathOrOptions.filename ?? "input.js"
         : filePathOrOptions;
-    const mergedOptions = {
+    const mergedOptions = withConfigCache({
       ...eslintConstructorOptions(this.options),
       ...textOptions
-    };
+    });
     const report = lintText(code, {
       ...mergedOptions,
       filePath
@@ -2506,7 +2506,7 @@ export class CLIEngine {
   }
 
   getConfigForFile(filePath) {
-    return publicCalculatedConfig(eslintConstructorOptions(this.options), filePath);
+    return publicCalculatedConfig(withConfigCache(eslintConstructorOptions(this.options)), filePath);
   }
 }
 
@@ -2648,12 +2648,12 @@ export function runCli(args = [], options = {}) {
     return run(parsed.passthroughArgs, options);
   }
 
-  const cliOptions = {
+  const cliOptions = withConfigCache({
     ...options,
     ...parsed.options,
     extraArgs: parsed.passthroughArgs,
     preserveNativeDefaults: Boolean(parsed.options.noConfig)
-  };
+  });
   const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
   const report = lintFiles(targets, cliOptions);
   report.diagnostics = normalizeReportDiagnostics(report.diagnostics, cliOptions);
@@ -2899,6 +2899,7 @@ function booleanFlagValue(arg) {
 }
 
 export function lintFiles(paths, options = {}) {
+  options = withConfigCache(options);
   const targets = lintTargetsForInput(paths, options);
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
@@ -3077,6 +3078,7 @@ function mergeNativeReports(reports) {
 }
 
 export function lintText(code, options = {}) {
+  options = withConfigCache(options);
   if (typeof code !== "string") {
     throw new TypeError("code must be a string");
   }
@@ -3143,7 +3145,7 @@ function buildNativeLintArgs(paths, options) {
   if (!options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
     const configForRuleSelection = options.noConfig
       ? undefined
-      : options.config ? readConfig(options.config, options.cwd) : undefined;
+      : options.config ? readConfig(options.config, options.cwd, options.configCache) : undefined;
     const enabledRules = enabledRuleNamesFromConfigs(
       configForRuleSelection,
       options.baseConfig,
@@ -3187,6 +3189,12 @@ function mergeLintOptions(base, override) {
     ...eslintConstructorOptions(base),
     ...override
   };
+}
+
+function withConfigCache(options) {
+  // Executable configs are otherwise re-evaluated at every per-file lookup.
+  // Keep the cache on the options object so one public invocation shares it.
+  return options.configCache ? options : { ...options, configCache: new Map() };
 }
 
 function eslintConstructorOptions(options) {
@@ -3361,7 +3369,7 @@ function rulesFromFileConfig(options, filePath) {
     return {};
   }
 
-  const config = readConfig(configPath, options.cwd);
+  const config = readConfig(configPath, options.cwd, options.configCache);
   return rulesFromConfig(config, filePath, dirname(configPath));
 }
 
@@ -3375,7 +3383,7 @@ function configDataFromFileConfig(options, filePath) {
     return {};
   }
 
-  const config = readConfig(configPath, options.cwd);
+  const config = readConfig(configPath, options.cwd, options.configCache);
   return configDataFromConfig(config, filePath, dirname(configPath));
 }
 
@@ -3396,7 +3404,7 @@ function defaultLintTargets(options = {}) {
     return ["."];
   }
 
-  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd));
+  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache));
   return targets.length > 0
     ? targets.map((target) => resolveConfigPattern(target, dirname(configPath)))
     : ["."];
@@ -3488,7 +3496,9 @@ function configPathFromDirectory(directory) {
 function withTemporaryConfig(options, callback) {
   const fileConfigPath = !options.noConfig ? configPathForOptions(options) : undefined;
   const shouldMaterializeFileConfig = Boolean(fileConfigPath);
-  const fileConfig = shouldMaterializeFileConfig ? readConfig(fileConfigPath, options.cwd) : undefined;
+  const fileConfig = shouldMaterializeFileConfig
+    ? readConfig(fileConfigPath, options.cwd, options.configCache)
+    : undefined;
   const configs = [options.baseConfig, fileConfig, options.overrideConfig];
   const rules = shouldMaterializeFileConfig
     ? materializedRulesFromConfigs(...configs)
@@ -4015,7 +4025,7 @@ function ignorePatternsFromFileConfig(options, filePath) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  return ignorePatternsFromConfig(readConfig(configPath, options.cwd)).map((pattern) =>
+  return ignorePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache)).map((pattern) =>
     rebaseConfigPattern(pattern, dirname(configPath), cwd)
   );
 }

--- a/npm/utoo-lint/lib/config-loader.cjs
+++ b/npm/utoo-lint/lib/config-loader.cjs
@@ -38,17 +38,25 @@ function isFile(path) {
   }
 }
 
-function readConfig(path, cwd) {
+function readConfig(path, cwd, cache) {
   const configPath = resolvePath(cwd ?? process.cwd(), path);
-  if (isExecutableConfigPath(configPath)) {
-    return readExecutableConfig(configPath, cwd);
+  if (cache?.has(configPath)) {
+    return cache.get(configPath);
   }
 
-  try {
-    return JSON.parse(readFileSync(configPath, "utf8"));
-  } catch (error) {
-    throw configReadError(configPath, error.message);
+  let config;
+  if (isExecutableConfigPath(configPath)) {
+    config = readExecutableConfig(configPath, cwd);
+  } else {
+    try {
+      config = JSON.parse(readFileSync(configPath, "utf8"));
+    } catch (error) {
+      throw configReadError(configPath, error.message);
+    }
   }
+
+  cache?.set(configPath, config);
+  return config;
 }
 
 function isExecutableConfigPath(path) {

--- a/npm/utoo-lint/lib/config-loader.js
+++ b/npm/utoo-lint/lib/config-loader.js
@@ -39,17 +39,25 @@ function isFile(path) {
   }
 }
 
-export function readConfig(path, cwd) {
+export function readConfig(path, cwd, cache) {
   const configPath = resolvePath(cwd ?? process.cwd(), path);
-  if (isExecutableConfigPath(configPath)) {
-    return readExecutableConfig(configPath, cwd);
+  if (cache?.has(configPath)) {
+    return cache.get(configPath);
   }
 
-  try {
-    return JSON.parse(readFileSync(configPath, "utf8"));
-  } catch (error) {
-    throw configReadError(configPath, error.message);
+  let config;
+  if (isExecutableConfigPath(configPath)) {
+    config = readExecutableConfig(configPath, cwd);
+  } else {
+    try {
+      config = JSON.parse(readFileSync(configPath, "utf8"));
+    } catch (error) {
+      throw configReadError(configPath, error.message);
+    }
   }
+
+  cache?.set(configPath, config);
+  return config;
 }
 
 export function isExecutableConfigPath(path) {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -389,6 +389,34 @@ test("CLI loads utlint.config.ts and --no-config bypasses it", (t) => {
   assert.match(unconfigured.stderr, /no-debugger/);
 });
 
+test("ESM and CommonJS CLI evaluate a TypeScript config once per lint invocation", (t) => {
+  const project = createProject(t);
+  const counterPath = write(join(project, "config-load-count.txt"), "0");
+  write(
+    join(project, "utlint.config.ts"),
+    [
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      `const counterPath = ${JSON.stringify(counterPath)};`,
+      'writeFileSync(counterPath, String(Number(readFileSync(counterPath, "utf8")) + 1));',
+      'export default { rules: { "no-debugger": "off" } };',
+      ""
+    ].join("\n")
+  );
+  const firstSource = write(join(project, "src", "first.ts"), "debugger;\n");
+  const secondSource = write(join(project, "src", "second.ts"), "debugger;\n");
+
+  const options = {
+    cwd: project,
+    binary: testBinary()
+  };
+  const firstResult = runCli([firstSource, secondSource], options);
+  const secondResult = commonJSRunCli([firstSource, secondSource], options);
+
+  assert.equal(firstResult.status, 0, firstResult.stderr);
+  assert.equal(secondResult.status, 0, secondResult.stderr);
+  assert.equal(readFileSync(counterPath, "utf8"), "2");
+});
+
 test("CommonJS API discovers and loads utlint.config.ts", async (t) => {
   const project = createProject(t);
   const configPath = write(


### PR DESCRIPTION
## Summary

- cache loaded project configs for the duration of one public lint invocation
- share the invocation cache across target discovery, ignore filtering, per-file rule grouping, and temporary config materialization
- cover both ESM and CommonJS CLI entry points with a regression test

## Root cause

`utlint.config.ts` is executable and is loaded through a synchronous child process. A multi-file lint run called `readConfig` repeatedly during per-file config lookup, so the same TypeScript config was re-evaluated for every file and at several additional phases.

The cache is attached only to the invocation's internal options object. Separate `runCli`, `lintFiles`, or `lintText` calls still reload the config, so long-lived API users do not receive stale configuration.

## Impact

In the Umi repository integration that exposed this, scanning 881 files with `utlint.config.ts` dropped from about 70 seconds to about 1.1 seconds, while preserving the same 9 diagnostics.

## Validation

- `zig build -Doptimize=ReleaseFast -j1`
- `UTOO_LINT_BIN=zig-out/bin/utoo-lint pnpm --dir npm/utoo-lint test` — 63/63 passing
- Node.js 18 config-loading suite — 63/63 passing
- Umi downstream scan — 881 files, 9 diagnostics, exit code 0
