### PR TITLE
fix: align frontend preset scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,13 @@ jobs:
       - name: Verify npm wrapper
         run: |
           node npm/utoo-lint/bin/utoo-lint.js --no-config test/fixtures/bad.ts
+          frontend_fixture="$(mktemp -d)"
+          trap 'rm -rf "$frontend_fixture"' EXIT
+          mkdir -p "$frontend_fixture/src"
+          cp npm/utoo-lint/configs/frontend.json "$frontend_fixture/utlint.config.json"
+          cp test/fixtures/bad.ts "$frontend_fixture/src/bad.ts"
           set +e
-          node npm/utoo-lint/bin/utoo-lint.js --config=npm/utoo-lint/configs/frontend.json test/fixtures/bad.ts
+          node npm/utoo-lint/bin/utoo-lint.js --config="$frontend_fixture/utlint.config.json" "$frontend_fixture/src/bad.ts"
           status=$?
           set -e
           test "$status" -eq 1

--- a/README.md
+++ b/README.md
@@ -91,21 +91,18 @@ Without a config file, `utoo-lint` uses its built-in default rules. It supports
 Create `utlint.config.ts`:
 
 ```ts
-import { defineConfig, globalIgnores } from "@utoo/lint/config";
+import { defineConfig } from "@utoo/lint/config";
 import frontend from "@utoo/lint/configs/frontend";
 
-export default defineConfig(
-  globalIgnores(["dist/", "coverage/"]),
-  {
-    ...frontend,
-    files: ["src/**/*.{js,jsx,ts,tsx}"],
-    rules: {
-      ...frontend.rules,
-      "no-console": "off",
-      "react/no-forward-ref": "off"
-    }
+export default defineConfig({
+  ...frontend,
+  ignores: [...frontend.ignores, ".next", "storybook-static"],
+  rules: {
+    ...frontend.rules,
+    "no-console": "off",
+    "react/no-forward-ref": "off"
   }
-);
+});
 ```
 
 The frontend preset uses `error` for correctness and safety checks that should
@@ -117,8 +114,8 @@ visible without blocking adoption:
 | `error` | `react-hooks/rules-of-hooks`, `react/jsx-key`, `react/no-children-prop`, `react/no-danger-with-children`, `react/void-dom-elements-no-children`, `no-script-url`, `promise/no-nesting` |
 | `warn` | `react-hooks/exhaustive-deps`, `react/no-array-index-key`, `react/no-unstable-nested-components`, `react/no-forward-ref`, `unused-imports/no-unused-imports`, `@typescript-eslint/no-unused-vars`, `@typescript-eslint/ban-types` |
 
