### PR TITLE
fix: avoid diagnostic output buffer overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ Raw reports include active diagnostics, suppressed diagnostics, fixed outputs,
 and an exit code. The compatibility layer also exports `Linter`, `CLIEngine`,
 `RuleTester`, and `SourceCode` APIs.
 
+The Node wrapper captures up to 64 MiB from each native stdout and stderr
+stream by default. Programmatic `run`, `runCli`, and `runFishlint` calls can set
+`maxBuffer` to another positive byte count. Set `UTOO_LINT_MAX_BUFFER` to apply
+the same limit to CLI invocations; output beyond the configured bound reports
+`ENOBUFS` instead of being truncated.
+
 ## Documentation
 
 - [Rule status](docs/rule-status.md) — implemented rules and autofix coverage

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -251,6 +251,12 @@ Raw reports include active diagnostics, suppressed diagnostics, fixed outputs,
 and an exit code. The compatibility layer also exports `Linter`, `CLIEngine`,
 `RuleTester`, and `SourceCode` APIs.
 
+The Node wrapper captures up to 64 MiB from each native stdout and stderr
+stream by default. Programmatic `run`, `runCli`, and `runFishlint` calls can set
+`maxBuffer` to another positive byte count. Set `UTOO_LINT_MAX_BUFFER` to apply
+the same limit to CLI invocations; output beyond the configured bound reports
+`ENOBUFS` instead of being truncated.
+
 ## Supported platforms
 
 The package installs a platform-specific optional dependency containing the

--- a/npm/utoo-lint/bin/fishlint.js
+++ b/npm/utoo-lint/bin/fishlint.js
@@ -61,6 +61,8 @@ const STYLELINT_VALUE_FLAGS = new Set([
   "-f",
   "-o"
 ]);
+const DEFAULT_NATIVE_MAX_BUFFER = 64 * 1024 * 1024;
+const nativeOutputMaxBuffer = readNativeMaxBuffer();
 
 if (isVersionRequest(values)) {
   printVersion();
@@ -182,7 +184,10 @@ const needsReportOutput =
   ignoredFiltered.diagnostics.length > 0 ||
   usesJsonWithMetadataFormat(nativeValues) ||
   ruleResolution.configuredRules.size > 0;
-const result = spawnSync(binary, needsReportOutput ? withJsonFormat(ruleConfig.args) : ruleConfig.args, { encoding: "utf8" });
+const result = spawnSync(binary, needsReportOutput ? withJsonFormat(ruleConfig.args) : ruleConfig.args, {
+  encoding: "utf8",
+  maxBuffer: nativeOutputMaxBuffer
+});
 
 if (result.error) {
   console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
@@ -1102,7 +1107,7 @@ function runFlatConfigGroups(binary, translatedArgs, selectedConfig, ruleOverrid
       ...withoutConfigAndTargets(translatedArgs),
       `--config=${runtimeConfig.file}`,
       ...group.files
-    ]), { encoding: "utf8" });
+    ]), { encoding: "utf8", maxBuffer: nativeOutputMaxBuffer });
     cleanupRuleConfig(runtimeConfig);
     if (result.error) {
       return { error: result.error };
@@ -1500,11 +1505,26 @@ function parseJsonReport(stdout) {
 }
 
 function jsonDiagnosticCounts(binary, args) {
-  const result = spawnSync(binary, withJsonFormat(args), { encoding: "utf8" });
+  const result = spawnSync(binary, withJsonFormat(args), {
+    encoding: "utf8",
+    maxBuffer: nativeOutputMaxBuffer
+  });
   if (result.error) {
     return null;
   }
   return diagnosticCounts(result.stdout ?? "");
+}
+
+function readNativeMaxBuffer() {
+  const configured = process.env.UTOO_LINT_MAX_BUFFER;
+  if (configured === undefined || configured === "") {
+    return DEFAULT_NATIVE_MAX_BUFFER;
+  }
+  const value = Number(configured);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError("UTOO_LINT_MAX_BUFFER must be a positive integer byte count");
+  }
+  return value;
 }
 
 function withJsonFormat(args) {

--- a/npm/utoo-lint/bin/utoo-lint.js
+++ b/npm/utoo-lint/bin/utoo-lint.js
@@ -4,20 +4,20 @@ import { runCli } from "../index.js";
 
 if (process.argv[2] === "migrate") {
   const { runMigrate } = await import("./migrate.js");
-  process.exit(await runMigrate(process.argv.slice(3)));
-}
+  process.exitCode = await runMigrate(process.argv.slice(3));
+} else {
+  let result;
+  try {
+    result = runCli(process.argv.slice(2), { stdio: "inherit" });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
 
-let result;
-try {
-  result = runCli(process.argv.slice(2), { stdio: "inherit" });
-} catch (error) {
-  console.error(error.message);
-  process.exit(1);
+  if (result?.error) {
+    console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
+    process.exitCode = 1;
+  } else if (result) {
+    process.exitCode = result.status ?? 1;
+  }
 }
-
-if (result.error) {
-  console.error(`utoo-lint: failed to run native binary: ${result.error.message}`);
-  process.exit(1);
-}
-
-process.exit(result.status ?? 1);

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -694,6 +694,20 @@ class CLIEngine {
   }
 }
 
+const DEFAULT_NATIVE_MAX_BUFFER = 64 * 1024 * 1024;
+
+function nativeMaxBuffer(options, env) {
+  const configured = options.maxBuffer ?? env.UTOO_LINT_MAX_BUFFER;
+  if (configured === undefined || configured === "") {
+    return DEFAULT_NATIVE_MAX_BUFFER;
+  }
+  const value = typeof configured === "number" ? configured : Number(configured);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError("maxBuffer and UTOO_LINT_MAX_BUFFER must be a positive integer byte count");
+  }
+  return value;
+}
+
 function run(args = [], options = {}) {
   const cliArgs = normalizeStringArray(args, "args");
   const env = options.env ? { ...process.env, ...options.env } : process.env;
@@ -704,7 +718,8 @@ function run(args = [], options = {}) {
     env,
     encoding: options.encoding ?? "utf8",
     input: options.input,
-    stdio: options.stdio
+    stdio: options.stdio,
+    maxBuffer: nativeMaxBuffer(options, env)
   });
 }
 
