### PR TITLE
fix: align and document global ignore semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ export default defineConfig({
 });
 ```
 
+Use `globalIgnores()` as a separate config entry to exclude files or
+directories from the whole flat config:
+
+```ts
+import { defineConfig, globalIgnores } from "@utoo/lint/config";
+
+export default defineConfig(
+  globalIgnores(["dist/", ".next/", "**/generated/"]),
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-debugger": "error"
+    }
+  }
+);
+```
+
+The helper returns an ignore-only entry containing `ignores` and an optional
+`name`. Only global entries prune directories during target discovery.
+`ignores` beside `files`, `rules`, or another config key is entry-scoped: it
+stops that entry from applying to matching files, but does not exclude them
+from other entries. With no CLI targets, global ignores filter the config's
+`files` patterns, or the current-directory scan when no `files` are configured.
+Use `dist/` or `.next/` for config-relative directories and `**/generated/`
+for matches at any depth. This intentionally follows
+[ESLint flat config ignore semantics](https://eslint.org/docs/latest/use/configure/ignore).
+
 A TypeScript config is trusted executable code and must export a
 JSON-serializable object or flat config array. The npm wrapper executes it,
 materializes the result as JSON, and invokes the native binary. The raw binary

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,41 @@ export default defineConfig({
 });
 ```
 
