### PR TITLE
fix: handle catch completion in no-unreachable

### DIFF
--- a/src/rules/no_unreachable.zig
+++ b/src/rules/no_unreachable.zig
@@ -45,10 +45,22 @@ fn alwaysExits(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .if_statement => |statement| statement.alternate != .null and
             alwaysExits(tree, statement.consequent) and
             alwaysExits(tree, statement.alternate),
-        .try_statement => |statement| alwaysExits(tree, statement.block) or
-            alwaysExits(tree, statement.finalizer),
+        .try_statement => |statement| tryAlwaysExits(tree, statement),
         else => false,
     };
+}
+
+fn tryAlwaysExits(tree: *const ast.Tree, statement: ast.TryStatement) bool {
+    if (alwaysExits(tree, statement.finalizer)) return true;
+
+    const block_exits = alwaysExits(tree, statement.block);
+    if (statement.handler == .null) return block_exits;
+
+    const handler_body = switch (tree.data(statement.handler)) {
+        .catch_clause => |handler| handler.body,
+        else => return false,
+    };
+    return block_exits and alwaysExits(tree, handler_body);
 }
 
 fn rangeAlwaysExits(tree: *const ast.Tree, range: ast.IndexRange) bool {

--- a/tests/rules/no_unreachable.zig
+++ b/tests/rules/no_unreachable.zig
@@ -61,7 +61,7 @@ test "reports no-unreachable after if statements where both branches exit" {
 test "reports no-unreachable after try statements that exit" {
     const source =
         \\function first() {
-        \\  try { return value; } catch (error) { recover(error); }
+        \\  try { return value; } catch (error) { throw error; }
         \\  call();
         \\}
         \\function second() {
@@ -83,6 +83,32 @@ test "reports no-unreachable after try statements that exit" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_unreachable.id));
+}
+
+test "does not report after try when catch can complete normally" {
+    const source =
+        \\async function render(ignoreError) {
+        \\  try {
+        \\    return await Promise.reject(new Error("render failed"));
+        \\  } catch (error) {
+        \\    if (!ignoreError) {
+        \\      throw error;
+        \\    }
+        \\  }
+        \\
+        \\  return "fallback";
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .eol_last = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unreachable.id));
 }
 
 test "does not report no-unreachable for reachable statements or hoisted declarations" {


### PR DESCRIPTION
## Summary

- Fix no-unreachable false positives after try/catch statements whose catch clause can complete normally.
- Treat a try statement with a handler as always exiting only when both the try block and catch body exit; an exiting finalizer still takes precedence.
- Add regression coverage for conditional rethrows followed by reachable fallback code.

Closes #1051

## Test Plan

- Run Zig formatting checks.
- Run the full Zig test suite in ReleaseFast mode (1873/1873 passed).
- Build in ReleaseFast mode and verify npm packaging and the CLI wrapper.
- Run the npm package tests (71/71 passed).