### PR TITLE
feat: support wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,52 @@ jobs:
 
       - name: Test npm package
         run: pnpm --dir npm/utoo-lint test
+
+  test-wasm:
+    name: Test WebAssembly (Node 24)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+
+      - name: Build and stage WebAssembly package
+        run: pnpm package:wasm
+
+      - name: Verify WebAssembly artifacts
+        run: |
+          test -s zig-out/bin/utoo-lint.wasm
+          test -s npm/@utoo/lint-wasm/utoo-lint.wasm
+
+      - name: Test raw WebAssembly ABI
+        run: pnpm test:wasm
+
+      - name: Test WebAssembly package
+        run: pnpm --dir npm/@utoo/lint-wasm test
+
+      - name: Test WebAssembly package types
+        run: pnpm --dir npm/@utoo/lint-wasm test:types
+
+      - name: Verify WebAssembly npm package contents
+        run: |
+          pnpm --dir npm/@utoo/lint-wasm pack --pack-destination "${RUNNER_TEMP}"
+          package_tarball="$(find "${RUNNER_TEMP}" -maxdepth 1 -type f -name 'utoo-lint-wasm-*.tgz' -print -quit)"
+          test -n "${package_tarball}"
+          tar -tzf "${package_tarball}" > "${RUNNER_TEMP}/utoo-lint-wasm-files.txt"
+          grep -Fxq 'package/utoo-lint.wasm' "${RUNNER_TEMP}/utoo-lint-wasm-files.txt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,9 +102,84 @@ jobs:
           path: dist/native
           if-no-files-found: error
 