+### Global and Entry-Scoped Ignores
+
+Use `globalIgnores()` to exclude files or whole directories from every config
+entry. The helper returns an ignore-only entry, so pass it as a separate
+`defineConfig()` argument or array item:
+
+```ts
+import { defineConfig, globalIgnores } from "@utoo/lint/config";
+
+export default defineConfig(
+  globalIgnores(["dist/", ".next/", "**/generated/"]),
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-debugger": "error"
+    }
+  }
+);
+```
+
+An entry is global only when it contains `ignores` and, optionally, `name`.
+Adding `files`, `rules`, or another config key makes its `ignores` patterns
+entry-scoped: they stop that entry from applying to matching files, but do not
+exclude those files from other entries. Only global ignores prune matching
+directories during file discovery. A trailing slash expresses a directory;
+use `dist/` or `.next/` for a directory beside the config and
+`**/generated/` for directories with that name at any depth.
+
+When no lint target is passed, the npm/Node wrapper discovers targets from the
+config's `files` patterns, or scans the current directory if there are none.
+Global ignores filter that discovery and prevent traversal into ignored
+directories. Entry-scoped ignores are evaluated later, while resolving the
+matching config for each discovered file. This shape intentionally follows
+[ESLint flat config's global and non-global ignore semantics](https://eslint.org/docs/latest/use/configure/ignore).
+
 `defineConfig()` accepts config objects and flat config arrays and returns a
 flat array. It also provides editor completion and compile-time checking from
 the exported configuration types. A TypeScript config is trusted executable

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -114,6 +114,33 @@ export default defineConfig({
 });
 ```
 
+Use `globalIgnores()` as a separate config entry when files or directories
+must be excluded from every entry:
+
+```ts
+import { defineConfig, globalIgnores } from "@utoo/lint/config";
+
+export default defineConfig(
+  globalIgnores(["dist/", ".next/", "**/generated/"]),
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-debugger": "error"
+    }
+  }
+);
+```
+
+`globalIgnores()` returns an ignore-only object containing `ignores` and a
+generated `name`. Only such global entries prune directories during target
+discovery. By contrast, `ignores` beside `files`, `rules`, or another config
+key is entry-scoped: it prevents that entry from applying to matching files,
+but does not exclude them from other entries. With no CLI targets, global
+ignores filter the config's `files` patterns, or the current-directory scan
+when no `files` are configured. Directory patterns such as `dist/` and
+`.next/` are relative to the config; use `**/generated/` to match at any depth.
+This intentionally follows [ESLint flat config ignore semantics](https://eslint.org/docs/latest/use/configure/ignore).
+
 The two canonical names represent one active config and are not implicitly
 merged. For the npm/Node entry point, discovery is nearest-directory-first.
 Within the same directory, `utlint.config.ts` takes precedence over

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -796,7 +796,7 @@ function isIgnoredTarget(target, patterns) {
 }
 
 function normalizeIgnoredPattern(pattern) {
-  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, "")).replace(/\/+$/, "");
 }
 
 function matchesIgnorePattern(target, pattern) {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -4118,11 +4118,18 @@ function ignorePatternsFromConfig(config) {
     return config.flatMap((entry) => ignorePatternsFromConfig(entry));
   }
 
-  const flatConfigIgnores = config.files ? [] : normalizeIgnorePatterns(config.ignores);
+  const flatConfigIgnores = isGlobalIgnoreEntry(config) ? normalizeIgnorePatterns(config.ignores) : [];
   return [
     ...normalizeIgnorePatterns(config.ignorePatterns),
     ...flatConfigIgnores
   ];
+}
+
+function isGlobalIgnoreEntry(config) {
+  if (!config || typeof config !== "object" || !config.ignores) {
+    return false;
+  }
+  return Object.keys(config).every((key) => key === "name" || key === "ignores");
 }
 
 function normalizeIgnorePatterns(patterns) {
@@ -4160,7 +4167,7 @@ function normalizeIgnoredPath(filePath, cwd) {
 }
 
 function normalizeIgnoredPattern(pattern) {
-  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, "")).replace(/\/+$/, "");
 }
 
 function pathIgnoredByPatterns(target, patterns) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -4121,11 +4121,18 @@ function ignorePatternsFromConfig(config) {
     return config.flatMap((entry) => ignorePatternsFromConfig(entry));
   }
 
-  const flatConfigIgnores = config.files ? [] : normalizeIgnorePatterns(config.ignores);
+  const flatConfigIgnores = isGlobalIgnoreEntry(config) ? normalizeIgnorePatterns(config.ignores) : [];
   return [
     ...normalizeIgnorePatterns(config.ignorePatterns),
     ...flatConfigIgnores
   ];
+}
+
+function isGlobalIgnoreEntry(config) {
+  if (!config || typeof config !== "object" || !config.ignores) {
+    return false;
+  }
+  return Object.keys(config).every((key) => key === "name" || key === "ignores");
 }
 
 function normalizeIgnorePatterns(patterns) {
@@ -4163,7 +4170,7 @@ function normalizeIgnoredPath(filePath, cwd) {
 }
 
 function normalizeIgnoredPattern(pattern) {
-  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, ""));
+  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, "")).replace(/\/+$/, "");
 }
 
 function pathIgnoredByPatterns(target, patterns) {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -245,13 +245,13 @@ test("fishlint applies a flat global ignore entry before per-file rule grouping"
     join(project, "utlint.config.ts"),
     [
       "export default [",
-      '  { name: "generated", ignores: ["src/ignored.ts"] },',
+      '  { name: "generated", ignores: ["dist/"] },',
       '  { rules: { "no-debugger": "error" } }',
       "];",
       ""
     ].join("\n")
   );
-  const ignoredSource = write(join(project, "src", "ignored.ts"), "debugger;\n");
+  const ignoredSource = write(join(project, "dist", "ignored.ts"), "debugger;\n");
   const reportedSource = write(join(project, "src", "reported.ts"), "debugger;\n");
 
   const result = spawnSync(
@@ -852,6 +852,43 @@ test("utlint.config.ts can import defineConfig and provide default files", (t) =
   });
 
   assert.equal(result.status, 0, result.stderr);
+});
+
+test("globalIgnores prunes default targets while config-entry ignores stay scoped", (t) => {
+  const project = createProject(t);
+  const packageLinkDirectory = join(project, "node_modules", "@utoo");
+  mkdirSync(packageLinkDirectory, { recursive: true });
+  symlinkSync(packageDirectory, join(packageLinkDirectory, "lint"), "dir");
+  write(join(project, "dist", "index.ts"), "debugger;\n");
+  write(join(project, ".next", "index.ts"), "debugger;\n");
+  write(join(project, "packages", "app", "generated", "index.ts"), "debugger;\n");
+  write(join(project, "src", "scoped", "index.ts"), "debugger;\n");
+  write(
+    join(project, "utlint.config.ts"),
+    [
+      'import { defineConfig, globalIgnores } from "@utoo/lint/config";',
+      "export default defineConfig(",
+      '  globalIgnores(["dist/", ".next/", "**/generated/"]),',
+      '  { ignores: ["src/scoped/"], rules: { "no-debugger": "off" } },',
+      '  { files: ["**/*.ts"], rules: { "no-debugger": "error" } },',
+      ");",
+      ""
+    ].join("\n")
+  );
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute([], {
+      cwd: project,
+      binary: testBinary(),
+      encoding: "utf8"
+    });
+
+    assert.equal(result.status, 1, result.stderr);
+    assert.match(result.stderr, /src\/scoped\/index\.ts/);
+    assert.doesNotMatch(result.stderr, /dist\/index\.ts/);
+    assert.doesNotMatch(result.stderr, /\.next\/index\.ts/);
+    assert.doesNotMatch(result.stderr, /generated\/index\.ts/);
+  }
 });
 
 test("--rules overrides the selected project config", (t) => {


### PR DESCRIPTION
## Summary

- document `globalIgnores()` beside the TypeScript config examples
- explain global versus entry-scoped ignores, directory patterns, and default target discovery
- align npm ESM/CommonJS global-entry detection with the ignore-only flat-config shape
- normalize trailing-slash directory patterns consistently in the npm CLI and fishlint

## Problem

The helper and its ESLint-compatible semantics were not documented. While adding coverage, the npm entry point was also treating any config without `files` as globally ignored, so an entry containing both `ignores` and `rules` could incorrectly prune default targets.

## Validation

- `node --test --test-concurrency=1 --test-name-pattern="global ignore entry|globalIgnores prunes" test/config-loading.test.mjs`
- `pnpm --dir npm/utoo-lint test` (70/70 passed)

Closes #1047
