### PR TITLE
chore: move repository to utooland

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
 	Please provide enough information so that others can review your PR.
-	Learn more about contributing: https://github.com/fireairforce/utoo-lint/blob/main/CONTRIBUTING.md
+	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
 -->
 
 ## Summary

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,12 +28,9 @@ jobs:
   codspeed:
     name: CodSpeed
     runs-on: ubuntu-latest
-    env:
-      CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -62,19 +59,9 @@ jobs:
       - name: Generate benchmark corpus
         run: pnpm --dir benchmarks generate -- --files=1000 --statements=30 --out=fixtures/codspeed
 
-      - name: Run benchmark smoke
-        if: env.CODSPEED_TOKEN == ''
-        run: pnpm --dir benchmarks codspeed -- --target=fixtures/codspeed --time=100 --warmup-time=0
-
-      - name: Skip CodSpeed upload
-        if: env.CODSPEED_TOKEN == ''
-        run: echo "CODSPEED_TOKEN is not configured; ran benchmark smoke only."
-
       - name: Run CodSpeed benchmarks
-        if: env.CODSPEED_TOKEN != ''
         uses: CodSpeedHQ/action@v4
         with:
           mode: walltime
           working-directory: benchmarks
           run: pnpm codspeed -- --target=fixtures/codspeed
