### PR TITLE
fix: preserve ESLint flat config scopes

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -27,13 +27,12 @@ npx utoo-lint migrate eslint --from eslint.config.js --output utlint.config.json
 ```
 
 The generated config is a native `utoo-lint` config, not an ESLint config
-executed through a compatibility layer. The current migrator flattens ESLint
-flat-config entries into one JSON object: it unions `files` and `ignores`, and
-later entries win when the same supported rule appears more than once. Review
-the result manually when entries give one rule different per-file values. It
-also skips formatter-only rules such as `prettier/prettier` and reports
-unsupported rules that still need a native utoo rule or a deliberate
-replacement.
+executed through a compatibility layer. ESLint flat-config entries remain
+separate and in their original order, including their `files`, `ignores`, and
+supported rule values. This preserves per-file overrides and keeps ignore-only
+entries global while other ignores remain entry-scoped. The migrator also skips
+formatter-only rules such as `prettier/prettier` and reports unsupported rules
+that still need a native utoo rule or a deliberate replacement.
 
 For a preview without writing a file:
 
@@ -44,6 +43,10 @@ npx utoo-lint migrate eslint --print --report=json
 The selected value for each rule is preserved, including arrays such as
 `["error", { ...options }]`. Native utoo rules consume the options they support;
 unsupported rules are reported instead of being copied.
+
+Flat-config output starts with a schema metadata entry, followed by the
+migrated entries. Matching entries are applied in array order, so a later value
+for the same rule retains ESLint's override behavior.
 
 ## Add a Config File
 

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -178,43 +178,33 @@ function migrateEslintConfig(options) {
   const eslintConfig = loadEslintConfig(sourcePath, options.cwd);
   const supportedRuleIds = new Set(new Linter().getRules().keys());
   const entries = normalizeConfigEntries(eslintConfig);
-  const rules = {};
-  const files = new Set();
-  const ignores = new Set();
+  const migratedEntries = [];
   const supportedRules = [];
   const unsupportedRules = [];
   const ignoredRules = [];
 
   for (const entry of entries) {
-    addPatterns(files, entry.files);
-    addPatterns(ignores, entry.ignores);
-    if (!entry.rules || typeof entry.rules !== "object") {
-      continue;
-    }
-    for (const [ruleId, ruleConfig] of Object.entries(entry.rules)) {
-      if (IGNORED_RULES.has(ruleId)) {
-        ignoredRules.push({ ruleId, reason: IGNORED_RULES.get(ruleId) });
-        continue;
+    const rules = {};
+    if (entry.rules && typeof entry.rules === "object") {
+      for (const [ruleId, ruleConfig] of Object.entries(entry.rules)) {
+        if (IGNORED_RULES.has(ruleId)) {
+          ignoredRules.push({ ruleId, reason: IGNORED_RULES.get(ruleId) });
+          continue;
+        }
+        if (!supportedRuleIds.has(ruleId)) {
+          unsupportedRules.push(ruleId);
+          continue;
+        }
+        rules[ruleId] = migratableRuleConfig(ruleConfig);
+        supportedRules.push(ruleId);
       }
-      if (!supportedRuleIds.has(ruleId)) {
-        unsupportedRules.push(ruleId);
-        continue;
-      }
-      rules[ruleId] = migratableRuleConfig(ruleConfig);
-      supportedRules.push(ruleId);
     }
+    migratedEntries.push(migratableConfigEntry(entry, rules));
   }
 
-  const config = {
-    $schema: SCHEMA_URL
-  };
-  if (files.size > 0) {
-    config.files = [...files];
-  }
-  if (ignores.size > 0) {
-    config.ignores = [...ignores];
-  }
-  config.rules = sortObjectByKey(rules);
+  const config = Array.isArray(eslintConfig)
+    ? [{ $schema: SCHEMA_URL }, ...migratedEntries]
+    : { $schema: SCHEMA_URL, ...(migratedEntries[0] ?? { rules: {} }) };
 
   return {
     config,
@@ -282,15 +272,43 @@ function normalizeConfigEntries(config) {
   return [];
 }
 
-function addPatterns(target, value) {
-  if (!value) {
-    return;
+function migratableConfigEntry(entry, rules) {
+  const migrated = {};
+  if (typeof entry.name === "string") {
+    migrated.name = entry.name;
   }
+  const files = migratablePatterns(entry.files);
+  if (files.length > 0) {
+    migrated.files = files;
+  }
+  const ignores = migratablePatterns(entry.ignores);
+  if (ignores.length > 0) {
+    migrated.ignores = ignores;
+  }
+  if (!isGlobalIgnoreEntry(entry)) {
+    migrated.rules = sortObjectByKey(rules);
+  }
+  return migrated;
+}
+
+function migratablePatterns(value) {
+  const patterns = [];
+  collectMigratablePatterns(value, patterns);
+  return [...new Set(patterns)];
+}
+
+function collectMigratablePatterns(value, patterns) {
   for (const pattern of Array.isArray(value) ? value : [value]) {
-    if (typeof pattern === "string") {
-      target.add(pattern);
+    if (Array.isArray(pattern)) {
+      collectMigratablePatterns(pattern, patterns);
+    } else if (typeof pattern === "string") {
+      patterns.push(pattern);
     }
   }
+}
+
+function isGlobalIgnoreEntry(entry) {
+  return Boolean(entry.ignores) && Object.keys(entry).every((key) => key === "name" || key === "ignores");
 }
 
 function migratableRuleConfig(ruleConfig) {

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -2,49 +2,62 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "title": "utoo-lint configuration",
-  "type": "object",
-  "additionalProperties": true,
-  "properties": {
-    "$schema": {
-      "type": "string"
+  "oneOf": [
+    {
+      "$ref": "#/definitions/configObject"
     },
-    "rules": {
-      "description": "ESLint-compatible rule severity map. Unknown rule names are rejected by utoo-lint.",
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/configObject"
+      }
+    }
+  ],
+  "definitions": {
+    "configObject": {
       "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/ruleSeverity"
+      "additionalProperties": true,
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "rules": {
+          "description": "ESLint-compatible rule severity map. Unknown rule names are rejected by utoo-lint.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ruleSeverity"
+          }
+        },
+        "files": {
+          "description": "File globs this config entry applies to.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "ignores": {
+          "description": "File globs ignored by this config entry.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
       }
     },
-    "files": {
-      "description": "File globs this config entry applies to.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "ignores": {
-      "description": "File globs ignored by this config entry.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    }
-  },
-  "definitions": {
     "ruleSeverity": {
       "oneOf": [
         {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -447,7 +447,81 @@ test("migrator defaults to utlint.config.json", (t) => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(existsSync(outputPath), true);
-  assert.equal(JSON.parse(readFileSync(outputPath, "utf8")).$schema.endsWith("/schema.json"), true);
+  const config = JSON.parse(readFileSync(outputPath, "utf8"));
+  assert.equal(config[0].$schema.endsWith("/schema.json"), true);
+  assert.deepEqual(config[1], {
+    files: ["src/**/*.ts"],
+    rules: { "no-debugger": "error" }
+  });
+});
+
+test("migrator preserves flat config scopes, global ignores, and override order", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, "eslint.config.mjs"),
+    [
+      "export default [",
+      '  { name: "global ignores", ignores: ["dist/"] },',
+      '  { name: "source", files: ["src/**/*.js"], ignores: ["src/generated/**"], rules: { "no-console": "error", "no-debugger": "warn" } },',
+      '  { name: "tests", files: ["test/**/*.js"], rules: { "no-console": "off", "no-debugger": "error" } },',
+      '  { name: "late source override", files: ["src/special/**/*.js"], rules: { "no-console": "off" } },',
+      '  { name: "scoped ignores", ignores: ["fixtures/**"], languageOptions: { ecmaVersion: 2022 } }',
+      "];",
+      ""
+    ].join("\n")
+  );
+  const outputPath = join(project, "utlint.config.json");
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, `--output=${outputPath}`],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const config = JSON.parse(readFileSync(outputPath, "utf8"));
+  assert.equal(config[0].$schema.endsWith("/schema.json"), true);
+  assert.deepEqual(config.slice(1), [
+    { name: "global ignores", ignores: ["dist/"] },
+    {
+      name: "source",
+      files: ["src/**/*.js"],
+      ignores: ["src/generated/**"],
+      rules: { "no-console": "error", "no-debugger": "warn" }
+    },
+    {
+      name: "tests",
+      files: ["test/**/*.js"],
+      rules: { "no-console": "off", "no-debugger": "error" }
+    },
+    {
+      name: "late source override",
+      files: ["src/special/**/*.js"],
+      rules: { "no-console": "off" }
+    },
+    { name: "scoped ignores", ignores: ["fixtures/**"], rules: {} }
+  ]);
+
+  const sourcePath = write(join(project, "src", "index.js"), "console.log('source');\ndebugger;\n");
+  const testPath = write(join(project, "test", "index.js"), "console.log('test');\ndebugger;\n");
+  const specialPath = write(join(project, "src", "special", "index.js"), "console.log('special');\ndebugger;\n");
+  const lint = spawnSync(
+    process.execPath,
+    [cliPath, `--config=${outputPath}`, "--format=json", sourcePath, testPath, specialPath],
+    { cwd: project, env: { ...process.env, UTOO_LINT_BIN: testBinary() }, encoding: "utf8" }
+  );
+
+  assert.equal(lint.status, 1, lint.stderr);
+  const diagnostics = JSON.parse(lint.stdout).diagnostics;
+  assert.deepEqual(
+    diagnostics.map(({ filePath, ruleId, severity }) => ({ filePath, ruleId, severity })),
+    [
+      { filePath: sourcePath, ruleId: "no-debugger", severity: "warning" },
+      { filePath: sourcePath, ruleId: "no-console", severity: "error" },
+      { filePath: testPath, ruleId: "no-debugger", severity: "error" },
+      { filePath: specialPath, ruleId: "no-debugger", severity: "warning" }
+    ]
+  );
 });
 
 test("migrator config stdout does not corrupt its serialized input", (t) => {
@@ -464,7 +538,7 @@ test("migrator config stdout does not corrupt its serialized input", (t) => {
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(JSON.parse(result.stdout).rules["no-debugger"], "error");
+  assert.equal(JSON.parse(result.stdout)[1].rules["no-debugger"], "error");
 });
 
 test("ESLint.findConfigFile prefers utlint.config.ts over utlint.config.json in the same directory", async (t) => {


### PR DESCRIPTION
## Summary
- emit migrated flat configs as ordered entries instead of flattening scopes
- preserve per-entry files, ignores, rule values, and global ignore-only semantics
- extend the JSON schema for flat config arrays and update migration docs

## Tests
- `node --test --test-concurrency=1 --test-name-pattern=migrator npm/utoo-lint/test/config-loading.test.mjs`
- `pnpm --dir npm/utoo-lint test`

Closes #1059
