### PR TITLE
feat: type the frontend config preset

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,22 @@ export default defineConfig({
 });
 ```
 
+The packaged frontend preset has a typed export and can be extended directly
+without copying its JSON file or asserting its rule types:
+
+```ts
+import { defineConfig } from "@utoo/lint/config";
+import frontend from "@utoo/lint/configs/frontend";
+
+export default defineConfig({
+  ...frontend,
+  rules: {
+    ...frontend.rules,
+    "no-console": "off",
+  },
+});
+```
+
 `defineConfig()` accepts config objects and flat config arrays and returns a
 flat array. It also provides editor completion and compile-time checking from
 the exported configuration types. A TypeScript config is trusted executable

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -114,6 +114,21 @@ export default defineConfig({
 });
 ```
 
+The packaged frontend preset is also available as a typed config import:
+
+```ts
+import { defineConfig } from "@utoo/lint/config";
+import frontend from "@utoo/lint/configs/frontend";
+
+export default defineConfig({
+  ...frontend,
+  rules: {
+    ...frontend.rules,
+    "no-console": "off",
+  },
+});
+```
+
 The two canonical names represent one active config and are not implicitly
 merged. For the npm/Node entry point, discovery is nearest-directory-first.
 Within the same directory, `utlint.config.ts` takes precedence over

--- a/npm/utoo-lint/configs/frontend.d.ts
+++ b/npm/utoo-lint/configs/frontend.d.ts
@@ -1,0 +1,8 @@
+import type { ConfigObject } from "../index.js";
+
+declare const frontend: ConfigObject & {
+  readonly $schema: string;
+  readonly rules: NonNullable<ConfigObject["rules"]>;
+};
+
+export default frontend;

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -16,7 +16,8 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test": "node --test --test-concurrency=1 test/*.test.mjs"
+    "test": "node --test --test-concurrency=1 test/*.test.mjs && pnpm test:types",
+    "test:types": "tsc -p test/types/tsconfig.json"
   },
   "types": "./index.d.ts",
   "exports": {
@@ -45,7 +46,10 @@
       "import": "./universal.js",
       "require": "./universal.cjs"
     },
-    "./configs/frontend": "./configs/frontend.json",
+    "./configs/frontend": {
+      "types": "./configs/frontend.d.ts",
+      "default": "./configs/frontend.json"
+    },
     "./schema": "./schema.json",
     "./package.json": "./package.json"
   },
@@ -88,5 +92,8 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3"
   }
 }

--- a/npm/utoo-lint/test/types/frontend-config.ts
+++ b/npm/utoo-lint/test/types/frontend-config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@utoo/lint/config";
+import frontend from "@utoo/lint/configs/frontend";
+
+export default defineConfig({
+  rules: {
+    ...frontend.rules,
+  },
+});

--- a/npm/utoo-lint/test/types/tsconfig.json
+++ b/npm/utoo-lint/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": ["frontend-config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,10 @@ importers:
       jiti:
         specifier: 2.7.0
         version: 2.7.0
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
     optionalDependencies:
       '@utoo/lint-darwin-arm64':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- add a TypeScript declaration for the packaged frontend preset
- expose the declaration through the package export map
- compile a typed preset-extension fixture in the npm test suite
- document extending the preset from a TypeScript config

## Problem

Importing `@utoo/lint/configs/frontend` exposed the raw JSON type. TypeScript widened rule severities such as `"error"` to `string`, so spreading `frontend.rules` into `defineConfig()` failed type checking.

## Validation

- `pnpm --dir npm/utoo-lint test`
- `pnpm --dir npm/utoo-lint pack --dry-run --json`

Closes #1046
