### PR TITLE
style: refine playground appearance

### DIFF
--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -58,15 +58,15 @@ function defineEditorTheme(monaco: MonacoInstance): void {
       { token: 'type.identifier', foreground: 'D2A8FF' },
     ],
     colors: {
-      'editor.background': '#0D1117',
-      'editor.foreground': '#C9D1D9',
+      'editor.background': '#121418',
+      'editor.foreground': '#D1D5DB',
       'editorCursor.foreground': '#58A6FF',
-      'editorGutter.background': '#0D1117',
-      'editorIndentGuide.background1': '#21262D',
-      'editorIndentGuide.activeBackground1': '#30363D',
+      'editorGutter.background': '#121418',
+      'editorIndentGuide.background1': '#252A32',
+      'editorIndentGuide.activeBackground1': '#303641',
       'editorLineNumber.activeForeground': '#8B949E',
       'editorLineNumber.foreground': '#7D8590',
-      'editor.lineHighlightBackground': '#161B22',
+      'editor.lineHighlightBackground': '#1A1D23',
       'editor.selectionBackground': '#264F78',
       'editor.inactiveSelectionBackground': '#1F3D5A',
       'editorWhitespace.foreground': '#30363D',
@@ -639,10 +639,6 @@ export default function PlaygroundPage() {
         </aside>
       </section>
 
-      <footer className="footer-note">
-        Runs locally in your browser · Single-file linting · Project rules may
-        be skipped
-      </footer>
     </main>
   );
 }

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -1,21 +1,21 @@
 :root {
-  color: #c9d1d9;
-  background: #0d1117;
+  color: #d1d5db;
+  background: #121418;
   color-scheme: dark;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --canvas: #0d1117;
-  --surface: #161b22;
-  --surface-hover: #1c2128;
-  --line: #30363d;
-  --line-muted: #21262d;
-  --text: #c9d1d9;
-  --text-strong: #f0f6fc;
-  --muted: #8b949e;
-  --muted-subtle: #7d8590;
+  --canvas: #121418;
+  --surface: #1a1d23;
+  --surface-hover: #23272f;
+  --line: #303641;
+  --line-muted: #252a32;
+  --text: #d1d5db;
+  --text-strong: #f4f5f7;
+  --muted: #969da8;
+  --muted-subtle: #7f8793;
   --accent: #2f81f7;
   --success: #3fb950;
   --error: #f85149;
@@ -60,7 +60,7 @@ textarea:focus-visible {
 
 .playground-shell {
   display: grid;
-  grid-template-rows: 58px minmax(0, 1fr) 30px;
+  grid-template-rows: 58px minmax(0, 1fr);
   width: 100%;
   height: 100vh;
   height: 100dvh;
@@ -76,7 +76,6 @@ textarea:focus-visible {
 .brand-title,
 .diagnostic-meta,
 .segmented-control,
-.footer-note,
 .panel-hint {
   display: flex;
   align-items: center;
@@ -627,17 +626,6 @@ textarea:focus-visible {
   color: #e3b341;
 }
 
-.footer-note {
-  min-width: 0;
-  padding: 0 14px;
-  overflow: hidden;
-  border-top: 1px solid var(--line);
-  color: var(--muted-subtle);
-  font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @media (min-width: 901px) and (max-height: 659px) {
   body {
     overflow: auto;
@@ -654,7 +642,7 @@ textarea:focus-visible {
   }
 
   .playground-shell {
-    grid-template-rows: auto auto 30px;
+    grid-template-rows: auto auto;
     height: auto;
     min-height: 100vh;
   }
@@ -701,10 +689,6 @@ textarea:focus-visible {
 }
 
 @media (max-width: 620px) {
-  .playground-shell {
-    grid-template-rows: auto auto 30px;
-  }
-
   .controlbar {
     height: auto;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- remove the redundant playground footer note
- replace the harsh blue-black background with a softer graphite palette
- keep the Monaco editor and responsive layout in sync with the updated theme

## Test Plan

- pnpm playground:typecheck
- pnpm playground:build
- visually verified desktop and 390px mobile layouts