### PR TITLE
fix: clean unused import autofix whitespace

### DIFF
--- a/src/rules/unused_imports_no_unused_imports.zig
+++ b/src/rules/unused_imports_no_unused_imports.zig
@@ -169,11 +169,12 @@ fn buildFixes(
     unused_count: usize,
 ) Allocator.Error!bool {
     if (unused_count == bindings.len) {
-        const replacement = try commentsOnlyReplacement(allocator, tree, tree.span(declaration_index));
+        const declaration_span = tree.span(declaration_index);
+        const replacement = try commentsOnlyReplacement(allocator, tree, declaration_span);
         errdefer allocator.free(replacement);
         try replacements.append(allocator, replacement);
         try fixes.append(allocator, .{
-            .span = tree.span(declaration_index),
+            .span = declarationRemovalSpan(tree.source, declaration_span),
             .replacement = replacement,
         });
         return true;
@@ -181,7 +182,7 @@ fn buildFixes(
 
     for (bindings) |binding| {
         if (!binding.used) {
-            try fixes.append(allocator, .{ .span = tree.span(binding.specifier), .replacement = "" });
+            try fixes.append(allocator, .{ .span = bindingRemovalSpan(tree, binding.specifier), .replacement = "" });
         }
     }
 
@@ -353,18 +354,39 @@ fn commentsOnlyReplacement(allocator: Allocator, tree: *const ast.Tree, span: as
     var cursor = span.start;
     for (tree.comments) |comment| {
         if (comment.span.start < span.start or comment.span.end > span.end) continue;
-        try appendWhitespace(allocator, &output, tree.source[cursor..comment.span.start]);
+        try appendLineBreaks(allocator, &output, tree.source[cursor..comment.span.start]);
         try output.appendSlice(allocator, tree.source[comment.span.start..comment.span.end]);
         cursor = comment.span.end;
     }
-    try appendWhitespace(allocator, &output, tree.source[cursor..span.end]);
+    try appendLineBreaks(allocator, &output, tree.source[cursor..span.end]);
     return output.toOwnedSlice(allocator);
 }
 
-fn appendWhitespace(allocator: Allocator, output: *std.ArrayList(u8), source: []const u8) Allocator.Error!void {
+fn appendLineBreaks(allocator: Allocator, output: *std.ArrayList(u8), source: []const u8) Allocator.Error!void {
     for (source) |byte| {
-        if (std.ascii.isWhitespace(byte)) try output.append(allocator, byte);
+        if (byte == '\r' or byte == '\n') try output.append(allocator, byte);
     }
+}
+
+fn declarationRemovalSpan(source: []const u8, declaration_span: ast.Span) ast.Span {
+    var start = declaration_span.start;
+    const start_of_line = lineStart(source, start);
+    while (start > start_of_line and isHorizontalWhitespace(source[start - 1])) start -= 1;
+
+    var end = declaration_span.end;
+    while (end < source.len and isHorizontalWhitespace(source[end])) end += 1;
+    return .{ .start = start, .end = end };
+}
+
+fn bindingRemovalSpan(tree: *const ast.Tree, specifier: ast.NodeIndex) ast.Span {
+    var span = tree.span(specifier);
+    const start_of_line = lineStart(tree.source, span.start);
+    while (span.start > start_of_line and isHorizontalWhitespace(tree.source[span.start - 1])) span.start -= 1;
+    return span;
+}
+
+fn isHorizontalWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t';
 }
 
 fn appendRemoval(allocator: Allocator, fixes: *std.ArrayList(core.Fix), position: u32) Allocator.Error!void {

--- a/tests/rules/unused_imports_no_unused_imports.zig
+++ b/tests/rules/unused_imports_no_unused_imports.zig
@@ -87,6 +87,60 @@ test "autofix removes an empty declaration but preserves comments and side effec
     try std.testing.expectEqual(@as(usize, 0), fixed_result.diagnostics.len);
 }
 
+test "autofix leaves deleted import lines free of spaces and tabs" {
+    const cases = [_]struct {
+        source: []const u8,
+        expected: []const u8,
+    }{
+        .{
+            .source = "import { Clean } from \"./clean\";\n\nexport const value = 1;",
+            .expected = "\n\nexport const value = 1;",
+        },
+        .{
+            .source = "\timport Unused from \"package\"; \t\nexport const value = 1;",
+            .expected = "\nexport const value = 1;",
+        },
+        .{
+            .source = "import * as Unused from \"package\";   // keep trailing\nexport const value = 1;",
+            .expected = "// keep trailing\nexport const value = 1;",
+        },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSourceAndFix(std.testing.allocator, case.source, "fixture.ts", ruleOptions());
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(result.fixed);
+        try std.testing.expectEqualStrings(case.expected, result.output);
+        var lines = std.mem.splitScalar(u8, result.output, '\n');
+        while (lines.next()) |line| {
+            if (std.mem.trim(u8, line, " \t").len == 0) {
+                try std.testing.expectEqual(@as(usize, 0), line.len);
+            }
+        }
+        try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result.result, "parse"));
+    }
+}
+
+test "unused import autofix is idempotent" {
+    const source =
+        \\import UnusedDefault from "default-package";
+        \\import { Used, UnusedNamed } from "named-package";
+        \\console.log(Used);
+    ;
+
+    var first = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", ruleOptions());
+    defer first.deinit(std.testing.allocator);
+    try std.testing.expect(first.fixed);
+
+    var second = try lint.lintSourceAndFix(std.testing.allocator, first.output, "fixture.js", ruleOptions());
+    defer second.deinit(std.testing.allocator);
+    try std.testing.expect(!second.fixed);
+    try std.testing.expectEqual(@as(usize, 0), second.passes);
+    try std.testing.expectEqualStrings(first.output, second.output);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(second.result, "parse"));
+}
+
 test "autofix keeps mixed import forms syntactically valid" {
     const cases = [_]struct {
         source: []const u8,

--- a/tests/snapshots/specs/unused-imports/no-unused-imports/invalid.tsx.snap
+++ b/tests/snapshots/specs/unused-imports/no-unused-imports/invalid.tsx.snap
@@ -33,10 +33,10 @@ count: 2
 
 ### Fix 1.1
 
-- byte span: 7..20
-- start: 1:8
+- byte span: 6..20
+- start: 1:7
 - end: 1:21
-- source: "UnusedDefault"
+- source: " UnusedDefault"
 - replacement: ""
 
 ### Fix 1.2
@@ -73,7 +73,7 @@ count: 2
 - remaining diagnostics: 0
 
 ```tsx
-import  {
+import {
   Used,
   Kept as UsedAlias,
 } from "package";

--- a/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.options.json
+++ b/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 6,
+  "fixes": "required"
+}

--- a/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.ts
+++ b/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.ts
@@ -1,0 +1,17 @@
+// keep leading default comment
+import UnusedDefault from "default-package";   // keep trailing default comment
+import { UnusedNamed } from "named-package";
+import * as UnusedNamespace from "namespace-package";
+import type { UnusedType } from "type-package";
+import /* keep block */ {
+  // keep line
+  UnusedCommented,
+} from "commented-package";
+import {
+  Used,
+  UnusedMultiline,
+  // keep partial comment
+  UsedToo,
+} from "mixed-package";
+
+console.log(Used, UsedToo);

--- a/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.ts.snap
+++ b/tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.ts.snap
@@ -1,0 +1,169 @@
+---
+fixture: "tests/snapshots/specs/unused-imports/no-unused-imports/whitespace.ts"
+rule: "unused-imports/no-unused-imports"
+---
+
+# Input
+
+```ts
+// keep leading default comment
+import UnusedDefault from "default-package";   // keep trailing default comment
+import { UnusedNamed } from "named-package";
+import * as UnusedNamespace from "namespace-package";
+import type { UnusedType } from "type-package";
+import /* keep block */ {
+  // keep line
+  UnusedCommented,
+} from "commented-package";
+import {
+  Used,
+  UnusedMultiline,
+  // keep partial comment
+  UsedToo,
+} from "mixed-package";
+
+console.log(Used, UsedToo);
+```
+
+# Diagnostics
+
+count: 6
+
+## Diagnostic 1
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedDefault' is defined but never used."
+- byte span: 39..52
+- start: 2:8
+- end: 2:21
+- source: "UnusedDefault"
+- fixes: 1
+
+### Fix 1.1
+
+- byte span: 32..79
+- start: 2:1
+- end: 2:48
+- source: "import UnusedDefault from \"default-package\";   "
+- replacement: ""
+
+## Diagnostic 2
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedNamed' is defined but never used."
+- byte span: 121..132
+- start: 3:10
+- end: 3:21
+- source: "UnusedNamed"
+- fixes: 1
+
+### Fix 2.1
+
+- byte span: 112..156
+- start: 3:1
+- end: 3:45
+- source: "import { UnusedNamed } from \"named-package\";"
+- replacement: ""
+
+## Diagnostic 3
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedNamespace' is defined but never used."
+- byte span: 169..184
+- start: 4:13
+- end: 4:28
+- source: "UnusedNamespace"
+- fixes: 1
+
+### Fix 3.1
+
+- byte span: 157..210
+- start: 4:1
+- end: 4:54
+- source: "import * as UnusedNamespace from \"namespace-package\";"
+- replacement: ""
+
+## Diagnostic 4
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedType' is defined but never used."
+- byte span: 225..235
+- start: 5:15
+- end: 5:25
+- source: "UnusedType"
+- fixes: 1
+
+### Fix 4.1
+
+- byte span: 211..258
+- start: 5:1
+- end: 5:48
+- source: "import type { UnusedType } from \"type-package\";"
+- replacement: ""
+
+## Diagnostic 5
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedCommented' is defined but never used."
+- byte span: 302..317
+- start: 8:3
+- end: 8:18
+- source: "UnusedCommented"
+- fixes: 1
+
+### Fix 5.1
+
+- byte span: 259..346
+- start: 6:1
+- end: 9:28
+- source: "import /* keep block */ {\n  // keep line\n  UnusedCommented,\n} from \"commented-package\";"
+- replacement: "/* keep block */\n// keep line\n\n"
+
+## Diagnostic 6
+
+- rule: "unused-imports/no-unused-imports"
+- severity: "warning"
+- message: "'UnusedMultiline' is defined but never used."
+- byte span: 366..381
+- start: 12:3
+- end: 12:18
+- source: "UnusedMultiline"
+- fixes: 1
+
+### Fix 6.1
+
+- byte span: 364..383
+- start: 12:1
+- end: 13:1
+- source: "  UnusedMultiline,\n"
+- replacement: ""
+
+# First fix pass
+
+- fixed: true
+- applied diagnostics: 6
+- remaining diagnostics: 0
+
+```ts
+// keep leading default comment
+// keep trailing default comment
+
+
+
+/* keep block */
+// keep line
+
+
+import {
+  Used,
+  // keep partial comment
+  UsedToo,
+} from "mixed-package";
+
+console.log(Used, UsedToo);
+```


### PR DESCRIPTION
## Summary

- remove horizontal whitespace when an entire unused import declaration is deleted while preserving its newline structure
- retain comments without recreating whitespace-only lines, including leading, trailing, block, and line-comment cases
- clean adjacent horizontal spacing in partial import fixes without disturbing used specifiers or comma placement
- add autofix snapshots for default, named, namespace, type-only, multiline, and comment-adjacent imports
- verify a second fix pass is a no-op

## Parser audit

- linted original and fixed JavaScript/TypeScript fixtures with explicit `parse` assertions
- snapshot validation reparses every fixed output
- no Yuku parser regression observed with v0.9.1

## Testing

- `zig build test --summary all` — 1957/1957 tests passed; 11/11 rule snapshots passed
- `zig build`
- `git diff --check`

Closes #1095
