### PR TITLE
build: update yuku to v0.9.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,12 +10,18 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const codegen_options = b.addOptions();
+    codegen_options.addOption(bool, "source_maps", true);
+    const parser_extension_module = b.addOptions().createModule();
+
     const parser_module = b.createModule(.{
         .root_source_file = b.path("vendor/yuku/src/parser/root.zig"),
         .target = target,
         .optimize = optimize,
     });
     parser_module.addImport("util", util_module);
+    parser_module.addImport("codegen_options", codegen_options.createModule());
+    parser_module.addImport("parser_extension", parser_extension_module);
 
     const lint_module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),


### PR DESCRIPTION
## Summary

- Update the Yuku submodule from `7dfff641` to the `v0.9.1` release.
- Register Yuku 0.9's parser extension and codegen option modules in the Zig build.
- Pick up the latest TypeScript grammar diagnostics, parser extension points, decorator preservation, and `for-in`/`for-of` validation fixes.

## Validation

- `zig fmt --check build.zig src tests`
- `git diff --check`
- `zig build test`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- CLI npm wrapper verification
- `pnpm --dir npm/utoo-lint test` — 82 tests and TypeScript type tests
- GitHub CI on Node.js 20 and 24
- CodSpeed benchmark and performance analysis
