### PR TITLE
feat: improve lint output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Use machine-readable output:
 utoo-lint --format=json src
 ```
 
+The default text output groups diagnostics by file, aligns locations and
+severity, and ends with separate error and warning totals. Colors are enabled
+for interactive terminals; use `--color` to force them or `--no-color` to
+disable them (for example, in snapshot tests). JSON output remains stable for
+editor and CI integrations.
+
 ### Autofix
 
 Apply safe fixes from all enabled rules that support autofix:

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -41,6 +41,11 @@ Use machine-readable output:
 pnpm exec utoo-lint --format=json src
 ```
 
+The default terminal output groups diagnostics by file, aligns their location
+and severity, and summarizes errors and warnings separately. Color is detected
+automatically; pass `--color` to force it or `--no-color` to disable it. JSON
+output remains stable for editor and CI integrations.
+
 ## Autofix
 
 Apply safe fixes from all enabled rules that support autofix:

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -747,6 +747,14 @@ function parseUtooLintCliArgs(args = []) {
       passthroughArgs.push(arg);
       continue;
     }
+    if (arg === "--color") {
+      options.color = true;
+      continue;
+    }
+    if (arg === "--no-color") {
+      options.color = false;
+      continue;
+    }
     if (arg.startsWith("-")) {
       passthroughArgs.push(arg);
       continue;
@@ -826,7 +834,7 @@ function runCli(args = [], options = {}) {
   if (cliOptions.format === "json" || parsed.passthroughArgs.includes("--json")) {
     return completedRunResult(status, `${JSON.stringify(publicCliReport(report))}\n`, report.stderr ?? "", options);
   }
-  return completedRunResult(status, "", `${report.stderr ?? ""}${formatNativeTextReport(report)}`, options);
+  return completedRunResult(status, "", `${report.stderr ?? ""}${formatNativeTextReport(report, cliOptions)}`, options);
 }
 
 function publicCliReport(report) {
@@ -838,16 +846,80 @@ function publicCliReport(report) {
   };
 }
 
-function formatNativeTextReport(report) {
+function formatNativeTextReport(report, options = {}) {
+  const diagnostics = report.diagnostics ?? [];
+  const files = report.files ?? 0;
+  const color = shouldUseColor(options);
+
+  if (diagnostics.length === 0) {
+    return `${paint(color, "\u001b[32m", "✓")} ${pluralize(files, "file")} checked, no problems found\n`;
+  }
+
   const lines = [];
-  for (const diagnostic of report.diagnostics ?? []) {
-    const rule = diagnostic.ruleId ? ` [${diagnostic.ruleId}]` : "";
+  const locationWidth = diagnostics.reduce(
+    (width, diagnostic) => Math.max(width, diagnosticLocation(diagnostic).length),
+    0
+  );
+  let currentFile;
+
+  for (const diagnostic of diagnostics) {
+    const filePath = diagnostic.filePath ?? "<unknown>";
+    if (filePath !== currentFile) {
+      if (lines.length > 0) lines.push("");
+      lines.push(paint(color, "\u001b[1m", filePath));
+      currentFile = filePath;
+    }
+
+    const location = diagnosticLocation(diagnostic).padStart(locationWidth);
+    const severity = diagnostic.severity === "warning" || diagnostic.severity === 1 ? "warning" : "error";
+    const severityColor = severity === "error" ? "\u001b[31m" : "\u001b[33m";
+    const message = String(diagnostic.message ?? "").replace(/\s*[\r\n]+\s*/g, " ");
+    const rule = diagnostic.ruleId ? `  ${paint(color, "\u001b[2m", diagnostic.ruleId)}` : "";
     lines.push(
-      `${diagnostic.filePath}:${diagnostic.line ?? 0}:${diagnostic.column ?? 0}: ${diagnostic.severity ?? "error"}: ${diagnostic.message}${rule}`
+      `  ${paint(color, "\u001b[2m", location)}  ${paint(color, severityColor, severity.padEnd(7))}  ${message}${rule}`
     );
   }
-  lines.push(`${report.files ?? 0} file(s) checked, ${(report.diagnostics ?? []).length} diagnostic(s)`);
+
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error" || diagnostic.severity === 2).length;
+  const warnings = diagnostics.length - errors;
+  const markerColor = errors > 0 ? "\u001b[31m" : "\u001b[33m";
+  lines.push("");
+  lines.push(
+    `${paint(color, markerColor, "✖")} ${pluralize(diagnostics.length, "problem")} (${pluralize(errors, "error")}, ${pluralize(warnings, "warning")})`
+  );
+
+  const fixable = diagnostics.filter(diagnosticIsFixable).length;
+  const fixRequested = options.fix || options.extraArgs?.includes("--fix") || options.extraArgs?.includes("--fix-dry-run");
+  if (fixable > 0 && !fixRequested) {
+    lines.push(`  ${pluralize(fixable, "problem")} potentially fixable with the \`--fix\` option.`);
+  }
+  lines.push(`  ${pluralize(files, "file")} checked`);
   return `${lines.join("\n")}\n`;
+}
+
+function diagnosticLocation(diagnostic) {
+  return `${diagnostic.line ?? 0}:${diagnostic.column ?? 0}`;
+}
+
+function diagnosticIsFixable(diagnostic) {
+  return Boolean(diagnostic.fix) || (Array.isArray(diagnostic.fixes) && diagnostic.fixes.length > 0);
+}
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function paint(enabled, code, text) {
+  return enabled ? `${code}${text}\u001b[0m` : text;
+}
+
+function shouldUseColor(options = {}) {
+  if (options.color === true) return true;
+  if (options.color === false) return false;
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) return false;
+  if ((env.FORCE_COLOR && env.FORCE_COLOR !== "0") || (env.CLICOLOR_FORCE && env.CLICOLOR_FORCE !== "0")) return true;
+  return Boolean(process.stderr.isTTY);
 }
 
 function runFishlint(args = [], options = {}) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -88,6 +88,7 @@ export interface LintOptions {
   threads?: number;
   rules?: string[] | string;
   format?: "text" | "json" | string;
+  color?: boolean;
   config?: string;
   configFile?: string;
   noConfig?: boolean;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -2583,6 +2583,14 @@ function parseUtooLintCliArgs(args = []) {
       passthroughArgs.push(arg);
       continue;
     }
+    if (arg === "--color") {
+      options.color = true;
+      continue;
+    }
+    if (arg === "--no-color") {
+      options.color = false;
+      continue;
+    }
     if (arg.startsWith("-")) {
       passthroughArgs.push(arg);
       continue;
@@ -2662,7 +2670,7 @@ export function runCli(args = [], options = {}) {
   if (cliOptions.format === "json" || parsed.passthroughArgs.includes("--json")) {
     return completedRunResult(status, `${JSON.stringify(publicCliReport(report))}\n`, report.stderr ?? "", options);
   }
-  return completedRunResult(status, "", `${report.stderr ?? ""}${formatNativeTextReport(report)}`, options);
+  return completedRunResult(status, "", `${report.stderr ?? ""}${formatNativeTextReport(report, cliOptions)}`, options);
 }
 
 function publicCliReport(report) {
@@ -2674,16 +2682,80 @@ function publicCliReport(report) {
   };
 }
 
-function formatNativeTextReport(report) {
+function formatNativeTextReport(report, options = {}) {
+  const diagnostics = report.diagnostics ?? [];
+  const files = report.files ?? 0;
+  const color = shouldUseColor(options);
+
+  if (diagnostics.length === 0) {
+    return `${paint(color, "\u001b[32m", "✓")} ${pluralize(files, "file")} checked, no problems found\n`;
+  }
+
   const lines = [];
-  for (const diagnostic of report.diagnostics ?? []) {
-    const rule = diagnostic.ruleId ? ` [${diagnostic.ruleId}]` : "";
+  const locationWidth = diagnostics.reduce(
+    (width, diagnostic) => Math.max(width, diagnosticLocation(diagnostic).length),
+    0
+  );
+  let currentFile;
+
+  for (const diagnostic of diagnostics) {
+    const filePath = diagnostic.filePath ?? "<unknown>";
+    if (filePath !== currentFile) {
+      if (lines.length > 0) lines.push("");
+      lines.push(paint(color, "\u001b[1m", filePath));
+      currentFile = filePath;
+    }
+
+    const location = diagnosticLocation(diagnostic).padStart(locationWidth);
+    const severity = diagnostic.severity === "warning" || diagnostic.severity === 1 ? "warning" : "error";
+    const severityColor = severity === "error" ? "\u001b[31m" : "\u001b[33m";
+    const message = String(diagnostic.message ?? "").replace(/\s*[\r\n]+\s*/g, " ");
+    const rule = diagnostic.ruleId ? `  ${paint(color, "\u001b[2m", diagnostic.ruleId)}` : "";
     lines.push(
-      `${diagnostic.filePath}:${diagnostic.line ?? 0}:${diagnostic.column ?? 0}: ${diagnostic.severity ?? "error"}: ${diagnostic.message}${rule}`
+      `  ${paint(color, "\u001b[2m", location)}  ${paint(color, severityColor, severity.padEnd(7))}  ${message}${rule}`
     );
   }
-  lines.push(`${report.files ?? 0} file(s) checked, ${(report.diagnostics ?? []).length} diagnostic(s)`);
+
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error" || diagnostic.severity === 2).length;
+  const warnings = diagnostics.length - errors;
+  const markerColor = errors > 0 ? "\u001b[31m" : "\u001b[33m";
+  lines.push("");
+  lines.push(
+    `${paint(color, markerColor, "✖")} ${pluralize(diagnostics.length, "problem")} (${pluralize(errors, "error")}, ${pluralize(warnings, "warning")})`
+  );
+
+  const fixable = diagnostics.filter(diagnosticIsFixable).length;
+  const fixRequested = options.fix || options.extraArgs?.includes("--fix") || options.extraArgs?.includes("--fix-dry-run");
+  if (fixable > 0 && !fixRequested) {
+    lines.push(`  ${pluralize(fixable, "problem")} potentially fixable with the \`--fix\` option.`);
+  }
+  lines.push(`  ${pluralize(files, "file")} checked`);
   return `${lines.join("\n")}\n`;
+}
+
+function diagnosticLocation(diagnostic) {
+  return `${diagnostic.line ?? 0}:${diagnostic.column ?? 0}`;
+}
+
+function diagnosticIsFixable(diagnostic) {
+  return Boolean(diagnostic.fix) || (Array.isArray(diagnostic.fixes) && diagnostic.fixes.length > 0);
+}
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function paint(enabled, code, text) {
+  return enabled ? `${code}${text}\u001b[0m` : text;
+}
+
+function shouldUseColor(options = {}) {
+  if (options.color === true) return true;
+  if (options.color === false) return false;
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) return false;
+  if ((env.FORCE_COLOR && env.FORCE_COLOR !== "0") || (env.CLICOLOR_FORCE && env.CLICOLOR_FORCE !== "0")) return true;
+  return Boolean(process.stderr.isTTY);
 }
 
 export function runFishlint(args = [], options = {}) {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -575,6 +575,60 @@ test("raw native binary reports configured warnings without failing", (t) => {
   assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.severity), ["warning"]);
 });
 
+test("raw native binary groups text diagnostics and supports color overrides", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), 'debugger;\nconsole.log("x");\n');
+
+  const plain = spawnSync(
+    testBinary(),
+    ["--no-color", "--no-config", "--rules=no-debugger,no-console", sourcePath],
+    { cwd: project, encoding: "utf8" }
+  );
+  assert.equal(plain.status, 0, plain.stderr);
+  assert.doesNotMatch(plain.stderr, /\u001b\[/);
+  assert.equal(plain.stderr.match(new RegExp(sourcePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length, 1);
+  assert.match(plain.stderr, /^\s+1:1\s+warning\s+Unexpected debugger statement\.\s+no-debugger$/m);
+  assert.match(plain.stderr, /^\s+2:1\s+warning\s+Unexpected console statement\.\s+no-console$/m);
+  assert.match(plain.stderr, /✖ 2 problems \(0 errors, 2 warnings\)/);
+
+  const colored = spawnSync(
+    testBinary(),
+    ["--color", "--no-config", "--rules=no-debugger", sourcePath],
+    { cwd: project, encoding: "utf8", env: { ...process.env, NO_COLOR: "1" } }
+  );
+  assert.equal(colored.status, 0, colored.stderr);
+  assert.match(colored.stderr, /\u001b\[1m/);
+  assert.match(colored.stderr, /\u001b\[33mwarning/);
+
+  write(join(project, "utlint.config.json"), '{ "rules": { "no-debugger": "error", "no-console": "warn" } }\n');
+  const mixed = spawnSync(testBinary(), ["--no-color", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  assert.equal(mixed.status, 1, mixed.stderr);
+  assert.match(mixed.stderr, /✖ 2 problems \(1 error, 1 warning\)/);
+});
+
+test("raw native binary gives clean and fixable text summaries", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "const value = 1;\n");
+
+  const clean = spawnSync(testBinary(), ["--no-color", "--no-config", "--rules=no-debugger", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  assert.equal(clean.status, 0, clean.stderr);
+  assert.equal(clean.stderr, "✓ 1 file checked, no problems found\n");
+
+  writeFileSync(sourcePath, "const value = 1;;\n");
+  const fixable = spawnSync(testBinary(), ["--no-color", "--no-config", "--rules=no-extra-semi", sourcePath], {
+    cwd: project,
+    encoding: "utf8"
+  });
+  assert.equal(fixable.status, 0, fixable.stderr);
+  assert.match(fixable.stderr, /1 problem potentially fixable with the `--fix` option\./);
+});
+
 test("raw native binary applies array and numeric config severities", (t) => {
   const project = createProject(t);
   const sourcePath = write(join(project, "index.js"), "debugger;\n");
@@ -784,6 +838,72 @@ test("--rules overrides the selected project config", (t) => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stderr, /no-debugger/);
+});
+
+test("utoo-lint text output groups diagnostics by file and summarizes severities", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "src", "index.js"), 'debugger;\nconsole.log("x");\n');
+
+  const result = runCli(
+    ["--no-color", "--no-config", "--rules=no-debugger,no-console", sourcePath],
+    { cwd: project, binary: testBinary(), encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+  assert.doesNotMatch(result.stderr, /\u001b\[/);
+  assert.equal(result.stderr.match(new RegExp(sourcePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length, 1);
+  assert.match(result.stderr, /^\s+1:1\s+warning\s+Unexpected debugger statement\.\s+no-debugger$/m);
+  assert.match(result.stderr, /^\s+2:1\s+warning\s+Unexpected console statement\.\s+no-console$/m);
+  assert.match(result.stderr, /✖ 2 problems \(0 errors, 2 warnings\)/);
+  assert.match(result.stderr, /1 file checked/);
+
+  write(join(project, "utlint.config.json"), '{ "rules": { "no-debugger": "error", "no-console": "warn" } }\n');
+  const mixed = runCli(["--no-color", sourcePath], {
+    cwd: project,
+    binary: testBinary(),
+    encoding: "utf8"
+  });
+  assert.equal(mixed.status, 1, mixed.stderr);
+  assert.match(mixed.stderr, /✖ 2 problems \(1 error, 1 warning\)/);
+});
+
+test("utoo-lint text output reports clean runs and supports forced color", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "const value = 1;\n");
+
+  const clean = runCli(["--no-color", "--no-config", "--rules=no-debugger", sourcePath], {
+    cwd: project,
+    binary: testBinary(),
+    encoding: "utf8"
+  });
+  assert.equal(clean.status, 0, clean.stderr);
+  assert.equal(clean.stderr, "✓ 1 file checked, no problems found\n");
+
+  writeFileSync(sourcePath, "debugger;\n");
+  const colored = runCli(["--color", "--no-config", "--rules=no-debugger", sourcePath], {
+    cwd: project,
+    binary: testBinary(),
+    encoding: "utf8",
+    env: { NO_COLOR: "1" }
+  });
+  assert.equal(colored.status, 0, colored.stderr);
+  assert.match(colored.stderr, /\u001b\[1m/);
+  assert.match(colored.stderr, /\u001b\[33mwarning/);
+});
+
+test("utoo-lint text output points out autofixable problems", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "index.js"), "const value = 1;;\n");
+
+  const result = runCli(["--no-color", "--no-config", "--rules=no-extra-semi", sourcePath], {
+    cwd: project,
+    binary: testBinary(),
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /1 problem potentially fixable with the `--fix` option\./);
 });
 
 test("later flat config entries can turn a rule back on", async (t) => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,12 +8,14 @@ const Stats = struct {
     files: usize = 0,
     diagnostics: usize = 0,
     errors: usize = 0,
+    fixable: usize = 0,
     fixed: usize = 0,
 
     fn add(self: *Stats, other: Stats) void {
         self.files += other.files;
         self.diagnostics += other.diagnostics;
         self.errors += other.errors;
+        self.fixable += other.fixable;
         self.fixed += other.fixed;
     }
 };
@@ -67,6 +69,7 @@ const WorkQueue = struct {
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
+    use_color: bool,
     next_index: std.atomic.Value(usize) = .init(0),
     print_mutex: std.Io.Mutex = .init,
 };
@@ -105,6 +108,7 @@ pub fn main(init: std.process.Init) !void {
     var thread_count_override: ?usize = null;
     var output_format: OutputFormat = .text;
     var fix_mode: FixMode = .none;
+    var color_override: ?bool = null;
     var targets: std.ArrayList([]const u8) = .empty;
     defer targets.deinit(allocator);
 
@@ -129,6 +133,10 @@ pub fn main(init: std.process.Init) !void {
             thread_count_override = parsed;
         } else if (std.mem.eql(u8, arg, "--json")) {
             output_format = .json;
+        } else if (std.mem.eql(u8, arg, "--color")) {
+            color_override = true;
+        } else if (std.mem.eql(u8, arg, "--no-color")) {
+            color_override = false;
         } else if (std.mem.eql(u8, arg, "--fix")) {
             if (fix_mode == .dry_run) {
                 std.debug.print("utoo-lint: --fix and --fix-dry-run cannot be used together\n", .{});
@@ -1254,17 +1262,9 @@ pub fn main(init: std.process.Init) !void {
         try lintFilesJson(allocator, io, files.items, options, &rule_severities, fix_mode, &stats, &json_diagnostics, &json_outputs);
         try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_outputs.items);
     } else {
-        try lintFiles(allocator, io, files.items, options, &rule_severities, fix_mode, thread_count_override, &stats);
-
-        if (fix_mode == .none) {
-            std.debug.print("{d} file(s) checked, {d} diagnostic(s)\n", .{ stats.files, stats.diagnostics });
-        } else {
-            std.debug.print("{d} file(s) checked, {d} diagnostic(s), {d} fixed\n", .{
-                stats.files,
-                stats.diagnostics,
-                stats.fixed,
-            });
-        }
+        const use_color = color_override orelse detectColorSupport(io, init.environ_map.*);
+        try lintFiles(allocator, io, files.items, options, &rule_severities, fix_mode, thread_count_override, use_color, &stats);
+        printTextSummary(stats, fix_mode, use_color);
     }
 
     if (stats.errors > 0) {
@@ -1820,6 +1820,7 @@ fn lintFiles(
     rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
     thread_count_override: ?usize,
+    use_color: bool,
     stats: *Stats,
 ) !void {
     if (files.len == 0) return;
@@ -1827,7 +1828,7 @@ fn lintFiles(
     const worker_count = @min(files.len, thread_count_override orelse (std.Thread.getCpuCount() catch 1));
     if (worker_count <= 1) {
         for (files) |file| {
-            try lintFile(std.heap.smp_allocator, io, file, options, rule_severities, fix_mode, stats, null);
+            try lintFile(std.heap.smp_allocator, io, file, options, rule_severities, fix_mode, use_color, stats, null);
         }
         return;
     }
@@ -1838,6 +1839,7 @@ fn lintFiles(
         .options = options,
         .rule_severities = rule_severities,
         .fix_mode = fix_mode,
+        .use_color = use_color,
     };
 
     const threads = try allocator.alloc(std.Thread, worker_count);
@@ -1906,6 +1908,7 @@ fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
             queue.options,
             queue.rule_severities,
             queue.fix_mode,
+            queue.use_color,
             &result.stats,
             &queue.print_mutex,
         ) catch |err| {
@@ -1965,6 +1968,7 @@ fn lintFile(
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
     fix_mode: FixMode,
+    use_color: bool,
     stats: *Stats,
     print_mutex: ?*std.Io.Mutex,
 ) !void {
@@ -1981,7 +1985,7 @@ fn lintFile(
     if (fix_mode == .none) {
         var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
         defer result.deinit(allocator);
-        return printResultDiagnostics(io, print_mutex, path, source, result, rule_severities, stats);
+        return printResultDiagnostics(allocator, io, print_mutex, path, source, result, rule_severities, use_color, stats);
     }
 
     var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
@@ -1994,35 +1998,62 @@ fn lintFile(
         }
     }
 
-    printResultDiagnostics(io, print_mutex, path, fixed.output, fixed.result, rule_severities, stats);
+    try printResultDiagnostics(allocator, io, print_mutex, path, fixed.output, fixed.result, rule_severities, use_color, stats);
 }
 
 fn printResultDiagnostics(
+    allocator: std.mem.Allocator,
     io: std.Io,
     print_mutex: ?*std.Io.Mutex,
     path: []const u8,
     source: []const u8,
     result: lint.Result,
     rule_severities: *const RuleSeverityMap,
+    use_color: bool,
     stats: *Stats,
-) void {
+) !void {
+    if (result.diagnostics.len == 0) return;
+
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    const writer = &output.writer;
+    try writeStyled(writer, use_color, "\x1b[1m", path);
+    try writer.writeByte('\n');
+
+    var location_width: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        const position = lint.offsetToLineColumn(source, diagnostic.span.start);
+        location_width = @max(location_width, decimalDigits(position.line) + 1 + decimalDigits(position.column));
+    }
+
     for (result.diagnostics) |diagnostic| {
         const severity = effectiveDiagnosticSeverity(rule_severities, diagnostic);
         const position = lint.offsetToLineColumn(source, diagnostic.span.start);
-        printLocked(io, print_mutex, "{s}:{d}:{d}: {s}: {s} [{s}]\n", .{
-            path,
-            position.line,
-            position.column,
-            severity.toString(),
-            diagnostic.message,
-            diagnostic.rule_id,
-        });
+        const current_width = decimalDigits(position.line) + 1 + decimalDigits(position.column);
+        try writer.writeAll("  ");
+        try writer.splatByteAll(' ', location_width - current_width);
+        if (use_color) try writer.writeAll("\x1b[2m");
+        try writer.print("{d}:{d}", .{ position.line, position.column });
+        if (use_color) try writer.writeAll("\x1b[0m");
+        try writer.writeAll("  ");
+        if (use_color) try writer.writeAll(if (severity == .@"error") "\x1b[31m" else "\x1b[33m");
+        try writer.writeAll(severity.toString());
+        if (use_color) try writer.writeAll("\x1b[0m");
+        try writer.splatByteAll(' ', 9 - severity.toString().len);
+        try writeSingleLine(writer, diagnostic.message);
+        try writer.writeAll("  ");
+        try writeStyled(writer, use_color, "\x1b[2m", diagnostic.rule_id);
+        try writer.writeByte('\n');
 
         stats.diagnostics += 1;
+        if (diagnostic.fixes.len > 0) stats.fixable += 1;
         if (severity == .@"error") {
             stats.errors += 1;
         }
     }
+    try writer.writeByte('\n');
+
+    printLocked(io, print_mutex, "{s}", .{output.writer.buffered()});
 }
 
 fn appendJsonDiagnostic(
@@ -2174,6 +2205,85 @@ fn writeJsonReport(
     try stdout.flush();
 }
 
+fn detectColorSupport(io: std.Io, environ: std.process.Environ.Map) bool {
+    if (environ.get("NO_COLOR") != null or environ.get("NODE_DISABLE_COLORS") != null) return false;
+    if (nonZeroEnv(environ.get("FORCE_COLOR")) or nonZeroEnv(environ.get("CLICOLOR_FORCE"))) return true;
+    std.Io.File.stderr().enableAnsiEscapeCodes(io) catch return false;
+    return true;
+}
+
+fn nonZeroEnv(value: ?[]const u8) bool {
+    const present = value orelse return false;
+    return present.len > 0 and !std.mem.eql(u8, present, "0");
+}
+
+fn printTextSummary(stats: Stats, fix_mode: FixMode, use_color: bool) void {
+    if (stats.diagnostics == 0) {
+        if (use_color) std.debug.print("\x1b[32m", .{});
+        std.debug.print("✓", .{});
+        if (use_color) std.debug.print("\x1b[0m", .{});
+        std.debug.print(" {d} file{s} checked, no problems found\n", .{ stats.files, pluralSuffix(stats.files) });
+        if (stats.fixed > 0) {
+            std.debug.print("  {d} problem{s} fixed.\n", .{ stats.fixed, pluralSuffix(stats.fixed) });
+        }
+        return;
+    }
+
+    if (use_color) std.debug.print("{s}", .{if (stats.errors > 0) "\x1b[31m" else "\x1b[33m"});
+    std.debug.print("✖", .{});
+    if (use_color) std.debug.print("\x1b[0m", .{});
+    const warnings = stats.diagnostics - stats.errors;
+    std.debug.print(" {d} problem{s} ({d} error{s}, {d} warning{s})\n", .{
+        stats.diagnostics,
+        pluralSuffix(stats.diagnostics),
+        stats.errors,
+        pluralSuffix(stats.errors),
+        warnings,
+        pluralSuffix(warnings),
+    });
+    if (stats.fixable > 0 and fix_mode == .none) {
+        std.debug.print("  {d} problem{s} potentially fixable with the `--fix` option.\n", .{
+            stats.fixable,
+            pluralSuffix(stats.fixable),
+        });
+    }
+    if (stats.fixed > 0) {
+        std.debug.print("  {d} problem{s} fixed.\n", .{ stats.fixed, pluralSuffix(stats.fixed) });
+    }
+    std.debug.print("  {d} file{s} checked\n", .{ stats.files, pluralSuffix(stats.files) });
+}
+
+fn pluralSuffix(count: usize) []const u8 {
+    return if (count == 1) "" else "s";
+}
+
+fn decimalDigits(value: usize) usize {
+    var number = value;
+    var digits: usize = 1;
+    while (number >= 10) : (number /= 10) digits += 1;
+    return digits;
+}
+
+fn writeStyled(writer: *std.Io.Writer, use_color: bool, style: []const u8, text_value: []const u8) !void {
+    if (use_color) try writer.writeAll(style);
+    try writer.writeAll(text_value);
+    if (use_color) try writer.writeAll("\x1b[0m");
+}
+
+fn writeSingleLine(writer: *std.Io.Writer, message: []const u8) !void {
+    var index: usize = 0;
+    while (index < message.len) {
+        const line_end = std.mem.indexOfAnyPos(u8, message, index, "\r\n") orelse {
+            try writer.writeAll(message[index..]);
+            return;
+        };
+        try writer.writeAll(message[index..line_end]);
+        index = line_end;
+        while (index < message.len and (message[index] == '\r' or message[index] == '\n' or message[index] == ' ' or message[index] == '\t')) : (index += 1) {}
+        if (index < message.len and line_end > 0 and message[line_end - 1] != ' ') try writer.writeByte(' ');
+    }
+}
+
 fn printLocked(
     io: std.Io,
     mutex: ?*std.Io.Mutex,
@@ -2205,6 +2315,8 @@ fn printHelp() void {
         \\  --no-config              Do not read utlint.config.json (or legacy config names)
         \\  --format=text|json       Select diagnostic output format
         \\  --json                   Alias for --format=json
+        \\  --color                  Force colors in text output
+        \\  --no-color               Disable colors in text output
         \\  --fix                    Apply autofixes and write files to disk
         \\  --fix-dry-run            Apply autofixes without writing files
         \\  --threads=N              Number of worker threads to use


### PR DESCRIPTION
## Before / After

### Before

![Before: diagnostics were printed as long lines with repeated absolute paths](https://github.com/user-attachments/assets/b57696d0-d438-431c-ada5-c9ccd910ad5f)

### After

![After: diagnostics are grouped by file with aligned columns and a summary](https://github.com/user-attachments/assets/f23e96e5-d5ff-4f67-abd9-93d26042cfee)

## Summary

The previous text reporter printed every diagnostic as one long line, repeatedly including the full file path. This made large lint runs difficult to scan, caused long messages to wrap awkwardly, and did not distinguish errors from warnings in the final summary.

This PR updates both the native binary and npm CLI output to follow familiar ESLint-style conventions:

- group diagnostics by file and align location, severity, message, and rule columns
- summarize errors, warnings, checked files, fixed problems, and potentially fixable problems
- detect terminal color automatically and add `--color` / `--no-color` overrides
- keep ESM, CommonJS, and native CLI text output consistent
- preserve the existing JSON output for editor and CI integrations
- document the new behavior and add regression coverage for clean, mixed-severity, colored, and fixable runs

## Test Plan

- `zig build test`
  - Zig unit tests pass
  - 8 rule snapshots pass
- `pnpm --dir npm/utoo-lint test`
  - 68 tests pass
- `git diff --check`
- manually verified grouped native output and unchanged `--format=json` output