+  build-wasm:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    name: Build WebAssembly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+
+      - name: Build and stage WebAssembly package
+        run: pnpm package:wasm
+
+      - name: Verify WebAssembly artifacts
+        run: |
+          test -s zig-out/bin/utoo-lint.wasm
+          test -s npm/@utoo/lint-wasm/utoo-lint.wasm
+
+      - name: Test raw WebAssembly ABI
+        run: pnpm test:wasm
+
+      - name: Test WebAssembly package
+        run: pnpm --dir npm/@utoo/lint-wasm test
+
+      - name: Test WebAssembly package types
+        run: pnpm --dir npm/@utoo/lint-wasm test:types
+
+      - name: Verify WebAssembly npm package contents
+        run: |
+          pnpm --dir npm/@utoo/lint-wasm pack --pack-destination "${RUNNER_TEMP}"
+          package_tarball="$(find "${RUNNER_TEMP}" -maxdepth 1 -type f -name 'utoo-lint-wasm-*.tgz' -print -quit)"
+          test -n "${package_tarball}"
+          tar -tzf "${package_tarball}" > "${RUNNER_TEMP}/utoo-lint-wasm-files.txt"
+          grep -Fxq 'package/utoo-lint.wasm' "${RUNNER_TEMP}/utoo-lint-wasm-files.txt"
+
+      - name: Package WebAssembly release assets
+        run: |
+          mkdir -p dist/wasm-release
+          cp npm/@utoo/lint-wasm/utoo-lint.wasm dist/wasm-release/utoo-lint.wasm
+          gzip -9 -c dist/wasm-release/utoo-lint.wasm > dist/wasm-release/utoo-lint.wasm.gz
+          (cd dist/wasm-release && shasum -a 256 utoo-lint.wasm > utoo-lint.wasm.sha256)
+          test -s dist/wasm-release/utoo-lint.wasm
+          test -s dist/wasm-release/utoo-lint.wasm.gz
+          test -s dist/wasm-release/utoo-lint.wasm.sha256
+          (cd dist/wasm-release && shasum -a 256 -c utoo-lint.wasm.sha256)
+
+      - name: Upload WebAssembly release artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-utoo-lint-wasm
+          path: dist/wasm-release/*
+          if-no-files-found: error
+
+      - name: Upload WebAssembly npm package
+        uses: actions/upload-artifact@v6
+        with:
+          name: wasm-package
+          path: npm/@utoo/lint-wasm/utoo-lint.wasm
+          if-no-files-found: error
+
   publish-github-release:
     name: Publish GitHub Release assets
-    needs: build-release-assets
+    needs: [build-release-assets, build-wasm]
     if: (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: ubuntu-latest
     steps:
@@ -125,7 +200,7 @@ jobs:
 
   publish-npm:
     name: Publish npm packages
-    needs: build-release-assets
+    needs: [build-release-assets, build-wasm]
     if: (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.publish_npm && inputs.release_tag != '')
     runs-on: ubuntu-latest
     permissions:
@@ -155,6 +230,12 @@ jobs:
           pattern: native-*
           path: dist/native-packages
           merge-multiple: true
+
+      - name: Download WebAssembly npm package
+        uses: actions/download-artifact@v7
+        with:
+          name: wasm-package
+          path: dist/wasm-package
 
       - name: Resolve release version
         id: release_version
@@ -187,12 +268,12 @@ jobs:
           const path = require("node:path");
 
           const version = process.env.VERSION;
-          const nativeRoot = "npm/@utoo";
-          const nativePackagePaths = fs
-            .readdirSync(nativeRoot)
+          const scopedRoot = "npm/@utoo";
+          const scopedPackagePaths = fs
+            .readdirSync(scopedRoot)
             .filter((name) => name.startsWith("lint-"))
-            .map((name) => path.join(nativeRoot, name, "package.json"));
-          const packagePaths = ["npm/utoo-lint/package.json", ...nativePackagePaths];
+            .map((name) => path.join(scopedRoot, name, "package.json"));
+          const packagePaths = ["npm/utoo-lint/package.json", ...scopedPackagePaths];
 
           for (const packagePath of packagePaths) {
             const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
@@ -213,6 +294,12 @@ jobs:
             mkdir -p "npm/@utoo/${package_name}/bin"
             cp -R "${package_dir}/bin/." "npm/@utoo/${package_name}/bin/"
           done
+
+      - name: Stage WebAssembly into workspace package
+        run: |
+          test -s dist/wasm-package/utoo-lint.wasm
+          cp dist/wasm-package/utoo-lint.wasm npm/@utoo/lint-wasm/utoo-lint.wasm
+          test -s npm/@utoo/lint-wasm/utoo-lint.wasm
 
       - name: Verify package contents
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-out/
 dist/
 node_modules/
 .DS_Store
+npm/@utoo/lint-wasm/utoo-lint.wasm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,20 @@ pnpm add -g ./npm/utoo-lint
 utoo-lint test/fixtures/bad.ts
 ```
 
+Build, stage, and validate the browser WebAssembly package:
+
+```bash
+pnpm package:wasm
+pnpm test:wasm
+pnpm --dir npm/@utoo/lint-wasm test
+pnpm --dir npm/@utoo/lint-wasm test:types
+```
+
 The npm package layout is:
 
 - `npm/utoo-lint` is the public CLI wrapper published as `@utoo/lint`.
+- `npm/@utoo/lint-wasm` is the browser-ready package published as
+  `@utoo/lint-wasm`.
 - `npm/@utoo/lint-darwin-arm64` is published as
   `@utoo/lint-darwin-arm64`.
 - `npm/@utoo/lint-darwin-x64` is published as `@utoo/lint-darwin-x64`.
@@ -171,12 +182,16 @@ GitHub Releases publish binary archives for:
 - `utoo-lint-linux-arm64.tar.gz`
 - `utoo-lint-linux-x64.tar.gz`
 - `utoo-lint-windows-x64.zip`
+- `utoo-lint.wasm`
+- `utoo-lint.wasm.gz`
+- `utoo-lint.wasm.sha256`
 
-Each archive is uploaded with a matching `.sha256` file.
+Each native archive is uploaded with a matching `.sha256` file. The
+WebAssembly checksum covers the raw `utoo-lint.wasm` artifact.
 
-The release workflow builds all release archives, stages all native npm
-packages from the same binaries, uploads the archives to the GitHub Release,
-and publishes the native packages before the CLI wrapper.
+The release workflow builds all native and WebAssembly assets, stages the npm
+packages from the same artifacts, uploads the release assets to GitHub, and
+publishes the scoped packages before the CLI wrapper.
 
 Required GitHub repository secret:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ lint engine with familiar configuration, CLI, and JavaScript APIs.
 
 [Installation](#installation) · [Quick start](#quick-start) ·
 [Rules](docs/rule-status.md) · [Configuration](docs/configuration.md) ·
-[ESLint migration](docs/eslint-migration.md)
+[WebAssembly](docs/wasm.md) · [ESLint migration](docs/eslint-migration.md)
 
 ## Why utoo-lint?
 
@@ -30,6 +30,8 @@ lint engine with familiar configuration, CLI, and JavaScript APIs.
   and ESM/CommonJS APIs are included.
 - **Portable installation** — Prebuilt binaries are available for macOS,
   Linux, and Windows on supported architectures.
+- **Browser-ready engine** — The separate `@utoo/lint-wasm` package runs
+  single-file linting and autofix entirely in memory.
 
 ## Performance
 
@@ -262,6 +264,35 @@ stream by default. Programmatic `run`, `runCli`, and `runFishlint` calls can set
 the same limit to CLI invocations; output beyond the configured bound reports
 `ENOBUFS` instead of being truncated.
 
+## WebAssembly
+
+Use the separate `@utoo/lint-wasm` package for browser playgrounds, Web
+Workers, and other ESM runtimes that support WebAssembly:
+
+```bash
+pnpm add @utoo/lint-wasm
+```
+
+```js
+import { createUtooLint } from "@utoo/lint-wasm";
+
+const linter = await createUtooLint();
+const report = linter.lint("debugger;", {
+  filePath: "playground.js",
+  rules: { "no-debugger": "error" }
+});
+
+console.log(report.diagnostics);
+```
+
+The WebAssembly build has no WASI or real-filesystem dependency. It lints one
+in-memory source at a time; enabled rules that require project I/O are not run
+and are reported in `skippedRules`. For an interactive playground, keep the
+linter instance in a Web Worker so synchronous lint calls do not block the UI.
+
+See the [WebAssembly guide](docs/wasm.md) for the Node ESM API, autofix,
+configuration semantics, Worker setup, and local build commands.
+
 ## Documentation
 
 - [Rule status](docs/rule-status.md) — implemented rules and autofix coverage
@@ -269,6 +300,8 @@ the same limit to CLI invocations; output beyond the configured bound reports
   values
 - [Suppression comments](docs/suppressions.md) — line, file, and range
   suppressions
+- [WebAssembly](docs/wasm.md) — browser and Node ESM usage, runtime boundaries,
+  and Playground integration
 - [Migrating from ESLint](docs/eslint-migration.md) — migration workflow and
   compatibility notes
 - [Contributing](CONTRIBUTING.md) — local development, rule work, and releases

--- a/build.zig
+++ b/build.zig
@@ -52,6 +52,67 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run utoo-lint");
     run_step.dependOn(&run_cmd.step);
 
+    const wasm_target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .freestanding,
+        .cpu_features_add = std.Target.wasm.featureSet(&.{
+            .bulk_memory,
+            .nontrapping_fptoint,
+            .sign_ext,
+            .simd128,
+        }),
+    });
+
+    const wasm_util_module = b.createModule(.{
+        .root_source_file = b.path("vendor/yuku/src/util/root.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+    });
+
+    const wasm_parser_module = b.createModule(.{
+        .root_source_file = b.path("vendor/yuku/src/parser/root.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+    });
+    wasm_parser_module.addImport("util", wasm_util_module);
+    wasm_parser_module.addImport("codegen_options", codegen_options.createModule());
+    wasm_parser_module.addImport("parser_extension", parser_extension_module);
+
+    const wasm_lint_module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+    });
+    wasm_lint_module.addImport("parser", wasm_parser_module);
+
+    const wasm_module = b.createModule(.{
+        .root_source_file = b.path("src/wasm.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+        .strip = true,
+    });
+    wasm_module.addImport("utoo_lint", wasm_lint_module);
+
+    const wasm = b.addExecutable(.{
+        .name = "utoo-lint",
+        .root_module = wasm_module,
+    });
+    wasm.entry = .disabled;
+    wasm.rdynamic = true;
+    // Options is currently a large value type and passes through several stack
+    // frames. Keep enough linear-memory stack for browser calls until it is
+    // refactored to pass by pointer.
+    wasm.stack_size = 8 * 1024 * 1024;
+
+    const wasm_step = b.step("wasm", "Build the WebAssembly module");
+    wasm_step.dependOn(&b.addInstallArtifact(wasm, .{}).step);
+
+    const run_wasm_tests = b.addSystemCommand(&.{"node"});
+    run_wasm_tests.addFileArg(b.path("tests/wasm.mjs"));
+    run_wasm_tests.addFileArg(wasm.getEmittedBin());
+    const wasm_test_step = b.step("test-wasm", "Build and test the WebAssembly module");
+    wasm_test_step.dependOn(&run_wasm_tests.step);
+
     const test_module = b.createModule(.{
         .root_source_file = b.path("tests/all.zig"),
         .target = target,

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -1,0 +1,201 @@
+# WebAssembly
+
+`@utoo/lint-wasm` is the browser-ready, ESM-only WebAssembly distribution of
+utoo-lint. It is designed for lint playgrounds, editor integrations, Web
+Workers, and Node ESM programs that lint source already held in memory.
+
+The WebAssembly module is freestanding: it imports neither WASI nor a host
+filesystem API.
+
+## Installation
+
+```bash
+pnpm add @utoo/lint-wasm
+```
+
+The package includes its JavaScript loader, TypeScript declarations, and the
+`utoo-lint.wasm` binary. A bundler or asset server must preserve the emitted
+Wasm asset when deploying a browser application.
+
+## Browser ESM
+
+Create one linter and reuse it across edits:
+
+```js
+import { createUtooLint } from "@utoo/lint-wasm";
+
+const linter = await createUtooLint();
+const report = linter.lint("const answer = 42; debugger;", {
+  filePath: "playground.ts",
+  rules: {
+    "no-debugger": "error",
+    "no-unused-vars": "warn"
+  }
+});
+
+for (const diagnostic of report.diagnostics) {
+  console.log(diagnostic.ruleId, diagnostic.message, diagnostic.range);
+}
+```
+
+`createUtooLint()` loads and instantiates the Wasm module asynchronously. The
+returned instance's `lint()` and `lintAndFix()` methods are synchronous, which
+makes reuse inexpensive but also means an interactive UI should call them from
+a Web Worker.
+
+## Node ESM
+
+The async convenience functions lazily create and reuse a default instance:
+
+```js
+import { lint, lintAndFix } from "@utoo/lint-wasm";
+
+const report = await lint("debugger;", {
+  filePath: "snippet.js",
+  rules: { "no-debugger": "error" }
+});
+
+const fixed = await lintAndFix("const value = 1;;;", {
+  filePath: "snippet.js",
+  rules: { "no-extra-semi": "error" }
+});
+
+console.log(report.diagnostics);
+console.log(fixed.output);
+```
+
+Use `createUtooLint()` when an application needs an explicit instance or wants
+to supply its own Wasm URL, response, bytes, compiled module, or instance:
+
+```js
+const linter = await createUtooLint({
+  wasm: new URL("./utoo-lint.wasm", import.meta.url)
+});
+```
+
+## In-Memory Execution Model
+
+Each call accepts one source string plus options. `filePath` is a virtual path:
+its extension selects JavaScript, TypeScript, JSX, or TSX parsing, but the file
+is never read or written. The Wasm build does not discover project config,
+expand globs, traverse directories, resolve modules, or inspect dependencies.
+
+`lintAndFix()` returns the fixed source in `output`; it does not modify a file.
+Diagnostics from that call describe the final output and set
+`diagnosticsSource` to `"output"`. Plain `lint()` diagnostics describe the
+input. Diagnostic and fix `range` values are UTF-16 offsets, so they can be
+used directly with JavaScript strings and browser editor APIs.
+
+Suppressed findings are returned separately in `suppressedDiagnostics`.
+
+## Rule Selection
+
+Omitting `rules` uses utoo-lint's built-in default rule set:
+
+```js
+linter.lint(source, { filePath: "input.js" });
+```
+
+Providing a `rules` object starts from all lint rules disabled and enables only
+the entries in that object. In particular, an empty object disables every
+configurable lint rule:
+
+```js
+linter.lint(source, { filePath: "input.js", rules: {} });
+```
+
+Parser diagnostics can still be returned when `rules` is empty because parsing
+is required to process the source.
+
+Rules that need real project I/O cannot execute in the freestanding module. If
+one of these rules is enabled, the call succeeds and its rule ID is included in
+`skippedRules` rather than silently pretending that the project check ran. The
+current filesystem-backed set is:
+
+- `@alipay/ant/no-phantom-dependencies`
+- `@alipay/ant/prefer-import-from-stdlib`
+- `import/default`
+- `import/export`
+- `import/named`
+- `import/namespace`
+- `import/no-cycle`
+- `import/no-named-as-default`
+- `import/no-named-as-default-member`
+- `import/no-unresolved`
+
+Check `skippedRules` on every result before presenting a Playground run as
+equivalent to project-wide CLI linting.
+
+## Playground Architecture
+
+Keep the initialized linter inside a long-lived Web Worker. Send only the
+latest source and options to it, and discard stale responses in the UI when a
+newer edit has already been queued.
+
+```js
+// lint.worker.js
+import { createUtooLint } from "@utoo/lint-wasm";
+
+const linterPromise = createUtooLint();
+
+self.onmessage = async ({ data }) => {
+  const { id, source, options, fix = false } = data;
+
+  try {
+    const linter = await linterPromise;
+    const result = fix
+      ? linter.lintAndFix(source, options)
+      : linter.lint(source, options);
+    self.postMessage({ id, result });
+  } catch (error) {
+    self.postMessage({
+      id,
+      error: {
+        name: error.name,
+        code: error.code,
+        message: error.message,
+        ruleId: error.ruleId
+      }
+    });
+  }
+};
+```
+
+Debounce editor events on the main thread and attach a monotonically
+increasing `id` to each request. This keeps lint execution off the rendering
+thread without repeatedly compiling the Wasm module.
+
+## Build and Test
+
+Initialize the Yuku submodule and use the Zig version documented in
+`CONTRIBUTING.md`, then install workspace dependencies:
+
+```bash
+git submodule update --init --recursive
+pnpm install
+```
+
+Build the raw freestanding module:
+
+```bash
+pnpm build:wasm
+```
+
+The output is `zig-out/bin/utoo-lint.wasm`. To build it and copy it into the npm
+package directory, run:
+
+```bash
+pnpm package:wasm
+```
+
+Run the raw ABI and JavaScript wrapper tests, followed by the staged package
+and declaration tests:
+
+```bash
+pnpm test:wasm
+pnpm --dir npm/@utoo/lint-wasm test
+pnpm --dir npm/@utoo/lint-wasm test:types
+```
+
+The ABI test also verifies that the module has no imports and exposes the
+expected memory, allocator, ABI version, and lint entry points.

--- a/npm/@utoo/lint-wasm/LICENSE
+++ b/npm/@utoo/lint-wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 utoo-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/@utoo/lint-wasm/README.md
+++ b/npm/@utoo/lint-wasm/README.md
@@ -1,0 +1,63 @@
+# `@utoo/lint-wasm`
+
+Browser-ready WebAssembly build of utoo-lint. It runs JavaScript, TypeScript,
+JSX, and TSX lint rules entirely in memory and is suitable for playgrounds and
+Web Workers.
+
+```sh
+pnpm add @utoo/lint-wasm
+```
+
+```js
+import { createUtooLint } from "@utoo/lint-wasm";
+
+const linter = await createUtooLint();
+const result = linter.lint(`const value = console.log("hello");`, {
+  filePath: "playground.ts",
+  rules: {
+    "no-console": "warn",
+    "no-unused-vars": "error"
+  }
+});
+
+console.log(result.diagnostics);
+```
+
+Use `lintAndFix()` to preview safe fixes without changing any files:
+
+```js
+const fixed = linter.lintAndFix("const value = 1;;;", {
+  filePath: "playground.js",
+  rules: { "no-extra-semi": "error" }
+});
+
+console.log(fixed.output);
+```
+
+Diagnostic and fix ranges are UTF-16 offsets, so they can be passed directly
+to JavaScript string APIs and browser editors. Run the linter in a Web Worker
+for interactive editors so large inputs do not block the main thread.
+
+Rules that need a real project filesystem cannot run in the freestanding
+module. Enabled rules in that category are returned in `skippedRules`; this
+currently covers dependency-aware import rules and project-config-aware Alipay
+rules. All parser, basic, and in-memory semantic rules remain available.
+
+Omit `rules` to use utoo-lint's default rule set. Pass `rules: {}` when the
+playground should start with every rule disabled and then enable individual
+rules from its UI.
+
+`createUtooLint()` also accepts a URL, `Response`, bytes, compiled
+`WebAssembly.Module`, or `WebAssembly.Instance` through its `wasm` option for
+custom hosting and testing:
+
+```js
+const linter = await createUtooLint({
+  wasm: new URL("/assets/utoo-lint.wasm", location.href)
+});
+```
+
+Serve the file with `Content-Type: application/wasm` to enable streaming
+compilation. The loader automatically falls back to buffered compilation when
+that MIME type is unavailable. Production hosting should also enable Brotli or
+gzip compression for the `.wasm` asset.

--- a/npm/@utoo/lint-wasm/index.d.ts
+++ b/npm/@utoo/lint-wasm/index.d.ts
@@ -1,0 +1,92 @@
+export type RuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | false | true;
+export type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]];
+
+export interface LintFix {
+  range: [number, number];
+  text: string;
+}
+
+export interface LintSuppression {
+  kind: "directive";
+  justification: string;
+}
+
+export interface LintDiagnostic {
+  ruleId: string;
+  severity: "warning" | "error";
+  message: string;
+  /** UTF-16 offsets suitable for JavaScript strings and browser editors. */
+  range: [number, number];
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  fixes: LintFix[];
+  suppression?: LintSuppression;
+}
+
+export interface LintOptions {
+  filePath?: string;
+  filename?: string;
+  rules?: Record<string, RuleConfig>;
+}
+
+export interface LintResultBase {
+  version: 1;
+  ok: true;
+  offsetEncoding: "utf-16";
+  filePath: string;
+  diagnostics: LintDiagnostic[];
+  suppressedDiagnostics: LintDiagnostic[];
+  /** Enabled rules that need a real project filesystem and were not run. */
+  skippedRules: string[];
+}
+
+export interface LintOnlyResult extends LintResultBase {
+  mode: "lint";
+  diagnosticsSource: "input";
+  fixed: false;
+  passes: 0;
+  appliedDiagnostics: 0;
+}
+
+export interface LintFixResult extends LintResultBase {
+  mode: "fix";
+  diagnosticsSource: "output";
+  fixed: boolean;
+  passes: number;
+  appliedDiagnostics: number;
+  output: string;
+}
+
+export type LintResult = LintOnlyResult | LintFixResult;
+
+export type WasmSource =
+  | string
+  | URL
+  | Response
+  | ArrayBuffer
+  | ArrayBufferView
+  | WebAssembly.Module
+  | WebAssembly.Instance;
+
+export interface CreateUtooLintOptions {
+  wasm?: WasmSource;
+  imports?: WebAssembly.Imports;
+}
+
+export interface UtooLintWasm {
+  readonly abiVersion: number;
+  lint(source: string, options?: LintOptions): LintOnlyResult;
+  lintAndFix(source: string, options?: LintOptions): LintFixResult;
+}
+
+export class UtooLintWasmError extends Error {
+  readonly code: string;
+  readonly ruleId?: string;
+  readonly cause?: unknown;
+}
+
+export function createUtooLint(options?: CreateUtooLintOptions): Promise<UtooLintWasm>;
+export function lint(source: string, options?: LintOptions): Promise<LintOnlyResult>;
+export function lintAndFix(source: string, options?: LintOptions): Promise<LintFixResult>;