@@ -955,7 +970,8 @@ function runFishlint(args = [], options = {}) {
     env,
     encoding: options.encoding ?? "utf8",
     input: options.input,
-    stdio: options.stdio
+    stdio: options.stdio,
+    maxBuffer: nativeMaxBuffer(options, env)
   });
 }
 

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -93,6 +93,8 @@ export interface LintOptions {
   cwd?: string;
   binary?: string;
   env?: Record<string, string | undefined>;
+  /** Maximum bytes captured from each native stdout/stderr stream. Defaults to 64 MiB. */
+  maxBuffer?: number;
   threads?: number;
   rules?: string[] | string;
   format?: "text" | "json" | string;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -2599,6 +2599,20 @@ export class CLIEngine {
   }
 }
 
+const DEFAULT_NATIVE_MAX_BUFFER = 64 * 1024 * 1024;
+
+function nativeMaxBuffer(options, env) {
+  const configured = options.maxBuffer ?? env.UTOO_LINT_MAX_BUFFER;
+  if (configured === undefined || configured === "") {
+    return DEFAULT_NATIVE_MAX_BUFFER;
+  }
+  const value = typeof configured === "number" ? configured : Number(configured);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError("maxBuffer and UTOO_LINT_MAX_BUFFER must be a positive integer byte count");
+  }
+  return value;
+}
+
 export function run(args = [], options = {}) {
   const cliArgs = normalizeStringArray(args, "args");
   const env = options.env ? { ...process.env, ...options.env } : process.env;
@@ -2609,7 +2623,8 @@ export function run(args = [], options = {}) {
     env,
     encoding: options.encoding ?? "utf8",
     input: options.input,
-    stdio: options.stdio
+    stdio: options.stdio,
+    maxBuffer: nativeMaxBuffer(options, env)
   });
 }
 
@@ -2860,7 +2875,8 @@ export function runFishlint(args = [], options = {}) {
     env,
     encoding: options.encoding ?? "utf8",
     input: options.input,
-    stdio: options.stdio
+    stdio: options.stdio,
+    maxBuffer: nativeMaxBuffer(options, env)
   });
 }
 

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -8,10 +8,15 @@ import { fileURLToPath } from "node:url";
 
 import { createRequire } from "node:module";
 
-import { ESLint, Linter, lintFiles, lintText, resolveBinary, runCli } from "../index.js";
+import { ESLint, Linter, lintFiles, lintText, resolveBinary, run, runCli } from "../index.js";
 
 const require = createRequire(import.meta.url);
-const { ESLint: CommonJSESLint, Linter: CommonJSLinter, runCli: commonJSRunCli } = require("../index.cjs");
+const {
+  ESLint: CommonJSESLint,
+  Linter: CommonJSLinter,
+  run: commonJSRun,
+  runCli: commonJSRunCli
+} = require("../index.cjs");
 
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = join(packageDirectory, "bin", "utoo-lint.js");
@@ -24,6 +29,8 @@ const builtBinary = resolve(
   "bin",
   process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint"
 );
