### PR TITLE
feat: deploy and refine lint playground

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -1,0 +1,71 @@
+name: Deploy Playground
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-playground.yml"
+      - "apps/playground/**"
+      - "npm/@utoo/lint-wasm/**"
+      - "scripts/package-wasm.sh"
+      - "src/**"
+      - "vendor/**"
+      - "build.zig"
+      - "build.zig.zon"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: playground-production
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+
+      - name: Build and audit Playground
+        run: pnpm playground:build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy apps/playground/dist/client
+            --project-name=utoo-lint-playground
+            --branch=main
+            --commit-hash=${{ github.sha }}
+            --commit-dirty=false
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -20,10 +20,9 @@ on:
 
 permissions:
   contents: read
-  deployments: write
 
 concurrency:
-  group: playground-production
+  group: playground-production-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -31,19 +30,21 @@ env:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
@@ -52,13 +53,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
 
       - name: Build and audit Playground
         run: pnpm playground:build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -68,4 +69,3 @@ jobs:
             --branch=main
             --commit-hash=${{ github.sha }}
             --commit-dirty=false
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -48,7 +48,9 @@ URLs, so repository-subpath hosting needs an origin rewrite or a dedicated
 domain.
 
 The production Playground is deployed to
-[`utoo-lint-playground.pages.dev`](https://utoo-lint-playground.pages.dev/).
+[`utlint.umijs.org`](https://utlint.umijs.org/), with
+[`utoo-lint-playground.pages.dev`](https://utoo-lint-playground.pages.dev/) as
+the underlying Cloudflare Pages domain.
 Pushes to `main` that affect the Playground or its WASM sources are deployed by
 `.github/workflows/deploy-playground.yml`. The repository must provide the
 `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` Actions secrets; the API

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -54,7 +54,9 @@ the underlying Cloudflare Pages domain.
 Pushes to `main` that affect the Playground or its WASM sources are deployed by
 `.github/workflows/deploy-playground.yml`. The repository must provide the
 `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` Actions secrets; the API
-token only needs `Account > Cloudflare Pages > Edit` permission.
+token only needs `Account > Cloudflare Pages > Edit` permission. Limit its
+account resources to the specific account that owns `utoo-lint-playground`;
+no zone permission is required.
 
 ## Runtime boundaries
 

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -47,6 +47,13 @@ Cloudflare Pages and Netlify. The current EVJS output uses root-relative asset
 URLs, so repository-subpath hosting needs an origin rewrite or a dedicated
 domain.
 
+The production Playground is deployed to
+[`utoo-lint-playground.pages.dev`](https://utoo-lint-playground.pages.dev/).
+Pushes to `main` that affect the Playground or its WASM sources are deployed by
+`.github/workflows/deploy-playground.yml`. The repository must provide the
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` Actions secrets; the API
+token only needs `Account > Cloudflare Pages > Edit` permission.
+
 ## Runtime boundaries
 
 - Linting and autofix run in a long-lived Web Worker.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -6,7 +6,7 @@
     "dev": "ev dev",
     "build": "ev build && node scripts/stage-static.mjs && node scripts/verify-dist.mjs",
     "inspect": "ev inspect --json",
-    "test": "node --test scripts/lint-client.test.mjs",
+    "test": "pnpm --workspace-root package:wasm && node --test scripts/lint-client.test.mjs",
     "typecheck": "ev prepare && tsc --noEmit"
   },
   "dependencies": {

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "ev dev",
-    "build": "ev build && node scripts/verify-dist.mjs",
+    "build": "ev build && node scripts/stage-static.mjs && node scripts/verify-dist.mjs",
     "inspect": "ev inspect --json",
     "test": "node --test scripts/lint-client.test.mjs",
     "typecheck": "ev prepare && tsc --noEmit"

--- a/apps/playground/public/_headers
+++ b/apps/playground/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self' data:; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:
+  Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY

--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -18,6 +18,9 @@ await run(
     ),
     '--ignoreConfig',
     fileURLToPath(new URL('../src/features/lint/client.ts', import.meta.url)),
+    fileURLToPath(
+      new URL('../src/features/playground/model.ts', import.meta.url),
+    ),
     '--target',
     'es2022',
     '--module',
@@ -34,7 +37,14 @@ await run(
 );
 await writeFile(join(outputDirectory, 'package.json'), '{"type":"module"}');
 const { LintWorkerClient } = await import(
-  pathToFileURL(join(outputDirectory, 'client.js')).href
+  pathToFileURL(join(outputDirectory, 'lint', 'client.js')).href
+);
+const {
+  fileNameForLanguage,
+  INITIAL_SOURCES,
+  RECOMMENDED_RULES,
+} = await import(
+  pathToFileURL(join(outputDirectory, 'playground', 'model.js')).href
 );
 await rm(outputDirectory, { force: true, recursive: true });
 
@@ -131,4 +141,33 @@ test('can discard queued work before its debounce replacement is ready', async (
     worker.messages.map(({ source }) => source),
     ['active'],
   );
+});
+
+test('fixes every diagnostic in each default Playground fixture', async () => {
+  const { createUtooLint } = await import('@utoo/lint-wasm');
+  const linter = await createUtooLint();
+
+  for (const [language, source] of Object.entries(INITIAL_SOURCES)) {
+    const options = {
+      filePath: fileNameForLanguage(language),
+      rules: RECOMMENDED_RULES,
+    };
+    const before = linter.lint(source, options);
+    assert.ok(
+      before.diagnostics.length > 0,
+      `${language} should demonstrate lint errors`,
+    );
+    assert.ok(
+      before.diagnostics.every((diagnostic) => diagnostic.fixes.length > 0),
+      `${language} should only demonstrate fixable diagnostics`,
+    );
+
+    const fixed = linter.lintAndFix(source, options);
+    assert.equal(fixed.fixed, true, `${language} should be changed`);
+    assert.deepEqual(
+      fixed.diagnostics,
+      [],
+      `${language} should be clean after one Fix all action`,
+    );
+  }
 });

--- a/apps/playground/scripts/stage-static.mjs
+++ b/apps/playground/scripts/stage-static.mjs
@@ -1,0 +1,10 @@
+import { copyFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+await copyFile(
+  path.join(appDir, 'public', '_headers'),
+  path.join(appDir, 'dist', 'client', '_headers'),
+);

--- a/apps/playground/scripts/verify-dist.mjs
+++ b/apps/playground/scripts/verify-dist.mjs
@@ -5,7 +5,12 @@ import { fileURLToPath } from 'node:url';
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const clientDir = path.join(appDir, 'dist', 'client');
 const deploymentFile = path.join(appDir, 'dist', 'deployment-metadata.json');
-const requiredFiles = ['index.html', '_redirects', 'deployment.static.json'];
+const requiredFiles = [
+  'index.html',
+  '_headers',
+  '_redirects',
+  'deployment.static.json',
+];
 const forbiddenText = [
   '@alipay/evjs',
   'registry.antgroup-inc.cn',
@@ -64,6 +69,20 @@ if (Object.keys(canonicalDeployment.server ?? {}).length !== 0) {
 const indexHtml = await readFile(path.join(clientDir, 'index.html'), 'utf8');
 if (!indexHtml.includes('id="__EVJS_CLIENT_RUNTIME__"')) {
   throw new Error('missing EVJS browser runtime');
+}
+
+const headers = await readFile(path.join(clientDir, '_headers'), 'utf8');
+for (const directive of [
+  "default-src 'self'",
+  "script-src 'self' 'wasm-unsafe-eval'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  'X-Content-Type-Options: nosniff',
+  'X-Frame-Options: DENY',
+]) {
+  if (!headers.includes(directive)) {
+    throw new Error(`missing security header directive: ${directive}`);
+  }
 }
 
 for (const match of indexHtml.matchAll(/(?:href|src)="([^"]+)"/g)) {

--- a/apps/playground/src/features/playground/model.ts
+++ b/apps/playground/src/features/playground/model.ts
@@ -31,37 +31,35 @@ export type PlaygroundLanguage = (typeof LANGUAGES)[number]['id'];
 
 export const INITIAL_SOURCES: Record<PlaygroundLanguage, string> = {
   typescript: `function greet(name: string) {
-  const unused = 42;
-  debugger;
   let message = \`Hello, \${name}\`;;
-  return message;
+  const messages = new Array(message, 'Welcome');
+  return { messages: messages };
 }
 
 greet('utoo');
 `,
   javascript: `function greet(name) {
-  const unused = 42;
-  debugger;
   let message = \`Hello, \${name}\`;;
-  return message;
+  const messages = new Array(message, 'Welcome');
+  return { messages: messages };
 }
 
 greet('utoo');
 `,
   tsx: `function Greeting({ name }: { name: string }) {
-  const unused = 42;
-  debugger;
   let message = \`Hello, \${name}\`;;
-  return <h1>{message}</h1>;
+  const messages = new Array(message, 'Welcome');
+  const props = { messages: messages };
+  return <h1>{props.messages.join(' ')}</h1>;
 }
 
 export default <Greeting name="utoo" />;
 `,
   jsx: `function Greeting({ name }) {
-  const unused = 42;
-  debugger;
   let message = \`Hello, \${name}\`;;
-  return <h1>{message}</h1>;
+  const messages = new Array(message, 'Welcome');
+  const props = { messages: messages };
+  return <h1>{props.messages.join(' ')}</h1>;
 }
 
 export default <Greeting name="utoo" />;
@@ -69,10 +67,10 @@ export default <Greeting name="utoo" />;
 };
 
 export const RECOMMENDED_RULES = {
-  'no-debugger': 'error',
-  'no-unused-vars': 'warn',
-  'prefer-const': 'warn',
+  'no-array-constructor': 'error',
   'no-extra-semi': 'error',
+  'object-shorthand': 'warn',
+  'prefer-const': 'warn',
 } satisfies Record<string, RuleConfig>;
 
 export const INITIAL_RULES = JSON.stringify(RECOMMENDED_RULES, null, 2);

--- a/apps/playground/src/features/playground/splitter.tsx
+++ b/apps/playground/src/features/playground/splitter.tsx
@@ -1,0 +1,168 @@
+import {
+  useEffect,
+  type KeyboardEvent,
+  type PointerEvent,
+  type RefObject,
+} from 'react';
+
+type SplitterOrientation = 'horizontal' | 'vertical';
+
+interface SplitterProps {
+  ariaControls: string;
+  ariaLabel: string;
+  containerRef: RefObject<HTMLElement | null>;
+  minPrimaryPx: number;
+  minSecondaryPx: number;
+  onChange(value: number): void;
+  onReset(): void;
+  orientation: SplitterOrientation;
+  value: number;
+}
+
+const SPLITTER_SIZE_PX = 7;
+
+function getBounds(
+  container: HTMLElement | null,
+  orientation: SplitterOrientation,
+  minPrimaryPx: number,
+  minSecondaryPx: number,
+) {
+  const size =
+    orientation === 'vertical'
+      ? container?.clientWidth ?? 0
+      : container?.clientHeight ?? 0;
+
+  if (size <= minPrimaryPx + minSecondaryPx + SPLITTER_SIZE_PX) {
+    return { min: 0, max: 100 };
+  }
+
+  return {
+    min: (minPrimaryPx / size) * 100,
+    max: ((size - minSecondaryPx - SPLITTER_SIZE_PX) / size) * 100,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function Splitter({
+  ariaControls,
+  ariaLabel,
+  containerRef,
+  minPrimaryPx,
+  minSecondaryPx,
+  onChange,
+  onReset,
+  orientation,
+  value,
+}: SplitterProps) {
+  const bounds = getBounds(
+    containerRef.current,
+    orientation,
+    minPrimaryPx,
+    minSecondaryPx,
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver(() => {
+      const nextBounds = getBounds(
+        container,
+        orientation,
+        minPrimaryPx,
+        minSecondaryPx,
+      );
+      const nextValue = clamp(value, nextBounds.min, nextBounds.max);
+      if (Math.abs(nextValue - value) > 0.01) onChange(nextValue);
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, minPrimaryPx, minSecondaryPx, onChange, orientation, value]);
+
+  const updateFromPointer = (event: PointerEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    const size = orientation === 'vertical' ? rect.width : rect.height;
+    if (size <= 0) return;
+
+    const position =
+      orientation === 'vertical'
+        ? event.clientX - rect.left
+        : event.clientY - rect.top;
+    const nextBounds = getBounds(
+      container,
+      orientation,
+      minPrimaryPx,
+      minSecondaryPx,
+    );
+    onChange(clamp((position / size) * 100, nextBounds.min, nextBounds.max));
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    updateFromPointer(event);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+    updateFromPointer(event);
+  };
+
+  const handlePointerEnd = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 8 : 2;
+    let nextValue: number | undefined;
+
+    if (event.key === 'Home') nextValue = bounds.min;
+    if (event.key === 'End') nextValue = bounds.max;
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onReset();
+      return;
+    }
+
+    if (orientation === 'vertical') {
+      if (event.key === 'ArrowLeft') nextValue = value - step;
+      if (event.key === 'ArrowRight') nextValue = value + step;
+    } else {
+      if (event.key === 'ArrowUp') nextValue = value - step;
+      if (event.key === 'ArrowDown') nextValue = value + step;
+    }
+
+    if (nextValue === undefined) return;
+    event.preventDefault();
+    onChange(clamp(nextValue, bounds.min, bounds.max));
+  };
+
+  return (
+    <div
+      aria-controls={ariaControls}
+      aria-label={ariaLabel}
+      aria-orientation={orientation}
+      aria-valuemax={Math.round(bounds.max)}
+      aria-valuemin={Math.round(bounds.min)}
+      aria-valuenow={Math.round(value)}
+      className={`pane-splitter pane-splitter-${orientation}`}
+      onDoubleClick={onReset}
+      onKeyDown={handleKeyDown}
+      onPointerCancel={handlePointerEnd}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      role="separator"
+      tabIndex={0}
+    />
+  );
+}

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -7,7 +7,10 @@ import {
   useRef,
   useState,
 } from 'react';
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import utooRabbitUrl from '../../../../assets/utoo-lint-mark-gpt.png';
 import { LintWorkerClient } from '../features/lint/client';
 import {
@@ -22,6 +25,7 @@ import {
   type PlaygroundLanguage,
 } from '../features/playground/model';
 import '../features/playground/monaco';
+import { Splitter } from '../features/playground/splitter';
 import '../style.css';
 
 type EditorInstance = Parameters<OnMount>[0];
@@ -30,6 +34,8 @@ type RulesMode = 'recommended' | 'custom';
 type RunPhase = 'idle' | 'running' | 'ready' | 'error';
 
 const EDITOR_THEME = 'utoo-dark';
+const DEFAULT_EDITOR_RATIO = 68;
+const DEFAULT_RULES_RATIO = 42;
 
 interface RunState {
   phase: RunPhase;
@@ -87,8 +93,12 @@ export default function PlaygroundPage() {
   const editorRef = useRef<EditorInstance | null>(null);
   const monacoRef = useRef<MonacoInstance | null>(null);
   const clientRef = useRef<LintWorkerClient | null>(null);
+  const workspaceRef = useRef<HTMLElement | null>(null);
+  const sidePanelRef = useRef<HTMLElement | null>(null);
   const languageTabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const latestRequestRef = useRef(0);
+  const [editorRatio, setEditorRatio] = useState(DEFAULT_EDITOR_RATIO);
+  const [rulesRatio, setRulesRatio] = useState(DEFAULT_RULES_RATIO);
 
   if (!clientRef.current) clientRef.current = new LintWorkerClient();
 
@@ -384,7 +394,11 @@ export default function PlaygroundPage() {
         </section>
       </header>
 
-      <section className="workspace">
+      <section
+        className="workspace"
+        ref={workspaceRef}
+        style={{ '--editor-ratio': `${editorRatio}%` } as CSSProperties}
+      >
         <div
           aria-labelledby={`language-tab-${language}`}
           className="editor-panel"
@@ -418,8 +432,8 @@ export default function PlaygroundPage() {
                 fontFamily:
                   "'SFMono-Regular', Consolas, 'Liberation Mono', monospace",
                 fontLigatures: true,
-                fontSize: 14,
-                lineHeight: 22,
+                fontSize: 16,
+                lineHeight: 25,
                 minimap: { enabled: false },
                 padding: { top: 16 },
                 renderLineHighlight: 'gutter',
@@ -431,13 +445,29 @@ export default function PlaygroundPage() {
           </div>
         </div>
 
+        <Splitter
+          ariaControls="source-editor-panel lint-side-panel"
+          ariaLabel="Resize source editor and lint sidebar"
+          containerRef={workspaceRef}
+          minPrimaryPx={480}
+          minSecondaryPx={340}
+          onChange={setEditorRatio}
+          onReset={() => setEditorRatio(DEFAULT_EDITOR_RATIO)}
+          orientation="vertical"
+          value={editorRatio}
+        />
+
         <aside
           aria-label="Lint configuration and diagnostics"
           className="side-panel"
+          id="lint-side-panel"
+          ref={sidePanelRef}
+          style={{ '--rules-ratio': `${rulesRatio}%` } as CSSProperties}
         >
           <section
             aria-labelledby="rules-panel-title"
             className="rules-section"
+            id="rules-panel"
           >
             <div className="panel-heading rules-heading">
               <h2 className="panel-title" id="rules-panel-title">
@@ -493,10 +523,23 @@ export default function PlaygroundPage() {
             )}
           </section>
 
+          <Splitter
+            ariaControls="rules-panel diagnostics-panel"
+            ariaLabel="Resize rules and diagnostics panels"
+            containerRef={sidePanelRef}
+            minPrimaryPx={180}
+            minSecondaryPx={220}
+            onChange={setRulesRatio}
+            onReset={() => setRulesRatio(DEFAULT_RULES_RATIO)}
+            orientation="horizontal"
+            value={rulesRatio}
+          />
+
           <section
             aria-busy={runState.phase === 'idle' || runState.phase === 'running'}
             aria-labelledby="diagnostics-panel-title"
             className="diagnostics-section"
+            id="diagnostics-panel"
           >
             <div className="panel-heading">
               <h2 className="panel-title" id="diagnostics-panel-title">

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -278,12 +278,25 @@ export default function PlaygroundPage() {
     languageTabRefs.current[nextIndex]?.focus();
   };
 
-  const canFix =
-    runState.phase === 'ready' &&
-    diagnostics.some((diagnostic) => diagnostic.fixes.length > 0);
+  const fixableCount = diagnostics.filter(
+    (diagnostic) => diagnostic.fixes.length > 0,
+  ).length;
+  const canFix = runState.phase === 'ready' && fixableCount > 0;
   const hasValidRules = rulesMode === 'recommended' || parsedRules.ok;
   const isRetry = runState.phase === 'error';
   const hasCustomRulesError = rulesMode === 'custom' && !parsedRules.ok;
+  const fixButtonText = isRetry
+    ? 'Retry'
+    : canFix && fixableCount < diagnostics.length
+      ? `Fix ${fixableCount}`
+      : 'Fix all';
+  const fixButtonLabel = isRetry
+    ? 'Retry lint'
+    : canFix
+      ? fixableCount === diagnostics.length
+        ? `Fix all ${fixableCount} diagnostics`
+        : `Fix ${fixableCount} of ${diagnostics.length} diagnostics with safe autofixes`
+      : 'No safe autofixes available';
   const rulesDescriptionId = hasCustomRulesError
     ? 'rules-config-error'
     : rulesMode === 'recommended'
@@ -371,12 +384,14 @@ export default function PlaygroundPage() {
           <span aria-hidden="true" className="toolbar-divider" />
 
           <button
+            aria-label={fixButtonLabel}
             className="fix-button"
             disabled={isRetry ? !hasValidRules : !canFix}
             onClick={() => void execute(isRetry ? 'lint' : 'fix')}
+            title={fixButtonLabel}
             type="button"
           >
-            {isRetry ? 'Retry' : 'Fix all'}
+            {fixButtonText}
           </button>
 
           <a

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -20,6 +20,7 @@
   --success: #3fb950;
   --error: #f85149;
   --warning: #d29922;
+  --splitter-size: 7px;
 }
 
 * {
@@ -59,11 +60,11 @@ textarea:focus-visible {
 
 .playground-shell {
   display: grid;
-  grid-template-rows: 52px minmax(0, 1fr) 28px;
+  grid-template-rows: 58px minmax(0, 1fr) 30px;
   width: 100%;
   height: 100vh;
   height: 100dvh;
-  min-height: 620px;
+  min-height: 660px;
   background: var(--canvas);
 }
 
@@ -84,8 +85,8 @@ textarea:focus-visible {
 .topbar {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 20px;
-  padding: 0 16px;
+  gap: 24px;
+  padding: 0 18px;
   border-bottom: 1px solid var(--line);
   background: var(--surface);
 }
@@ -118,14 +119,14 @@ textarea:focus-visible {
 .brand h1 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 650;
   letter-spacing: -0.02em;
 }
 
 .brand-title span {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .brand-title span::before {
@@ -136,14 +137,14 @@ textarea:focus-visible {
 
 .github-link {
   display: inline-flex;
-  min-height: 28px;
+  min-height: 32px;
   flex: none;
   align-items: center;
   gap: 4px;
   margin-left: 2px;
   padding: 0 6px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   text-decoration: none;
 }
@@ -179,9 +180,9 @@ textarea:focus-visible {
 .language-tabs button {
   position: relative;
   min-width: 0;
-  padding: 0 11px;
+  padding: 0 13px;
   border-bottom: 2px solid transparent;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 550;
 }
 
@@ -200,7 +201,7 @@ textarea:focus-visible {
   gap: 12px;
   margin-left: auto;
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   white-space: nowrap;
 }
 
@@ -261,7 +262,7 @@ textarea:focus-visible {
 
 .fix-button {
   min-width: 0;
-  min-height: 28px;
+  min-height: 32px;
   margin-left: 6px;
   padding: 0 7px;
   border: 0;
@@ -269,7 +270,7 @@ textarea:focus-visible {
   color: var(--text);
   background: transparent;
   cursor: pointer;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
 }
 
@@ -290,7 +291,9 @@ textarea:focus-visible {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) clamp(330px, 29vw, 420px);
+  grid-template-columns:
+    minmax(480px, var(--editor-ratio, 68%)) var(--splitter-size)
+    minmax(340px, 1fr);
   min-height: 0;
 }
 
@@ -304,18 +307,17 @@ textarea:focus-visible {
 
 .editor-panel {
   display: grid;
-  grid-template-rows: 36px minmax(0, 1fr);
-  border-right: 1px solid var(--line);
+  grid-template-rows: 40px minmax(0, 1fr);
 }
 
 .panel-heading {
   justify-content: space-between;
-  min-height: 36px;
-  padding: 0 12px;
+  min-height: 40px;
+  padding: 0 14px;
   border-bottom: 1px solid var(--line);
   color: var(--text);
   background: var(--surface);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
 }
 
@@ -335,7 +337,7 @@ textarea:focus-visible {
 
 .panel-hint {
   color: var(--muted-subtle);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 450;
 }
 
@@ -347,7 +349,9 @@ textarea:focus-visible {
 
 .side-panel {
   display: grid;
-  grid-template-rows: 238px minmax(0, 1fr);
+  grid-template-rows:
+    minmax(180px, var(--rules-ratio, 42%)) var(--splitter-size)
+    minmax(220px, 1fr);
 }
 
 .rules-section,
@@ -356,8 +360,56 @@ textarea:focus-visible {
 }
 
 .rules-section {
-  grid-template-rows: 36px minmax(0, 1fr) auto;
-  border-bottom: 1px solid var(--line);
+  grid-template-rows: 40px minmax(0, 1fr) auto;
+}
+
+.pane-splitter {
+  position: relative;
+  z-index: 2;
+  min-width: 0;
+  min-height: 0;
+  background: transparent;
+  cursor: default;
+  touch-action: none;
+  user-select: none;
+}
+
+.pane-splitter::before {
+  position: absolute;
+  background: var(--line);
+  content: "";
+  transition: background-color 120ms ease;
+}
+
+.pane-splitter-vertical {
+  cursor: col-resize;
+}
+
+.pane-splitter-vertical::before {
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+}
+
+.pane-splitter-horizontal {
+  cursor: row-resize;
+}
+
+.pane-splitter-horizontal::before {
+  top: 3px;
+  right: 0;
+  left: 0;
+  height: 1px;
+}
+
+.pane-splitter:hover::before,
+.pane-splitter:focus-visible::before {
+  background: var(--accent);
+}
+
+.pane-splitter:focus-visible {
+  outline: none;
 }
 
 .rules-heading {
@@ -372,7 +424,7 @@ textarea:focus-visible {
 .segmented-control button {
   padding: 0;
   border-bottom: 2px solid transparent;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .segmented-control button.is-active {
@@ -383,15 +435,15 @@ textarea:focus-visible {
 .rules-editor {
   width: 100%;
   min-height: 0;
-  padding: 12px;
+  padding: 14px;
   resize: none;
   border: 0;
   color: var(--text);
   background: var(--canvas);
   font-family:
     "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 11px;
-  line-height: 1.55;
+  font-size: 14px;
+  line-height: 1.6;
   scrollbar-color: #484f58 transparent;
   tab-size: 2;
 }
@@ -408,9 +460,9 @@ textarea:focus-visible {
 .config-error,
 .rules-note {
   margin: 0;
-  padding: 7px 12px;
+  padding: 8px 14px;
   border-top: 1px solid var(--line-muted);
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.45;
 }
 
@@ -425,12 +477,12 @@ textarea:focus-visible {
 }
 
 .diagnostics-section {
-  grid-template-rows: 36px minmax(0, 1fr) auto;
+  grid-template-rows: 40px minmax(0, 1fr) auto;
 }
 
 .diagnostic-total {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
 
@@ -444,11 +496,11 @@ textarea:focus-visible {
 
 .diagnostic-card {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
-  gap: 8px;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 10px;
   width: 100%;
   margin: 0;
-  padding: 10px 12px;
+  padding: 12px 14px;
   border: 0;
   border-bottom: 1px solid var(--line-muted);
   color: inherit;
@@ -464,7 +516,7 @@ textarea:focus-visible {
 .severity-symbol {
   display: block;
   padding-top: 1px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   line-height: 1;
   text-align: center;
@@ -485,17 +537,17 @@ textarea:focus-visible {
 .diagnostic-message {
   display: block;
   color: var(--text);
-  font-size: 11px;
+  font-size: 14px;
   font-weight: 450;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 .diagnostic-meta {
   flex-wrap: wrap;
-  gap: 7px;
-  margin-top: 4px;
+  gap: 8px;
+  margin-top: 5px;
   color: var(--muted-subtle);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .diagnostic-meta code {
@@ -525,13 +577,13 @@ textarea:focus-visible {
 .empty-state strong {
   margin: 7px 0 3px;
   color: var(--text);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 550;
 }
 
 .empty-state span:last-child {
   max-width: 240px;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -557,11 +609,11 @@ textarea:focus-visible {
 .notice-row {
   display: flex;
   gap: 4px;
-  padding: 7px 12px;
+  padding: 8px 14px;
   border-top: 1px solid var(--line-muted);
   color: var(--muted);
   background: var(--surface);
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.45;
 }
 
@@ -577,22 +629,22 @@ textarea:focus-visible {
 
 .footer-note {
   min-width: 0;
-  padding: 0 12px;
+  padding: 0 14px;
   overflow: hidden;
   border-top: 1px solid var(--line);
   color: var(--muted-subtle);
-  font-size: 10px;
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-@media (min-width: 901px) and (max-height: 619px) {
+@media (min-width: 901px) and (max-height: 659px) {
   body {
     overflow: auto;
   }
 
   .playground-shell {
-    height: 620px;
+    height: 660px;
   }
 }
 
@@ -602,7 +654,7 @@ textarea:focus-visible {
   }
 
   .playground-shell {
-    grid-template-rows: auto auto 28px;
+    grid-template-rows: auto auto 30px;
     height: auto;
     min-height: 100vh;
   }
@@ -614,18 +666,22 @@ textarea:focus-visible {
   }
 
   .brand {
-    height: 52px;
+    height: 58px;
     padding: 0 12px;
     border-bottom: 1px solid var(--line);
   }
 
   .controlbar {
-    height: 44px;
+    height: 48px;
     padding: 0 8px;
   }
 
   .workspace {
     grid-template-columns: 1fr;
+  }
+
+  .pane-splitter {
+    display: none;
   }
 
   .editor-panel {
@@ -636,7 +692,7 @@ textarea:focus-visible {
   }
 
   .side-panel {
-    grid-template-rows: 238px minmax(400px, auto);
+    grid-template-rows: 260px minmax(400px, auto);
   }
 
   .diagnostics-section {
@@ -646,7 +702,7 @@ textarea:focus-visible {
 
 @media (max-width: 620px) {
   .playground-shell {
-    grid-template-rows: auto auto 28px;
+    grid-template-rows: auto auto 30px;
   }
 
   .controlbar {
@@ -657,7 +713,7 @@ textarea:focus-visible {
 
   .language-tabs {
     width: 100%;
-    height: 42px;
+    height: 44px;
     overflow-x: auto;
     border-bottom: 1px solid var(--line);
   }
@@ -667,7 +723,7 @@ textarea:focus-visible {
   }
 
   .run-summary {
-    min-height: 40px;
+    min-height: 44px;
     margin-left: 12px;
   }
 
@@ -687,11 +743,11 @@ textarea:focus-visible {
   }
 
   .side-panel {
-    grid-template-rows: 220px minmax(340px, auto);
+    grid-template-rows: 240px minmax(360px, auto);
   }
 
   .diagnostics-section {
-    min-height: 340px;
+    min-height: 360px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
     "bench:generate": "pnpm --dir benchmarks generate",
     "bench": "pnpm --dir benchmarks bench",
     "bench:chart": "pnpm --dir benchmarks chart"
+  },
+  "pnpm": {
+    "overrides": {
+      "dompurify": "3.4.14"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: 3.4.14
+
 importers:
 
   .: {}
@@ -1214,8 +1217,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3166,7 +3169,7 @@ snapshots:
   domparser-win32-x64-msvc@0.1.1:
     optional: true
 
-  dompurify@3.4.8:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3627,7 +3630,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.14
       marked: 14.0.0
 
   ms@2.0.0: {}


### PR DESCRIPTION
## Summary

- deploy the static EVJS Playground to the existing `utoo-lint-playground` Cloudflare Pages project after relevant changes land on `main`
- restrict production deployments to `main`, pin third-party actions, use least-privilege credentials, and ship verified browser security headers
- add accessible resizable editor, Rules, and Diagnostics panes with more comfortable typography
- make every default diagnostic safely fixable so one `Fix all` action produces a clean file, while partial custom fixes show their actual count
- keep Monaco, the Web Worker, and WebAssembly runtime fully local to the browser

## Test Plan

- [x] `pnpm playground:typecheck`
- [x] `pnpm --filter @utoo/lint-playground test`
- [x] `pnpm playground:build`
- [x] `pnpm audit --prod --audit-level low`
- [x] `actionlint .github/workflows/deploy-playground.yml`
- [x] verify Cloudflare Pages headers and SPA fallback locally with Wrangler
- [x] verify mouse drag, keyboard resize, reset, Monaco relayout, and responsive stacking in Chrome
- [x] verify browser `Fix all` changes 4 fixable diagnostics to 0 errors and 0 warnings in one click
- [x] verify the production root, WASM content type, custom domain, and TLS certificate

Production: https://utlint.umijs.org/