--- a/npm/@utoo/lint-wasm/index.js
+++ b/npm/@utoo/lint-wasm/index.js
@@ -1,0 +1,221 @@
+const defaultWasmUrl = new URL("./utoo-lint.wasm", import.meta.url);
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const ABI_VERSION = 1;
+const MAX_SOURCE_BYTES = 64 * 1024 * 1024;
+const MAX_OPTIONS_BYTES = 1024 * 1024;
+
+let defaultLinterPromise;
+
+export class UtooLintWasmError extends Error {
+  constructor(message, options = {}) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "UtooLintWasmError";
+    this.code = options.code ?? "wasm_error";
+    this.ruleId = options.ruleId;
+  }
+}
+
+export async function createUtooLint(options = {}) {
+  const instance = await instantiate(options.wasm ?? defaultWasmUrl, options.imports ?? {});
+  return createApi(instance);
+}
+
+export async function lint(source, options) {
+  defaultLinterPromise ??= createUtooLint();
+  return (await defaultLinterPromise).lint(source, options);
+}
+
+export async function lintAndFix(source, options) {
+  defaultLinterPromise ??= createUtooLint();
+  return (await defaultLinterPromise).lintAndFix(source, options);
+}
+
+function createApi(instance) {
+  const exports = instance?.exports;
+  if (
+    !(exports?.memory instanceof WebAssembly.Memory) ||
+    typeof exports.alloc !== "function" ||
+    typeof exports.free !== "function" ||
+    typeof exports.lint !== "function" ||
+    typeof exports.abi_version !== "function"
+  ) {
+    throw new UtooLintWasmError("Invalid utoo-lint WebAssembly module", {
+      code: "invalid_wasm_module"
+    });
+  }
+
+  const version = exports.abi_version();
+  if (version !== ABI_VERSION) {
+    throw new UtooLintWasmError(
+      `Unsupported utoo-lint WebAssembly ABI version ${version}; expected ${ABI_VERSION}`,
+      { code: "unsupported_abi_version" }
+    );
+  }
+
+  function run(source, options = {}, fix = false) {
+    if (typeof source !== "string") {
+      throw new TypeError("source must be a string");
+    }
+
+    const sourceBytes = encoder.encode(source);
+    assertRequestSize(sourceBytes.length, MAX_SOURCE_BYTES, "source", "64 MiB");
+    const optionsBytes = encoder.encode(JSON.stringify({
+      version: ABI_VERSION,
+      filePath: options.filePath ?? options.filename ?? "input.js",
+      fix: fix ? "apply" : "none",
+      ...(options.rules === undefined ? {} : { rules: options.rules })
+    }));
+    assertRequestSize(optionsBytes.length, MAX_OPTIONS_BYTES, "options", "1 MiB");
+
+    const sourceAllocationLength = sourceBytes.length || 1;
+    const optionsAllocationLength = optionsBytes.length || 1;
+    const sourcePtr = allocate(exports, sourceBytes.length, "source");
+    let optionsPtr = 0;
+    let resultPtr = 0;
+    let resultAllocationLength = 0;
+
+    try {
+      new Uint8Array(exports.memory.buffer, sourcePtr, sourceBytes.length).set(sourceBytes);
+      optionsPtr = allocate(exports, optionsBytes.length, "options");
+      new Uint8Array(exports.memory.buffer, optionsPtr, optionsBytes.length).set(optionsBytes);
+
+      resultPtr = exports.lint(sourcePtr, sourceBytes.length, optionsPtr, optionsBytes.length);
+      if (resultPtr === 0) {
+        throw new UtooLintWasmError("utoo-lint WebAssembly execution failed", {
+          code: "wasm_execution_failed"
+        });
+      }
+
+      const memoryByteLength = exports.memory.buffer.byteLength;
+      if (!Number.isInteger(resultPtr) || resultPtr < 0 || resultPtr > memoryByteLength - 4) {
+        throw new UtooLintWasmError("utoo-lint WebAssembly returned an invalid buffer", {
+          code: "invalid_result_buffer"
+        });
+      }
+
+      const resultLength = new DataView(exports.memory.buffer).getUint32(resultPtr, true);
+      resultAllocationLength = 4 + resultLength;
+      if (resultAllocationLength > memoryByteLength - resultPtr) {
+        resultAllocationLength = 0;
+        throw new UtooLintWasmError("utoo-lint WebAssembly returned an invalid buffer", {
+          code: "invalid_result_buffer"
+        });
+      }
+
+      let result;
+      try {
+        const json = decoder.decode(
+          new Uint8Array(exports.memory.buffer, resultPtr + 4, resultLength)
+        );
+        result = JSON.parse(json);
+      } catch (cause) {
+        throw new UtooLintWasmError("utoo-lint WebAssembly returned invalid JSON", {
+          code: "invalid_result_json",
+          cause
+        });
+      }
+      if (!result.ok) {
+        throw new UtooLintWasmError(result.error?.message ?? "utoo-lint failed", {
+          code: result.error?.code,
+          ruleId: result.error?.ruleId
+        });
+      }
+      return result;
+    } finally {
+      if (resultPtr !== 0 && resultAllocationLength !== 0) {
+        exports.free(resultPtr, resultAllocationLength);
+      }
+      if (optionsPtr !== 0) exports.free(optionsPtr, optionsAllocationLength);
+      if (sourcePtr !== 0) exports.free(sourcePtr, sourceAllocationLength);
+    }
+  }
+
+  return Object.freeze({
+    abiVersion: version,
+    lint: run,
+    lintAndFix(source, options = {}) {
+      return run(source, options, true);
+    }
+  });
+}
+
+function allocate(exports, length, name) {
+  let pointer;
+  try {
+    pointer = exports.alloc(length);
+  } catch (cause) {
+    throw new UtooLintWasmError(`utoo-lint could not allocate the ${name} buffer`, {
+      code: "wasm_allocation_failed",
+      cause
+    });
+  }
+  if (pointer === 0) {
+    throw new UtooLintWasmError(`utoo-lint could not allocate the ${name} buffer`, {
+      code: "wasm_out_of_memory"
+    });
+  }
+  const allocationLength = length || 1;
+  if (
+    !Number.isInteger(pointer) ||
+    pointer < 0 ||
+    pointer > exports.memory.buffer.byteLength - allocationLength
+  ) {
+    throw new UtooLintWasmError(`utoo-lint returned an invalid ${name} allocation`, {
+      code: "invalid_allocation"
+    });
+  }
+  return pointer;
+}
+
+function assertRequestSize(actual, maximum, name, displayMaximum) {
+  if (actual > maximum) {
+    throw new UtooLintWasmError(`${name} exceeds the ${displayMaximum} WebAssembly limit`, {
+      code: "REQUEST_TOO_LARGE"
+    });
+  }
+}
+
+async function instantiate(input, imports) {
+  if (input instanceof WebAssembly.Instance) return input;
+  if (input instanceof WebAssembly.Module) {
+    return WebAssembly.instantiate(input, imports);
+  }
+  if (typeof Response !== "undefined" && input instanceof Response) {
+    return instantiateResponse(input, imports);
+  }
+  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) {
+    return normalizeInstance(await WebAssembly.instantiate(input, imports));
+  }
+
+  const url = input instanceof URL ? input : new URL(input, import.meta.url);
+  if (url.protocol === "file:") {
+    // Keep the Node-only module specifier opaque to browser bundlers. This
+    // branch is only reachable for file: URLs, including the default URL when
+    // the package is used directly from Node.js.
+    const nodeFsPromises = "node:fs/promises";
+    const { readFile } = await import(nodeFsPromises);
+    return normalizeInstance(await WebAssembly.instantiate(await readFile(url), imports));
+  }
+  return instantiateResponse(await fetch(url), imports);
+}
+
+async function instantiateResponse(response, imports) {
+  if (!response.ok) {
+    throw new UtooLintWasmError(
+      `Unable to load utoo-lint WebAssembly: ${response.status} ${response.statusText}`,
+      { code: "wasm_fetch_failed" }
+    );
+  }
+  try {
+    return normalizeInstance(await WebAssembly.instantiateStreaming(response.clone(), imports));
+  } catch {
+    return normalizeInstance(
+      await WebAssembly.instantiate(await response.arrayBuffer(), imports)
+    );
+  }
+}
+
+function normalizeInstance(result) {
+  return result instanceof WebAssembly.Instance ? result : result.instance;
+}

