### PR TITLE
feat: support suppression comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Useful docs:
   documentation links.
 - [Configuration](docs/configuration.md) describes `utlint.config.ts` and
   `utlint.config.json` for frontend projects.
+- [Suppression comments](docs/suppressions.md) documents `utlint-ignore`,
+  file-level, and range suppressions.
 - [Migrating from ESLint](docs/eslint-migration.md) covers the current migration
   path.
 - [Contributing](CONTRIBUTING.md) covers local development, rule work,
@@ -101,6 +103,20 @@ with JSON output, changed sources are returned in the `outputs` array. Fixes run
 until the source is stable, subject to a safety pass limit. Diagnostics remain
 when a rule or a particular code shape cannot be fixed safely. See
 [Rule status](docs/rule-status.md) for per-rule autofix coverage.
+
+### Suppression comments
+
+Suppress a rule for the next line of code with `utlint-ignore`:
+
+```js
+// utlint-ignore no-debugger: generated breakpoint
+debugger;
+```
+
+Use `utlint-ignore-all` at the top of a file or matching
+`utlint-ignore-start` / `utlint-ignore-end` comments for a range. See
+[Suppression comments](docs/suppressions.md) for the complete syntax and API
+behavior.
 
 ## Configuration
 

--- a/docs/suppressions.md
+++ b/docs/suppressions.md
@@ -1,0 +1,63 @@
+# Suppression comments
+
+`utoo-lint` supports Biome-style suppression comments using the
+`utlint-ignore` prefix. A suppression may target one rule or all lint rules.
+Adding an explanation after `:` is recommended; APIs preserve it with the
+suppressed diagnostic.
+
+## Next line of code
+
+Use `utlint-ignore` before the code that should be exempt:
+
+```js
+// utlint-ignore no-debugger: generated breakpoint
+debugger;
+```
+
+Blank lines and other comments may appear between the directive and the code.
+An intervening line of code consumes the directive. Omit the rule ID to
+suppress every lint rule for that line of code:
+
+```js
+// utlint-ignore: generated statement
+debugger; console.log("generated");
+```
+
+## Entire file
+
+Use `utlint-ignore-all` before any code in the file:
+
+```js
+// utlint-ignore-all no-debugger: generated file
+```
+
+Leading comments, a UTF-8 byte-order mark, and a script shebang may precede
+the directive. An `utlint-ignore-all` placed after code has no effect.
+
+## Range
+
+Use matching `utlint-ignore-start` and `utlint-ignore-end` directives:
+
+```js
+// utlint-ignore-start no-debugger: generated section
+debugger;
+debugger;
+// utlint-ignore-end no-debugger: generated section
+```
+
+Ranges may overlap or nest. A named end closes a range for the same rule; an
+end without a rule ID closes an all-rules range.
+
+All four directives work in line or block comments. Rule IDs use the same
+names as configuration, including namespaced IDs such as
+`@typescript-eslint/no-unused-vars`.
+
+## Diagnostics and autofix
+
+Suppression applies to lint-rule diagnostics, including diagnostics from
+ESLint-compatible custom rules. Parse errors are never suppressed. A
+suppressed diagnostic's fix is not applied by `--fix` or `--fix-dry-run`.
+
+Native JSON and the `lintFiles()` / `lintText()` APIs expose suppressed items
+in `suppressedDiagnostics`. The ESLint-compatible API exposes them in
+`suppressedMessages`, including the directive explanation in `suppressions`.

--- a/npm/README.md
+++ b/npm/README.md
@@ -101,10 +101,13 @@ The CommonJS entry is kept behaviorally aligned with the ESM API, including
 the fishlint wrapper and per-file flat config handling.
 
 `lintFiles()` and `lintText()` return an object with `files`, `filePaths`,
