### PR TITLE
feat: implement react/no-unstable-nested-components

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -317,6 +317,7 @@ instead of being rewritten.
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-multi-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md) | Supports `ignoreStateless` configuration |
+| [`react/no-unstable-nested-components`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) | Opt-in; supports `allowAsProps` and `propNamePattern`, including wrapped nested components |
 | [`react/no-redundant-should-component-update`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md) | Implemented |
 | [`react/no-render-return-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md) | Implemented for eslint-plugin-react's default/latest React version behavior |
 | [`react/no-string-refs`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) | Supports `noTemplateLiterals` configuration |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -352,6 +352,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-find-dom-node",
   "react/no-is-mounted",
   "react/no-multi-comp",
+  "react/no-unstable-nested-components",
   "react/no-redundant-should-component-update",
   "react/no-render-return-value",
   "react/no-string-refs",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -355,6 +355,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-find-dom-node",
   "react/no-is-mounted",
   "react/no-multi-comp",
+  "react/no-unstable-nested-components",
   "react/no-redundant-should-component-update",
   "react/no-render-return-value",
   "react/no-string-refs",

--- a/src/core.zig
+++ b/src/core.zig
@@ -1500,6 +1500,27 @@ pub const ReactHooksAdditionalHooksPattern = struct {
     }
 };
 
+pub const max_react_no_unstable_nested_components_prop_name_pattern_len = 256;
+
+pub const ReactNoUnstableNestedComponentsPropNamePattern = struct {
+    custom: bool = false,
+    length: usize = 0,
+    storage: [max_react_no_unstable_nested_components_prop_name_pattern_len]u8 = undefined,
+
+    pub fn pattern(self: *const ReactNoUnstableNestedComponentsPropNamePattern) []const u8 {
+        if (!self.custom) return "render*";
+        return self.storage[0..self.length];
+    }
+
+    pub fn set(self: *ReactNoUnstableNestedComponentsPropNamePattern, pattern_value: []const u8) bool {
+        if (pattern_value.len > max_react_no_unstable_nested_components_prop_name_pattern_len) return false;
+        @memcpy(self.storage[0..pattern_value.len], pattern_value);
+        self.custom = true;
+        self.length = pattern_value.len;
+        return true;
+    }
+};
+
 pub const max_no_useless_escape_allow_regex_characters = 32;
 
 pub const NoUselessEscapeAllowRegexCharactersError = error{
@@ -2921,6 +2942,9 @@ pub const Options = struct {
     react_no_is_mounted: bool = true,
     react_no_multi_comp: bool = true,
     react_no_multi_comp_ignore_stateless: bool = true,
+    react_no_unstable_nested_components: bool = false,
+    react_no_unstable_nested_components_allow_as_props: bool = false,
+    react_no_unstable_nested_components_prop_name_pattern: ReactNoUnstableNestedComponentsPropNamePattern = .{},
     react_no_redundant_should_component_update: bool = true,
     react_no_render_return_value: bool = true,
     react_no_will_update_set_state: bool = true,
@@ -3793,6 +3817,10 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "react/no-multi-comp")) {
             self.react_no_multi_comp_ignore_stateless = try reactNoMultiCompIgnoreStatelessFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "react/no-unstable-nested-components")) {
+            self.react_no_unstable_nested_components_allow_as_props = try reactNoUnstableNestedComponentsAllowAsPropsFromConfig(value);
+            self.react_no_unstable_nested_components_prop_name_pattern = try reactNoUnstableNestedComponentsPropNamePatternFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "react/no-children-prop")) {
             self.react_no_children_prop_allow_functions = try reactNoChildrenPropAllowFunctionsFromConfig(value);
@@ -8753,6 +8781,37 @@ pub const Options = struct {
         return switch (config.get("ignoreStateless") orelse return true) {
             .bool => |ignore_stateless| ignore_stateless,
             else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn reactNoUnstableNestedComponentsAllowAsPropsFromConfig(value: std.json.Value) RuleConfigError!bool {
+        const config = reactNoUnstableNestedComponentsConfigObject(value) orelse return false;
+        return switch (config.get("allowAsProps") orelse return false) {
+            .bool => |allow_as_props| allow_as_props,
+            else => error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn reactNoUnstableNestedComponentsPropNamePatternFromConfig(value: std.json.Value) RuleConfigError!ReactNoUnstableNestedComponentsPropNamePattern {
+        const config = reactNoUnstableNestedComponentsConfigObject(value) orelse return .{};
+        const pattern_value = switch (config.get("propNamePattern") orelse return .{}) {
+            .string => |pattern| pattern,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        var pattern = ReactNoUnstableNestedComponentsPropNamePattern{};
+        if (!pattern.set(pattern_value)) return error.UnsupportedRuleConfigValue;
+        return pattern;
+    }
+
+    fn reactNoUnstableNestedComponentsConfigObject(value: std.json.Value) ?std.json.ObjectMap {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return null,
+        };
+        if (items.len < 2) return null;
+        return switch (items[1]) {
+            .object => |object| object,
+            else => null,
         };
     }
 

--- a/src/rules/react_no_unstable_nested_components.zig
+++ b/src/rules/react_no_unstable_nested_components.zig
@@ -1,0 +1,420 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-unstable-nested-components";
+
+const message = "Do not define components during render. Move the component definition out of the parent component";
+
+pub const Options = struct {
+    allow_as_props: bool = false,
+    prop_name_pattern: []const u8 = "render*",
+};
+
+pub fn checkFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (function.body == .null or !functionReturnsJSXOrNull(tree, index)) return;
+    try checkCandidate(allocator, diagnostics, tree, index, function.id, ctx, options);
+}
+
+pub fn checkArrowFunction(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (!functionReturnsJSXOrNull(tree, index)) return;
+    try checkCandidate(allocator, diagnostics, tree, index, .null, ctx, options);
+}
+
+fn checkCandidate(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    own_name_index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (isDirectCollectionCallback(tree, index, &ctx.path)) return;
+
+    const prop_name = propNameFromAncestors(tree, &ctx.path);
+    if (prop_name) |name| {
+        if (propIsAllowed(name, options)) return;
+    } else if (!hasComponentName(tree, index, own_name_index, &ctx.path, 0)) {
+        return;
+    }
+
+    if (!hasEnclosingComponent(tree, &ctx.path)) return;
+    try core.addDiagnostic(allocator, diagnostics, .warning, id, message, tree.span(index));
+}
+
+fn hasEnclosingComponent(tree: *const ast.Tree, path: *const traverser.NodePath) bool {
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |ancestor_index| : (depth += 1) {
+        switch (tree.data(ancestor_index)) {
+            .function => |function| {
+                if (isReactClassRenderMethod(tree, path, depth)) return true;
+                if (function.body != .null and functionReturnsJSXOrNull(tree, ancestor_index) and
+                    hasComponentName(tree, ancestor_index, function.id, path, depth))
+                {
+                    return true;
+                }
+            },
+            .arrow_function_expression => {
+                if (functionReturnsJSXOrNull(tree, ancestor_index) and
+                    hasComponentName(tree, ancestor_index, .null, path, depth))
+                {
+                    return true;
+                }
+            },
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn hasComponentName(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    own_name_index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    depth: usize,
+) bool {
+    if (bindingIdentifierName(tree, own_name_index)) |name| {
+        if (startsUppercase(name)) return true;
+    }
+    const assigned_name = assignedName(tree, index, path, depth + 1) orelse return false;
+    return startsUppercase(assigned_name);
+}
+
+fn assignedName(
+    tree: *const ast.Tree,
+    start_index: ast.NodeIndex,
+    path: *const traverser.NodePath,
+    start_depth: usize,
+) ?[]const u8 {
+    var child = start_index;
+    var depth = start_depth;
+    while (path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .chain_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .parenthesized_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .ts_as_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .ts_satisfies_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .ts_non_null_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .ts_type_assertion => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .ts_instantiation_expression => |expression| {
+                if (expression.expression != child) return null;
+            },
+            .call_expression => |call| {
+                if (!isWrapperArgument(tree, call, child)) return null;
+            },
+            .variable_declarator => |declarator| {
+                if (declarator.init != child) return null;
+                return bindingIdentifierName(tree, declarator.id);
+            },
+            .assignment_expression => |expression| {
+                if (expression.right != child) return null;
+                return assignmentName(tree, expression.left);
+            },
+            .object_property => |property| {
+                if (property.value != child) return null;
+                return propertyName(tree, property.key, property.computed);
+            },
+            .export_default_declaration => return "Component",
+            else => return null,
+        }
+        child = parent_index;
+    }
+    return null;
+}
+
+fn isWrapperArgument(tree: *const ast.Tree, call: ast.CallExpression, child: ast.NodeIndex) bool {
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0 or arguments[0] != child) return false;
+    return !isCollectionCallbackCall(tree, call);
+}
+
+fn isDirectCollectionCallback(tree: *const ast.Tree, index: ast.NodeIndex, path: *const traverser.NodePath) bool {
+    var child = index;
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .chain_expression => |expression| if (expression.expression != child) return false,
+            .parenthesized_expression => |expression| if (expression.expression != child) return false,
+            .ts_as_expression => |expression| if (expression.expression != child) return false,
+            .ts_satisfies_expression => |expression| if (expression.expression != child) return false,
+            .ts_non_null_expression => |expression| if (expression.expression != child) return false,
+            .ts_type_assertion => |expression| if (expression.expression != child) return false,
+            .call_expression => |call| {
+                const arguments = tree.extra(call.arguments);
+                return arguments.len > 0 and arguments[0] == child and isCollectionCallbackCall(tree, call);
+            },
+            else => return false,
+        }
+        child = parent_index;
+    }
+    return false;
+}
+
+fn isCollectionCallbackCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const name = propertyName(tree, member.property, member.computed) orelse return false;
+    const methods = [_][]const u8{
+        "every", "filter", "find", "findIndex", "flatMap", "forEach", "map", "reduce", "reduceRight", "some", "sort",
+    };
+    for (methods) |method| {
+        if (std.mem.eql(u8, name, method)) return true;
+    }
+    return false;
+}
+
+fn propNameFromAncestors(tree: *const ast.Tree, path: *const traverser.NodePath) ?[]const u8 {
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |ancestor_index| : (depth += 1) {
+        switch (tree.data(ancestor_index)) {
+            .jsx_attribute => |attribute| return jsxIdentifierName(tree, attribute.name),
+            .object_property => |property| return propertyName(tree, property.key, property.computed),
+            .function, .arrow_function_expression => return null,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn propIsAllowed(name: []const u8, options: Options) bool {
+    if (options.allow_as_props) return true;
+    if (std.mem.eql(u8, name, "children")) return true;
+    return wildcardMatches(options.prop_name_pattern, name);
+}
+
+fn wildcardMatches(pattern: []const u8, value: []const u8) bool {
+    var pattern_index: usize = 0;
+    var value_index: usize = 0;
+    var star_index: ?usize = null;
+    var retry_value_index: usize = 0;
+
+    while (value_index < value.len) {
+        if (pattern_index < pattern.len and pattern[pattern_index] == value[value_index]) {
+            pattern_index += 1;
+            value_index += 1;
+        } else if (pattern_index < pattern.len and pattern[pattern_index] == '*') {
+            star_index = pattern_index;
+            pattern_index += 1;
+            retry_value_index = value_index;
+        } else if (star_index) |star| {
+            pattern_index = star + 1;
+            retry_value_index += 1;
+            value_index = retry_value_index;
+        } else {
+            return false;
+        }
+    }
+    while (pattern_index < pattern.len and pattern[pattern_index] == '*') pattern_index += 1;
+    return pattern_index == pattern.len;
+}
+
+fn isReactClassRenderMethod(tree: *const ast.Tree, path: *const traverser.NodePath, function_depth: usize) bool {
+    const method_index = path.ancestor(function_depth + 1) orelse return false;
+    const method = switch (tree.data(method_index)) {
+        .method_definition => |method| method,
+        else => return false,
+    };
+    const method_name = propertyName(tree, method.key, method.computed) orelse return false;
+    if (!std.mem.eql(u8, method_name, "render")) return false;
+
+    const class_body_index = path.ancestor(function_depth + 2) orelse return false;
+    if (tree.data(class_body_index) != .class_body) return false;
+    const class_index = path.ancestor(function_depth + 3) orelse return false;
+    const class = switch (tree.data(class_index)) {
+        .class => |class| class,
+        else => return false,
+    };
+    return isReactComponentClass(tree, class);
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn functionReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .function => |function| function.body != .null and bodyReturnsJSXOrNull(tree, function.body),
+        .arrow_function_expression => |arrow| if (arrow.expression)
+            isJSXOrNullValue(tree, arrow.body)
+        else
+            bodyReturnsJSXOrNull(tree, arrow.body),
+        else => false,
+    };
+}
+
+fn bodyReturnsJSXOrNull(tree: *const ast.Tree, body_index: ast.NodeIndex) bool {
+    const range = switch (tree.data(body_index)) {
+        .function_body => |body| body.body,
+        .block_statement => |block| block.body,
+        else => return false,
+    };
+    return rangeReturnsJSXOrNull(tree, range);
+}
+
+fn rangeReturnsJSXOrNull(tree: *const ast.Tree, range: ast.IndexRange) bool {
+    for (tree.extra(range)) |statement_index| {
+        if (statementReturnsJSXOrNull(tree, statement_index)) return true;
+    }
+    return false;
+}
+
+fn statementReturnsJSXOrNull(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(index)) {
+        .return_statement => |statement| isJSXOrNullValue(tree, statement.argument),
+        .block_statement => |block| rangeReturnsJSXOrNull(tree, block.body),
+        .if_statement => |statement| statementReturnsJSXOrNull(tree, statement.consequent) or
+            statementReturnsJSXOrNull(tree, statement.alternate),
+        .switch_statement => |statement| {
+            for (tree.extra(statement.cases)) |case_index| {
+                const case = switch (tree.data(case_index)) {
+                    .switch_case => |case| case,
+                    else => continue,
+                };
+                if (rangeReturnsJSXOrNull(tree, case.consequent)) return true;
+            }
+            return false;
+        },
+        .function, .arrow_function_expression => false,
+        else => false,
+    };
+}
+
+fn isJSXOrNullValue(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    if (index == .null) return false;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .jsx_element, .jsx_fragment, .null_literal => true,
+        .call_expression => |call| isCreateElementCall(tree, call),
+        .conditional_expression => |conditional| isJSXOrNullValue(tree, conditional.consequent) or
+            isJSXOrNullValue(tree, conditional.alternate),
+        .logical_expression => |logical| isJSXOrNullValue(tree, logical.left) or isJSXOrNullValue(tree, logical.right),
+        .sequence_expression => |sequence| {
+            if (sequence.expressions.len == 0) return false;
+            const items = tree.extra(sequence.expressions);
+            return isJSXOrNullValue(tree, items[items.len - 1]);
+        },
+        else => false,
+    };
+}
+
+fn isCreateElementCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createElement");
+    }
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const property = propertyName(tree, member.property, member.computed) orelse return false;
+    return std.mem.eql(u8, property, "createElement");
+}
+
+fn assignmentName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    const current = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, current)) |name| return name;
+    const member = switch (tree.data(current)) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    return propertyName(tree, member.property, member.computed);
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (index == .null or computed) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn jsxIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .jsx_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn startsUppercase(name: []const u8) bool {
+    return name.len > 0 and std.ascii.isUpper(name[0]);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            .ts_instantiation_expression => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -300,6 +300,7 @@ pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_multi_comp = @import("react_no_multi_comp.zig");
+pub const react_no_unstable_nested_components = @import("react_no_unstable_nested_components.zig");
 pub const react_no_redundant_should_component_update = @import("react_no_redundant_should_component_update.zig");
 pub const react_no_render_return_value = @import("react_no_render_return_value.zig");
 pub const react_no_this_in_sfc = @import("react_no_this_in_sfc.zig");
@@ -1705,6 +1706,12 @@ const BasicVisitor = struct {
         if (self.options.react_no_multi_comp) {
             try react_no_multi_comp.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, &self.react_no_multi_comp_state, .{
                 .ignore_stateless = self.options.react_no_multi_comp_ignore_stateless,
+            });
+        }
+        if (self.options.react_no_unstable_nested_components) {
+            try react_no_unstable_nested_components.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, .{
+                .allow_as_props = self.options.react_no_unstable_nested_components_allow_as_props,
+                .prop_name_pattern = self.options.react_no_unstable_nested_components_prop_name_pattern.pattern(),
             });
         }
         return .proceed;
@@ -3127,6 +3134,12 @@ const BasicVisitor = struct {
         }
         if (self.options.react_display_name) {
             try react_display_name.checkArrowFunction(self.allocator, ctx.tree, index, ctx.path.parent(), &self.react_display_name_state, reactDisplayNameOptions(self.options));
+        }
+        if (self.options.react_no_unstable_nested_components) {
+            try react_no_unstable_nested_components.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .allow_as_props = self.options.react_no_unstable_nested_components_allow_as_props,
+                .prop_name_pattern = self.options.react_no_unstable_nested_components_prop_name_pattern.pattern(),
+            });
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1149,6 +1149,7 @@ comptime {
 
 comptime {
     _ = @import("rules/react_no_multi_comp.zig");
+    _ = @import("rules/react_no_unstable_nested_components.zig");
 }
 
 comptime {

--- a/tests/rules/react_no_unstable_nested_components.zig
+++ b/tests/rules/react_no_unstable_nested_components.zig
@@ -1,0 +1,193 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.react_no_unstable_nested_components.id;
+
+test "reports nested function declarations, expressions, arrows, and wrappers" {
+    const source =
+        \\function Parent() {
+        \\  function Decl() { return <div />; }
+        \\  const Expr = function Expr() { return <span />; };
+        \\  const Arrow = () => <section />;
+        \\  const Wrapped = memo(() => <article />);
+        \\  return <Wrapped />;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+}
+
+test "allows module components and ordinary nested helpers and callbacks" {
+    const source =
+        \\const ModuleArrow = () => <div />;
+        \\function ModuleDeclaration() { return <div />; }
+        \\function Parent({ items }) {
+        \\  const helper = () => <span />;
+        \\  const rows = items.map(() => <ModuleArrow />);
+        \\  function callback(value) { return value + 1; }
+        \\  callback(rows.length);
+        \\  return <main>{rows}{helper()}</main>;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+}
+
+test "supports render props, custom prop patterns, and allowAsProps" {
+    const source =
+        \\function Parent() {
+        \\  const props = {
+        \\    renderItem: () => <div />,
+        \\    slotHeader: () => <header />,
+        \\    footer: () => <footer />,
+        \\  };
+        \\  return <Panel {...props} />;
+        \\}
+    ;
+
+    var default_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(default_result, rule_id));
+
+    var custom_options = ruleOptions();
+    try std.testing.expect(custom_options.react_no_unstable_nested_components_prop_name_pattern.set("slot*"));
+    var custom_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", custom_options);
+    defer custom_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(custom_result, rule_id));
+
+    var allow_options = ruleOptions();
+    allow_options.react_no_unstable_nested_components_allow_as_props = true;
+    var allow_result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", allow_options);
+    defer allow_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(allow_result, rule_id));
+}
+
+test "supports JSX render props and children compatibility" {
+    const source =
+        \\function Parent() {
+        \\  return (
+        \\    <Panel
+        \\      renderItem={() => <div />}
+        \\      footer={() => <footer />}
+        \\    >
+        \\      {() => <span />}
+        \\    </Panel>
+        \\  );
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+}
+
+test "reports nested components in React class render methods" {
+    const source =
+        \\class Parent extends React.Component {
+        \\  render() {
+        \\    const Child = () => <div />;
+        \\    return <Child />;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+}
+
+test "accepts CLI and upstream-compatible rule configuration" {
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.react_no_unstable_nested_components);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"warn\",{\"allowAsProps\":true,\"propNamePattern\":\"slot*\",\"customValidators\":[\"shape\"]}]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue(rule_id, config.value);
+
+    try std.testing.expect(options.react_no_unstable_nested_components_allow_as_props);
+    try std.testing.expectEqualStrings("slot*", options.react_no_unstable_nested_components_prop_name_pattern.pattern());
+}
+
+test "parses JS TS JSX and TSX fixtures without parser diagnostics" {
+    const Fixture = struct {
+        path: []const u8,
+        source: []const u8,
+    };
+    const fixtures = [_]Fixture{
+        .{
+            .path = "fixture.js",
+            .source =
+            \\function Parent() {
+            \\  function Decl() { return React.createElement("div"); }
+            \\  const Expr = function Expr() { return React.createElement("span"); };
+            \\  const Arrow = () => React.createElement("article");
+            \\  return React.createElement(Arrow);
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.jsx",
+            .source =
+            \\function Parent() {
+            \\  function Decl() { return <div />; }
+            \\  const Expr = function Expr() { return <span />; };
+            \\  const Arrow = () => <article />;
+            \\  return <Arrow />;
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.ts",
+            .source =
+            \\function Parent(): unknown {
+            \\  function Decl(): unknown { return React.createElement("div"); }
+            \\  const Expr = function Expr(): unknown { return React.createElement("span"); };
+            \\  const Arrow = (): unknown => React.createElement("article");
+            \\  return React.createElement(Arrow);
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.tsx",
+            .source =
+            \\function Parent<T extends object>(props: T) {
+            \\  function Decl(): JSX.Element { return <div data-props={props} />; }
+            \\  const Expr = function Expr(): JSX.Element { return <span />; };
+            \\  const Arrow = (): JSX.Element => <article />;
+            \\  return <Arrow />;
+            \\}
+            ,
+        },
+    };
+
+    for (fixtures) |fixture| {
+        var result = try lint.lintSource(std.testing.allocator, fixture.source, fixture.path, ruleOptions());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+        try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+    }
+}
+
+fn ruleOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_no_unstable_nested_components = true;
+    return options;
+}


### PR DESCRIPTION
## Summary

- add native `react/no-unstable-nested-components` diagnostics for nested function declarations, function expressions, and arrow components
- support `allowAsProps` and `propNamePattern`, plus memoized and wrapped component definitions
- keep the rule opt-in and expose it through project config, `--rules`, and the npm wrapper
- document the new rule

## Parser audit

- exercised `.js`, `.jsx`, `.ts`, and `.tsx` fixtures
- asserted zero `parse` diagnostics for every fixture
- no Yuku parser regression observed with v0.9.1

## Testing

- `zig build test --summary all` — 1962/1962 tests passed
- `zig build`
- `git diff --check`

Closes #1093