--- a/npm/@utoo/lint-wasm/package.json
+++ b/npm/@utoo/lint-wasm/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@utoo/lint-wasm",
+  "version": "0.1.0",
+  "description": "Browser-ready WebAssembly build of utoo-lint",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/utooland/utoo-lint.git",
+    "directory": "npm/@utoo/lint-wasm"
+  },
+  "bugs": {
+    "url": "https://github.com/utooland/utoo-lint/issues"
+  },
+  "homepage": "https://github.com/utooland/utoo-lint#readme",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    },
+    "./utoo-lint.wasm": "./utoo-lint.wasm",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.d.ts",
+    "index.js",
+    "LICENSE",
+    "README.md",
+    "utoo-lint.wasm"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs",
+    "test:types": "tsc -p test/types/tsconfig.json"
+  },
+  "keywords": [
+    "browser",
+    "javascript",
+    "linter",
+    "typescript",
+    "wasm",
+    "webassembly",
+    "zig"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3"
+  }
+}

--- a/npm/@utoo/lint-wasm/test/lint.test.mjs
+++ b/npm/@utoo/lint-wasm/test/lint.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  createUtooLint,
+  lint,
+  UtooLintWasmError,
+} from "../index.js";
+
+const wasmUrl = new URL("../utoo-lint.wasm", import.meta.url);
+const wasmBytesPromise = readFile(wasmUrl);
+
+async function instantiateInstrumented(overrides = {}) {
+  const { instance } = await WebAssembly.instantiate(await wasmBytesPromise, {});
+  const calls = { alloc: [], free: [], lint: [] };
+  const instrumentedExports = {
+    ...instance.exports,
+    alloc(...args) {
+      calls.alloc.push(args);
+      return (overrides.alloc ?? instance.exports.alloc)(...args);
+    },
+    free(...args) {
+      calls.free.push(args);
+      return (overrides.free ?? instance.exports.free)(...args);
+    },
+    lint(...args) {
+      calls.lint.push(args);
+      return (overrides.lint ?? instance.exports.lint)(...args);
+    },
+    abi_version: overrides.abi_version ?? instance.exports.abi_version,
+  };
+  const instrumentedInstance = new Proxy(instance, {
+    get(target, property) {
+      if (property === "exports") return instrumentedExports;
+      return Reflect.get(target, property, target);
+    },
+  });
+  return { calls, instance, instrumentedInstance };
+}
+
+test("loads the packaged WebAssembly module", async () => {
+  const linter = await createUtooLint();
+  assert.equal(linter.abiVersion, 1);
+  const result = linter.lint("debugger;", {
+    filePath: "input.js",
+    rules: { "no-debugger": "warn" },
+  });
+  assert.equal(result.diagnostics[0]?.severity, "warning");
+});
+
+test("provides a lazy convenience API", async () => {
+  const result = await lint("const value = 1;;;", {
+    filePath: "input.js",
+    rules: { "no-extra-semi": "error" },
+  });
+  assert.ok(result.diagnostics.some((item) => item.ruleId === "no-extra-semi"));
+});
+
+test("loads browser-friendly Response, byte, and compiled module inputs", async () => {
+  const bytes = await wasmBytesPromise;
+  const response = new Response(bytes, {
+    headers: { "content-type": "application/octet-stream" },
+  });
+  const fromResponse = await createUtooLint({ wasm: response });
+  const fromBytes = await createUtooLint({ wasm: new Uint8Array(bytes) });
+  const fromModule = await createUtooLint({ wasm: await WebAssembly.compile(bytes) });
+
+  for (const linter of [fromResponse, fromBytes, fromModule]) {
+    assert.equal(linter.lint("", { rules: {} }).diagnostics.length, 0);
+  }
+});
+
+test("keeps working after memory growth and releases every owned buffer", async () => {
+  const { calls, instance, instrumentedInstance } = await instantiateInstrumented();
+  const linter = await createUtooLint({ wasm: instrumentedInstance });
+  const initialMemory = instance.exports.memory.buffer.byteLength;
+  const source = `${"// padding\n".repeat(10_000)}debugger;`;
+
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    const result = linter.lint(source, {
+      rules: { "no-debugger": "error" },
+    });
+    assert.equal(result.diagnostics[0]?.ruleId, "no-debugger");
+  }
+
+  assert.ok(instance.exports.memory.buffer.byteLength > initialMemory);
+  assert.equal(calls.alloc.length, 6);
+  assert.equal(calls.lint.length, 3);
+  assert.equal(calls.free.length, 9);
+});
+
+test("exposes structured lint failures and still releases the ABI buffers", async () => {
+  const { calls, instrumentedInstance } = await instantiateInstrumented();
+  const linter = await createUtooLint({ wasm: instrumentedInstance });
+
+  assert.throws(
+    () => linter.lint("", { rules: { "unknown/rule": "error" } }),
+    (error) => {
+      assert.ok(error instanceof UtooLintWasmError);
+      assert.equal(error.code, "UNKNOWN_RULE");
+      assert.equal(error.ruleId, "unknown/rule");
+      return true;
+    },
+  );
+  assert.equal(calls.free.length, 3);
+});
+
+test("normalizes malformed ABI responses and releases their result allocation", async () => {
+  let memory;
+  let nativeAlloc;
+  const setup = await instantiateInstrumented({
+    lint() {
+      const pointer = nativeAlloc(5);
+      const view = new DataView(memory.buffer);
+      view.setUint32(pointer, 1, true);
+      view.setUint8(pointer + 4, "{".charCodeAt(0));
+      return pointer;
+    },
+  });
+  memory = setup.instance.exports.memory;
+  nativeAlloc = setup.instance.exports.alloc;
+  const linter = await createUtooLint({ wasm: setup.instrumentedInstance });
+
+  assert.throws(
+    () => linter.lint("", { rules: {} }),
+    (error) => {
+      assert.ok(error instanceof UtooLintWasmError);
+      assert.equal(error.code, "invalid_result_json");
+      assert.ok(error.cause instanceof SyntaxError);
+      return true;
+    },
+  );
+  assert.equal(setup.calls.free.length, 3);
+});
+
+test("rejects unsupported ABI versions before allocating", async () => {
+  const setup = await instantiateInstrumented({ abi_version: () => 2 });
+  await assert.rejects(
+    createUtooLint({ wasm: setup.instrumentedInstance }),
+    (error) => error instanceof UtooLintWasmError && error.code === "unsupported_abi_version",
+  );
+  assert.equal(setup.calls.alloc.length, 0);
+});
+
+test("rejects oversized options before allocating WebAssembly memory", async () => {
+  const setup = await instantiateInstrumented();
+  const linter = await createUtooLint({ wasm: setup.instrumentedInstance });
+
+  assert.throws(
+    () => linter.lint("", { filePath: "x".repeat(1024 * 1024), rules: {} }),
+    (error) => error instanceof UtooLintWasmError && error.code === "REQUEST_TOO_LARGE",
+  );
+  assert.equal(setup.calls.alloc.length, 0);
+});
+
+test("rejects failed allocations without writing to or freeing address zero", async () => {
+  let allocation = 0;
+  let nativeAlloc;
+  const setup = await instantiateInstrumented({
+    alloc(length) {
+      allocation += 1;
+      return allocation === 2 ? 0 : nativeAlloc(length);
+    },
+  });
+  nativeAlloc = setup.instance.exports.alloc;
+  const linter = await createUtooLint({ wasm: setup.instrumentedInstance });
+
+  assert.throws(
+    () => linter.lint("debugger;", { rules: { "no-debugger": "error" } }),
+    (error) => error instanceof UtooLintWasmError && error.code === "wasm_out_of_memory",
+  );
+  assert.equal(setup.calls.free.length, 1);
+  assert.notEqual(setup.calls.free[0][0], 0);
+});
+
+test("validates the result header before reading across memory", async () => {
+  const setup = await instantiateInstrumented({
+    lint() {
+      return 0xffff_ffff;
+    },
+  });
+  const linter = await createUtooLint({ wasm: setup.instrumentedInstance });
+
+  assert.throws(
+    () => linter.lint("", { rules: {} }),
+    (error) => error instanceof UtooLintWasmError && error.code === "invalid_result_buffer",
+  );
+  assert.equal(setup.calls.free.length, 2);
+});