-`diagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
+`diagnostics`, `suppressedDiagnostics`, and `exitCode`. Each diagnostic includes `filePath`, `line`,
 `column`, `severity`, `message`, and `ruleId`, with disabled per-file rules
 filtered from the diagnostics. `exitCode` is recalculated from the filtered
-diagnostics: warnings return 0 and errors return 1. The `ESLint` export is an
+diagnostics: warnings return 0 and errors return 1. Diagnostics matched by
+`utlint-ignore`, `utlint-ignore-all`, or a start/end suppression range appear
+in `suppressedDiagnostics`; ESLint-compatible results map them to
+`suppressedMessages`. The `ESLint` export is an
 alias for `UtooLint`
 and supports the common `lintFiles()`, `lintText()`,
 `loadFormatter()`, `isPathIgnored()`, and `calculateConfigForFile()` methods for

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -67,6 +67,24 @@ when a rule or a particular code shape cannot be fixed safely. The current
 [rule status](https://github.com/fireairforce/utoo-lint/blob/main/docs/rule-status.md)
 lists autofix coverage by rule.
 
+## Suppression comments
+
+Suppress a rule for the next line of code with `utlint-ignore`:
+
+```js
+// utlint-ignore no-debugger: generated breakpoint
+debugger;
+```
+
+Omit the rule ID to suppress all lint rules for the next line of code. Use
+`utlint-ignore-all` before any code for a file-level suppression, or matching
+`utlint-ignore-start` and `utlint-ignore-end` comments for a range. Line and
+block comments are supported. Parse errors remain visible, and fixes from
+suppressed diagnostics are not applied.
+
+Native reports expose suppressed items in `suppressedDiagnostics`; the ESLint
+compatibility API exposes them in `suppressedMessages`.
+
 ## Configuration
 
 `utoo-lint` supports two canonical project config formats:

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -514,7 +514,7 @@ class UtooLint {
     const results = reportToESLintResults(report, {
       source: code,
       filePath,
-      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0 || (report.suppressedDiagnostics?.length ?? 0) > 0,
       ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(nativeOptions, filePath)
     });
     if (report.files !== 0) {
@@ -641,7 +641,7 @@ class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
-      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0 || (report.suppressedDiagnostics?.length ?? 0) > 0,
       ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
@@ -842,6 +842,7 @@ function publicCliReport(report) {
     files: report.files ?? 0,
     filePaths: report.filePaths ?? [],
     diagnostics: report.diagnostics ?? [],
+    suppressedDiagnostics: report.suppressedDiagnostics ?? [],
     outputs: report.outputs ?? []
   };
 }
@@ -1140,7 +1141,7 @@ function lintFiles(paths, options = {}) {
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
   if (lintPaths.length === 0) {
-    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
@@ -1205,8 +1206,10 @@ function finalizeLintReport(report, ignoredDiagnostics, options) {
   if (!options.deferDiagnosticConfigFiltering) {
     report.filePaths = normalizeReportFilePaths(report.filePaths, options);
     report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeDiagnosticFilePaths(report.suppressedDiagnostics, options);
     report.outputs = normalizeReportOutputs(report.outputs, options);
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeReportDiagnostics(report.suppressedDiagnostics, options);
     report.exitCode = exitCodeForDiagnostics(report.diagnostics);
   }
   return report;
@@ -1303,6 +1306,7 @@ function mergeNativeReports(reports) {
     files: reports.reduce((count, item) => count + (item.files ?? 0), 0),
     filePaths: reports.flatMap((item) => item.filePaths ?? []),
     diagnostics: reports.flatMap((item) => item.diagnostics ?? []),
+    suppressedDiagnostics: reports.flatMap((item) => item.suppressedDiagnostics ?? []),
     outputs: reports.flatMap((item) => item.outputs ?? []),
     exitCode: reports.some((item) => item.exitCode) ? 1 : 0
   };
@@ -1335,6 +1339,7 @@ function lintText(code, options = {}) {
         files: 0,
         filePaths: [],
         diagnostics,
+        suppressedDiagnostics: [],
         exitCode: exitCodeForDiagnostics(diagnostics)
       };
     }
@@ -1356,7 +1361,12 @@ function lintText(code, options = {}) {
       ...diagnostic,
       filePath: requestedPath
     }));
+    report.suppressedDiagnostics = (report.suppressedDiagnostics ?? []).map((diagnostic) => ({
+      ...diagnostic,
+      filePath: requestedPath
+    }));
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeReportDiagnostics(report.suppressedDiagnostics, options);
     report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     return report;
   } finally {
@@ -1888,7 +1898,10 @@ class Linter {
       config: calculatedConfig({ cwd: verifyOptions.cwd, noConfig: true, overrideConfig: config }, normalizedFilePath)
     });
     const customRuleFilter = applyDisableDirectives(customRuleMessages, sourceCode);
-    this.suppressedMessages = customRuleFilter.suppressedMessages;
+    this.suppressedMessages = [
+      ...(report.suppressedDiagnostics ?? []).map((diagnostic) => suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities)),
+      ...customRuleFilter.suppressedMessages
+    ];
     this.times = { passes: [] };
     this.fixPassCount = 0;
     return [
@@ -2197,14 +2210,18 @@ function applyDisableDirectives(messages, sourceCode) {
   const directives = sourceCode.getDisableDirectives()
     .filter((directive) => directive.node?.loc?.start?.line)
     .sort((left, right) => left.node.loc.start.line - right.node.loc.start.line);
-  if (directives.length === 0) {
+  const utlintDirectives = sourceCode.getAllComments()
+    .map((comment) => utlintDirectiveFromComment(comment, sourceCode))
+    .filter(Boolean)
+    .sort((left, right) => left.node.range[0] - right.node.range[0]);
+  if (directives.length === 0 && utlintDirectives.length === 0) {
     return { messages, suppressedMessages: [] };
   }
 
   const kept = [];
   const suppressed = [];
   for (const message of messages) {
-    const directive = disableDirectiveForMessage(message, directives);
+    const directive = utlintDirectiveForMessage(message, utlintDirectives) ?? disableDirectiveForMessage(message, directives);
     if (directive) {
       suppressed.push({
         ...message,
@@ -2218,6 +2235,68 @@ function applyDisableDirectives(messages, sourceCode) {
     }
   }
   return { messages: kept, suppressedMessages: suppressed };
+}
+
+function utlintDirectiveFromComment(comment, sourceCode) {
+  const match = String(comment?.value ?? "").trim().match(/^(utlint-ignore(?:-all|-start|-end)?)\b\s*(.*)$/u);
+  if (!match) {
+    return null;
+  }
+
+  const [, type, tail] = match;
+  const colon = tail.indexOf(":");
+  const rawRuleId = (colon === -1 ? tail : tail.slice(0, colon)).trim();
+  const justification = colon === -1 ? "" : tail.slice(colon + 1).trim();
+  const nextToken = sourceCode.getAllTokens().find((token) => token.range?.[0] >= comment.range?.[1]);
+  return {
+    type,
+    node: comment,
+    ruleId: rawRuleId || null,
+    justification,
+    nextCodeLine: nextToken?.loc?.start?.line ?? null,
+    topLevel: sourceCode.getAllTokens().every((token) => token.range?.[0] >= comment.range?.[0])
+  };
+}
+
+function utlintDirectiveForMessage(message, directives) {
+  let allRulesRangeDepth = 0;
+  let namedRuleRangeDepth = 0;
+  let allRulesRangeDirective = null;
+  let namedRuleRangeDirective = null;
+
+  for (const directive of directives) {
+    if (directive.node.loc.start.line > message.line) {
+      break;
+    }
+    if (directive.type === "utlint-ignore-start") {
+      if (directive.ruleId == null) {
+        allRulesRangeDirective ??= directive;
+        allRulesRangeDepth += 1;
+      } else if (directive.ruleId === message.ruleId) {
+        namedRuleRangeDirective ??= directive;
+        namedRuleRangeDepth += 1;
+      }
+      continue;
+    }
+    if (directive.type === "utlint-ignore-end") {
+      if (directive.ruleId == null && allRulesRangeDepth > 0) {
+        allRulesRangeDepth -= 1;
+        if (allRulesRangeDepth === 0) allRulesRangeDirective = null;
+      } else if (directive.ruleId === message.ruleId && namedRuleRangeDepth > 0) {
+        namedRuleRangeDepth -= 1;
+        if (namedRuleRangeDepth === 0) namedRuleRangeDirective = null;
+      }
+      continue;
+    }
+    if (directive.type === "utlint-ignore-all" && directive.topLevel && disableDirectiveMatchesRule(directive, message.ruleId)) {
+      return directive;
+    }
+    if (directive.type === "utlint-ignore" && directive.nextCodeLine === message.line && disableDirectiveMatchesRule(directive, message.ruleId)) {
+      return directive;
+    }
+  }
+
+  return namedRuleRangeDirective ?? allRulesRangeDirective;
 }
 
 function disableDirectiveForMessage(message, directives) {
@@ -3695,6 +3774,18 @@ function reportToESLintResults(report, textOptions = {}) {
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
+  for (const diagnostic of report.suppressedDiagnostics ?? []) {
+    const filePath = textOptions.filePath ?? normalizeESLintFilePath(diagnostic.filePath, textOptions.cwd);
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    const ruleSeverities = textOptions.ruleSeverityForFile?.(filePath) ?? textOptions.ruleSeverities;
+    if (diagnostic.ruleId && ruleSeverities?.get(diagnostic.ruleId) === 0) {
+      continue;
+    }
+    byFile.get(filePath).suppressedMessages.push(suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities));
+  }
+
   for (const fixed of report.outputs ?? []) {
     const filePath = textOptions.filePath ?? normalizeESLintFilePath(fixed.filePath, textOptions.cwd);
     if (!byFile.has(filePath)) {
@@ -4396,6 +4487,16 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
     message.fix = fixes.length === 1 ? fixes[0] : fixes;
   }
   return message;
+}
+
+function suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities) {
+  return {
+    ...diagnosticToESLintMessage(diagnostic, ruleSeverities),
+    suppressions: [{
+      kind: diagnostic.suppression?.kind ?? "directive",
+      justification: diagnostic.suppression?.justification ?? ""
+    }]
+  };
 }
 
 function finalizeESLintResult(result) {

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -9,10 +9,17 @@ export interface LintMessage {
   nodeType?: string | null;
   fix?: LintFix | LintFix[];
   suggestions?: LintSuggestion[];
+  suppressions?: LintSuppression[];
 }
 
-export interface LintDiagnostic extends Omit<LintMessage, "severity"> {
+export interface LintSuppression {
+  kind: "directive";
+  justification: string;
+}
+
+export interface LintDiagnostic extends Omit<LintMessage, "severity" | "suppressions"> {
   severity: "warning" | "error";
+  suppression?: LintSuppression;
 }
 
 export interface LintFix {
@@ -42,6 +49,7 @@ export interface LintReport {
   files: number;
   filePaths: string[];
   diagnostics: LintDiagnostic[];
+  suppressedDiagnostics: LintDiagnostic[];
   outputs?: Array<{ filePath: string; output: string }>;
   exitCode: number;
   stderr?: string;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -517,7 +517,7 @@ export class UtooLint {
     const results = reportToESLintResults(report, {
       source: code,
       filePath,
-      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0 || (report.suppressedDiagnostics?.length ?? 0) > 0,
       ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(nativeOptions, filePath)
     });
     if (report.files !== 0) {
@@ -635,7 +635,10 @@ export class Linter {
       config: calculatedConfig({ cwd: verifyOptions.cwd, noConfig: true, overrideConfig: config }, normalizedFilePath)
     });
     const customRuleFilter = applyDisableDirectives(customRuleMessages, sourceCode);
-    this.suppressedMessages = customRuleFilter.suppressedMessages;
+    this.suppressedMessages = [
+      ...(report.suppressedDiagnostics ?? []).map((diagnostic) => suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities)),
+      ...customRuleFilter.suppressedMessages
+    ];
     this.times = { passes: [] };
     this.fixPassCount = 0;
     return [
@@ -944,14 +947,18 @@ function applyDisableDirectives(messages, sourceCode) {
   const directives = sourceCode.getDisableDirectives()
     .filter((directive) => directive.node?.loc?.start?.line)
     .sort((left, right) => left.node.loc.start.line - right.node.loc.start.line);
-  if (directives.length === 0) {
+  const utlintDirectives = sourceCode.getAllComments()
+    .map((comment) => utlintDirectiveFromComment(comment, sourceCode))
+    .filter(Boolean)
+    .sort((left, right) => left.node.range[0] - right.node.range[0]);
+  if (directives.length === 0 && utlintDirectives.length === 0) {
     return { messages, suppressedMessages: [] };
   }
 
   const kept = [];
   const suppressed = [];
   for (const message of messages) {
-    const directive = disableDirectiveForMessage(message, directives);
+    const directive = utlintDirectiveForMessage(message, utlintDirectives) ?? disableDirectiveForMessage(message, directives);
     if (directive) {
       suppressed.push({
         ...message,
@@ -965,6 +972,68 @@ function applyDisableDirectives(messages, sourceCode) {
     }
   }
   return { messages: kept, suppressedMessages: suppressed };
+}
+
+function utlintDirectiveFromComment(comment, sourceCode) {
+  const match = String(comment?.value ?? "").trim().match(/^(utlint-ignore(?:-all|-start|-end)?)\b\s*(.*)$/u);
+  if (!match) {
+    return null;
+  }
+
+  const [, type, tail] = match;
+  const colon = tail.indexOf(":");
+  const rawRuleId = (colon === -1 ? tail : tail.slice(0, colon)).trim();
+  const justification = colon === -1 ? "" : tail.slice(colon + 1).trim();
+  const nextToken = sourceCode.getAllTokens().find((token) => token.range?.[0] >= comment.range?.[1]);
+  return {
+    type,
+    node: comment,
+    ruleId: rawRuleId || null,
+    justification,
+    nextCodeLine: nextToken?.loc?.start?.line ?? null,
+    topLevel: sourceCode.getAllTokens().every((token) => token.range?.[0] >= comment.range?.[0])
+  };
+}
+
+function utlintDirectiveForMessage(message, directives) {
+  let allRulesRangeDepth = 0;
+  let namedRuleRangeDepth = 0;
+  let allRulesRangeDirective = null;
+  let namedRuleRangeDirective = null;
+
+  for (const directive of directives) {
+    if (directive.node.loc.start.line > message.line) {
+      break;
+    }
+    if (directive.type === "utlint-ignore-start") {
+      if (directive.ruleId == null) {
+        allRulesRangeDirective ??= directive;
+        allRulesRangeDepth += 1;
+      } else if (directive.ruleId === message.ruleId) {
+        namedRuleRangeDirective ??= directive;
+        namedRuleRangeDepth += 1;
+      }
+      continue;
+    }
+    if (directive.type === "utlint-ignore-end") {
+      if (directive.ruleId == null && allRulesRangeDepth > 0) {
+        allRulesRangeDepth -= 1;
+        if (allRulesRangeDepth === 0) allRulesRangeDirective = null;
+      } else if (directive.ruleId === message.ruleId && namedRuleRangeDepth > 0) {
+        namedRuleRangeDepth -= 1;
+        if (namedRuleRangeDepth === 0) namedRuleRangeDirective = null;
+      }
+      continue;
+    }
+    if (directive.type === "utlint-ignore-all" && directive.topLevel && disableDirectiveMatchesRule(directive, message.ruleId)) {
+      return directive;
+    }
+    if (directive.type === "utlint-ignore" && directive.nextCodeLine === message.line && disableDirectiveMatchesRule(directive, message.ruleId)) {
+      return directive;
+    }
+  }
+
+  return namedRuleRangeDirective ?? allRulesRangeDirective;
 }
 
 function disableDirectiveForMessage(message, directives) {
@@ -2477,7 +2546,7 @@ export class CLIEngine {
     const results = maybeFilterQuietResults(reportToESLintResults(report, {
       source: code,
       filePath: normalizeESLintFilePath(filePath, mergedOptions.cwd),
-      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0,
+      includeEmptyTextResult: report.files !== 0 || (report.diagnostics?.length ?? 0) > 0 || (report.suppressedDiagnostics?.length ?? 0) > 0,
       ruleSeverityForFile: (filePath) => ruleSeverityMapForOptions(mergedOptions, filePath)
     }), mergedOptions);
     return resultsToCLIEngineReport(results);
@@ -2678,6 +2747,7 @@ function publicCliReport(report) {
     files: report.files ?? 0,
     filePaths: report.filePaths ?? [],
     diagnostics: report.diagnostics ?? [],
+    suppressedDiagnostics: report.suppressedDiagnostics ?? [],
     outputs: report.outputs ?? []
   };
 }
@@ -2976,7 +3046,7 @@ export function lintFiles(paths, options = {}) {
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
   const lintPaths = filteredLintPaths(targets, options);
   if (lintPaths.length === 0) {
-    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
+    return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
@@ -3041,8 +3111,10 @@ function finalizeLintReport(report, ignoredDiagnostics, options) {
   if (!options.deferDiagnosticConfigFiltering) {
     report.filePaths = normalizeReportFilePaths(report.filePaths, options);
     report.diagnostics = normalizeDiagnosticFilePaths(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeDiagnosticFilePaths(report.suppressedDiagnostics, options);
     report.outputs = normalizeReportOutputs(report.outputs, options);
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeReportDiagnostics(report.suppressedDiagnostics, options);
     report.exitCode = exitCodeForDiagnostics(report.diagnostics);
   }
   return report;
@@ -3139,6 +3211,7 @@ function mergeNativeReports(reports) {
     files: reports.reduce((count, item) => count + (item.files ?? 0), 0),
     filePaths: reports.flatMap((item) => item.filePaths ?? []),
     diagnostics: reports.flatMap((item) => item.diagnostics ?? []),
+    suppressedDiagnostics: reports.flatMap((item) => item.suppressedDiagnostics ?? []),
     outputs: reports.flatMap((item) => item.outputs ?? []),
     exitCode: reports.some((item) => item.exitCode) ? 1 : 0
   };
@@ -3171,6 +3244,7 @@ export function lintText(code, options = {}) {
         files: 0,
         filePaths: [],
         diagnostics,
+        suppressedDiagnostics: [],
         exitCode: exitCodeForDiagnostics(diagnostics)
       };
     }
@@ -3192,7 +3266,12 @@ export function lintText(code, options = {}) {
       ...diagnostic,
       filePath: requestedPath
     }));
+    report.suppressedDiagnostics = (report.suppressedDiagnostics ?? []).map((diagnostic) => ({
+      ...diagnostic,
+      filePath: requestedPath
+    }));
     report.diagnostics = normalizeReportDiagnostics(report.diagnostics, options);
+    report.suppressedDiagnostics = normalizeReportDiagnostics(report.suppressedDiagnostics, options);
     report.exitCode = exitCodeForDiagnostics(report.diagnostics);
     return report;
   } finally {
@@ -3696,6 +3775,18 @@ function reportToESLintResults(report, textOptions = {}) {
       continue;
     }
     byFile.get(filePath).messages.push(diagnosticToESLintMessage(diagnostic, ruleSeverities));
+  }
+
+  for (const diagnostic of report.suppressedDiagnostics ?? []) {
+    const filePath = textOptions.filePath ?? normalizeESLintFilePath(diagnostic.filePath, textOptions.cwd);
+    if (!byFile.has(filePath)) {
+      byFile.set(filePath, emptyESLintResult(filePath, textOptions.source));
+    }
+    const ruleSeverities = textOptions.ruleSeverityForFile?.(filePath) ?? textOptions.ruleSeverities;
+    if (diagnostic.ruleId && ruleSeverities?.get(diagnostic.ruleId) === 0) {
+      continue;
+    }
+    byFile.get(filePath).suppressedMessages.push(suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities));
   }
 
   for (const fixed of report.outputs ?? []) {
@@ -4399,6 +4490,16 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
     message.fix = fixes.length === 1 ? fixes[0] : fixes;
   }
   return message;
+}
+
+function suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities) {
+  return {
+    ...diagnosticToESLintMessage(diagnostic, ruleSeverities),
+    suppressions: [{
+      kind: diagnostic.suppression?.kind ?? "directive",
+      justification: diagnostic.suppression?.justification ?? ""
+    }]
+  };
 }
 
 function finalizeESLintResult(result) {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -8,10 +8,10 @@ import { fileURLToPath } from "node:url";
 
 import { createRequire } from "node:module";
 
-import { ESLint, lintFiles, lintText, resolveBinary, runCli } from "../index.js";
+import { ESLint, Linter, lintFiles, lintText, resolveBinary, runCli } from "../index.js";
 
 const require = createRequire(import.meta.url);
-const { ESLint: CommonJSESLint, runCli: commonJSRunCli } = require("../index.cjs");
+const { ESLint: CommonJSESLint, Linter: CommonJSLinter, runCli: commonJSRunCli } = require("../index.cjs");
 
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = join(packageDirectory, "bin", "utoo-lint.js");
@@ -43,6 +43,150 @@ function write(path, source = "{}\n") {
   writeFileSync(path, source);
   return path;
 }
+
+test("ESLint exposes diagnostics suppressed by utlint-ignore", async () => {
+  const eslint = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: { rules: { "no-debugger": "error" } }
+  });
+
+  const [result] = await eslint.lintText(
+    "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",
+    { filePath: "suppressed.js" }
+  );
+
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-debugger");
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated breakpoint" }
+  ]);
+});
+
+test("CommonJS ESLint exposes diagnostics suppressed by utlint-ignore", async () => {
+  const eslint = new CommonJSESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: { rules: { "no-debugger": "error" } }
+  });
+
+  const [result] = await eslint.lintText(
+    "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",
+    { filePath: "suppressed.js" }
+  );
+
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-debugger");
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated breakpoint" }
+  ]);
+});
+
+test("ESM and CommonJS Linter expose suppressed messages", (t) => {
+  const previousBinary = process.env.UTOO_LINT_BIN;
+  process.env.UTOO_LINT_BIN = testBinary();
+  t.after(() => {
+    if (previousBinary === undefined) {
+      delete process.env.UTOO_LINT_BIN;
+    } else {
+      process.env.UTOO_LINT_BIN = previousBinary;
+    }
+  });
+
+  for (const LinterImplementation of [Linter, CommonJSLinter]) {
+    const linter = new LinterImplementation();
+    const messages = linter.verify(
+      "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",
+      { rules: { "no-debugger": "error" } },
+      { filename: "suppressed.js" }
+    );
+
+    assert.deepEqual(messages, []);
+    assert.equal(linter.getSuppressedMessages().length, 1);
+    assert.deepEqual(linter.getSuppressedMessages()[0].suppressions, [
+      { kind: "directive", justification: "generated breakpoint" }
+    ]);
+  }
+});
+
+test("lintText returns suppressed native diagnostics with the requested file path", () => {
+  const report = lintText(
+    "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",
+    {
+      binary: testBinary(),
+      noConfig: true,
+      filePath: "suppressed.js",
+      overrideConfig: { rules: { "no-debugger": "error" } }
+    }
+  );
+
+  assert.deepEqual(report.diagnostics, []);
+  assert.equal(report.suppressedDiagnostics.length, 1);
+  assert.equal(report.suppressedDiagnostics[0].filePath, "suppressed.js");
+  assert.equal(report.suppressedDiagnostics[0].suppression.justification, "generated breakpoint");
+});
+
+test("raw native CLI reports utlint-ignore suppressions without failing", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(
+    join(project, "suppressed.js"),
+    "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n"
+  );
+
+  const result = spawnSync(
+    testBinary(),
+    ["--no-config", "--rules=no-debugger", "--format=json", sourcePath],
+    { cwd: project, encoding: "utf8" }
+  );
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(report.diagnostics, []);
+  assert.equal(report.suppressedDiagnostics.length, 1);
+  assert.equal(report.suppressedDiagnostics[0].ruleId, "no-debugger");
+});
+
+test("utlint-ignore suppresses ESLint-compatible custom rules", async () => {
+  const eslint = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: {
+      plugins: {
+        custom: {
+          rules: {
+            report: {
+              create(context) {
+                return {
+                  Program(node) {
+                    context.report({
+                      node,
+                      loc: { start: { line: 2, column: 0 }, end: { line: 2, column: 5 } },
+                      message: "custom report"
+                    });
+                  }
+                };
+              }
+            }
+          }
+        }
+      },
+      rules: { "custom/report": "error" }
+    }
+  });
+
+  const [result] = await eslint.lintText(
+    "// utlint-ignore custom/report: generated declaration\nvalue;\n",
+    { filePath: "suppressed.js" }
+  );
+
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated declaration" }
+  ]);
+});
 
 for (const filename of ["utlint.config.ts", "utlint.config.json"]) {
   test(`ESLint.findConfigFile discovers ${filename}`, async (t) => {

--- a/src/core.zig
+++ b/src/core.zig
@@ -8934,6 +8934,11 @@ pub const Diagnostic = struct {
     span: ast.Span,
     severity: Severity,
     fixes: []Fix,
+    suppression: ?Suppression = null,
+};
+
+pub const Suppression = struct {
+    justification: []const u8,
 };
 
 pub const Fix = struct {
@@ -8943,12 +8948,11 @@ pub const Fix = struct {
 
 pub const Result = struct {
     diagnostics: []Diagnostic,
+    suppressed_diagnostics: []Diagnostic = &.{},
 
     pub fn deinit(self: *Result, allocator: Allocator) void {
-        for (self.diagnostics) |diagnostic| {
-            freeDiagnostic(allocator, diagnostic);
-        }
-        allocator.free(self.diagnostics);
+        freeDiagnosticSlice(allocator, self.diagnostics);
+        freeDiagnosticSlice(allocator, self.suppressed_diagnostics);
     }
 
     pub fn hasDiagnostics(self: Result) bool {
@@ -9081,9 +9085,15 @@ fn dupeFixes(allocator: Allocator, fixes: []const Fix) Allocator.Error![]Fix {
     return owned;
 }
 
-fn freeDiagnostic(allocator: Allocator, diagnostic: Diagnostic) void {
+pub fn freeDiagnostic(allocator: Allocator, diagnostic: Diagnostic) void {
     allocator.free(diagnostic.message);
     freeFixes(allocator, diagnostic.fixes);
+    if (diagnostic.suppression) |suppression| allocator.free(suppression.justification);
+}
+
+pub fn freeDiagnosticSlice(allocator: Allocator, diagnostics: []Diagnostic) void {
+    for (diagnostics) |diagnostic| freeDiagnostic(allocator, diagnostic);
+    if (diagnostics.len > 0) allocator.free(diagnostics);
 }
 
 fn freeFixes(allocator: Allocator, fixes: []Fix) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,11 @@ const JsonFix = struct {
     text: []const u8,
 };
 
+const JsonSuppression = struct {
+    kind: []const u8,
+    justification: []const u8,
+};
+
 const JsonDiagnostic = struct {
     filePath: []const u8,
     line: usize,
@@ -44,6 +49,7 @@ const JsonDiagnostic = struct {
     message: []const u8,
     ruleId: []const u8,
     fixes: []const JsonFix,
+    suppression: ?JsonSuppression = null,
 };
 
 const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
@@ -60,6 +66,7 @@ const JsonReport = struct {
     files: usize,
     filePaths: []const []const u8,
     diagnostics: []const JsonDiagnostic,
+    suppressedDiagnostics: []const JsonDiagnostic,
     outputs: []const JsonOutput,
 };
 
@@ -1249,6 +1256,8 @@ pub fn main(init: std.process.Init) !void {
 
     var json_diagnostics: JsonDiagnosticList = .empty;
     defer freeJsonDiagnostics(allocator, &json_diagnostics);
+    var json_suppressed_diagnostics: JsonDiagnosticList = .empty;
+    defer freeJsonDiagnostics(allocator, &json_suppressed_diagnostics);
     var json_outputs: JsonOutputList = .empty;
     defer freeJsonOutputs(allocator, &json_outputs);
     const json_diagnostics_ptr: ?*JsonDiagnosticList = if (output_format == .json) &json_diagnostics else null;
@@ -1259,8 +1268,8 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (output_format == .json) {
-        try lintFilesJson(allocator, io, files.items, options, &rule_severities, fix_mode, &stats, &json_diagnostics, &json_outputs);
-        try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_outputs.items);
+        try lintFilesJson(allocator, io, files.items, options, &rule_severities, fix_mode, &stats, &json_diagnostics, &json_suppressed_diagnostics, &json_outputs);
+        try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_suppressed_diagnostics.items, json_outputs.items);
     } else {
         const use_color = color_override orelse detectColorSupport(io, init.environ_map.*);
         try lintFiles(allocator, io, files.items, options, &rule_severities, fix_mode, thread_count_override, use_color, &stats);
@@ -1427,7 +1436,7 @@ fn collectLintablePaths(
         if (json_diagnostics) |diagnostics| {
             const message = try std.fmt.allocPrint(allocator, "unable to stat path: {s}", .{@errorName(err)});
             defer allocator.free(message);
-            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{});
+            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{}, null);
         } else {
             std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
         }
@@ -1889,10 +1898,11 @@ fn lintFilesJson(
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
+    json_suppressed_diagnostics: *JsonDiagnosticList,
     json_outputs: *JsonOutputList,
 ) !void {
     for (files) |file| {
-        try lintFileJson(allocator, io, file, options, rule_severities, fix_mode, stats, json_diagnostics, json_outputs);
+        try lintFileJson(allocator, io, file, options, rule_severities, fix_mode, stats, json_diagnostics, json_suppressed_diagnostics, json_outputs);
     }
 }
 
@@ -1927,12 +1937,13 @@ fn lintFileJson(
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
+    json_suppressed_diagnostics: *JsonDiagnosticList,
     json_outputs: *JsonOutputList,
 ) !void {
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
         defer allocator.free(message);
-        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{});
+        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{}, null);
         stats.errors += 1;
         stats.diagnostics += 1;
         return;
@@ -1944,7 +1955,8 @@ fn lintFileJson(
     if (fix_mode == .none) {
         var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
         defer result.deinit(allocator);
-        return appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, rule_severities, stats);
+        try appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, rule_severities, stats);
+        return appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, source, result, rule_severities);
     }
 
     var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
@@ -1959,6 +1971,7 @@ fn lintFileJson(
     }
 
     try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, rule_severities, stats);
+    try appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, fixed.output, fixed.result, rule_severities);
 }
 
 fn lintFile(
@@ -2067,6 +2080,7 @@ fn appendJsonDiagnostic(
     rule_id: []const u8,
     source: []const u8,
     fixes: []const lint.Fix,
+    suppression: ?JsonSuppression,
 ) !void {
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
@@ -2080,6 +2094,17 @@ fn appendJsonDiagnostic(
     const owned_fixes = try dupeJsonFixes(allocator, source, fixes);
     errdefer freeOwnedJsonFixes(allocator, owned_fixes);
 
+    const owned_suppression: ?JsonSuppression = if (suppression) |item| suppression: {
+        const kind = try allocator.dupe(u8, item.kind);
+        errdefer allocator.free(kind);
+        const justification = try allocator.dupe(u8, item.justification);
+        break :suppression .{ .kind = kind, .justification = justification };
+    } else null;
+    errdefer if (owned_suppression) |item| {
+        allocator.free(item.kind);
+        allocator.free(item.justification);
+    };
+
     try diagnostics.append(allocator, .{
         .filePath = owned_path,
         .line = line,
@@ -2088,6 +2113,7 @@ fn appendJsonDiagnostic(
         .message = owned_message,
         .ruleId = owned_rule_id,
         .fixes = owned_fixes,
+        .suppression = owned_suppression,
     });
 }
 
@@ -2114,10 +2140,41 @@ fn appendJsonResultDiagnostics(
             diagnostic.rule_id,
             source,
             diagnostic.fixes,
+            null,
         );
 
         stats.diagnostics += 1;
         if (severity == .@"error") stats.errors += 1;
+    }
+}
+
+fn appendJsonResultSuppressedDiagnostics(
+    allocator: std.mem.Allocator,
+    json_diagnostics: *JsonDiagnosticList,
+    path: []const u8,
+    source: []const u8,
+    result: lint.Result,
+    rule_severities: *const RuleSeverityMap,
+) !void {
+    for (result.suppressed_diagnostics) |diagnostic| {
+        const severity = effectiveDiagnosticSeverity(rule_severities, diagnostic);
+        const position = lint.offsetToLineColumn(source, diagnostic.span.start);
+        try appendJsonDiagnostic(
+            allocator,
+            json_diagnostics,
+            path,
+            position.line,
+            position.column,
+            severity.toString(),
+            diagnostic.message,
+            diagnostic.rule_id,
+            source,
+            diagnostic.fixes,
+            if (diagnostic.suppression) |suppression| .{
+                .kind = "directive",
+                .justification = suppression.justification,
+            } else null,
+        );
     }
 }
 
@@ -2172,6 +2229,10 @@ fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosti
         allocator.free(diagnostic.message);
         allocator.free(diagnostic.ruleId);
         freeOwnedJsonFixes(allocator, diagnostic.fixes);
+        if (diagnostic.suppression) |suppression| {
+            allocator.free(suppression.kind);
+            allocator.free(suppression.justification);
+        }
     }
     diagnostics.deinit(allocator);
 }
@@ -2189,6 +2250,7 @@ fn writeJsonReport(
     stats: Stats,
     file_paths: []const []const u8,
     diagnostics: []const JsonDiagnostic,
+    suppressed_diagnostics: []const JsonDiagnostic,
     outputs: []const JsonOutput,
 ) !void {
     var stdout_buffer: [4096]u8 = undefined;
@@ -2199,8 +2261,9 @@ fn writeJsonReport(
         .files = stats.files,
         .filePaths = file_paths,
         .diagnostics = diagnostics,
+        .suppressedDiagnostics = suppressed_diagnostics,
         .outputs = outputs,
-    }, .{}, stdout);
+    }, .{ .emit_null_optional_fields = false }, stdout);
     try stdout.writeByte('\n');
     try stdout.flush();
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -3,6 +3,7 @@ const parser = @import("parser");
 const core = @import("core.zig");
 const fixer = @import("fixer.zig");
 const semantic_compat = @import("semantic_compat.zig");
+const suppressions = @import("suppressions.zig");
 
 const ast = parser.ast;
 const Allocator = std.mem.Allocator;
@@ -10,6 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const Severity = core.Severity;
 pub const Options = core.Options;
 pub const Diagnostic = core.Diagnostic;
+pub const Suppression = core.Suppression;
 pub const Fix = core.Fix;
 pub const Result = core.Result;
 pub const ApplyFixesResult = fixer.ApplyResult;
@@ -116,6 +118,8 @@ pub fn lintSourceWithIo(
 ) Allocator.Error!Result {
     var diagnostics: core.DiagnosticList = .empty;
     errdefer core.freeDiagnostics(allocator, &diagnostics);
+    var suppressed_diagnostics: core.DiagnosticList = .empty;
+    errdefer core.freeDiagnostics(allocator, &suppressed_diagnostics);
 
     var effective_options = options;
     if (isDefinitionFile(path) and effective_options.typescript_eslint_no_namespace_allow_definition_files) {
@@ -139,8 +143,15 @@ pub fn lintSourceWithIo(
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
     }
 
+    try suppressions.apply(allocator, &diagnostics, &suppressed_diagnostics, &tree);
+
+    const owned_diagnostics = try diagnostics.toOwnedSlice(allocator);
+    errdefer core.freeDiagnosticSlice(allocator, owned_diagnostics);
+    const owned_suppressed_diagnostics = try suppressed_diagnostics.toOwnedSlice(allocator);
+
     return .{
-        .diagnostics = try diagnostics.toOwnedSlice(allocator),
+        .diagnostics = owned_diagnostics,
+        .suppressed_diagnostics = owned_suppressed_diagnostics,
     };
 }
 

--- a/src/rules/capitalized_comments.zig
+++ b/src/rules/capitalized_comments.zig
@@ -138,6 +138,7 @@ fn isIgnoredComment(value: []const u8) bool {
         "globals",
         "jshint",
         "jslint",
+        "utlint-",
     })) return true;
 
     return startsWithAnyIgnoreCase(value, &.{

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -1,0 +1,272 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+const DirectiveKind = enum {
+    ignore,
+    ignore_all,
+    ignore_start,
+    ignore_end,
+};
+
+const DirectiveTarget = struct {
+    rule_id: ?[]const u8,
+    justification: []const u8,
+
+    fn matches(self: DirectiveTarget, rule_id: []const u8) bool {
+        return self.rule_id == null or std.mem.eql(u8, self.rule_id.?, rule_id);
+    }
+};
+
+const ParsedDirective = struct {
+    kind: DirectiveKind,
+    target: DirectiveTarget,
+};
+
+const Directive = struct {
+    kind: DirectiveKind,
+    target: DirectiveTarget,
+    span_start: u32,
+    next_code_offset: ?u32 = null,
+    top_level: bool = false,
+};
+
+pub fn apply(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    suppressed_diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+) Allocator.Error!void {
+    if (diagnostics.items.len == 0 or tree.comments.len == 0) return;
+
+    var directives = try collectDirectives(allocator, tree);
+    defer directives.deinit(allocator);
+    if (directives.items.len == 0) return;
+
+    var line_starts = try collectLineStarts(allocator, tree.source);
+    defer line_starts.deinit(allocator);
+
+    const decisions = try allocator.alloc(?core.Suppression, diagnostics.items.len);
+    defer allocator.free(decisions);
+    var suppressed_count: usize = 0;
+    for (diagnostics.items, 0..) |diagnostic, index| {
+        decisions[index] = suppressionFor(directives.items, line_starts.items, diagnostic);
+        if (decisions[index] != null) suppressed_count += 1;
+    }
+    if (suppressed_count == 0) return;
+
+    var kept: core.DiagnosticList = .empty;
+    errdefer kept.deinit(allocator);
+    try kept.ensureTotalCapacity(allocator, diagnostics.items.len);
+    try suppressed_diagnostics.ensureUnusedCapacity(allocator, suppressed_count);
+
+    const owned_justifications = try allocator.alloc(?[]u8, diagnostics.items.len);
+    @memset(owned_justifications, null);
+    var ownership_transferred = false;
+    defer {
+        if (!ownership_transferred) {
+            for (owned_justifications) |justification| {
+                if (justification) |owned| allocator.free(owned);
+            }
+        }
+        allocator.free(owned_justifications);
+    }
+    for (decisions, 0..) |decision, index| {
+        if (decision) |suppression| {
+            owned_justifications[index] = try allocator.dupe(u8, suppression.justification);
+        }
+    }
+
+    for (diagnostics.items, 0..) |item, index| {
+        var diagnostic = item;
+        if (owned_justifications[index]) |justification| {
+            diagnostic.suppression = .{ .justification = justification };
+            suppressed_diagnostics.appendAssumeCapacity(diagnostic);
+        } else {
+            kept.appendAssumeCapacity(diagnostic);
+        }
+    }
+    ownership_transferred = true;
+
+    diagnostics.deinit(allocator);
+    diagnostics.* = kept;
+}
+
+fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Error!std.ArrayList(Directive) {
+    var directives: std.ArrayList(Directive) = .empty;
+    errdefer directives.deinit(allocator);
+
+    for (tree.comments) |comment| {
+        const parsed = parseCommentDirective(tree.string(comment.value)) orelse continue;
+        try directives.append(allocator, .{
+            .kind = parsed.kind,
+            .target = parsed.target,
+            .span_start = comment.span.start,
+            .next_code_offset = if (parsed.kind == .ignore) nextCodeOffset(tree, comment.span.end) else null,
+            .top_level = parsed.kind == .ignore_all and isTopLevelComment(tree, comment),
+        });
+    }
+
+    return directives;
+}
+
+fn parseCommentDirective(value: []const u8) ?ParsedDirective {
+    const kinds = [_]struct { prefix: []const u8, kind: DirectiveKind }{
+        .{ .prefix = "utlint-ignore-start", .kind = .ignore_start },
+        .{ .prefix = "utlint-ignore-end", .kind = .ignore_end },
+        .{ .prefix = "utlint-ignore-all", .kind = .ignore_all },
+        .{ .prefix = "utlint-ignore", .kind = .ignore },
+    };
+    for (kinds) |entry| {
+        if (parseDirectiveTarget(value, entry.prefix)) |target| {
+            return .{ .kind = entry.kind, .target = target };
+        }
+    }
+    return null;
+}
+
+fn parseDirectiveTarget(value: []const u8, prefix: []const u8) ?DirectiveTarget {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    if (!std.mem.startsWith(u8, trimmed, prefix)) return null;
+    if (trimmed.len == prefix.len) return .{ .rule_id = null, .justification = "" };
+    if (trimmed[prefix.len] != ':' and !std.ascii.isWhitespace(trimmed[prefix.len])) return null;
+
+    const tail = std.mem.trim(u8, trimmed[prefix.len..], " \t\r\n");
+    const rule_end = std.mem.indexOfScalar(u8, tail, ':') orelse tail.len;
+    const rule_id = std.mem.trim(u8, tail[0..rule_end], " \t\r\n");
+    const justification = if (rule_end < tail.len)
+        std.mem.trim(u8, tail[rule_end + 1 ..], " \t\r\n")
+    else
+        "";
+    return .{
+        .rule_id = if (rule_id.len == 0) null else rule_id,
+        .justification = justification,
+    };
+}
+
+fn suppressionFor(
+    directives: []const Directive,
+    line_starts: []const u32,
+    diagnostic: core.Diagnostic,
+) ?core.Suppression {
+    if (std.mem.eql(u8, diagnostic.rule_id, "parse")) return null;
+
+    const diagnostic_line = lineAtOffset(line_starts, diagnostic.span.start);
+    var all_rules_range_depth: usize = 0;
+    var named_rule_range_depth: usize = 0;
+    var all_rules_range_justification: []const u8 = "";
+    var named_rule_range_justification: []const u8 = "";
+
+    for (directives) |directive| {
+        if (directive.span_start > diagnostic.span.start) break;
+
+        switch (directive.kind) {
+            .ignore_start => {
+                if (directive.target.rule_id) |rule_id| {
+                    if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
+                        if (named_rule_range_depth == 0) named_rule_range_justification = directive.target.justification;
+                        named_rule_range_depth += 1;
+                    }
+                } else {
+                    if (all_rules_range_depth == 0) all_rules_range_justification = directive.target.justification;
+                    all_rules_range_depth += 1;
+                }
+            },
+            .ignore_end => {
+                if (directive.target.rule_id) |rule_id| {
+                    if (std.mem.eql(u8, rule_id, diagnostic.rule_id) and named_rule_range_depth > 0) named_rule_range_depth -= 1;
+                } else if (all_rules_range_depth > 0) {
+                    all_rules_range_depth -= 1;
+                }
+            },
+            .ignore_all => {
+                if (directive.top_level and directive.target.matches(diagnostic.rule_id)) {
+                    return .{ .justification = directive.target.justification };
+                }
+            },
+            .ignore => {
+                const next_offset = directive.next_code_offset orelse continue;
+                if (lineAtOffset(line_starts, next_offset) == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
+                    return .{ .justification = directive.target.justification };
+                }
+            },
+        }
+    }
+
+    if (named_rule_range_depth > 0) return .{ .justification = named_rule_range_justification };
+    if (all_rules_range_depth > 0) return .{ .justification = all_rules_range_justification };
+    return null;
+}
+
+fn isTopLevelComment(tree: *const ast.Tree, target: ast.Comment) bool {
+    var cursor: usize = if (std.mem.startsWith(u8, tree.source, "\xef\xbb\xbf")) 3 else 0;
+    if (std.mem.startsWith(u8, tree.source[cursor..], "#!")) {
+        cursor = if (std.mem.indexOfScalarPos(u8, tree.source, cursor, '\n')) |newline|
+            newline + 1
+        else
+            tree.source.len;
+    }
+    for (tree.comments) |comment| {
+        if (comment.span.start >= target.span.start) break;
+        const comment_start: usize = @intCast(comment.span.start);
+        if (comment_start < cursor) continue;
+        if (!isWhitespaceOnly(tree.source[cursor..comment_start])) return false;
+        cursor = @intCast(comment.span.end);
+    }
+    return isWhitespaceOnly(tree.source[cursor..@as(usize, @intCast(target.span.start))]);
+}
+
+fn isWhitespaceOnly(value: []const u8) bool {
+    for (value) |byte| {
+        if (!std.ascii.isWhitespace(byte)) return false;
+    }
+    return true;
+}
+
+fn nextCodeOffset(tree: *const ast.Tree, start: u32) ?u32 {
+    var offset: usize = @intCast(start);
+    while (offset < tree.source.len) {
+        while (offset < tree.source.len and std.ascii.isWhitespace(tree.source[offset])) : (offset += 1) {}
+        if (offset == tree.source.len) return null;
+
+        var skipped_comment = false;
+        for (tree.comments) |comment| {
+            if (comment.span.start < offset) continue;
+            if (comment.span.start > offset) break;
+            offset = @intCast(comment.span.end);
+            skipped_comment = true;
+            break;
+        }
+        if (skipped_comment) continue;
+
+        return @intCast(offset);
+    }
+    return null;
+}
+
+fn collectLineStarts(allocator: Allocator, source: []const u8) Allocator.Error!std.ArrayList(u32) {
+    var starts: std.ArrayList(u32) = .empty;
+    errdefer starts.deinit(allocator);
+    try starts.append(allocator, 0);
+    for (source, 0..) |byte, index| {
+        if (byte == '\n' and index + 1 < source.len) try starts.append(allocator, @intCast(index + 1));
+    }
+    return starts;
+}
+
+fn lineAtOffset(line_starts: []const u32, offset: u32) usize {
+    var low: usize = 0;
+    var high = line_starts.len;
+    while (low < high) {
+        const middle = low + (high - low) / 2;
+        if (line_starts[middle] <= offset) {
+            low = middle + 1;
+        } else {
+            high = middle;
+        }
+    }
+    return low;
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -3,6 +3,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("suppressions.zig");
+}
+
+comptime {
     _ = @import("rules/accessor_pairs.zig");
 }
 

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -1,0 +1,277 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("helpers.zig");
+
+test "utlint-ignore suppresses a rule diagnostic on the next line" {
+    const source =
+        \\// utlint-ignore no-debugger: generated breakpoint
+        \\debugger;
+        \\debugger;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    try std.testing.expectEqualStrings(lint.rules.no_debugger.id, result.suppressed_diagnostics[0].rule_id);
+    try std.testing.expectEqualStrings("generated breakpoint", result.suppressed_diagnostics[0].suppression.?.justification);
+}
+
+test "utlint-ignore targets the next line of code across blank and comment lines" {
+    const source =
+        \\// utlint-ignore no-debugger: generated breakpoint
+        \\
+        \\// Kept next to the generated statement.
+        \\debugger;
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "utlint-ignore does not skip over an intervening line of code" {
+    const source =
+        \\// utlint-ignore no-debugger: applies to the declaration
+        \\const value = 1;
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "utlint-ignore works in block comments" {
+    const source =
+        \\/* utlint-ignore no-debugger: generated breakpoint */
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+}
+
+test "utlint-ignore text inside a string is not a directive" {
+    const source =
+        \\const text = "// utlint-ignore no-debugger: not a comment";
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "utlint-ignore suppresses all rule diagnostics when no rule is named" {
+    const source =
+        \\// utlint-ignore: generated code
+        \\debugger; console.log("generated");
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+    options.no_console = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}
+
+test "suppression directives do not violate capitalized-comments" {
+    const source =
+        \\// utlint-ignore no-debugger: generated breakpoint
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+    options.capitalized_comments = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}
+
+test "suppression comments do not hide parse diagnostics" {
+    const source =
+        \\// utlint-ignore: invalid generated syntax
+        \\const = ;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", lint.Options.allDisabled());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(helpers.hasRule(result, "parse"));
+}
+
+test "autofix does not apply fixes from suppressed diagnostics" {
+    const source =
+        \\// utlint-ignore no-extra-semi: generated statement
+        \\const value = 1;;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var fixed = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer fixed.deinit(std.testing.allocator);
+
+    try std.testing.expect(!fixed.fixed);
+    try std.testing.expectEqualStrings(source, fixed.output);
+    try std.testing.expectEqual(@as(usize, 1), fixed.result.suppressed_diagnostics.len);
+}
+
+test "utlint-ignore-all suppresses a named rule throughout the file" {
+    const source =
+        \\// utlint-ignore-all no-debugger: generated file
+        \\debugger;
+        \\debugger; console.log("still linted");
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+    options.no_console = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, lint.rules.no_debugger.id));
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_console.id));
+}
+
+test "utlint-ignore-all remains top-level after a shebang" {
+    const source =
+        \\#!/usr/bin/env node
+        \\// utlint-ignore-all no-debugger: generated executable
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "utlint-ignore-all suppresses all rules after a BOM and leading comments" {
+    const source =
+        "\xef\xbb\xbf" ++
+        "// Generated file.\n" ++
+        "/* utlint-ignore-all: generated file */\n" ++
+        "debugger; console.log(\"generated\");\n";
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+    options.no_console = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    try std.testing.expectEqual(@as(usize, 2), result.suppressed_diagnostics.len);
+    try std.testing.expectEqualStrings("generated file", result.suppressed_diagnostics[0].suppression.?.justification);
+}
+
+test "utlint-ignore-all is ignored when it appears after code" {
+    const source =
+        \\debugger;
+        \\// utlint-ignore-all no-debugger: too late
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "utlint-ignore-start and utlint-ignore-end suppress a named rule in a range" {
+    const source =
+        \\debugger;
+        \\// utlint-ignore-start no-debugger: generated section
+        \\debugger; console.log("still linted");
+        \\// utlint-ignore-end no-debugger: generated section
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+    options.no_console = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_debugger.id));
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_console.id));
+}
+
+test "nested suppression ranges stay active until their matching ends" {
+    const source =
+        \\// utlint-ignore-start no-debugger: outer generated section
+        \\// utlint-ignore-start no-debugger: inner generated section
+        \\debugger;
+        \\// utlint-ignore-end no-debugger: inner generated section
+        \\debugger;
+        \\// utlint-ignore-end no-debugger: outer generated section
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+}
+
+test "a named range end does not close an all-rules range" {
+    const source =
+        \\// utlint-ignore-start: generated section
+        \\debugger;
+        \\// utlint-ignore-end no-debugger: unrelated range end
+        \\debugger;
+        \\// utlint-ignore-end: generated section
+        \\debugger;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_debugger = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_debugger.id));
+}


### PR DESCRIPTION
## Summary

- add Biome-style `utlint-ignore`, `utlint-ignore-all`, and `utlint-ignore-start` / `utlint-ignore-end` suppression comments
- support rule-scoped and all-rule suppressions across line and block comments, including BOM, shebang, nested ranges, and next-code-line behavior
- keep parse diagnostics visible and exclude suppressed diagnostics from autofix, statistics, and exit status
- expose suppressed diagnostics through native JSON, ESM/CJS APIs, ESLint-compatible `suppressedMessages`, and `Linter#getSuppressedMessages()`
- document the syntax and add native/npm regression coverage

## Why

Projects need a first-class way to acknowledge intentional lint exceptions without disabling a rule globally. The syntax follows Biome's suppression model while using the utoo-lint-specific `utlint-ignore` prefix.

## User impact

Suppressed diagnostics remain observable through APIs together with their justification, but they no longer fail lint runs or apply fixes. Existing active diagnostics and parse errors keep their current behavior.

## Validation

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all` — 1889/1889 tests passed
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test` — 77/77 tests passed plus TypeScript type checking
- `git diff --check`
