### PR TITLE
feat: map equivalent eslint-react rule aliases

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -45,6 +45,21 @@ The selected value for each rule is preserved, including arrays such as
 `["error", { ...options }]`. Native utoo rules consume the options they support;
 unsupported rules are reported instead of being copied.
 
+The migrator translates the following `@eslint-react` aliases when their
+behavior has a native equivalent:
+
+| ESLint rule | utoo-lint rule |
+| --- | --- |
+| `@eslint-react/no-array-index-key` | `react/no-array-index-key` |
+| `@eslint-react/dom-no-find-dom-node` | `react/no-find-dom-node` |
+| `@eslint-react/dom-no-render-return-value` | `react/no-render-return-value` |
+| `@eslint-react/dom-no-void-elements-with-children` | `react/void-dom-elements-no-children` |
+| `@eslint-react/rules-of-hooks` | `react-hooks/rules-of-hooks` |
+
+Translated aliases are listed separately in the migration report. Other
+`@eslint-react` rules remain unsupported unless an explicit equivalent is added;
+the migrator does not infer mappings from similar names.
+
 ## Add a Config File
 
 Create `utlint.config.json` in the project root, or copy the packaged frontend

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -16,6 +16,13 @@ const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const IGNORED_RULES = new Map([
   ["prettier/prettier", "formatting is outside utoo-lint"]
 ]);
+const RULE_ALIASES = new Map([
+  ["@eslint-react/no-array-index-key", "react/no-array-index-key"],
+  ["@eslint-react/dom-no-find-dom-node", "react/no-find-dom-node"],
+  ["@eslint-react/dom-no-render-return-value", "react/no-render-return-value"],
+  ["@eslint-react/dom-no-void-elements-with-children", "react/void-dom-elements-no-children"],
+  ["@eslint-react/rules-of-hooks", "react-hooks/rules-of-hooks"]
+]);
 const SCHEMA_URL = "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json";
 const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
 import { writeFileSync } from "node:fs";