+const largeDiagnosticCount = 20_000;
+const testOutputMaxBuffer = 64 * 1024 * 1024;
 
 function testBinary() {
   if (existsSync(builtBinary)) {
@@ -78,6 +85,84 @@ test("frontend typed and JSON entry points expose the same reviewed rule set", (
     Object.keys(fromJson.rules).some((ruleId) => /prettier|format|indent|quotes|semi/.test(ruleId)),
     false
   );
+});
+
+function createLargeDiagnosticProject(t) {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "fixture.js"), "debugger;\n".repeat(largeDiagnosticCount));
+  const configPath = write(
+    join(project, "utlint.config.json"),
+    `${JSON.stringify({ rules: { "no-debugger": "error" } }, null, 2)}\n`
+  );
+  return { project, sourcePath, configPath };
+}
+
+function assertLargeJsonReport(stdout) {
+  const byteLength = Buffer.byteLength(stdout);
+  assert.ok(byteLength > 1024 * 1024, `expected more than 1 MiB of JSON, received ${byteLength} bytes`);
+  const report = JSON.parse(stdout);
+  assert.equal(report.diagnostics.length, largeDiagnosticCount);
+  assert.ok(report.diagnostics.every((diagnostic) => diagnostic.ruleId === "no-debugger"));
+}
+
+test("ESM and CommonJS run capture diagnostic JSON larger than Node's default spawnSync buffer", (t) => {
+  const { project, sourcePath, configPath } = createLargeDiagnosticProject(t);
+  const args = [`--config=${configPath}`, "--format=json", sourcePath];
+  const result = run(args, { binary: testBinary(), cwd: project });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "");
+  assertLargeJsonReport(result.stdout);
+
+  const commonJSResult = commonJSRun(args, { binary: testBinary(), cwd: project });
+  assert.equal(commonJSResult.error, undefined);
+  assert.equal(commonJSResult.status, 1);
+  assert.equal(commonJSResult.stderr, "");
+  assertLargeJsonReport(commonJSResult.stdout);
+
+  const bufferedOutputArgs = ["--eval", `process.stdout.write("x".repeat(4096))`];
+  const capped = run(bufferedOutputArgs, { binary: process.execPath, maxBuffer: 1024 });
+  assert.equal(capped.error?.code, "ENOBUFS");
+
+  const envCapped = run(bufferedOutputArgs, {
+    binary: process.execPath,
+    env: { UTOO_LINT_MAX_BUFFER: "1024" }
+  });
+  assert.equal(envCapped.error?.code, "ENOBUFS");
+
+  const missing = run([], { binary: join(project, "missing-utoo-lint") });
+  assert.equal(missing.error?.code, "ENOENT");
+});
+
+test("CLI preserves large JSON and text reports with the correct exit status", (t) => {
+  const { project, sourcePath, configPath } = createLargeDiagnosticProject(t);
+  const env = { ...process.env, UTOO_LINT_BIN: testBinary() };
+  const commonArgs = [`--config=${configPath}`, sourcePath];
+
+  const json = spawnSync(process.execPath, [cliPath, "--format=json", ...commonArgs], {
+    cwd: project,
+    env,
+    encoding: "utf8",
+    maxBuffer: testOutputMaxBuffer
+  });
+  assert.equal(json.error, undefined);
+  assert.equal(json.status, 1);
+  assert.equal(json.stderr, "");
+  assertLargeJsonReport(json.stdout);
+
+  const text = spawnSync(process.execPath, [cliPath, "--no-color", ...commonArgs], {
+    cwd: project,
+    env,
+    encoding: "utf8",
+    maxBuffer: testOutputMaxBuffer
+  });
+  assert.equal(text.error, undefined);
+  assert.equal(text.status, 1);
+  assert.equal(text.stdout, "");
+  assert.ok(Buffer.byteLength(text.stderr) > 1024 * 1024);
+  assert.equal(text.stderr.match(/no-debugger/g)?.length, largeDiagnosticCount);
+  assert.match(text.stderr, /20000 problems \(20000 errors, 0 warnings\)/);
 });
 
 test("ESLint exposes diagnostics suppressed by utlint-ignore", async () => {


### PR DESCRIPTION
## Summary

- raise captured native stdout and stderr from Node's implicit buffer to an explicit 64 MiB default
- allow programmatic callers to set `maxBuffer` and CLI users to set `UTOO_LINT_MAX_BUFFER`
- apply the same bounded strategy to ESM, CommonJS, and fishlint capture paths
- let the CLI process exit naturally so large stdout and stderr streams finish flushing
- keep `ENOBUFS` for deliberately exceeded configured limits and preserve distinct spawn errors such as `ENOENT`

## Parser audit

- generated a valid JavaScript fixture with 20,000 `debugger` statements
- verified every diagnostic is `no-debugger` in the large JSON reports
- observed zero `parse` diagnostics

## Testing

- `pnpm --dir npm/utoo-lint test` — 85/85 Node tests plus TypeScript type checks passed
- large-output regression — ESM/CommonJS API, JSON CLI, and text CLI all preserved 20,000 diagnostics and exit status 1
- `zig build test --summary all` — 1971/1971 tests passed; 11/11 rule snapshots passed
- `zig build`
- `git diff --check origin/main...HEAD`

Closes #1101
