### PR TITLE
feat: implement react/no-forward-ref

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -315,6 +315,7 @@ instead of being rewritten.
 | [`react/no-danger-with-children`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md) | Implemented |
 | [`react/no-deprecated`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
+| [`react/no-forward-ref`](https://eslint-react.xyz/docs/rules/no-forward-ref) | Opt-in React 19 diagnostic; recognizes named, aliased, default, and namespace imports from `react` |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |
 | [`react/no-multi-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md) | Supports `ignoreStateless` configuration |
 | [`react/no-redundant-should-component-update`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -350,6 +350,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-danger-with-children",
   "react/no-deprecated",
   "react/no-find-dom-node",
+  "react/no-forward-ref",
   "react/no-is-mounted",
   "react/no-multi-comp",
   "react/no-redundant-should-component-update",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -353,6 +353,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-danger-with-children",
   "react/no-deprecated",
   "react/no-find-dom-node",
+  "react/no-forward-ref",
   "react/no-is-mounted",
   "react/no-multi-comp",
   "react/no-redundant-should-component-update",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2918,6 +2918,7 @@ pub const Options = struct {
     react_no_children_prop: bool = true,
     react_no_children_prop_allow_functions: bool = false,
     react_no_find_dom_node: bool = true,
+    react_no_forward_ref: bool = false,
     react_no_is_mounted: bool = true,
     react_no_multi_comp: bool = true,
     react_no_multi_comp_ignore_stateless: bool = true,

--- a/src/root.zig
+++ b/src/root.zig
@@ -266,6 +266,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_undef_init or
         options.no_undef or
         options.react_jsx_no_undef or
+        options.react_no_forward_ref or
         options.no_unused_vars or
         options.no_useless_backreference or
         options.no_use_before_define or

--- a/src/rules/react_no_forward_ref.zig
+++ b/src/rules/react_no_forward_ref.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-forward-ref";
+
+const message = "In React 19, pass ref as a prop instead of using forwardRef";
+const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, traverser.semantic.SymbolId);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var direct_imports: std.StringHashMapUnmanaged(void) = .empty;
+    defer direct_imports.deinit(allocator);
+    var namespace_imports: std.StringHashMapUnmanaged(void) = .empty;
+    defer namespace_imports.deinit(allocator);
+    try collectReactImports(allocator, tree, &direct_imports, &namespace_imports);
+    if (direct_imports.count() == 0 and namespace_imports.count() == 0) return;
+
+    var reference_lookup = try buildReferenceLookup(allocator, symbol_table);
+    defer reference_lookup.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .reference_lookup = &reference_lookup,
+        .direct_imports = &direct_imports,
+        .namespace_imports = &namespace_imports,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    reference_lookup: *const ReferenceLookup,
+    direct_imports: *const std.StringHashMapUnmanaged(void),
+    namespace_imports: *const std.StringHashMapUnmanaged(void),
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const callee = unwrapTransparent(ctx.tree, call.callee);
+        if (!self.isForwardRefCallee(ctx.tree, callee)) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            message,
+            ctx.tree.span(callee),
+        );
+        return .proceed;
+    }
+
+    fn isForwardRefCallee(self: *const Visitor, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        if (tree.data(index) == .identifier_reference) {
+            return self.isImportedReference(tree, index, self.direct_imports);
+        }
+
+        const member = switch (tree.data(index)) {
+            .member_expression => |member| member,
+            else => return false,
+        };
+        const property = memberPropertyName(tree, member) orelse return false;
+        if (!std.mem.eql(u8, property, "forwardRef")) return false;
+
+        const object = unwrapTransparent(tree, member.object);
+        if (tree.data(object) != .identifier_reference) return false;
+        return self.isImportedReference(tree, object, self.namespace_imports);
+    }
+
+    fn isImportedReference(
+        self: *const Visitor,
+        tree: *const ast.Tree,
+        reference: ast.NodeIndex,
+        imported_names: *const std.StringHashMapUnmanaged(void),
+    ) bool {
+        const symbol_id = self.reference_lookup.get(reference) orelse return false;
+        if (symbol_id == .none) return false;
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.import) return false;
+        return imported_names.contains(tree.string(symbol.name));
+    }
+};
+
+fn collectReactImports(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    direct_imports: *std.StringHashMapUnmanaged(void),
+    namespace_imports: *std.StringHashMapUnmanaged(void),
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |program| program,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |declaration| declaration,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const source = stringLiteralValue(tree, declaration.source) orelse continue;
+        if (!std.mem.eql(u8, source, "react")) continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            switch (tree.data(specifier_index)) {
+                .import_specifier => |specifier| {
+                    if (specifier.import_kind == .type) continue;
+                    const imported = propertyName(tree, specifier.imported) orelse continue;
+                    if (!std.mem.eql(u8, imported, "forwardRef")) continue;
+                    const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+                    try direct_imports.put(allocator, local, {});
+                },
+                .import_default_specifier => |specifier| {
+                    const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+                    try namespace_imports.put(allocator, local, {});
+                },
+                .import_namespace_specifier => |specifier| {
+                    const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+                    try namespace_imports.put(allocator, local, {});
+                },
+                else => {},
+            }
+        }
+    }
+}
+
+fn buildReferenceLookup(
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!ReferenceLookup {
+    var lookup = ReferenceLookup.init(allocator);
+    errdefer lookup.deinit();
+    try lookup.ensureTotalCapacity(@intCast(symbol_table.references.len));
+
+    var iter = symbol_table.iterReferences();
+    while (iter.next()) |entry| {
+        try lookup.put(entry.reference.node, symbol_table.referenceSymbol(entry.id));
+    }
+    return lookup;
+}
+
+fn memberPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed) return stringLiteralValue(tree, member.property);
+    return propertyName(tree, member.property);
+}
+
+fn propertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -298,6 +298,7 @@ pub const react_forbid_prop_types = @import("react_forbid_prop_types.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
 pub const react_no_array_index_key = @import("react_no_array_index_key.zig");
 pub const react_no_find_dom_node = @import("react_no_find_dom_node.zig");
+pub const react_no_forward_ref = @import("react_no_forward_ref.zig");
 pub const react_no_is_mounted = @import("react_no_is_mounted.zig");
 pub const react_no_multi_comp = @import("react_no_multi_comp.zig");
 pub const react_no_redundant_should_component_update = @import("react_no_redundant_should_component_update.zig");
@@ -777,6 +778,10 @@ pub fn runSemantic(
             semantic_result.symbol_table,
             options.react_hooks_exhaustive_deps_additional_hooks,
         );
+    }
+
+    if (options.react_no_forward_ref) {
+        try react_no_forward_ref.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.alipay_ant_no_spread_params) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1109,6 +1109,7 @@ comptime {
 
 comptime {
     _ = @import("rules/react_no_find_dom_node.zig");
+    _ = @import("rules/react_no_forward_ref.zig");
 }
 
 comptime {

--- a/tests/rules/react_no_forward_ref.zig
+++ b/tests/rules/react_no_forward_ref.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.react_no_forward_ref.id;
+
+test "reports named aliased default and namespace React imports" {
+    const source =
+        \\import React, { forwardRef, forwardRef as withRef } from "react";
+        \\import * as ReactNS from "react";
+        \\const One = forwardRef((props, ref) => <div ref={ref} />);
+        \\const Two = withRef((props, ref) => <span ref={ref} />);
+        \\const Three = React.forwardRef((props, ref) => <main ref={ref} />);
+        \\const Four = ReactNS["forwardRef"]((props, ref) => <article ref={ref} />);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.warning, diagnostic.severity);
+    try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+}
+
+test "does not report unrelated functions methods imports or type-only imports" {
+    const source =
+        \\import { forwardRef as otherForwardRef } from "other-library";
+        \\import type { forwardRef as ForwardRefType } from "react";
+        \\function forwardRef(value) { return value; }
+        \\const React = { forwardRef(value) { return value; } };
+        \\const api = { forwardRef(value) { return value; } };
+        \\forwardRef(() => null);
+        \\otherForwardRef(() => null);
+        \\React.forwardRef(() => null);
+        \\api.forwardRef(() => null);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+}
+
+test "respects local shadowing of a React import" {
+    const source =
+        \\import { forwardRef } from "react";
+        \\function configure(forwardRef) {
+        \\  return forwardRef(() => null);
+        \\}
+        \\const Component = forwardRef(() => null);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+}
+
+test "is opt-in and accepted by CLI and project configuration" {
+    try std.testing.expect(!(lint.Options{}).react_no_forward_ref);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.react_no_forward_ref);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"warn\"]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.react_no_forward_ref);
+}
+
+test "parses JS TS JSX and TSX cases without parser diagnostics" {
+    const Fixture = struct {
+        path: []const u8,
+        source: []const u8,
+    };
+    const fixtures = [_]Fixture{
+        .{
+            .path = "fixture.js",
+            .source =
+            \\import { forwardRef } from "react";
+            \\const Component = forwardRef(function Component(props, ref) { return null; });
+            ,
+        },
+        .{
+            .path = "fixture.jsx",
+            .source =
+            \\import { forwardRef as withRef } from "react";
+            \\const Component = withRef((props, ref) => <div ref={ref} />);
+            ,
+        },
+        .{
+            .path = "fixture.ts",
+            .source =
+            \\import * as React from "react";
+            \\const Component = React.forwardRef<HTMLDivElement, { value: string }>((props, ref) => null);
+            ,
+        },
+        .{
+            .path = "fixture.tsx",
+            .source =
+            \\import React from "react";
+            \\const Component = React.forwardRef<HTMLDivElement, { value: string }>((props, ref) => <div ref={ref}>{props.value}</div>);
+            ,
+        },
+    };
+
+    for (fixtures) |fixture| {
+        var result = try lint.lintSource(std.testing.allocator, fixture.source, fixture.path, ruleOptions());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+fn ruleOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_no_forward_ref = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary

- add native, opt-in `react/no-forward-ref` support for React 19 projects
- detect named and aliased imports plus default and namespace member calls from `react`
- resolve semantic bindings so local functions, shadowed parameters, other-module imports, and unrelated methods named `forwardRef` are ignored
- keep the rule diagnostic-only and expose it through project config, `--rules`, and the npm wrapper
- document the new rule

## Parser audit

- exercised `.js`, `.jsx`, `.ts`, and `.tsx` fixtures
- asserted zero `parse` diagnostics for every fixture
- no Yuku parser regression observed with v0.9.1

## Testing

- `zig build test --summary all` — 1960/1960 tests passed
- `zig build`
- `git diff --check`

Closes #1094
