### PR TITLE
fix: count JSX member roots as variable references

### DIFF
--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -696,6 +696,33 @@ test("raw native binary counts JSX tags as uses for isolated unused-variable rul
   }
 });
 
+test("raw native binary counts JSX member roots as uses for isolated unused-variable rules", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(
+    join(project, "fixture.tsx"),
+    [
+      'import { motion } from "framer-motion";',
+      "",
+      "export function App() {",
+      "  return <motion.div>Utoo</motion.div>;",
+      "}",
+      ""
+    ].join("\n")
+  );
+
+  for (const rule of ["no-unused-vars", "@typescript-eslint/no-unused-vars"]) {
+    const result = spawnSync(
+      testBinary(),
+      ["--no-config", `--rules=${rule}`, "--format=json", sourcePath],
+      { cwd: project, encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(report.diagnostics, [], rule);
+  }
+});
+
 test("raw native binary keeps parse errors fatal with an empty rules config", (t) => {
   const project = createProject(t);
   write(join(project, "utlint.config.json"));

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -10,6 +10,7 @@ pub const id = "no-unused-vars";
 
 const SymbolId = traverser.semantic.SymbolId;
 const IgnoredDecls = std.AutoHashMap(ast.NodeIndex, void);
+const UsedSymbols = std.AutoHashMap(SymbolId, void);
 
 pub const Options = struct {
     rule_id: []const u8 = id,
@@ -91,11 +92,19 @@ pub fn runWithOptions(
     symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
+    var jsx_member_uses = UsedSymbols.init(allocator);
+    defer jsx_member_uses.deinit();
+    var jsx_member_visitor = JSXMemberUseVisitor{
+        .symbol_table = symbol_table,
+        .used_symbols = &jsx_member_uses,
+    };
+    try traverser.basic.traverse(JSXMemberUseVisitor, tree, &jsx_member_visitor);
+
     var parameters: std.ArrayList(Parameter) = .empty;
     defer parameters.deinit(allocator);
 
     if (options.check_parameters and options.args_after_used) {
-        try collectParameters(allocator, tree, symbol_table, &parameters);
+        try collectParameters(allocator, tree, symbol_table, &jsx_member_uses, &parameters);
         std.mem.sort(Parameter, parameters.items, {}, lessThanParameter);
     }
 
@@ -150,7 +159,7 @@ pub fn runWithOptions(
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
 
-        if (symbol_table.isReferenced(entry.id)) {
+        if (symbol_table.isReferenced(entry.id) or jsx_member_uses.contains(entry.id)) {
             if (options.report_used_ignore_pattern and isReportedUsedIgnoredName(name, flags, decls, &destructured_array_ignored_decls, options)) {
                 try core.addDiagnosticFmt(
                     allocator,
@@ -304,6 +313,7 @@ fn collectParameters(
     allocator: Allocator,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+    jsx_member_uses: *const UsedSymbols,
     parameters: *std.ArrayList(Parameter),
 ) Allocator.Error!void {
     var iter = symbol_table.iterSymbols();
@@ -318,9 +328,45 @@ fn collectParameters(
             .symbol_id = entry.id,
             .scope = symbol.scope,
             .start = tree.span(decls[0]).start,
-            .used = symbol_table.isReferenced(entry.id),
+            .used = symbol_table.isReferenced(entry.id) or jsx_member_uses.contains(entry.id),
         });
     }
+}
+
+const JSXMemberUseVisitor = struct {
+    symbol_table: traverser.semantic.SymbolTable,
+    used_symbols: *UsedSymbols,
+
+    pub fn enter_jsx_opening_element(
+        self: *JSXMemberUseVisitor,
+        opening: ast.JSXOpeningElement,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const member = switch (ctx.tree.data(opening.name)) {
+            .jsx_member_expression => |member| member,
+            else => return .proceed,
+        };
+        const root = jsxMemberRoot(ctx.tree, member.object) orelse return .proceed;
+        const identifier = ctx.tree.data(root).jsx_identifier;
+        const name = ctx.tree.string(identifier.name);
+        const scope = self.symbol_table.scopeOf(root);
+        const symbol_id = self.symbol_table.resolveValue(scope, name) orelse return .proceed;
+        try self.used_symbols.put(symbol_id, {});
+        return .proceed;
+    }
+};
+
+fn jsxMemberRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .jsx_identifier => return current,
+            .jsx_member_expression => |member| current = member.object,
+            else => return null,
+        }
+    }
+    return null;
 }
 
 fn lessThanParameter(_: void, a: Parameter, b: Parameter) bool {

--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -10,7 +10,6 @@ pub const id = "no-unused-vars";
 
 const SymbolId = traverser.semantic.SymbolId;
 const IgnoredDecls = std.AutoHashMap(ast.NodeIndex, void);
-const UsedSymbols = std.AutoHashMap(SymbolId, void);
 
 pub const Options = struct {
     rule_id: []const u8 = id,
@@ -92,19 +91,11 @@ pub fn runWithOptions(
     symbol_table: traverser.semantic.SymbolTable,
     options: Options,
 ) Allocator.Error!void {
-    var jsx_member_uses = UsedSymbols.init(allocator);
-    defer jsx_member_uses.deinit();
-    var jsx_member_visitor = JSXMemberUseVisitor{
-        .symbol_table = symbol_table,
-        .used_symbols = &jsx_member_uses,
-    };
-    try traverser.basic.traverse(JSXMemberUseVisitor, tree, &jsx_member_visitor);
-
     var parameters: std.ArrayList(Parameter) = .empty;
     defer parameters.deinit(allocator);
 
     if (options.check_parameters and options.args_after_used) {
-        try collectParameters(allocator, tree, symbol_table, &jsx_member_uses, &parameters);
+        try collectParameters(allocator, tree, symbol_table, &parameters);
         std.mem.sort(Parameter, parameters.items, {}, lessThanParameter);
     }
 
@@ -159,7 +150,7 @@ pub fn runWithOptions(
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
 
-        if (symbol_table.isReferenced(entry.id) or jsx_member_uses.contains(entry.id)) {
+        if (symbol_table.isReferenced(entry.id)) {
             if (options.report_used_ignore_pattern and isReportedUsedIgnoredName(name, flags, decls, &destructured_array_ignored_decls, options)) {
                 try core.addDiagnosticFmt(
                     allocator,
@@ -313,7 +304,6 @@ fn collectParameters(
     allocator: Allocator,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
-    jsx_member_uses: *const UsedSymbols,
     parameters: *std.ArrayList(Parameter),
 ) Allocator.Error!void {
     var iter = symbol_table.iterSymbols();
@@ -328,45 +318,9 @@ fn collectParameters(
             .symbol_id = entry.id,
             .scope = symbol.scope,
             .start = tree.span(decls[0]).start,
-            .used = symbol_table.isReferenced(entry.id) or jsx_member_uses.contains(entry.id),
+            .used = symbol_table.isReferenced(entry.id),
         });
     }
-}
-
-const JSXMemberUseVisitor = struct {
-    symbol_table: traverser.semantic.SymbolTable,
-    used_symbols: *UsedSymbols,
-
-    pub fn enter_jsx_opening_element(
-        self: *JSXMemberUseVisitor,
-        opening: ast.JSXOpeningElement,
-        _: ast.NodeIndex,
-        ctx: *traverser.basic.Ctx,
-    ) Allocator.Error!traverser.Action {
-        const member = switch (ctx.tree.data(opening.name)) {
-            .jsx_member_expression => |member| member,
-            else => return .proceed,
-        };
-        const root = jsxMemberRoot(ctx.tree, member.object) orelse return .proceed;
-        const identifier = ctx.tree.data(root).jsx_identifier;
-        const name = ctx.tree.string(identifier.name);
-        const scope = self.symbol_table.scopeOf(root);
-        const symbol_id = self.symbol_table.resolveValue(scope, name) orelse return .proceed;
-        try self.used_symbols.put(symbol_id, {});
-        return .proceed;
-    }
-};
-
-fn jsxMemberRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
-    var current = index;
-    while (current != .null) {
-        switch (tree.data(current)) {
-            .jsx_identifier => return current,
-            .jsx_member_expression => |member| current = member.object,
-            else => return null,
-        }
-    }
-    return null;
 }
 
 fn lessThanParameter(_: void, a: Parameter, b: Parameter) bool {

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -91,18 +91,6 @@ pub const SymbolTable = struct {
         return self.model.lookup(scope, name, .any);
     }
 
-    pub inline fn scopeOf(self: SymbolTable, node: ast.NodeIndex) yuku_semantic.ScopeId {
-        return self.model.scopeOf(node);
-    }
-
-    pub fn resolveValue(
-        self: SymbolTable,
-        scope: yuku_semantic.ScopeId,
-        name: []const u8,
-    ) ?yuku_semantic.SymbolId {
-        return self.model.lookup(scope, name, .value);
-    }
-
     pub inline fn referenceSymbol(self: SymbolTable, id: yuku_semantic.ReferenceId) yuku_semantic.SymbolId {
         return self.model.reference(id).symbol;
     }

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -91,6 +91,18 @@ pub const SymbolTable = struct {
         return self.model.lookup(scope, name, .any);
     }
 
+    pub inline fn scopeOf(self: SymbolTable, node: ast.NodeIndex) yuku_semantic.ScopeId {
+        return self.model.scopeOf(node);
+    }
+
+    pub fn resolveValue(
+        self: SymbolTable,
+        scope: yuku_semantic.ScopeId,
+        name: []const u8,
+    ) ?yuku_semantic.SymbolId {
+        return self.model.lookup(scope, name, .value);
+    }
+
     pub inline fn referenceSymbol(self: SymbolTable, id: yuku_semantic.ReferenceId) yuku_semantic.SymbolId {
         return self.model.reference(id).symbol;
     }

--- a/tests/rules/react_jsx_uses_vars.zig
+++ b/tests/rules/react_jsx_uses_vars.zig
@@ -72,6 +72,49 @@ test "component imports used only as JSX tags are not unused" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.typescript_eslint_no_unused_vars.id));
 }
 
+test "lowercase JSX member roots are variable references" {
+    const source =
+        \\import { motion } from "framer-motion";
+        \\
+        \\export function App() {
+        \\  return <motion.div>Utoo</motion.div>;
+        \\}
+    ;
+
+    var eslint_options = lint.Options.allDisabled();
+    eslint_options.no_unused_vars = true;
+    var eslint_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", eslint_options);
+    defer eslint_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(eslint_result, lint.rules.no_unused_vars.id));
+
+    var typescript_options = lint.Options.allDisabled();
+    typescript_options.typescript_eslint_no_unused_vars = true;
+    var typescript_result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", typescript_options);
+    defer typescript_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(typescript_result, lint.rules.typescript_eslint_no_unused_vars.id));
+}
+
+test "JSX member roots use the nearest lexical binding" {
+    const source =
+        \\import { motion } from "framer-motion";
+        \\
+        \\export function App() {
+        \\  const motion = { div: () => null };
+        \\  return <motion.div>Utoo</motion.div>;
+        \\}
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.typescript_eslint_no_unused_vars = true;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        helpers.countRule(result, lint.rules.typescript_eslint_no_unused_vars.id),
+    );
+}
+
 test "does not treat lowercase DOM JSX as variable usage" {
     const source =
         \\const div = 1;


### PR DESCRIPTION
## Summary

- update the vendored Yuku revision to include yuku-toolchain/yuku#180
- count lowercase JSX member-expression roots such as `motion` in `<motion.div>` as variable uses through Yuku's semantic references
- cover both unused-variable rules through unit and raw CLI regressions

## Root cause

Yuku records direct capitalized JSX tags as references, but its previous JSX binder applied the capitalization check to member expressions too. As a result, a lowercase member root such as `motion` never appeared in the symbol's use list even though `<motion.div>` is a value reference.

yuku-toolchain/yuku#180 fixes the binder to record member roots regardless of casing while keeping direct lowercase intrinsic tags such as `<div>` unbound. This PR updates the vendored Yuku revision and relies on that semantic reference directly, without a utoo-lint compatibility workaround.

## Validation

- `zig build test --summary all` — 1872/1872 tests passed
- `pnpm --dir npm/utoo-lint test` — 71/71 tests passed
- `zig build --summary all` — succeeded

Closes #1045
