### PR TITLE
feat: implement react-hooks/exhaustive-deps

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -323,6 +323,7 @@ instead of being rewritten.
 
 | Rule | Status |
 | --- | --- |
+| [`react-hooks/exhaustive-deps`](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) | Implements dependency-array validation for built-in hooks and `additionalHooks` literal, alternation, anchor, and wildcard patterns; reports missing, duplicate, unnecessary, complex, and unstable dependencies without type information |
 | [`react-hooks/rules-of-hooks`](https://legacy.reactjs.org/docs/hooks-rules.html) | Implemented for top-level, ordinary function, class method, callback, conditional branch, and loop checks |
 
 ## TypeScript ESLint rules

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -358,6 +358,7 @@ const BUILTIN_RULE_IDS = [
   "react/self-closing-comp",
   "react/style-prop-object",
   "react/void-dom-elements-no-children",
+  "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -361,6 +361,7 @@ const BUILTIN_RULE_IDS = [
   "react/self-closing-comp",
   "react/style-prop-object",
   "react/void-dom-elements-no-children",
+  "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1330,6 +1330,30 @@ pub const NoUnusedVarsIgnorePattern = struct {
     }
 };
 
+pub const max_react_hooks_additional_hooks_pattern_len = 256;
+
+pub const ReactHooksAdditionalHooksPatternError = error{
+    ReactHooksAdditionalHooksPatternTooLong,
+};
+
+pub const ReactHooksAdditionalHooksPattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_react_hooks_additional_hooks_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const ReactHooksAdditionalHooksPattern) ?[]const u8 {
+        if (!self.custom) return null;
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *ReactHooksAdditionalHooksPattern, pattern_value: []const u8) ReactHooksAdditionalHooksPatternError!void {
+        if (pattern_value.len > max_react_hooks_additional_hooks_pattern_len) return error.ReactHooksAdditionalHooksPatternTooLong;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+    }
+};
+
 pub const max_no_useless_escape_allow_regex_characters = 32;
 
 pub const NoUselessEscapeAllowRegexCharactersError = error{
@@ -2663,6 +2687,8 @@ pub const Options = struct {
     react_self_closing_comp_html: bool = true,
     react_style_prop_object: bool = true,
     react_void_dom_elements_no_children: bool = true,
+    react_hooks_exhaustive_deps: bool = true,
+    react_hooks_exhaustive_deps_additional_hooks: ReactHooksAdditionalHooksPattern = .{},
     react_hooks_rules_of_hooks: bool = true,
     radix: bool = true,
     radix_style: RadixStyle = .always,
@@ -3479,6 +3505,9 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "react/self-closing-comp")) {
             self.react_self_closing_comp_component = try reactSelfClosingCompBoolOptionFromConfig(value, "component", true);
             self.react_self_closing_comp_html = try reactSelfClosingCompBoolOptionFromConfig(value, "html", true);
+        }
+        if (std.mem.eql(u8, cli_name, "react-hooks/exhaustive-deps")) {
+            self.react_hooks_exhaustive_deps_additional_hooks = try reactHooksAdditionalHooksFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/array-type")) {
             self.typescript_eslint_array_type_style = try typescriptEslintArrayTypeStyleFromConfig(value);
@@ -8376,6 +8405,28 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn reactHooksAdditionalHooksFromConfig(value: std.json.Value) RuleConfigError!ReactHooksAdditionalHooksPattern {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const pattern_value = switch (config.get("additionalHooks") orelse return .{}) {
+            .string => |pattern_value| pattern_value,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (pattern_value.len == 0) return .{};
+
+        var pattern = ReactHooksAdditionalHooksPattern{};
+        pattern.set(pattern_value) catch return error.UnsupportedRuleConfigValue;
+        return pattern;
     }
 
     fn reactJsxPascalCaseAllowAllCapsFromConfig(value: std.json.Value) RuleConfigError!bool {

--- a/src/root.zig
+++ b/src/root.zig
@@ -219,6 +219,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_alert or
         options.no_async_promise_executor or
         options.alipay_ant_exhaustive_deps or
+        options.react_hooks_exhaustive_deps or
         options.alipay_ant_prefer_click_with_debounce or
         options.no_buffer_constructor or
         options.no_console or

--- a/src/rules/alipay_ant_exhaustive_deps.zig
+++ b/src/rules/alipay_ant_exhaustive_deps.zig
@@ -8,6 +8,13 @@ const Allocator = std.mem.Allocator;
 
 pub const id = "@alipay/ant/exhaustive-deps";
 
+pub const Options = struct {
+    rule_id: []const u8 = id,
+    additional_hooks: core.ReactHooksAdditionalHooksPattern = .{},
+    report_unnecessary_dependencies: bool = false,
+    report_unstable_dependencies: bool = false,
+};
+
 const SymbolId = traverser.semantic.SymbolId;
 const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
 const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
@@ -18,6 +25,16 @@ pub fn run(
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    return runWithOptions(allocator, diagnostics, tree, symbol_table, .{});
+}
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    options: Options,
 ) Allocator.Error!void {
     var reference_lookup = ReferenceLookup.init(allocator);
     defer reference_lookup.deinit();
@@ -41,9 +58,13 @@ pub fn run(
     var stable_symbols = SymbolSet.init(allocator);
     defer stable_symbols.deinit();
 
+    var unstable_symbols = SymbolSet.init(allocator);
+    defer unstable_symbols.deinit();
+
     var stable_visitor = StableSymbolVisitor{
         .decl_symbols = &decl_symbols,
         .stable_symbols = &stable_symbols,
+        .unstable_symbols = &unstable_symbols,
     };
     try traverser.basic.traverse(StableSymbolVisitor, tree, &stable_visitor);
 
@@ -53,6 +74,8 @@ pub fn run(
         .reference_lookup = &reference_lookup,
         .decl_symbols = &decl_symbols,
         .stable_symbols = &stable_symbols,
+        .unstable_symbols = &unstable_symbols,
+        .options = options,
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
 }
@@ -60,6 +83,7 @@ pub fn run(
 const StableSymbolVisitor = struct {
     decl_symbols: *const DeclSymbolMap,
     stable_symbols: *SymbolSet,
+    unstable_symbols: *SymbolSet,
 
     pub fn enter_variable_declarator(
         self: *StableSymbolVisitor,
@@ -72,11 +96,13 @@ const StableSymbolVisitor = struct {
             else => return .proceed,
         };
 
-        if (ctx.path.depth() <= 3 or
+        const stable = ctx.path.depth() <= 3 or
             (declaration.kind == .@"const" and isLiteralLike(ctx.tree, declarator.init)) or
-            isUseRefCall(ctx.tree, declarator.init))
-        {
-            try self.collectBinding(declarator.id);
+            isUseRefCall(ctx.tree, declarator.init);
+        if (stable) {
+            try self.collectBinding(self.stable_symbols, declarator.id);
+        } else if (declaration.kind == .@"const" and isUnstableInitializer(ctx.tree, declarator.init)) {
+            try self.collectBinding(self.unstable_symbols, declarator.id);
         }
 
         if (declaration.kind == .@"const") {
@@ -94,7 +120,7 @@ const StableSymbolVisitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (ctx.path.depth() <= 2 and function.id != .null) {
-            try self.collectBinding(function.id);
+            try self.collectBinding(self.stable_symbols, function.id);
         }
         return .proceed;
     }
@@ -118,13 +144,13 @@ const StableSymbolVisitor = struct {
 
         const elements = tree.extra(pattern.elements);
         if (elements.len < 2) return;
-        try self.collectBinding(elements[1]);
+        try self.collectBinding(self.stable_symbols, elements[1]);
     }
 
-    fn collectBinding(self: *StableSymbolVisitor, index: ast.NodeIndex) Allocator.Error!void {
+    fn collectBinding(self: *StableSymbolVisitor, symbols: *SymbolSet, index: ast.NodeIndex) Allocator.Error!void {
         if (index == .null) return;
         const symbol_id = self.decl_symbols.get(index) orelse return;
-        if (symbol_id != .none) try self.stable_symbols.put(symbol_id, {});
+        if (symbol_id != .none) try symbols.put(symbol_id, {});
     }
 };
 
@@ -134,6 +160,8 @@ const Visitor = struct {
     reference_lookup: *const ReferenceLookup,
     decl_symbols: *const DeclSymbolMap,
     stable_symbols: *const SymbolSet,
+    unstable_symbols: *const SymbolSet,
+    options: Options,
 
     pub fn enter_call_expression(
         self: *Visitor,
@@ -141,7 +169,7 @@ const Visitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
-        const hook = reactiveHook(ctx.tree, call) orelse return .proceed;
+        const hook = reactiveHook(ctx.tree, call, self.options.additional_hooks) orelse return .proceed;
         const args = ctx.tree.extra(call.arguments);
         if (args.len <= hook.callback_index) {
             try self.reportFmt(
@@ -159,7 +187,7 @@ const Visitor = struct {
                 self.allocator,
                 self.diagnostics,
                 .@"error",
-                id,
+                self.options.rule_id,
                 asyncEffectMessage,
                 ctx.tree.span(callback),
             );
@@ -276,7 +304,37 @@ const Visitor = struct {
             );
         }
 
+        var declared_iter = declared.iterator();
+        while (declared_iter.next()) |entry| {
+            const declared_key = entry.key_ptr.*;
+            const declared_node = entry.value_ptr.*;
+            if (self.options.report_unstable_dependencies and self.isUnstableDependency(ctx.tree, declared_node)) {
+                try self.reportFmt(
+                    ctx.tree,
+                    declared_node,
+                    "React Hook {s} has an unstable dependency: '{s}' is recreated on every render. Move it inside the Hook callback or wrap its initialization in useMemo or useCallback.",
+                    .{ hook.source, declared_key },
+                );
+                continue;
+            }
+            if (self.options.report_unnecessary_dependencies and !hook.is_effect and !usedSatisfiesDeclared(&used, declared_key)) {
+                try self.reportFmt(
+                    ctx.tree,
+                    declared_node,
+                    "React Hook {s} has an unnecessary dependency: '{s}'. Either exclude it or remove the dependency array.",
+                    .{ hook.source, declared_key },
+                );
+            }
+        }
+
         return .proceed;
+    }
+
+    fn isUnstableDependency(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        if (tree.data(unwrapTransparent(tree, index)) != .identifier_reference) return false;
+        const root = dependencyRootReference(tree, index) orelse return false;
+        const symbol_id = self.reference_lookup.get(root) orelse return false;
+        return symbol_id != .none and self.unstable_symbols.contains(symbol_id);
     }
 
     fn reportFmt(
@@ -286,7 +344,7 @@ const Visitor = struct {
         comptime fmt: []const u8,
         args: anytype,
     ) Allocator.Error!void {
-        try core.addDiagnosticFmt(self.allocator, self.diagnostics, .@"error", id, tree.span(index), fmt, args);
+        try core.addDiagnosticFmt(self.allocator, self.diagnostics, .@"error", self.options.rule_id, tree.span(index), fmt, args);
     }
 };
 
@@ -336,22 +394,23 @@ const ReactiveHook = struct {
     is_effect: bool,
 };
 
-fn reactiveHook(tree: *const ast.Tree, call: ast.CallExpression) ?ReactiveHook {
+fn reactiveHook(tree: *const ast.Tree, call: ast.CallExpression, additional_hooks: core.ReactHooksAdditionalHooksPattern) ?ReactiveHook {
     const name = hookNameForCallee(tree, call.callee) orelse return null;
     const callback_index: usize = if (std.mem.eql(u8, name, "useImperativeHandle")) 1 else 0;
-    if (!std.mem.eql(u8, name, "useEffect") and
-        !std.mem.eql(u8, name, "useLayoutEffect") and
-        !std.mem.eql(u8, name, "useCallback") and
-        !std.mem.eql(u8, name, "useMemo") and
-        !std.mem.eql(u8, name, "useImperativeHandle"))
-    {
+    const built_in = std.mem.eql(u8, name, "useEffect") or
+        std.mem.eql(u8, name, "useLayoutEffect") or
+        std.mem.eql(u8, name, "useCallback") or
+        std.mem.eql(u8, name, "useMemo") or
+        std.mem.eql(u8, name, "useImperativeHandle");
+    const additional = if (additional_hooks.pattern()) |pattern| matchesHookPattern(name, pattern) else false;
+    if (!built_in and !additional) {
         return null;
     }
     return .{
         .name = name,
         .source = nodeSource(tree, call.callee),
         .callback_index = callback_index,
-        .is_effect = std.mem.eql(u8, name, "useEffect") or std.mem.eql(u8, name, "useLayoutEffect"),
+        .is_effect = additional or std.mem.eql(u8, name, "useEffect") or std.mem.eql(u8, name, "useLayoutEffect"),
     };
 }
 
@@ -406,6 +465,16 @@ fn isLiteralLike(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return tree.data(unwrapTransparent(tree, index)).isLiteral();
 }
 
+fn isUnstableInitializer(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .array_expression, .object_expression, .arrow_function_expression, .new_expression => true,
+        .function => |function| function.type == .function_expression or function.type == .ts_empty_body_function_expression,
+        .class => |class| class.type == .class_expression,
+        else => false,
+    };
+}
+
 fn dependencyKey(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     const unwrapped = unwrapTransparent(tree, index);
     return switch (tree.data(unwrapped)) {
@@ -430,16 +499,150 @@ fn isStaticMemberChain(tree: *const ast.Tree, member: ast.MemberExpression) bool
 fn declaredSatisfies(declared: *const std.StringHashMap(ast.NodeIndex), used_key: []const u8) bool {
     var iter = declared.iterator();
     while (iter.next()) |entry| {
-        const declared_key = entry.key_ptr.*;
-        if (std.mem.eql(u8, declared_key, used_key)) return true;
-        if (used_key.len > declared_key.len and
-            std.mem.startsWith(u8, used_key, declared_key) and
-            used_key[declared_key.len] == '.')
-        {
-            return true;
-        }
+        if (declaredKeySatisfiesUsed(entry.key_ptr.*, used_key)) return true;
     }
     return false;
+}
+
+fn usedSatisfiesDeclared(used: *const std.StringHashMap(ast.NodeIndex), declared_key: []const u8) bool {
+    var iter = used.iterator();
+    while (iter.next()) |entry| {
+        if (declaredKeySatisfiesUsed(declared_key, entry.key_ptr.*)) return true;
+    }
+    return false;
+}
+
+fn declaredKeySatisfiesUsed(declared_key: []const u8, used_key: []const u8) bool {
+    if (std.mem.eql(u8, declared_key, used_key)) return true;
+    return used_key.len > declared_key.len and
+        std.mem.startsWith(u8, used_key, declared_key) and
+        used_key[declared_key.len] == '.';
+}
+
+fn dependencyRootReference(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    const unwrapped = unwrapTransparent(tree, index);
+    return switch (tree.data(unwrapped)) {
+        .identifier_reference => unwrapped,
+        .member_expression => |member| dependencyRootReference(tree, member.object),
+        .chain_expression => |chain| dependencyRootReference(tree, chain.expression),
+        else => null,
+    };
+}
+
+fn matchesHookPattern(value: []const u8, pattern: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    var body = pattern;
+    var anchored_start = false;
+    var anchored_end = false;
+    if (std.mem.startsWith(u8, body, "^")) {
+        anchored_start = true;
+        body = body[1..];
+    }
+    if (body.len > 0 and std.mem.endsWith(u8, body, "$") and !isPatternCharacterEscaped(body, body.len - 1)) {
+        anchored_end = true;
+        body = body[0 .. body.len - 1];
+    }
+    if (body.len >= 2 and body[0] == '(' and body[body.len - 1] == ')') {
+        body = body[1 .. body.len - 1];
+    }
+
+    var start: usize = 0;
+    while (start <= body.len) {
+        const separator = indexOfUnescapedPatternPipe(body[start..]);
+        const end = if (separator) |offset| start + offset else body.len;
+        if (matchesHookAlternative(value, body[start..end], anchored_start, anchored_end)) return true;
+        if (separator == null) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+fn indexOfUnescapedPatternPipe(pattern: []const u8) ?usize {
+    var index: usize = 0;
+    var escaped = false;
+    while (index < pattern.len) : (index += 1) {
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (pattern[index] == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (pattern[index] == '|') return index;
+    }
+    return null;
+}
+
+fn matchesHookAlternative(value: []const u8, pattern: []const u8, anchored_start: bool, anchored_end: bool) bool {
+    if (pattern.len == 0) return false;
+    if (anchored_start) return matchHookPatternAt(value, pattern, 0, 0, anchored_end);
+
+    var start: usize = 0;
+    while (start <= value.len) : (start += 1) {
+        if (matchHookPatternAt(value, pattern, start, 0, anchored_end)) return true;
+    }
+    return false;
+}
+
+fn isPatternCharacterEscaped(pattern: []const u8, index: usize) bool {
+    if (index == 0) return false;
+    var backslashes: usize = 0;
+    var cursor = index;
+    while (cursor > 0 and pattern[cursor - 1] == '\\') : (cursor -= 1) {
+        backslashes += 1;
+    }
+    return backslashes % 2 == 1;
+}
+
+fn matchHookPatternAt(value: []const u8, pattern: []const u8, value_index: usize, pattern_index: usize, anchored_end: bool) bool {
+    if (pattern_index >= pattern.len) return !anchored_end or value_index == value.len;
+    if (value_index > value.len) return false;
+
+    const token = readHookPatternToken(pattern, pattern_index);
+    const quantifier_index = pattern_index + token.pattern_len;
+    const quantifier = if (quantifier_index < pattern.len and (pattern[quantifier_index] == '*' or pattern[quantifier_index] == '+')) pattern[quantifier_index] else 0;
+    const next_pattern_index = quantifier_index + if (quantifier == 0) @as(usize, 0) else @as(usize, 1);
+
+    if (quantifier == 0) {
+        if (value_index >= value.len or !token.matches(value[value_index])) return false;
+        return matchHookPatternAt(value, pattern, value_index + 1, next_pattern_index, anchored_end);
+    }
+
+    var max_count: usize = 0;
+    while (value_index + max_count < value.len and token.matches(value[value_index + max_count])) : (max_count += 1) {}
+
+    const min_count: usize = if (quantifier == '+') 1 else 0;
+    if (max_count < min_count) return false;
+
+    var count = max_count + 1;
+    while (count > min_count) {
+        count -= 1;
+        if (matchHookPatternAt(value, pattern, value_index + count, next_pattern_index, anchored_end)) return true;
+    }
+    return false;
+}
+
+const HookPatternToken = struct {
+    kind: enum { literal, any },
+    literal: u8 = 0,
+    pattern_len: usize,
+
+    fn matches(self: HookPatternToken, value: u8) bool {
+        return switch (self.kind) {
+            .literal => self.literal == value,
+            .any => true,
+        };
+    }
+};
+
+fn readHookPatternToken(pattern: []const u8, index: usize) HookPatternToken {
+    if (pattern[index] == '.') return .{ .kind = .any, .pattern_len = 1 };
+    if (pattern[index] == '\\' and index + 1 < pattern.len) {
+        return .{ .kind = .literal, .literal = pattern[index + 1], .pattern_len = 2 };
+    }
+    return .{ .kind = .literal, .literal = pattern[index], .pattern_len = 1 };
 }
 
 fn isTopDependencyReference(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) bool {

--- a/src/rules/react_hooks_exhaustive_deps.zig
+++ b/src/rules/react_hooks_exhaustive_deps.zig
@@ -1,0 +1,24 @@
+const parser = @import("parser");
+const core = @import("../core.zig");
+const exhaustive_deps = @import("alipay_ant_exhaustive_deps.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = @import("std").mem.Allocator;
+
+pub const id = "react-hooks/exhaustive-deps";
+
+pub fn runWithOptions(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    additional_hooks: core.ReactHooksAdditionalHooksPattern,
+) Allocator.Error!void {
+    try exhaustive_deps.runWithOptions(allocator, diagnostics, tree, symbol_table, .{
+        .rule_id = id,
+        .additional_hooks = additional_hooks,
+        .report_unnecessary_dependencies = true,
+        .report_unstable_dependencies = true,
+    });
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -306,6 +306,7 @@ pub const react_prefer_es6_class = @import("react_prefer_es6_class.zig");
 pub const react_style_prop_object = @import("react_style_prop_object.zig");
 pub const react_self_closing_comp = @import("react_self_closing_comp.zig");
 pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
+pub const react_hooks_exhaustive_deps = @import("react_hooks_exhaustive_deps.zig");
 pub const react_hooks_rules_of_hooks = @import("react_hooks_rules_of_hooks.zig");
 pub const radix = @import("radix.zig");
 pub const require_await = @import("require_await.zig");
@@ -751,8 +752,18 @@ pub fn runSemantic(
         }
     }
 
-    if (options.alipay_ant_exhaustive_deps) {
+    if (options.alipay_ant_exhaustive_deps and !options.react_hooks_exhaustive_deps) {
         try alipay_ant_exhaustive_deps.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.react_hooks_exhaustive_deps) {
+        try react_hooks_exhaustive_deps.runWithOptions(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.react_hooks_exhaustive_deps_additional_hooks,
+        );
     }
 
     if (options.alipay_ant_no_spread_params) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1195,6 +1195,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_hooks_exhaustive_deps.zig");
+}
+
+comptime {
     _ = @import("rules/react_hooks_rules_of_hooks.zig");
 }
 

--- a/tests/rules/react_hooks_exhaustive_deps.zig
+++ b/tests/rules/react_hooks_exhaustive_deps.zig
@@ -1,0 +1,152 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_hooks_exhaustive_deps = true;
+    return options;
+}
+
+test "reports react-hooks/exhaustive-deps missing dependencies for effects and memoization" {
+    const source =
+        \\function App({ userId }) {
+        \\  useEffect(() => { sendAnalytics(userId); }, []);
+        \\  const doubled = useMemo(() => userId * 2, []);
+        \\  const log = useCallback(() => console.log(userId), []);
+        \\  return doubled + log;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_hooks_exhaustive_deps.id)) continue;
+        try std.testing.expect(std.mem.indexOf(u8, diagnostic.message, "missing dependency: 'userId'") != null);
+    }
+}
+
+test "allows complete react-hooks/exhaustive-deps arrays and stable values" {
+    const source =
+        \\const moduleValue = compute();
+        \\function helper() {}
+        \\function App(props) {
+        \\  const literal = 1;
+        \\  const ref = useRef();
+        \\  const [state, setState] = useState(0);
+        \\  useEffect(() => {
+        \\    const local = props.value;
+        \\    console.log(moduleValue, literal, ref.current, local, state);
+        \\    helper();
+        \\    setState(props.value);
+        \\  }, [props.value, state]);
+        \\  return useMemo(() => props.value * 2, [props.value]);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+}
+
+test "reports react-hooks/exhaustive-deps unnecessary and unstable dependencies" {
+    const source =
+        \\function App({ value, extra }) {
+        \\  const options = {};
+        \\  const handler = () => value;
+        \\  useMemo(() => value, [value, extra]);
+        \\  useEffect(() => console.log(options), [options]);
+        \\  useCallback(() => handler(), [handler]);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+    try std.testing.expect(hasMessage(result, "unnecessary dependency: 'extra'"));
+    try std.testing.expect(hasMessage(result, "unstable dependency: 'options'"));
+    try std.testing.expect(hasMessage(result, "unstable dependency: 'handler'"));
+}
+
+test "supports react-hooks/exhaustive-deps additionalHooks configuration" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"additionalHooks\":\"(useMyEffect|useTrackedEffect)\"}]",
+        .{},
+    );
+    defer parsed.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue(lint.rules.react_hooks_exhaustive_deps.id, parsed.value);
+
+    const source =
+        \\function App({ value }) {
+        \\  useMyEffect(() => console.log(value), []);
+        \\  useOtherEffect(() => console.log(value), []);
+        \\}
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[0].message, "missing dependency: 'value'") != null);
+}
+
+test "parses react-hooks/exhaustive-deps TypeScript and TSX callbacks" {
+    const source =
+        \\type Props = { value: number };
+        \\function App({ value }: Props) {
+        \\  const doubled = useMemo<number>(() => value * 2, []);
+        \\  return <span>{doubled}</span>;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.tsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[0].message, "missing dependency: 'value'") != null);
+}
+
+test "react-hooks/exhaustive-deps is configurable and can be disabled" {
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(lint.rules.react_hooks_exhaustive_deps.id, true));
+    try std.testing.expect(options.react_hooks_exhaustive_deps);
+    try std.testing.expect(options.setByCliName(lint.rules.react_hooks_exhaustive_deps.id, false));
+
+    const source =
+        \\function App({ value }) {
+        \\  useEffect(() => console.log(value), []);
+        \\}
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+}
+
+test "default exhaustive dependency checks use the standard rule id once" {
+    const source =
+        \\function App({ value }) {
+        \\  useEffect(() => console.log(value), []);
+        \\}
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", .{});
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.react_hooks_exhaustive_deps.id));
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_exhaustive_deps.id));
+}
+
+fn hasMessage(result: lint.Result, needle: []const u8) bool {
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.react_hooks_exhaustive_deps.id)) continue;
+        if (std.mem.indexOf(u8, diagnostic.message, needle) != null) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add native `react-hooks/exhaustive-deps` support by sharing the existing semantic dependency analyzer
- report missing, unnecessary, unstable, duplicate, literal, complex, and unknown dependency-array cases
- support common `additionalHooks` regex forms and avoid duplicate legacy Alipay diagnostics

## Tests
- `zig build test`
- `zig build`
- ESM `Linter` discovery and diagnostic smoke test
- `pnpm --dir npm/utoo-lint test`

Closes #1061