-          token: ${{ env.CODSPEED_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
       - name: Verify npm wrapper
         run: |
           node npm/utoo-lint/bin/utoo-lint.js --no-config test/fixtures/bad.ts
-          node npm/utoo-lint/bin/utoo-lint.js --config=npm/utoo-lint/configs/frontend.json test/fixtures/bad.ts && exit 1 || test "$?" = "1"
+          set +e
+          node npm/utoo-lint/bin/utoo-lint.js --config=npm/utoo-lint/configs/frontend.json test/fixtures/bad.ts
+          status=$?
+          set -e
+          test "$status" -eq 1
 
       - name: Test npm package
         run: pnpm --dir npm/utoo-lint test

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![npm version](https://img.shields.io/npm/v/%40utoo%2Flint?logo=npm)](https://www.npmjs.com/package/@utoo/lint)
 [![Node.js 20+](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![CI](https://github.com/fireairforce/utoo-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/fireairforce/utoo-lint/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/fireairforce/utoo-lint)](LICENSE)
+[![CI](https://github.com/utooland/utoo-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/utooland/utoo-lint/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/utooland/utoo-lint)](LICENSE)
 
 A high-performance linter for JavaScript and TypeScript, written in Zig and
 powered by [Yuku](https://github.com/yuku-toolchain/yuku).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ security fixes.
 
 Please report suspected vulnerabilities privately before public disclosure.
 
-- Prefer a [private GitHub security advisory](https://github.com/fireairforce/utoo-lint/security/advisories/new).
+- Prefer a [private GitHub security advisory](https://github.com/utooland/utoo-lint/security/advisories/new).
 - If private reporting is unavailable, contact a maintainer through a
   non-public channel instead of opening a public issue with exploit details.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ Use `utlint.config.json` for a static, runtime-independent config:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "files": ["src/**/*.{js,jsx,ts,tsx}"],
   "ignores": ["dist", "node_modules"],
   "rules": {
@@ -187,7 +187,7 @@ The template includes a `$schema` entry for editor validation and a focused set 
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "files": ["src/**/*.{js,jsx,ts,tsx}"],
   "ignores": ["dist", "node_modules"],
   "rules": {

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -58,7 +58,7 @@ Minimal config:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "rules": {
     "no-debugger": "error",
     "no-console": "off",

--- a/npm/@utoo/lint-darwin-arm64/package.json
+++ b/npm/@utoo/lint-darwin-arm64/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "os": [
     "darwin"
   ],

--- a/npm/@utoo/lint-darwin-x64/package.json
+++ b/npm/@utoo/lint-darwin-x64/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "os": [
     "darwin"
   ],

--- a/npm/@utoo/lint-linux-arm64/package.json
+++ b/npm/@utoo/lint-linux-arm64/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "os": [
     "linux"
   ],

--- a/npm/@utoo/lint-linux-x64/package.json
+++ b/npm/@utoo/lint-linux-x64/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "os": [
     "linux"
   ],

--- a/npm/@utoo/lint-win32-x64/package.json
+++ b/npm/@utoo/lint-win32-x64/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "os": [
     "win32"
   ],

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -4,8 +4,8 @@
 
 [![npm version](https://img.shields.io/npm/v/%40utoo%2Flint?logo=npm)](https://www.npmjs.com/package/@utoo/lint)
 [![Node.js 20+](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![CI](https://github.com/fireairforce/utoo-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/fireairforce/utoo-lint/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/fireairforce/utoo-lint)](https://github.com/fireairforce/utoo-lint/blob/main/LICENSE)
+[![CI](https://github.com/utooland/utoo-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/utooland/utoo-lint/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/utooland/utoo-lint)](https://github.com/utooland/utoo-lint/blob/main/LICENSE)
 
 A high-performance linter for JavaScript and TypeScript, written in Zig and
 powered by [Yuku](https://github.com/yuku-toolchain/yuku).
@@ -14,9 +14,9 @@ powered by [Yuku](https://github.com/yuku-toolchain/yuku).
 and JavaScript APIs.
 
 [Installation](#installation) · [Quick start](#quick-start) ·
-[Rules](https://github.com/fireairforce/utoo-lint/blob/main/docs/rule-status.md) ·
-[Configuration](https://github.com/fireairforce/utoo-lint/blob/main/docs/configuration.md) ·
-[GitHub](https://github.com/fireairforce/utoo-lint)
+[Rules](https://github.com/utooland/utoo-lint/blob/main/docs/rule-status.md) ·
+[Configuration](https://github.com/utooland/utoo-lint/blob/main/docs/configuration.md) ·
+[GitHub](https://github.com/utooland/utoo-lint)
 
 ## Why utoo-lint?
 
@@ -102,7 +102,7 @@ utx @utoo/lint
 ```
 
 See the
-[configuration guide](https://github.com/fireairforce/utoo-lint/blob/main/docs/configuration.md)
+[configuration guide](https://github.com/utooland/utoo-lint/blob/main/docs/configuration.md)
 for flat config arrays, global ignores, rule options, and config precedence.
 
 ### Add package scripts
@@ -146,7 +146,7 @@ and `2`. A selected config enables only the rules present in its resolved
 
 The npm CLI and JavaScript API load both formats. The raw native binary loads
 JSON only. See the
-[configuration guide](https://github.com/fireairforce/utoo-lint/blob/main/docs/configuration.md)
+[configuration guide](https://github.com/utooland/utoo-lint/blob/main/docs/configuration.md)
 for the complete behavior.
 
 ## Autofix
@@ -164,7 +164,7 @@ utx @utoo/lint --fix-dry-run --format=json src
 ```
 
 Fixes run until the source is stable, subject to a safety pass limit. The
-[rule status](https://github.com/fireairforce/utoo-lint/blob/main/docs/rule-status.md)
+[rule status](https://github.com/utooland/utoo-lint/blob/main/docs/rule-status.md)
 documents autofix support for each rule.
 
 ## Suppression comments
@@ -189,7 +189,7 @@ suppression. Parse errors are never suppressed, and suppressed fixes are not
 applied.
 
 See the
-[suppression comments guide](https://github.com/fireairforce/utoo-lint/blob/main/docs/suppressions.md)
+[suppression comments guide](https://github.com/utooland/utoo-lint/blob/main/docs/suppressions.md)
 for range examples and API behavior.
 
 ## Migrating from ESLint
@@ -204,7 +204,7 @@ utx @utoo/lint migrate eslint \
 
 The package also exposes `eslint` and `fishlint` compatibility commands for
 incremental replacement workflows. See the
-[migration guide](https://github.com/fireairforce/utoo-lint/blob/main/docs/eslint-migration.md)
+[migration guide](https://github.com/utooland/utoo-lint/blob/main/docs/eslint-migration.md)
 for supported mappings and known differences.
 
 ## JavaScript API
@@ -251,13 +251,13 @@ development.
 
 ## Documentation
 
-- [Rule status](https://github.com/fireairforce/utoo-lint/blob/main/docs/rule-status.md)
-- [Configuration](https://github.com/fireairforce/utoo-lint/blob/main/docs/configuration.md)
-- [Suppression comments](https://github.com/fireairforce/utoo-lint/blob/main/docs/suppressions.md)
-- [Migrating from ESLint](https://github.com/fireairforce/utoo-lint/blob/main/docs/eslint-migration.md)
-- [Benchmarks](https://github.com/fireairforce/utoo-lint/tree/main/benchmarks)
-- [Security policy](https://github.com/fireairforce/utoo-lint/blob/main/SECURITY.md)
+- [Rule status](https://github.com/utooland/utoo-lint/blob/main/docs/rule-status.md)
+- [Configuration](https://github.com/utooland/utoo-lint/blob/main/docs/configuration.md)
+- [Suppression comments](https://github.com/utooland/utoo-lint/blob/main/docs/suppressions.md)
+- [Migrating from ESLint](https://github.com/utooland/utoo-lint/blob/main/docs/eslint-migration.md)
+- [Benchmarks](https://github.com/utooland/utoo-lint/tree/main/benchmarks)
+- [Security policy](https://github.com/utooland/utoo-lint/blob/main/SECURITY.md)
 
 ## License
 
-[MIT](https://github.com/fireairforce/utoo-lint/blob/main/LICENSE)
+[MIT](https://github.com/utooland/utoo-lint/blob/main/LICENSE)

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -16,7 +16,7 @@ const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const IGNORED_RULES = new Map([
   ["prettier/prettier", "formatting is outside utoo-lint"]
 ]);
-const SCHEMA_URL = "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json";
+const SCHEMA_URL = "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json";
 const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";

--- a/npm/utoo-lint/configs/frontend.json
+++ b/npm/utoo-lint/configs/frontend.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "rules": {
     "no-debugger": "error",
     "no-alert": "error",

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fireairforce/utoo-lint.git"
+    "url": "git+https://github.com/utooland/utoo-lint.git"
   },
   "bugs": {
-    "url": "https://github.com/fireairforce/utoo-lint/issues"
+    "url": "https://github.com/utooland/utoo-lint/issues"
   },
-  "homepage": "https://github.com/fireairforce/utoo-lint#readme",
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/fireairforce/utoo-lint/main/npm/utoo-lint/schema.json",
+  "$id": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "title": "utoo-lint configuration",
   "type": "object",
   "additionalProperties": true,


### PR DESCRIPTION
## Summary

- Update repository links, package metadata, documentation, and templates for utooland/utoo-lint
- Switch CodSpeed benchmark uploads from a static token to GitHub OIDC
- Make the CI invalid-fixture exit-status assertion explicit and actionlint-safe

## External configuration

- npm Trusted Publishers for all six packages now point to utooland/utoo-lint
- The CodSpeed GitHub App is installed for the selected repository

## Validation

- pnpm --dir npm/utoo-lint test — 77 tests passed, including type checks
- actionlint .github/workflows/*.yml
- JSON parsing and git diff --check
- Benchmarks workflow completed successfully and uploaded performance data: https://github.com/utooland/utoo-lint/actions/runs/32349627188