--- a/npm/@utoo/lint-wasm/test/types/tsconfig.json
+++ b/npm/@utoo/lint-wasm/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["usage.ts"]
+}

--- a/npm/@utoo/lint-wasm/test/types/usage.ts
+++ b/npm/@utoo/lint-wasm/test/types/usage.ts
@@ -1,0 +1,37 @@
+import {
+  createUtooLint,
+  lint,
+  lintAndFix,
+  type LintDiagnostic,
+  type LintFixResult,
+  type LintOnlyResult,
+  type LintResult,
+} from "@utoo/lint-wasm";
+
+const linter = await createUtooLint();
+const direct: LintResult = linter.lint("debugger;", {
+  filePath: "input.js",
+  rules: { "no-debugger": "error" },
+});
+const diagnostic: LintDiagnostic | undefined = direct.diagnostics[0];
+void diagnostic?.range;
+
+const lintOnly: LintOnlyResult = await lint("console.log('x');", {
+  rules: { "no-console": "warn" },
+});
+// @ts-expect-error lint-only results deliberately have no output buffer.
+void lintOnly.output;
+
+const fixed: LintFixResult = await lintAndFix("const value = 1;;;", {
+  rules: { "no-extra-semi": 2 },
+});
+fixed.output.toUpperCase();
+
+function consume(result: LintResult) {
+  if (result.mode === "fix") {
+    result.output.toUpperCase();
+  } else {
+    result.fixed satisfies false;
+  }
+}
+void consume;

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,13 +1,34 @@
 # npm packaging
 
-This directory contains the npm CLI wrapper for `@utoo/lint` and the native platform packages.
+This directory contains the npm CLI wrapper for `@utoo/lint`, the native
+platform packages, and the standalone WebAssembly package.
 
 - `@utoo/lint` is the JavaScript CLI package.
+- `@utoo/lint-wasm` is the ESM wrapper and freestanding WebAssembly module for
+  browser and Node single-file linting.
 - `@utoo/lint-darwin-arm64` contains the native Zig binary for macOS arm64.
 - `@utoo/lint-darwin-x64` contains the native Zig binary for macOS x64.
 - `@utoo/lint-linux-arm64` contains the native Zig binary for Linux arm64.
 - `@utoo/lint-linux-x64` contains the native Zig binary for Linux x64.
 - `@utoo/lint-win32-x64` contains the native Zig binary for Windows x64.
+
+## WebAssembly Package
+
+`npm/@utoo/lint-wasm` is published independently from the Node CLI because it
+does not use a native platform package, WASI, or a real filesystem. The package
+contains `index.js`, TypeScript declarations, and `utoo-lint.wasm`.
+
+Build and stage the WebAssembly file before testing or packing the package:
+
+```bash
+pnpm package:wasm
+pnpm test:wasm
+pnpm --dir npm/@utoo/lint-wasm test
+pnpm --dir npm/@utoo/lint-wasm test:types
+```
+
+See the repository's [WebAssembly guide](../docs/wasm.md) for the public API
+and runtime behavior.
 
 ## Configuration Files
 

--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -254,6 +254,16 @@ stream by default. Programmatic `run`, `runCli`, and `runFishlint` calls can set
 the same limit to CLI invocations; output beyond the configured bound reports
 `ENOBUFS` instead of being truncated.
 