-Override any project-specific rule after spreading `frontend.rules`, as shown
-above.
+Override project-specific rules after spreading `frontend.rules`, and append
+framework-generated directories to `frontend.ignores`, as shown above.
 
 The preset intentionally enables no formatter or type-checker integration.
 Keep Prettier (or another formatter) and `tsc` as independent project steps.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ import frontend from "@utoo/lint/configs/frontend";
 
 export default defineConfig({
   ...frontend,
+  ignores: [...frontend.ignores, ".next", "storybook-static"],
   rules: {
     ...frontend.rules,
     "no-console": "off",
@@ -180,7 +181,7 @@ For a React or TypeScript frontend project, start by copying the packaged fronte
 
 ```bash
 cp node_modules/@utoo/lint/configs/frontend.json utlint.config.json
-npx utoo-lint src
+npx utoo-lint
 ```
 
 The template includes a `$schema` entry for editor validation and a focused set of browser, import, React, JSX a11y, and TypeScript rules:
@@ -189,7 +190,7 @@ The template includes a `$schema` entry for editor validation and a focused set 
 {
   "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
   "files": ["src/**/*.{js,jsx,ts,tsx}"],
-  "ignores": ["dist", "node_modules"],
+  "ignores": ["dist", "coverage", "node_modules"],
   "rules": {
     "no-debugger": "error",
     "no-console": "warn",
@@ -199,6 +200,13 @@ The template includes a `$schema` entry for editor validation and a focused set 
   }
 }
 ```
+
+With no target argument, the copied preset scans JavaScript and TypeScript
+under `src`. Its rules do not apply to `dist`, `coverage`, or `node_modules`,
+including when `.` is passed explicitly. Add framework-specific generated
+directories such as `.next`, `storybook-static`, or `build` to the copied
+`ignores` array. Typed configs can append to `frontend.ignores` as shown in the
+TypeScript example above.
 
 `utoo-lint` treats config severities like ESLint. `off`, `0`, and `false`
 disable a rule; `warn`, `warning`, `on`, and `1` report warnings; `error`, `2`,

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -79,21 +79,18 @@ Without a config file, `utoo-lint` uses its built-in default rules. It supports
 Create `utlint.config.ts`:
 
 ```ts
-import { defineConfig, globalIgnores } from "@utoo/lint/config";
+import { defineConfig } from "@utoo/lint/config";
 import frontend from "@utoo/lint/configs/frontend";
 
-export default defineConfig(
-  globalIgnores(["dist/", "coverage/"]),
-  {
-    ...frontend,
-    files: ["src/**/*.{js,jsx,ts,tsx}"],
-    rules: {
-      ...frontend.rules,
-      "no-console": "off",
-      "react/no-forward-ref": "off"
-    }
+export default defineConfig({
+  ...frontend,
+  ignores: [...frontend.ignores, ".next", "storybook-static"],
+  rules: {
+    ...frontend.rules,
+    "no-console": "off",
+    "react/no-forward-ref": "off"
   }
-);
+});
 ```
 
 The frontend preset uses `error` for correctness and safety checks that should
@@ -105,8 +102,8 @@ visible without blocking adoption:
 | `error` | `react-hooks/rules-of-hooks`, `react/jsx-key`, `react/no-children-prop`, `react/no-danger-with-children`, `react/void-dom-elements-no-children`, `no-script-url`, `promise/no-nesting` |
 | `warn` | `react-hooks/exhaustive-deps`, `react/no-array-index-key`, `react/no-unstable-nested-components`, `react/no-forward-ref`, `unused-imports/no-unused-imports`, `@typescript-eslint/no-unused-vars`, `@typescript-eslint/ban-types` |
 
-Override any project-specific rule after spreading `frontend.rules`, as shown
-above.
+Override project-specific rules after spreading `frontend.rules`, and append
+framework-generated directories to `frontend.ignores`, as shown above.
 
 The preset intentionally enables no formatter or type-checker integration.
 Keep Prettier (or another formatter) and `tsc` as independent project steps.

--- a/npm/utoo-lint/configs/frontend.d.ts
+++ b/npm/utoo-lint/configs/frontend.d.ts
@@ -52,6 +52,8 @@ export type FrontendRuleId =
 
 declare const frontend: ConfigObject & {
   readonly $schema: string;
+  readonly files: ["src/**/*.{js,jsx,ts,tsx}"];
+  readonly ignores: ["dist", "coverage", "node_modules"];
   readonly rules: Readonly<Record<FrontendRuleId, RuleConfig>>;
 };
 

--- a/npm/utoo-lint/configs/frontend.json
+++ b/npm/utoo-lint/configs/frontend.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json",
+  "files": ["src/**/*.{js,jsx,ts,tsx}"],
+  "ignores": ["dist", "coverage", "node_modules"],
   "rules": {
     "no-debugger": "error",
     "no-alert": "error",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -51,7 +51,7 @@ function write(path, source = "{}\n") {
   return path;
 }
 
-test("frontend typed and JSON entry points expose the same reviewed rule set", () => {
+test("frontend typed, package, and JSON entry points expose the same scope and rule set", () => {
   const jsonPath = join(packageDirectory, "configs", "frontend.json");
   const declarationPath = join(packageDirectory, "configs", "frontend.d.ts");
   const fromJson = JSON.parse(readFileSync(jsonPath, "utf8"));
@@ -61,6 +61,10 @@ test("frontend typed and JSON entry points expose the same reviewed rule set", (
   const declaration = readFileSync(declarationPath, "utf8");
   const typedRuleIds = [...declaration.matchAll(/^\s*\|\s*"([^"]+)";?$/gm)].map((match) => match[1]);
   assert.deepEqual(typedRuleIds, Object.keys(fromJson.rules));
+  assert.deepEqual(fromJson.files, ["src/**/*.{js,jsx,ts,tsx}"]);
+  assert.deepEqual(fromJson.ignores, ["dist", "coverage", "node_modules"]);
+  assert.match(declaration, /readonly files: \["src\/\*\*\/\*\.\{js,jsx,ts,tsx\}"\];/);
+  assert.match(declaration, /readonly ignores: \["dist", "coverage", "node_modules"\];/);
 
   const reviewedRules = {
     "react-hooks/rules-of-hooks": "error",
@@ -163,6 +167,45 @@ test("CLI preserves large JSON and text reports with the correct exit status", (
   assert.ok(Buffer.byteLength(text.stderr) > 1024 * 1024);
   assert.equal(text.stderr.match(/no-debugger/g)?.length, largeDiagnosticCount);
   assert.match(text.stderr, /20000 problems \(20000 errors, 0 warnings\)/);
+});
+
+test("frontend preset scopes default and explicit targets to source files", (t) => {
+  const project = createProject(t);
+  const sourcePath = write(join(project, "src", "index.js"), "debugger;\n");
+  const generatedPaths = [
+    write(join(project, "dist", "generated.js"), "debugger;\n"),
+    write(join(project, "coverage", "generated.js"), "debugger;\n"),
+    write(join(project, "node_modules", "example", "generated.js"), "debugger;\n")
+  ];
+  write(
+    join(project, "utlint.config.json"),
+    readFileSync(join(packageDirectory, "configs", "frontend.json"), "utf8")
+  );
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    for (const targets of [[], ["."]]) {
+      const result = execute(["--format=json", ...targets], {
+        cwd: project,
+        binary: testBinary(),
+        encoding: "utf8"
+      });
+
+      assert.equal(result.status, 1, result.stderr);
+      const report = JSON.parse(result.stdout);
+      assert.deepEqual(report.diagnostics.map((diagnostic) => diagnostic.ruleId), ["no-debugger"]);
+      assert.equal(resolve(report.diagnostics[0].filePath), resolve(sourcePath));
+      assert.equal(report.diagnostics.some((diagnostic) => diagnostic.ruleId === "parse"), false);
+      for (const generatedPath of generatedPaths) {
+        assert.equal(
+          report.diagnostics.some((diagnostic) => resolve(diagnostic.filePath) === resolve(generatedPath)),
+          false
+        );
+      }
+      if (targets.length === 0) {
+        assert.deepEqual(report.filePaths.map((filePath) => resolve(filePath)), [resolve(sourcePath)]);
+      }
+    }
+  }
 });
 
 test("ESLint exposes diagnostics suppressed by utlint-ignore", async () => {

--- a/npm/utoo-lint/test/types/frontend-config.ts
+++ b/npm/utoo-lint/test/types/frontend-config.ts
@@ -3,8 +3,12 @@ import frontend, { type FrontendRuleId } from "@utoo/lint/configs/frontend";
 
 const react19Rule: FrontendRuleId = "react/no-forward-ref";
 const nestedComponentRule: FrontendRuleId = "react/no-unstable-nested-components";
+const frontendSourcePattern: "src/**/*.{js,jsx,ts,tsx}" = frontend.files[0];
+const frontendCoverageIgnore: "coverage" = frontend.ignores[1];
 void react19Rule;
 void nestedComponentRule;
+void frontendSourcePattern;
+void frontendCoverageIgnore;
 
 export default defineConfig({
   rules: {


### PR DESCRIPTION
## Summary

- add the documented `src/**/*.{js,jsx,ts,tsx}` file scope to the packaged frontend preset
- exclude `dist`, `coverage`, and `node_modules` from frontend rule application
- expose the exact `files` and `ignores` values through the typed preset entry point
- verify the package export, JSON config, and declaration expose the same scope and rule set
- document no-target usage and extending ignores for framework-generated directories
- update the npm-wrapper smoke check to copy the preset into a representative frontend project before linting

## Parser audit

- linted matching JavaScript source and generated fixtures through ESM and CommonJS APIs
- exercised both the default target selection and an explicit `.` target
- observed exactly one source `no-debugger` diagnostic and zero `parse` diagnostics

## Testing

- `pnpm --dir npm/utoo-lint test` — 86/86 Node tests plus TypeScript type checks passed
- frontend scope regression — source reported once; `dist`, `coverage`, and `node_modules` produced no diagnostics
- npm-wrapper smoke scenario — copied preset reports 2 errors and 1 warning for `src/bad.ts` with exit status 1
- `zig build test --summary all` — 1971/1971 tests passed; 11/11 rule snapshots passed
- `zig build`
- `git diff --check origin/main...HEAD`

Closes #1102
