### PR TITLE
fix: ignore disabled unsupported ESLint rules

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -31,9 +31,10 @@ executed through a compatibility layer. The current migrator flattens ESLint
 flat-config entries into one JSON object: it unions `files` and `ignores`, and
 later entries win when the same supported rule appears more than once. Review
 the result manually when entries give one rule different per-file values. It
-also skips formatter-only rules such as `prettier/prettier` and reports
+also skips formatter-only rules such as `prettier/prettier` and reports enabled
 unsupported rules that still need a native utoo rule or a deliberate
-replacement.
+replacement. Disabled unsupported rules are omitted because they have no
+runtime behavior to migrate.
 
 For a preview without writing a file:
 
@@ -43,7 +44,9 @@ npx utoo-lint migrate eslint --print --report=json
 
 The selected value for each rule is preserved, including arrays such as
 `["error", { ...options }]`. Native utoo rules consume the options they support;
-unsupported rules are reported instead of being copied.
+enabled unsupported rules are reported instead of being copied. Unsupported
+rules configured as `"off"`, `0`, `false`, or an array with one of those
+severities do not block migration.
 
 ## Add a Config File
 

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -197,6 +197,9 @@ function migrateEslintConfig(options) {
         continue;
       }
       if (!supportedRuleIds.has(ruleId)) {
+        if (isRuleDisabled(ruleConfig)) {
+          continue;
+        }
         unsupportedRules.push(ruleId);
         continue;
       }
@@ -295,6 +298,11 @@ function addPatterns(target, value) {
 
 function migratableRuleConfig(ruleConfig) {
   return Array.isArray(ruleConfig) ? [...ruleConfig] : ruleConfig;
+}
+
+function isRuleDisabled(ruleConfig) {
+  const severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
+  return severity === "off" || severity === 0 || severity === false;
 }
 
 function sortObjectByKey(object) {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -467,6 +467,56 @@ test("migrator config stdout does not corrupt its serialized input", (t) => {
   assert.equal(JSON.parse(result.stdout).rules["no-debugger"], "error");
 });
 
+test("migrator omits disabled unsupported rules from the blocking report", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, "eslint.config.json"),
+    JSON.stringify({
+      rules: {
+        "example/off-string": "off",
+        "example/off-number": 0,
+        "example/off-boolean": false,
+        "example/off-string-array": ["off", { reason: "disabled" }],
+        "example/off-number-array": [0, { reason: "disabled" }],
+        "example/off-boolean-array": [false, { reason: "disabled" }],
+        "no-debugger": "error"
+      }
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).rules, { "no-debugger": "error" });
+  assert.deepEqual(JSON.parse(result.stderr).unsupportedRules, []);
+});
+
+test("migrator still blocks on enabled unsupported rules", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, "eslint.config.json"),
+    JSON.stringify({
+      rules: {
+        "example/disabled": "off",
+        "example/enabled": ["warn", { reason: "still active" }]
+      }
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(JSON.parse(result.stderr).unsupportedRules, ["example/enabled"]);
+});
+
 test("ESLint.findConfigFile prefers utlint.config.ts over utlint.config.json in the same directory", async (t) => {
   const project = createProject(t);
   const typescriptConfig = write(join(project, "utlint.config.ts"));


### PR DESCRIPTION
## Summary
- omit unsupported ESLint rules whose severity is disabled
- keep enabled unsupported rules blocking migration
- document the behavior and cover scalar/array severity forms

## Tests
- `zig build test`
- `zig build`
- `pnpm --dir npm/utoo-lint test`

Closes #1058