+## WebAssembly
+
+For browser playgrounds and in-memory Node ESM usage, install the independent
+`@utoo/lint-wasm` package. It ships a freestanding WebAssembly module rather
+than selecting one of the native platform packages used by `@utoo/lint`.
+
+See the
+[WebAssembly guide](https://github.com/utooland/utoo-lint/blob/main/docs/wasm.md)
+for its API, runtime boundaries, and Web Worker recommendation.
+
 ## Supported platforms
 
 The package installs a platform-specific optional dependency containing the
@@ -273,6 +283,7 @@ development.
 - [Rule status](https://github.com/utooland/utoo-lint/blob/main/docs/rule-status.md)
 - [Configuration](https://github.com/utooland/utoo-lint/blob/main/docs/configuration.md)
 - [Suppression comments](https://github.com/utooland/utoo-lint/blob/main/docs/suppressions.md)
+- [WebAssembly](https://github.com/utooland/utoo-lint/blob/main/docs/wasm.md)
 - [Migrating from ESLint](https://github.com/utooland/utoo-lint/blob/main/docs/eslint-migration.md)
 - [Benchmarks](https://github.com/utooland/utoo-lint/tree/main/benchmarks)
 - [Security policy](https://github.com/utooland/utoo-lint/blob/main/SECURITY.md)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
+    "build:wasm": "zig build wasm",
+    "package:wasm": "bash scripts/package-wasm.sh",
+    "test:wasm": "zig build test-wasm",
     "bench:generate": "pnpm --dir benchmarks generate",
     "bench": "pnpm --dir benchmarks bench",
     "bench:chart": "pnpm --dir benchmarks chart"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,12 @@ importers:
 
   npm/@utoo/lint-linux-x64: {}
 
+  npm/@utoo/lint-wasm:
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   npm/@utoo/lint-win32-x64: {}
 
   npm/utoo-lint:

--- a/scripts/package-wasm.sh
+++ b/scripts/package-wasm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_PATH="${ROOT_DIR}/zig-out/bin/utoo-lint.wasm"
+PACKAGE_PATH="${ROOT_DIR}/npm/@utoo/lint-wasm/utoo-lint.wasm"
+
+cd "${ROOT_DIR}"
+zig build wasm
+
+test -s "${SOURCE_PATH}"
+MAGIC="$(od -An -tx1 -N4 "${SOURCE_PATH}" | tr -d ' \n')"
+if [[ "${MAGIC}" != "0061736d" ]]; then
+  echo "invalid WebAssembly artifact: ${SOURCE_PATH}" >&2
+  exit 1
+fi
+
+cp "${SOURCE_PATH}" "${PACKAGE_PATH}"
+chmod 0644 "${PACKAGE_PATH}"
+test -s "${PACKAGE_PATH}"
+
+node --input-type=module -e '
+  import { readFile } from "node:fs/promises";
+
+  const bytes = await readFile(process.argv[1]);
+  const module = await WebAssembly.compile(bytes);
+  const imports = WebAssembly.Module.imports(module);
+  if (imports.length !== 0) {
+    throw new Error(`expected a freestanding module, found imports: ${JSON.stringify(imports)}`);
+  }
+
+  const exportedNames = new Set(WebAssembly.Module.exports(module).map(({ name }) => name));
+  for (const name of ["memory", "alloc", "free", "lint", "abi_version"]) {
+    if (!exportedNames.has(name)) throw new Error(`missing WebAssembly export: ${name}`);
+  }
+
+  const instance = await WebAssembly.instantiate(module, {});
+  if (instance.exports.abi_version() !== 1) {
+    throw new Error(`unsupported WebAssembly ABI: ${instance.exports.abi_version()}`);
+  }
+' "${PACKAGE_PATH}"
+
+echo "staged ${PACKAGE_PATH}"

--- a/src/root.zig
+++ b/src/root.zig
@@ -50,12 +50,26 @@ pub fn lintSourceAndFix(
     path: []const u8,
     options: Options,
 ) Allocator.Error!LintAndFixResult {
-    return lintSourceAndFixWithIo(allocator, null, source, path, options);
+    return lintSourceAndFixInternal(false, allocator, {}, source, path, options);
 }
 
 pub fn lintSourceAndFixWithIo(
     allocator: Allocator,
     io: ?std.Io,
+    source: []const u8,
+    path: []const u8,
+    options: Options,
+) Allocator.Error!LintAndFixResult {
+    if (io) |actual_io| {
+        return lintSourceAndFixInternal(true, allocator, actual_io, source, path, options);
+    }
+    return lintSourceAndFixInternal(false, allocator, {}, source, path, options);
+}
+
+fn lintSourceAndFixInternal(
+    comptime with_io: bool,
+    allocator: Allocator,
+    io: if (with_io) std.Io else void,
     source: []const u8,
     path: []const u8,
     options: Options,
@@ -67,7 +81,7 @@ pub fn lintSourceAndFixWithIo(
     var applied_diagnostics: usize = 0;
 
     while (passes < max_autofix_passes) {
-        var result = try lintSourceWithIo(allocator, io, output, path, options);
+        var result = try lintSourceInternal(with_io, allocator, io, output, path, options);
         var applied = applyFixes(allocator, output, result.diagnostics) catch |err| {
             result.deinit(allocator);
             return err;
@@ -93,7 +107,7 @@ pub fn lintSourceAndFixWithIo(
 
     return .{
         .output = output,
-        .result = try lintSourceWithIo(allocator, io, output, path, options),
+        .result = try lintSourceInternal(with_io, allocator, io, output, path, options),
         .fixed = true,
         .passes = passes,
         .applied_diagnostics = applied_diagnostics,
@@ -106,12 +120,26 @@ pub fn lintSource(
     path: []const u8,
     options: Options,
 ) Allocator.Error!Result {
-    return lintSourceWithIo(allocator, null, source, path, options);
+    return lintSourceInternal(false, allocator, {}, source, path, options);
 }
 
 pub fn lintSourceWithIo(
     allocator: Allocator,
     io: ?std.Io,
+    source: []const u8,
+    path: []const u8,
+    options: Options,
+) Allocator.Error!Result {
+    if (io) |actual_io| {
+        return lintSourceInternal(true, allocator, actual_io, source, path, options);
+    }
+    return lintSourceInternal(false, allocator, {}, source, path, options);
+}
+
+fn lintSourceInternal(
+    comptime with_io: bool,
+    allocator: Allocator,
+    io: if (with_io) std.Io else void,
     source: []const u8,
     path: []const u8,
     options: Options,
@@ -137,7 +165,11 @@ pub fn lintSourceWithIo(
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
-        try rules.runSemantic(allocator, &diagnostics, &tree, io, path, semantic_result, effective_options);
+        if (with_io) {
+            try rules.runSemanticWithIo(allocator, &diagnostics, &tree, io, path, semantic_result, effective_options);
+        } else {
+            try rules.runSemantic(allocator, &diagnostics, &tree, semantic_result, effective_options);
+        }
     } else {
         try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
         try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -745,28 +745,51 @@ pub fn runBasic(
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
 
-pub fn runSemantic(
+pub fn runSemanticWithIo(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
-    io: ?std.Io,
+    io: std.Io,
     file_path: []const u8,
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
     if (options.alipay_ant_no_phantom_dependencies) {
-        if (io) |actual_io| {
-            try alipay_ant_no_phantom_dependencies.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-                semantic_result.symbol_table,
-            );
-        }
+        try alipay_ant_no_phantom_dependencies.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+            semantic_result.symbol_table,
+        );
     }
 
+    try runSemanticBeforeIo(allocator, diagnostics, tree, semantic_result, options);
+
+    try runIoSemantic(allocator, diagnostics, tree, io, file_path, semantic_result, options);
+
+    try runSemanticAfterIo(allocator, diagnostics, tree, semantic_result, options);
+}
+
+pub fn runSemantic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    semantic_result: traverser.semantic.Result,
+    options: core.Options,
+) Allocator.Error!void {
+    try runSemanticBeforeIo(allocator, diagnostics, tree, semantic_result, options);
+    try runSemanticAfterIo(allocator, diagnostics, tree, semantic_result, options);
+}
+
+fn runSemanticBeforeIo(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    semantic_result: traverser.semantic.Result,
+    options: core.Options,
+) Allocator.Error!void {
     if (options.alipay_ant_exhaustive_deps and !options.react_hooks_exhaustive_deps) {
         try alipay_ant_exhaustive_deps.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
@@ -792,119 +815,119 @@ pub fn runSemantic(
     if (options.alipay_ant_prefer_click_with_debounce) {
         try alipay_ant_prefer_click_with_debounce.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
+}
 
+fn runIoSemantic(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    io: std.Io,
+    file_path: []const u8,
+    semantic_result: traverser.semantic.Result,
+    options: core.Options,
+) Allocator.Error!void {
     if (options.alipay_ant_prefer_import_from_stdlib) {
-        if (io) |actual_io| {
-            try alipay_ant_prefer_import_from_stdlib.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try alipay_ant_prefer_import_from_stdlib.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
 
     if (options.import_default) {
-        if (io) |actual_io| {
-            try import_default.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try import_default.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
     if (options.import_export) {
-        if (io) |actual_io| {
-            try import_export.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try import_export.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
     if (options.import_named) {
-        if (io) |actual_io| {
-            try import_named.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try import_named.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
     if (options.import_namespace) {
-        if (io) |actual_io| {
-            try import_namespace.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-                semantic_result.symbol_table,
-            );
-        }
+        try import_namespace.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+            semantic_result.symbol_table,
+        );
     }
     if (options.import_no_cycle) {
-        if (io) |actual_io| {
-            try import_no_cycle.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-                .{
-                    .amd = options.import_no_cycle_amd,
-                    .commonjs = options.import_no_cycle_commonjs,
-                    .max_depth = options.import_no_cycle_max_depth,
-                },
-            );
-        }
+        try import_no_cycle.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+            .{
+                .amd = options.import_no_cycle_amd,
+                .commonjs = options.import_no_cycle_commonjs,
+                .max_depth = options.import_no_cycle_max_depth,
+            },
+        );
     }
     if (options.import_no_named_as_default) {
-        if (io) |actual_io| {
-            try import_no_named_as_default.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try import_no_named_as_default.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
     if (options.import_no_named_as_default_member) {
-        if (io) |actual_io| {
-            try import_no_named_as_default_member.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-            );
-        }
+        try import_no_named_as_default_member.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+        );
     }
     if (options.import_no_unresolved) {
-        if (io) |actual_io| {
-            try import_no_unresolved.run(
-                allocator,
-                actual_io,
-                diagnostics,
-                tree,
-                file_path,
-                .{
-                    .amd = options.import_no_unresolved_amd,
-                    .commonjs = options.import_no_unresolved_commonjs,
-                    .ignore = options.import_no_unresolved_ignore,
-                },
-            );
-        }
+        try import_no_unresolved.run(
+            allocator,
+            io,
+            diagnostics,
+            tree,
+            file_path,
+            .{
+                .amd = options.import_no_unresolved_amd,
+                .commonjs = options.import_no_unresolved_commonjs,
+                .ignore = options.import_no_unresolved_ignore,
+            },
+        );
     }
+}
 
+fn runSemanticAfterIo(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    semantic_result: traverser.semantic.Result,
+    options: core.Options,
+) Allocator.Error!void {
     if (options.block_scoped_var) {
         try block_scoped_var.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -1,0 +1,497 @@
+//! Freestanding WebAssembly entry point for browser and worker runtimes.
+//!
+//! ABI version 1:
+//!   abi_version() -> u32
+//!   alloc(len) -> ptr
+//!   free(ptr, len)
+//!   lint(source_ptr, source_len, options_ptr, options_len) -> ptr
+//!
+//! `options` is UTF-8 JSON. The result is a length-prefixed UTF-8 JSON buffer:
+//! `[u32 byte_length little-endian][byte_length bytes]`. The caller owns every
+//! allocation and must release it with `free`.
+
+const std = @import("std");
+const lint_engine = @import("utoo_lint");
+
+const Allocator = std.mem.Allocator;
+const gpa = std.heap.wasm_allocator;
+const current_abi_version: u32 = 1;
+const max_source_size = 64 * 1024 * 1024;
+const max_options_size = 1024 * 1024;
+
+const FixMode = enum {
+    none,
+    apply,
+};
+
+const Failure = struct {
+    code: []const u8 = "INTERNAL_ERROR",
+    message: []const u8 = "utoo-lint failed",
+    rule_id: ?[]u8 = null,
+
+    fn deinit(self: *Failure, allocator: Allocator) void {
+        if (self.rule_id) |rule_id| allocator.free(rule_id);
+    }
+};
+
+const Config = struct {
+    options: lint_engine.Options,
+    severities: std.StringHashMap(lint_engine.Severity),
+    skipped_rules: std.ArrayList([]const u8) = .empty,
+    file_path: []const u8,
+    fix_mode: FixMode,
+
+    fn deinit(self: *Config, allocator: Allocator) void {
+        self.severities.deinit();
+        self.skipped_rules.deinit(allocator);
+    }
+};
+
+const Utf16Position = struct {
+    line: usize,
+    column: usize,
+};
+
+export fn abi_version() u32 {
+    return current_abi_version;
+}
+
+export fn alloc(len: usize) usize {
+    const allocation = gpa.alloc(u8, allocationLength(len)) catch return 0;
+    return @intFromPtr(allocation.ptr);
+}
+
+export fn free(ptr: [*]u8, len: usize) void {
+    gpa.free(ptr[0..allocationLength(len)]);
+}
+
+export fn lint(
+    source_ptr: [*]const u8,
+    source_len: usize,
+    options_ptr: [*]const u8,
+    options_len: usize,
+) usize {
+    if (source_len > max_source_size) {
+        const output = writeErrorResponse(gpa, .{
+            .code = "REQUEST_TOO_LARGE",
+            .message = "source exceeds the 64 MiB WebAssembly limit",
+        }) catch return 0;
+        return @intFromPtr(output.ptr);
+    }
+    if (options_len > max_options_size) {
+        const output = writeErrorResponse(gpa, .{
+            .code = "REQUEST_TOO_LARGE",
+            .message = "options exceed the 1 MiB WebAssembly limit",
+        }) catch return 0;
+        return @intFromPtr(output.ptr);
+    }
+
+    var failure: Failure = .{};
+    defer failure.deinit(gpa);
+    const output = run(
+        gpa,
+        source_ptr[0..source_len],
+        options_ptr[0..options_len],
+        &failure,
+    ) catch |err| {
+        if (err == error.OutOfMemory or err == error.ResponseTooLarge) return 0;
+        const error_output = writeErrorResponse(gpa, failure) catch return 0;
+        return @intFromPtr(error_output.ptr);
+    };
+    return @intFromPtr(output.ptr);
+}
+
+fn allocationLength(len: usize) usize {
+    return if (len == 0) 1 else len;
+}
+
+fn run(
+    allocator: Allocator,
+    source: []const u8,
+    options_json: []const u8,
+    failure: *Failure,
+) ![]u8 {
+    if (!std.unicode.utf8ValidateSlice(source)) {
+        failure.* = .{
+            .code = "INVALID_UTF8",
+            .message = "source must be valid UTF-8",
+        };
+        return error.InvalidUtf8;
+    }
+
+    var parsed_options: ?std.json.Parsed(std.json.Value) = null;
+    defer if (parsed_options) |*parsed| parsed.deinit();
+
+    const root: ?std.json.ObjectMap = if (options_json.len == 0)
+        null
+    else options: {
+        parsed_options = std.json.parseFromSlice(std.json.Value, allocator, options_json, .{}) catch {
+            failure.* = .{
+                .code = "INVALID_OPTIONS_JSON",
+                .message = "options must be valid JSON",
+            };
+            return error.InvalidOptions;
+        };
+        break :options switch (parsed_options.?.value) {
+            .object => |object| object,
+            else => {
+                failure.* = .{
+                    .code = "INVALID_OPTIONS",
+                    .message = "options must be a JSON object",
+                };
+                return error.InvalidOptions;
+            },
+        };
+    };
+
+    var config = try parseConfig(allocator, root, failure);
+    defer config.deinit(allocator);
+
+    if (config.fix_mode == .apply) {
+        var fixed = lint_engine.lintSourceAndFix(allocator, source, config.file_path, config.options) catch |err| {
+            if (err == error.OutOfMemory) return err;
+            failure.* = .{
+                .code = "FIX_FAILED",
+                .message = "the lint engine could not apply fixes",
+            };
+            return error.FixFailed;
+        };
+        defer fixed.deinit(allocator);
+        return writeSuccessResponse(
+            allocator,
+            fixed.output,
+            config.file_path,
+            fixed.result,
+            &config.severities,
+            config.skipped_rules.items,
+            &fixed,
+            .apply,
+        );
+    }
+
+    var result = lint_engine.lintSource(allocator, source, config.file_path, config.options) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        failure.* = .{
+            .code = "LINT_FAILED",
+            .message = "the lint engine could not process the source",
+        };
+        return error.LintFailed;
+    };
+    defer result.deinit(allocator);
+    return writeSuccessResponse(
+        allocator,
+        source,
+        config.file_path,
+        result,
+        &config.severities,
+        config.skipped_rules.items,
+        null,
+        .none,
+    );
+}
+
+fn parseConfig(
+    allocator: Allocator,
+    root: ?std.json.ObjectMap,
+    failure: *Failure,
+) !Config {
+    const file_path = if (root) |object|
+        if (object.get("filePath")) |value| switch (value) {
+            .string => |path| path,
+            else => {
+                failure.* = .{
+                    .code = "INVALID_OPTIONS",
+                    .message = "filePath must be a string",
+                };
+                return error.InvalidOptions;
+            },
+        } else "input.js"
+    else
+        "input.js";
+
+    const fix_mode: FixMode = if (root) |object|
+        if (object.get("fix")) |value| switch (value) {
+            .string => |mode| if (std.mem.eql(u8, mode, "none"))
+                .none
+            else if (std.mem.eql(u8, mode, "apply"))
+                .apply
+            else {
+                failure.* = .{
+                    .code = "INVALID_OPTIONS",
+                    .message = "fix must be either \"none\" or \"apply\"",
+                };
+                return error.InvalidOptions;
+            },
+            else => {
+                failure.* = .{
+                    .code = "INVALID_OPTIONS",
+                    .message = "fix must be either \"none\" or \"apply\"",
+                };
+                return error.InvalidOptions;
+            },
+        } else .none
+    else
+        .none;
+
+    if (root) |object| {
+        if (object.get("version")) |value| {
+            const version = switch (value) {
+                .integer => |integer| integer,
+                else => {
+                    failure.* = .{
+                        .code = "UNSUPPORTED_VERSION",
+                        .message = "options version must be 1",
+                    };
+                    return error.UnsupportedOptionsVersion;
+                },
+            };
+            if (version != current_abi_version) {
+                failure.* = .{
+                    .code = "UNSUPPORTED_VERSION",
+                    .message = "options version must be 1",
+                };
+                return error.UnsupportedOptionsVersion;
+            }
+        }
+    }
+
+    var config = Config{
+        .options = .{},
+        .severities = std.StringHashMap(lint_engine.Severity).init(allocator),
+        .file_path = file_path,
+        .fix_mode = fix_mode,
+    };
+    errdefer config.deinit(allocator);
+
+    const rules_value = if (root) |object| object.get("rules") else null;
+    if (rules_value) |value| {
+        const rules = switch (value) {
+            .object => |object| object,
+            else => {
+                failure.* = .{
+                    .code = "INVALID_OPTIONS",
+                    .message = "rules must be a JSON object",
+                };
+                return error.InvalidOptions;
+            },
+        };
+
+        config.options = lint_engine.Options.allDisabled();
+        var iterator = rules.iterator();
+        while (iterator.next()) |entry| {
+            config.options.setByRuleConfigValue(entry.key_ptr.*, entry.value_ptr.*) catch |err| {
+                failure.* = .{
+                    .code = if (err == error.UnknownRule) "UNKNOWN_RULE" else "INVALID_RULE_CONFIG",
+                    .message = @errorName(err),
+                    // The parsed JSON is released before the ABI error response
+                    // is encoded, so retain the rule id independently.
+                    .rule_id = try allocator.dupe(u8, entry.key_ptr.*),
+                };
+                return error.InvalidRuleConfig;
+            };
+
+            const severity = lint_engine.Options.severityFromRuleConfigValue(entry.value_ptr.*) catch |err| {
+                failure.* = .{
+                    .code = "INVALID_RULE_CONFIG",
+                    .message = @errorName(err),
+                    .rule_id = try allocator.dupe(u8, entry.key_ptr.*),
+                };
+                return error.InvalidRuleConfig;
+            };
+            if (severity) |configured_severity| {
+                try config.severities.put(entry.key_ptr.*, configured_severity);
+            }
+        }
+    }
+
+    try appendSkippedRules(allocator, &config.skipped_rules, config.options);
+    return config;
+}
+
+fn appendSkippedRules(
+    allocator: Allocator,
+    skipped_rules: *std.ArrayList([]const u8),
+    options: lint_engine.Options,
+) Allocator.Error!void {
+    if (options.alipay_ant_no_phantom_dependencies) try skipped_rules.append(allocator, "@alipay/ant/no-phantom-dependencies");
+    if (options.alipay_ant_prefer_import_from_stdlib) try skipped_rules.append(allocator, "@alipay/ant/prefer-import-from-stdlib");
+    if (options.import_default) try skipped_rules.append(allocator, "import/default");
+    if (options.import_export) try skipped_rules.append(allocator, "import/export");
+    if (options.import_named) try skipped_rules.append(allocator, "import/named");
+    if (options.import_namespace) try skipped_rules.append(allocator, "import/namespace");
+    if (options.import_no_cycle) try skipped_rules.append(allocator, "import/no-cycle");
+    if (options.import_no_named_as_default) try skipped_rules.append(allocator, "import/no-named-as-default");
+    if (options.import_no_named_as_default_member) try skipped_rules.append(allocator, "import/no-named-as-default-member");
+    if (options.import_no_unresolved) try skipped_rules.append(allocator, "import/no-unresolved");
+}
+
+fn writeSuccessResponse(
+    allocator: Allocator,
+    source: []const u8,
+    file_path: []const u8,
+    result: lint_engine.Result,
+    severities: *const std.StringHashMap(lint_engine.Severity),
+    skipped_rules: []const []const u8,
+    fixed_result: ?*const lint_engine.LintAndFixResult,
+    fix_mode: FixMode,
+) ![]u8 {
+    var output = std.Io.Writer.Allocating.init(allocator);
+    defer output.deinit();
+    const writer = &output.writer;
+    try writer.writeAll("\x00\x00\x00\x00{\"version\":1,\"ok\":true,\"mode\":");
+    try writeJsonValue(writer, if (fix_mode == .apply) "fix" else "lint");
+    try writer.writeAll(",\"offsetEncoding\":\"utf-16\",\"diagnosticsSource\":");
+    try writeJsonValue(writer, if (fix_mode == .apply) "output" else "input");
+    try writer.writeAll(",\"filePath\":");
+    try writeJsonValue(writer, file_path);
+    try writer.writeAll(",\"diagnostics\":");
+    try writeDiagnostics(writer, source, result.diagnostics, severities);
+    try writer.writeAll(",\"suppressedDiagnostics\":");
+    try writeDiagnostics(writer, source, result.suppressed_diagnostics, severities);
+    try writer.writeAll(",\"skippedRules\":");
+    try writeStringArray(writer, skipped_rules);
+
+    if (fixed_result) |fixed| {
+        try writer.writeAll(",\"fixed\":");
+        try writer.writeAll(if (fixed.fixed) "true" else "false");
+        try writer.print(",\"passes\":{d},\"appliedDiagnostics\":{d},\"output\":", .{
+            fixed.passes,
+            fixed.applied_diagnostics,
+        });
+        try writeJsonValue(writer, fixed.output);
+    } else {
+        try writer.writeAll(",\"fixed\":false,\"passes\":0,\"appliedDiagnostics\":0");
+    }
+    try writer.writeByte('}');
+    return finishResponse(allocator, &output);
+}
+
+fn writeErrorResponse(allocator: Allocator, failure: Failure) ![]u8 {
+    var output = std.Io.Writer.Allocating.init(allocator);
+    defer output.deinit();
+    const writer = &output.writer;
+    try writer.writeAll("\x00\x00\x00\x00{\"version\":1,\"ok\":false,\"error\":{\"code\":");
+    try writeJsonValue(writer, failure.code);
+    try writer.writeAll(",\"message\":");
+    try writeJsonValue(writer, failure.message);
+    if (failure.rule_id) |rule_id| {
+        try writer.writeAll(",\"ruleId\":");
+        try writeJsonValue(writer, rule_id);
+    }
+    try writer.writeAll("}}");
+    return finishResponse(allocator, &output);
+}
+
+fn finishResponse(allocator: Allocator, output: *std.Io.Writer.Allocating) ![]u8 {
+    const owned = try output.toOwnedSlice();
+    errdefer allocator.free(owned);
+    const payload_len = owned.len - 4;
+    if (payload_len > std.math.maxInt(u32)) return error.ResponseTooLarge;
+    std.mem.writeInt(u32, owned[0..4], @intCast(payload_len), .little);
+    return owned;
+}
+
+fn writeDiagnostics(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    diagnostics: []const lint_engine.Diagnostic,
+    severities: *const std.StringHashMap(lint_engine.Severity),
+) !void {
+    try writer.writeByte('[');
+    for (diagnostics, 0..) |diagnostic, index| {
+        if (index != 0) try writer.writeByte(',');
+        try writeDiagnostic(writer, source, diagnostic, severities);
+    }
+    try writer.writeByte(']');
+}
+
+fn writeDiagnostic(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    diagnostic: lint_engine.Diagnostic,
+    severities: *const std.StringHashMap(lint_engine.Severity),
+) !void {
+    const start = utf16Position(source, diagnostic.span.start);
+    const end = utf16Position(source, diagnostic.span.end);
+    const start_offset = lint_engine.offsetToUtf16Offset(source, diagnostic.span.start);
+    const end_offset = lint_engine.offsetToUtf16Offset(source, diagnostic.span.end);
+    const severity = severities.get(diagnostic.rule_id) orelse diagnostic.severity;
+
+    try writer.writeAll("{\"ruleId\":");
+    try writeJsonValue(writer, diagnostic.rule_id);
+    try writer.writeAll(",\"severity\":");
+    try writeJsonValue(writer, severity.toString());
+    try writer.writeAll(",\"message\":");
+    try writeJsonValue(writer, diagnostic.message);
+    try writer.print(",\"range\":[{d},{d}],\"line\":{d},\"column\":{d},\"endLine\":{d},\"endColumn\":{d},\"fixes\":", .{
+        start_offset,
+        end_offset,
+        start.line,
+        start.column,
+        end.line,
+        end.column,
+    });
+    try writeFixes(writer, source, diagnostic.fixes);
+    if (diagnostic.suppression) |suppression| {
+        try writer.writeAll(",\"suppression\":{\"kind\":\"directive\",\"justification\":");
+        try writeJsonValue(writer, suppression.justification);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte('}');
+}
+
+fn writeFixes(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    fixes: []const lint_engine.Fix,
+) !void {
+    try writer.writeByte('[');
+    for (fixes, 0..) |fix_item, index| {
+        if (index != 0) try writer.writeByte(',');
+        try writer.print("{{\"range\":[{d},{d}],\"text\":", .{
+            lint_engine.offsetToUtf16Offset(source, fix_item.span.start),
+            lint_engine.offsetToUtf16Offset(source, fix_item.span.end),
+        });
+        try writeJsonValue(writer, fix_item.replacement);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn writeStringArray(writer: *std.Io.Writer, values: []const []const u8) !void {
+    try writer.writeByte('[');
+    for (values, 0..) |value, index| {
+        if (index != 0) try writer.writeByte(',');
+        try writeJsonValue(writer, value);
+    }
+    try writer.writeByte(']');
+}
+
+fn writeJsonValue(writer: *std.Io.Writer, value: []const u8) !void {
+    try std.json.Stringify.value(value, .{}, writer);
+}
+
+fn utf16Position(source: []const u8, offset: u32) Utf16Position {
+    const end = @min(@as(usize, @intCast(offset)), source.len);
+    var line: usize = 1;
+    var column: usize = 1;
+    var byte_index: usize = 0;
+    while (byte_index < end) {
+        if (source[byte_index] == '\n') {
+            line += 1;
+            column = 1;
+            byte_index += 1;
+            continue;
+        }
+
+        const sequence_len = std.unicode.utf8ByteSequenceLength(source[byte_index]) catch 1;
+        if (byte_index + sequence_len > end or byte_index + sequence_len > source.len) {
+            column += 1;
+            byte_index += 1;
+            continue;
+        }
+        column += if (sequence_len == 4) 2 else 1;
+        byte_index += sequence_len;
+    }
+    return .{ .line = line, .column = column };
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  UtooLintWasmError,
+  createUtooLint,
+} from "../npm/@utoo/lint-wasm/index.js";
+
+const wasmPath = process.argv[2];
+if (!wasmPath) throw new Error("usage: node tests/wasm.mjs <utoo-lint.wasm>");
+
+const wasmBytes = await readFile(wasmPath);
+const wasmModule = await WebAssembly.compile(wasmBytes);
+const linter = await createUtooLint({ wasm: wasmModule });
+const rawInstance = await WebAssembly.instantiate(wasmModule, {});
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function callRaw(source, optionsJson) {
+  const { alloc, free, lint: rawLint, memory } = rawInstance.exports;
+  const sourceBytes = typeof source === "string" ? textEncoder.encode(source) : source;
+  const optionsBytes = textEncoder.encode(optionsJson);
+  const sourceLength = sourceBytes.length || 1;
+  const optionsLength = optionsBytes.length || 1;
+  const sourcePtr = alloc(sourceBytes.length);
+  let optionsPtr = 0;
+  let resultPtr = 0;
+  let resultLength = 0;
+
+  try {
+    new Uint8Array(memory.buffer, sourcePtr, sourceBytes.length).set(sourceBytes);
+    optionsPtr = alloc(optionsBytes.length);
+    new Uint8Array(memory.buffer, optionsPtr, optionsBytes.length).set(optionsBytes);
+    resultPtr = rawLint(sourcePtr, sourceBytes.length, optionsPtr, optionsBytes.length);
+    assert.notEqual(resultPtr, 0);
+    const payloadLength = new DataView(memory.buffer).getUint32(resultPtr, true);
+    resultLength = payloadLength + 4;
+    const payload = new Uint8Array(memory.buffer, resultPtr + 4, payloadLength).slice();
+    return JSON.parse(textDecoder.decode(payload));
+  } finally {
+    if (resultPtr !== 0) free(resultPtr, resultLength);
+    if (optionsPtr !== 0) free(optionsPtr, optionsLength);
+    free(sourcePtr, sourceLength);
+  }
+}
+
+test("exports a standalone ABI v1 module", () => {
+  assert.deepEqual(WebAssembly.Module.imports(wasmModule), []);
+  const exports = new Set(WebAssembly.Module.exports(wasmModule).map((item) => item.name));
+  for (const name of ["memory", "abi_version", "alloc", "free", "lint"]) {
+    assert.ok(exports.has(name), `missing WebAssembly export ${name}`);
+  }
+  assert.equal(linter.abiVersion, 1);
+});
+
+test("uses defaults only when rules is absent", () => {
+  const defaults = linter.lint("debugger;", { filePath: "input.js" });
+  assert.ok(defaults.diagnostics.some((item) => item.ruleId === "no-debugger"));
+
+  const empty = linter.lint("debugger;", { filePath: "input.js", rules: {} });
+  assert.ok(!empty.diagnostics.some((item) => item.ruleId === "no-debugger"));
+});
+
+test("parses JS, TS, JSX, and TSX by file name", () => {
+  const fixtures = [
+    ["input.js", "export const value = 1;"],
+    ["input.ts", "export const value: number = 1;"],
+    ["input.jsx", "export const value = <div />;"],
+    ["input.tsx", "export const value: JSX.Element = <div />;"],
+  ];
+
+  for (const [filePath, source] of fixtures) {
+    const result = linter.lint(source, { filePath, rules: {} });
+    assert.deepEqual(
+      result.diagnostics.filter((item) => item.ruleId === "parse"),
+      [],
+      filePath,
+    );
+  }
+});
+
+test("returns parser failures as diagnostics", () => {
+  const result = linter.lint("const = ;", { filePath: "input.js", rules: {} });
+  assert.ok(result.diagnostics.some((item) => item.ruleId === "parse"));
+});
+
+test("applies configured severity and UTF-16 ranges", () => {
+  const source = `const emoji = "😀中";\nconsole.log(emoji);`;
+  const result = linter.lint(source, {
+    filePath: "unicode.js",
+    rules: { "no-console": "warn" },
+  });
+  const diagnostic = result.diagnostics.find((item) => item.ruleId === "no-console");
+  assert.ok(diagnostic);
+  assert.equal(diagnostic.severity, "warning");
+  assert.match(source.slice(...diagnostic.range), /console/);
+  assert.equal(result.offsetEncoding, "utf-16");
+  assert.equal(result.diagnosticsSource, "input");
+});
+
+test("applies autofixes and reports diagnostics against output", () => {
+  const result = linter.lintAndFix("const value = 1;;;", {
+    filePath: "fix.js",
+    rules: { "no-extra-semi": "error" },
+  });
+  assert.equal(result.mode, "fix");
+  assert.equal(result.diagnosticsSource, "output");
+  assert.equal(result.fixed, true);
+  assert.equal(result.output, "const value = 1;");
+  assert.equal(result.passes, 1);
+  assert.ok(result.appliedDiagnostics > 0);
+  assert.ok(!result.diagnostics.some((item) => item.ruleId === "no-extra-semi"));
+});
+
+test("preserves suppression metadata", () => {
+  const source = "// utlint-ignore no-debugger: generated breakpoint\ndebugger;";
+  const result = linter.lint(source, {
+    filePath: "suppressed.js",
+    rules: { "no-debugger": "error" },
+  });
+  assert.equal(result.diagnostics.length, 0);
+  assert.equal(result.suppressedDiagnostics.length, 1);
+  assert.equal(result.suppressedDiagnostics[0].ruleId, "no-debugger");
+  assert.equal(result.suppressedDiagnostics[0].suppression?.justification, "generated breakpoint");
+});
+
+test("reports filesystem-backed rules as skipped", () => {
+  const result = linter.lint('import value from "./missing.js";', {
+    filePath: "input.js",
+    rules: { "import/no-unresolved": "error" },
+  });
+  assert.deepEqual(result.skippedRules, ["import/no-unresolved"]);
+});
+
+test("returns structured configuration errors", () => {
+  assert.throws(
+    () => linter.lint("value;", { rules: { "not-a-rule": "error" } }),
+    (error) => {
+      assert.ok(error instanceof UtooLintWasmError);
+      assert.equal(error.code, "UNKNOWN_RULE");
+      assert.equal(error.ruleId, "not-a-rule");
+      return true;
+    },
+  );
+});
+
+test("returns structured raw ABI request errors", () => {
+  assert.equal(callRaw("value;", "{").error.code, "INVALID_OPTIONS_JSON");
+  assert.equal(
+    callRaw("value;", JSON.stringify({ version: 2 })).error.code,
+    "UNSUPPORTED_VERSION",
+  );
+  assert.equal(
+    callRaw(new Uint8Array([0xff]), JSON.stringify({ version: 1 })).error.code,
+    "INVALID_UTF8",
+  );
+});
+
+test("supports empty and repeated calls across memory growth", () => {
+  for (let index = 0; index < 25; index += 1) {
+    const source = index === 24 ? `const text = "${"x".repeat(200_000)}";` : "";
+    const result = linter.lint(source, { filePath: "input.js", rules: {} });
+    assert.equal(result.ok, true);
+  }
+});


### PR DESCRIPTION
## Summary

- add a freestanding `wasm32` build that exposes a versioned allocation and in-memory lint ABI without WASI or filesystem imports
- publish the browser-ready, ESM-only `@utoo/lint-wasm` package with JavaScript loading helpers, TypeScript declarations, lint, and autofix APIs
- preserve JavaScript, TypeScript, JSX, and TSX diagnostics, UTF-16 ranges, suppression metadata, and structured configuration errors in WebAssembly
- report filesystem-backed rules through `skippedRules` while keeping native CLI rule behavior unchanged
- document playground and Web Worker usage, and wire Wasm staging, package validation, CI, npm publishing, and GitHub release assets into the existing workflows

## Test Plan

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- `pnpm --dir npm/utoo-lint test`
- verify the `@utoo/lint-wasm` tarball contains `utoo-lint.wasm`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check origin/main...HEAD`