@@ -184,6 +191,7 @@ function migrateEslintConfig(options) {
   const supportedRules = [];
   const unsupportedRules = [];
   const ignoredRules = [];
+  const translatedRules = [];
 
   for (const entry of entries) {
     addPatterns(files, entry.files);
@@ -192,16 +200,20 @@ function migrateEslintConfig(options) {
       continue;
     }
     for (const [ruleId, ruleConfig] of Object.entries(entry.rules)) {
+      const migratedRuleId = RULE_ALIASES.get(ruleId) ?? ruleId;
       if (IGNORED_RULES.has(ruleId)) {
         ignoredRules.push({ ruleId, reason: IGNORED_RULES.get(ruleId) });
         continue;
       }
-      if (!supportedRuleIds.has(ruleId)) {
+      if (!supportedRuleIds.has(migratedRuleId)) {
         unsupportedRules.push(ruleId);
         continue;
       }
-      rules[ruleId] = migratableRuleConfig(ruleConfig);
-      supportedRules.push(ruleId);
+      rules[migratedRuleId] = migratableRuleConfig(ruleConfig);
+      supportedRules.push(migratedRuleId);
+      if (migratedRuleId !== ruleId) {
+        translatedRules.push({ sourceRuleId: ruleId, targetRuleId: migratedRuleId });
+      }
     }
   }
 
@@ -224,6 +236,7 @@ function migrateEslintConfig(options) {
       supportedRules: uniqueSorted(supportedRules),
       unsupportedRules: uniqueSorted(unsupportedRules),
       ignoredRules: uniqueByRuleId(ignoredRules),
+      translatedRules: uniqueTranslatedRules(translatedRules),
       optionDroppedRules: []
     }
   };
@@ -313,6 +326,14 @@ function uniqueByRuleId(values) {
   return [...result.values()].sort((left, right) => left.ruleId.localeCompare(right.ruleId));
 }
 
+function uniqueTranslatedRules(values) {
+  const result = new Map();
+  for (const value of values) {
+    result.set(value.sourceRuleId, value);
+  }
+  return [...result.values()].sort((left, right) => left.sourceRuleId.localeCompare(right.sourceRuleId));
+}
+
 function writeReport(report, options, stream) {
   if (options.report === "json") {
     stream.write(JSON.stringify(report, null, 2) + "\n");
@@ -324,6 +345,9 @@ function writeReport(report, options, stream) {
     stream.write(`utoo-lint migrate eslint: wrote ${report.output}\n`);
   }
   stream.write(`utoo-lint migrate eslint: migrated ${report.supportedRules.length} supported rule(s)\n`);
+  if (report.translatedRules.length > 0) {
+    stream.write(`utoo-lint migrate eslint: translated ${report.translatedRules.length} rule alias(es): ${report.translatedRules.map((rule) => `${rule.sourceRuleId} -> ${rule.targetRuleId}`).join(", ")}\n`);
+  }
   if (report.ignoredRules.length > 0) {
     stream.write(`utoo-lint migrate eslint: ignored ${report.ignoredRules.length} rule(s): ${report.ignoredRules.map((rule) => rule.ruleId).join(", ")}\n`);
   }

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -467,6 +467,74 @@ test("migrator config stdout does not corrupt its serialized input", (t) => {
   assert.equal(JSON.parse(result.stdout).rules["no-debugger"], "error");
 });
 
+test("migrator translates reviewed @eslint-react aliases", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      rules: {
+        "@eslint-react/no-array-index-key": ["warn"],
+        "@eslint-react/dom-no-find-dom-node": 2,
+        "@eslint-react/dom-no-render-return-value": false,
+        "@eslint-react/dom-no-void-elements-with-children": ["error"],
+        "@eslint-react/rules-of-hooks": "error"
+      }
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).rules, {
+    "react-hooks/rules-of-hooks": "error",
+    "react/no-array-index-key": ["warn"],
+    "react/no-find-dom-node": 2,
+    "react/no-render-return-value": false,
+    "react/void-dom-elements-no-children": ["error"]
+  });
+  const report = JSON.parse(result.stderr);
+  assert.deepEqual(report.unsupportedRules, []);
+  assert.deepEqual(report.translatedRules, [
+    { sourceRuleId: "@eslint-react/dom-no-find-dom-node", targetRuleId: "react/no-find-dom-node" },
+    { sourceRuleId: "@eslint-react/dom-no-render-return-value", targetRuleId: "react/no-render-return-value" },
+    { sourceRuleId: "@eslint-react/dom-no-void-elements-with-children", targetRuleId: "react/void-dom-elements-no-children" },
+    { sourceRuleId: "@eslint-react/no-array-index-key", targetRuleId: "react/no-array-index-key" },
+    { sourceRuleId: "@eslint-react/rules-of-hooks", targetRuleId: "react-hooks/rules-of-hooks" }
+  ]);
+});
+
+test("migrator does not infer @eslint-react aliases without equivalent rules", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      rules: {
+        "@eslint-react/no-missing-key": "error",
+        "@eslint-react/dom-no-render": "warn"
+      }
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).rules, {});
+  const report = JSON.parse(result.stderr);
+  assert.deepEqual(report.translatedRules, []);
+  assert.deepEqual(report.unsupportedRules, [
+    "@eslint-react/dom-no-render",
+    "@eslint-react/no-missing-key"
+  ]);
+});
+
 test("ESLint.findConfigFile prefers utlint.config.ts over utlint.config.json in the same directory", async (t) => {
   const project = createProject(t);
   const typescriptConfig = write(join(project, "utlint.config.ts"));


### PR DESCRIPTION
## Summary
- add an explicit mapping table for five reviewed `@eslint-react` aliases
- preserve rule severities while translating to native React and Hooks IDs
- report translated aliases separately and leave non-equivalent rules unsupported

## Tests
- `node --test --test-concurrency=1 --test-name-pattern=migrator npm/utoo-lint/test/config-loading.test.mjs`
- `pnpm --dir npm/utoo-lint test`

Closes #1060
