### PR TITLE
feat: add AST inspector to playground

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -2,7 +2,9 @@
 
 The Playground runs utoo-lint entirely in the browser. It uses the public
 EVJS packages, Utoopack, Monaco Editor, a Web Worker, and the workspace
-`@utoo/lint-wasm` package.
+`@utoo/lint-wasm` package. Its AST inspector uses the public
+`@yuku-parser/wasm` 0.9.1 package, matching the Yuku revision vendored by
+utoo-lint.
 
 No `@alipay/*` package, private registry, internal runtime, or server process
 is required. EVJS discovers the root `src/pages/page.tsx` as a CSR SPA, and
@@ -37,7 +39,8 @@ pnpm playground:build
 ```
 
 The production build runs a deployment audit after `ev build`. It checks that
-the output is a complete static deployment, contains one valid WASM asset,
+the output is a complete static deployment, contains valid lint and parser
+WASM assets,
 requires no server, loads no remote runtime assets, and contains no known
 internal registry or release-chain markers.
 
@@ -62,6 +65,9 @@ no zone permission is required.
 
 - Linting and autofix run in a long-lived Web Worker.
 - The worker loads the freestanding WASM module once and reuses it.
+- AST parsing runs in a separate Worker and starts only after opening the AST
+  inspector.
+- Both WASM modules are bundled locally; the page makes no parser CDN request.
 - The Playground lints one in-memory JavaScript, TypeScript, JSX, or TSX file.
 - Rules that require filesystem access are reported as skipped.
 - Monaco is bundled locally; the page does not depend on a CDN.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -13,6 +13,7 @@
     "@evjs/ev": "0.3.16",
     "@monaco-editor/react": "4.7.0",
     "@utoo/lint-wasm": "workspace:*",
+    "@yuku-parser/wasm": "0.9.1",
     "monaco-editor": "0.56.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -18,6 +18,7 @@ await run(
     ),
     '--ignoreConfig',
     fileURLToPath(new URL('../src/features/lint/client.ts', import.meta.url)),
+    fileURLToPath(new URL('../src/features/ast/client.ts', import.meta.url)),
     fileURLToPath(
       new URL('../src/features/playground/model.ts', import.meta.url),
     ),
@@ -36,8 +37,22 @@ await run(
   { cwd: playgroundDirectory },
 );
 await writeFile(join(outputDirectory, 'package.json'), '{"type":"module"}');
+const compiledASTClient = join(outputDirectory, 'ast', 'client.js');
+await writeFile(
+  compiledASTClient,
+  (await readFile(compiledASTClient, 'utf8')).replace(
+    "from './protocol';",
+    "from './protocol.js';",
+  ),
+);
 const { LintWorkerClient } = await import(
   pathToFileURL(join(outputDirectory, 'lint', 'client.js')).href
+);
+const { ASTWorkerClient } = await import(
+  pathToFileURL(join(outputDirectory, 'ast', 'client.js')).href
+);
+const { AST_SOURCE_LENGTH_MAX } = await import(
+  pathToFileURL(join(outputDirectory, 'ast', 'protocol.js')).href
 );
 const {
   fileNameForLanguage,
@@ -143,8 +158,63 @@ test('can discard queued work before its debounce replacement is ready', async (
   );
 });
 
+test('coalesces queued AST work to the newest source', async (t) => {
+  MockWorker.instances = [];
+  globalThis.Worker = MockWorker;
+
+  const client = new ASTWorkerClient();
+  t.after(() => {
+    client.dispose();
+    delete globalThis.Worker;
+  });
+  const first = client.parse('first', 'index.ts');
+  void first.catch(() => {});
+  const superseded = client.parse('superseded', 'index.ts');
+  const supersededAssertion = assert.rejects(
+    superseded,
+    (error) =>
+      error?.name === 'AbortError' && /superseded/i.test(error.message),
+  );
+  const latest = client.parse('latest', 'index.ts');
+  void latest.catch(() => {});
+  const worker = MockWorker.instances[0];
+
+  assert.deepEqual(
+    worker.messages.map(({ source }) => source),
+    ['first'],
+  );
+  await supersededAssertion;
+
+  const firstResult = { diagnostics: [], elapsedMs: 1, program: {} };
+  worker.respond({ id: worker.messages[0].id, result: firstResult });
+  assert.equal(await first, firstResult);
+  assert.deepEqual(
+    worker.messages.map(({ source }) => source),
+    ['first', 'latest'],
+  );
+
+  const latestResult = { diagnostics: [], elapsedMs: 2, program: {} };
+  worker.respond({ id: worker.messages[1].id, result: latestResult });
+  assert.equal(await latest, latestResult);
+});
+
+test('rejects oversized AST input before starting a worker', async () => {
+  MockWorker.instances = [];
+  globalThis.Worker = MockWorker;
+
+  const client = new ASTWorkerClient();
+  await assert.rejects(
+    client.parse('x'.repeat(AST_SOURCE_LENGTH_MAX + 1), 'index.ts'),
+    (error) => error?.name === 'RangeError' && /exceeds/i.test(error.message),
+  );
+  assert.equal(MockWorker.instances.length, 0);
+  client.dispose();
+  delete globalThis.Worker;
+});
+
 test('fixes every diagnostic in each default Playground fixture', async () => {
   const { createUtooLint } = await import('@utoo/lint-wasm');
+  const { langFromPath, parse } = await import('@yuku-parser/wasm');
   const linter = await createUtooLint();
 
   for (const [language, source] of Object.entries(INITIAL_SOURCES)) {
@@ -169,5 +239,14 @@ test('fixes every diagnostic in each default Playground fixture', async () => {
       [],
       `${language} should be clean after one Fix all action`,
     );
+
+    const ast = parse(source, {
+      lang: langFromPath(options.filePath),
+      preserveParens: true,
+      sourceType: 'module',
+    });
+    assert.equal(ast.program.type, 'Program');
+    assert.equal(ast.program.start, 0);
+    assert.equal(ast.program.end, source.length);
   }
 });

--- a/apps/playground/scripts/verify-dist.mjs
+++ b/apps/playground/scripts/verify-dist.mjs
@@ -40,13 +40,36 @@ for (const fileName of requiredFiles) {
 
 const files = await collectFiles(clientDir);
 const wasmFiles = files.filter((file) => path.extname(file) === '.wasm');
-if (wasmFiles.length !== 1) {
-  throw new Error(`expected one WebAssembly asset, found ${wasmFiles.length}`);
+if (wasmFiles.length !== 2) {
+  throw new Error(`expected two WebAssembly assets, found ${wasmFiles.length}`);
 }
 
-const wasm = await readFile(wasmFiles[0]);
-if (wasm.length === 0 || !wasm.subarray(0, 4).equals(Buffer.from([0, 97, 115, 109]))) {
-  throw new Error('invalid WebAssembly asset');
+const wasmAssets = new Map();
+for (const file of wasmFiles) {
+  const name = path.basename(file);
+  const kind = name.includes('utoo-lint')
+    ? 'lint'
+    : name.includes('yuku-parser')
+      ? 'parser'
+      : undefined;
+  if (!kind || wasmAssets.has(kind)) {
+    throw new Error(`unexpected WebAssembly asset: ${name}`);
+  }
+
+  const contents = await readFile(file);
+  if (
+    contents.length === 0 ||
+    !contents.subarray(0, 4).equals(Buffer.from([0, 97, 115, 109]))
+  ) {
+    throw new Error(`invalid WebAssembly asset: ${name}`);
+  }
+  wasmAssets.set(kind, contents);
+}
+
+for (const kind of ['lint', 'parser']) {
+  if (!wasmAssets.has(kind)) {
+    throw new Error(`missing ${kind} WebAssembly asset`);
+  }
 }
 
 const deployment = JSON.parse(
@@ -106,7 +129,9 @@ for (const file of files) {
   }
 }
 
-const wasmSize = (wasm.length / 1024 / 1024).toFixed(1);
+const wasmSizes = [...wasmAssets]
+  .map(([kind, contents]) => `${kind} ${(contents.length / 1024 / 1024).toFixed(1)} MiB`)
+  .join(', ');
 console.log(
-  `verified static EVJS deployment (${files.length} files, ${wasmSize} MiB wasm)`,
+  `verified static EVJS deployment (${files.length} files, ${wasmSizes})`,
 );

--- a/apps/playground/src/features/ast/ast.worker.ts
+++ b/apps/playground/src/features/ast/ast.worker.ts
@@ -1,0 +1,59 @@
+/// <reference lib="webworker" />
+
+import {
+  AST_SOURCE_LENGTH_MAX,
+  normalizeASTWorkerError,
+  type ASTWorkerRequest,
+  type ASTWorkerResponse,
+} from './protocol';
+
+const workerScope = self as unknown as DedicatedWorkerGlobalScope;
+let parserPromise: Promise<typeof import('@yuku-parser/wasm')> | undefined;
+
+function getParser() {
+  if (!parserPromise) {
+    const candidate = import('@yuku-parser/wasm');
+    parserPromise = candidate;
+    void candidate.catch(() => {
+      if (parserPromise === candidate) parserPromise = undefined;
+    });
+  }
+
+  return parserPromise;
+}
+
+workerScope.onmessage = async ({ data }: MessageEvent<ASTWorkerRequest>) => {
+  const { filePath, id, source } = data;
+
+  try {
+    if (source.length > AST_SOURCE_LENGTH_MAX) {
+      throw new RangeError(
+        `AST input exceeds ${AST_SOURCE_LENGTH_MAX.toLocaleString()} characters`,
+      );
+    }
+
+    const { langFromPath, parse, sourceTypeFromPath } = await getParser();
+    const startedAt = performance.now();
+    const parsed = parse(source, {
+      attachComments: false,
+      lang: langFromPath(filePath),
+      preserveParens: true,
+      semanticErrors: false,
+      sourceType: sourceTypeFromPath(filePath),
+    });
+
+    workerScope.postMessage({
+      id,
+      result: {
+        diagnostics: parsed.diagnostics,
+        elapsedMs: performance.now() - startedAt,
+        program: parsed.program,
+      },
+    } satisfies ASTWorkerResponse);
+  } catch (error) {
+    workerScope.postMessage({
+      error: normalizeASTWorkerError(error),
+      id,
+    } satisfies ASTWorkerResponse);
+  }
+};

--- a/apps/playground/src/features/ast/client.ts
+++ b/apps/playground/src/features/ast/client.ts
@@ -1,0 +1,156 @@
+import {
+  AST_SOURCE_LENGTH_MAX,
+  type ASTParseResult,
+  type ASTWorkerError,
+  type ASTWorkerRequest,
+  type ASTWorkerResponse,
+} from './protocol';
+
+interface PendingRequest {
+  reject: (error: ASTClientError) => void;
+  request: ASTWorkerRequest;
+  resolve: (result: ASTParseResult) => void;
+}
+
+const SUPERSEDED_REQUEST: ASTWorkerError = {
+  message: 'The AST request was superseded by newer source',
+  name: 'AbortError',
+};
+
+export class ASTClientError extends Error {
+  constructor(error: ASTWorkerError) {
+    super(error.message);
+    this.name = error.name;
+  }
+}
+
+export class ASTWorkerClient {
+  #active: PendingRequest | undefined;
+  #nextId = 1;
+  #queued: PendingRequest | undefined;
+  #worker: Worker | undefined;
+
+  parse(source: string, filePath: string): Promise<ASTParseResult> {
+    if (source.length > AST_SOURCE_LENGTH_MAX) {
+      return Promise.reject(
+        new ASTClientError({
+          message: `AST input exceeds ${AST_SOURCE_LENGTH_MAX.toLocaleString()} characters`,
+          name: 'RangeError',
+        }),
+      );
+    }
+
+    const request = {
+      filePath,
+      id: this.#nextId++,
+      source,
+    } satisfies ASTWorkerRequest;
+
+    return new Promise((resolve, reject) => {
+      const pending = { reject, request, resolve } satisfies PendingRequest;
+
+      if (this.#active) {
+        this.cancelQueued();
+        this.#queued = pending;
+        return;
+      }
+
+      this.#start(pending);
+    });
+  }
+
+  cancelQueued(): void {
+    const queued = this.#queued;
+    if (!queued) return;
+
+    this.#queued = undefined;
+    queued.reject(new ASTClientError(SUPERSEDED_REQUEST));
+  }
+
+  dispose(): void {
+    this.#worker?.terminate();
+    this.#worker = undefined;
+    this.#rejectAll({
+      message: 'The AST worker was disposed',
+      name: 'AbortError',
+    });
+  }
+
+  #getWorker(): Worker {
+    if (this.#worker) return this.#worker;
+
+    const worker = new Worker(new URL('./ast.worker.ts', import.meta.url), {
+      name: 'utoo-lint-ast',
+      type: 'module',
+    });
+
+    worker.onmessage = ({ data }: MessageEvent<ASTWorkerResponse>) => {
+      const active = this.#active;
+      if (!active || active.request.id !== data.id) return;
+
+      this.#active = undefined;
+      if ('error' in data) {
+        active.reject(new ASTClientError(data.error));
+      } else {
+        active.resolve(data.result);
+      }
+      this.#startQueued();
+    };
+
+    worker.onerror = ({ message }) => {
+      if (this.#worker !== worker) return;
+      worker.terminate();
+      this.#worker = undefined;
+      this.#rejectAll({
+        message: message || 'The AST worker failed to load',
+        name: 'WorkerError',
+      });
+    };
+
+    worker.onmessageerror = () => {
+      if (this.#worker !== worker) return;
+      worker.terminate();
+      this.#worker = undefined;
+      this.#rejectAll({
+        message: 'The AST worker returned an unreadable response',
+        name: 'DataCloneError',
+      });
+    };
+
+    this.#worker = worker;
+    return worker;
+  }
+
+  #start(pending: PendingRequest): void {
+    this.#active = pending;
+
+    try {
+      this.#getWorker().postMessage(pending.request);
+    } catch (error) {
+      this.#worker?.terminate();
+      this.#worker = undefined;
+      this.#rejectAll({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Unable to send source to the AST worker',
+        name: error instanceof Error ? error.name : 'WorkerError',
+      });
+    }
+  }
+
+  #startQueued(): void {
+    const queued = this.#queued;
+    if (this.#active || !queued) return;
+
+    this.#queued = undefined;
+    this.#start(queued);
+  }
+
+  #rejectAll(error: ASTWorkerError): void {
+    this.#active?.reject(new ASTClientError(error));
+    this.#queued?.reject(new ASTClientError(error));
+    this.#active = undefined;
+    this.#queued = undefined;
+  }
+}

--- a/apps/playground/src/features/ast/protocol.ts
+++ b/apps/playground/src/features/ast/protocol.ts
@@ -1,0 +1,35 @@
+import type { Diagnostic, Program } from '@yuku-parser/wasm';
+
+export const AST_SOURCE_LENGTH_MAX = 256 * 1024;
+
+export interface ASTParseResult {
+  diagnostics: Diagnostic[];
+  elapsedMs: number;
+  program: Program;
+}
+
+export interface ASTWorkerRequest {
+  filePath: string;
+  id: number;
+  source: string;
+}
+
+export interface ASTWorkerError {
+  message: string;
+  name: string;
+}
+
+export type ASTWorkerResponse =
+  | { id: number; result: ASTParseResult }
+  | { error: ASTWorkerError; id: number };
+
+export function normalizeASTWorkerError(error: unknown): ASTWorkerError {
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name };
+  }
+
+  return {
+    message: typeof error === 'string' ? error : 'Unknown AST parser error',
+    name: 'Error',
+  };
+}

--- a/apps/playground/src/features/ast/tree.tsx
+++ b/apps/playground/src/features/ast/tree.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+
+const OPEN_DEPTH = 3;
+const MAX_BRANCH_CHILDREN = 1_000;
+const MAX_TREE_DEPTH = 96;
+const MAX_STRING_LENGTH = 240;
+
+interface ASTTreeProps {
+  onSelect(start: number, end: number): void;
+  program: unknown;
+}
+
+interface ASTValueProps {
+  depth: number;
+  name: string | null;
+  onSelect(start: number, end: number): void;
+  path: string;
+  value: unknown;
+}
+
+interface ASTNodeRecord extends Record<string, unknown> {
+  end?: number;
+  start?: number;
+  type: string;
+}
+
+function isBranch(value: unknown): value is unknown[] | Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !(value instanceof RegExp)
+  );
+}
+
+function isASTNode(value: unknown): value is ASTNodeRecord {
+  return (
+    isBranch(value) &&
+    !Array.isArray(value) &&
+    typeof value.type === 'string'
+  );
+}
+
+function ASTLeaf({ name, value }: Pick<ASTValueProps, 'name' | 'value'>) {
+  let className = 'ast-null';
+  let text = 'null';
+
+  if (typeof value === 'string') {
+    className = 'ast-str';
+    const clipped =
+      value.length > MAX_STRING_LENGTH
+        ? `${value.slice(0, MAX_STRING_LENGTH)}…`
+        : value;
+    text = JSON.stringify(clipped);
+  } else if (typeof value === 'number' || typeof value === 'bigint') {
+    className = 'ast-num';
+    text = typeof value === 'bigint' ? `${value}n` : String(value);
+  } else if (typeof value === 'boolean') {
+    className = 'ast-bool';
+    text = String(value);
+  } else if (value instanceof RegExp) {
+    className = 'ast-str';
+    text = String(value);
+  } else if (value === undefined) {
+    className = 'ast-null';
+    text = 'undefined';
+  }
+
+  return (
+    <div className="ast-row">
+      {name !== null && <span className="ast-key">{name}: </span>}
+      <span className={className}>{text}</span>
+    </div>
+  );
+}
+
+function ASTEmpty({ name, text }: { name: string | null; text: string }) {
+  return (
+    <div className="ast-row">
+      {name !== null && <span className="ast-key">{name}: </span>}
+      <span className="ast-meta">{text}</span>
+    </div>
+  );
+}
+
+function ASTBranch({
+  depth,
+  name,
+  onSelect,
+  path,
+  value,
+}: ASTValueProps & { value: unknown[] | Record<string, unknown> }) {
+  const [open, setOpen] = useState(depth < OPEN_DEPTH);
+  const node = isASTNode(value) ? value : undefined;
+  const entries = Array.isArray(value)
+    ? value.map((item, index) => [String(index), item] as const)
+    : Object.entries(value).filter(
+        ([key]) => !node || !['type', 'start', 'end'].includes(key),
+      );
+  const visibleEntries = entries.slice(0, MAX_BRANCH_CHILDREN);
+
+  const selectNode = () => {
+    if (
+      node &&
+      typeof node.start === 'number' &&
+      typeof node.end === 'number'
+    ) {
+      onSelect(node.start, node.end);
+    }
+  };
+
+  return (
+    <details
+      className="ast-branch"
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+      open={open}
+    >
+      <summary onClick={selectNode}>
+        {name !== null && <span className="ast-key">{name}: </span>}
+        {Array.isArray(value) && (
+          <span className="ast-meta">[{value.length}]</span>
+        )}
+        {node && (
+          <>
+            <span className="ast-type">{node.type}</span>
+            {typeof node.start === 'number' && typeof node.end === 'number' && (
+              <span className="ast-span">
+                {' '}
+                {node.start}:{node.end}
+              </span>
+            )}
+          </>
+        )}
+        {!Array.isArray(value) && !node && (
+          <span className="ast-meta">{'{}'}</span>
+        )}
+      </summary>
+
+      {open && (
+        <div className="ast-body">
+          {depth >= MAX_TREE_DEPTH ? (
+            <div className="ast-row ast-limit">Maximum tree depth reached</div>
+          ) : (
+            visibleEntries.map(([key, child]) => (
+              <ASTValue
+                depth={depth + 1}
+                key={`${path}/${key}`}
+                name={key}
+                onSelect={onSelect}
+                path={`${path}/${key}`}
+                value={child}
+              />
+            ))
+          )}
+          {entries.length > visibleEntries.length && (
+            <div className="ast-row ast-limit">
+              {entries.length - visibleEntries.length} more entries
+            </div>
+          )}
+        </div>
+      )}
+    </details>
+  );
+}
+
+function ASTValue(props: ASTValueProps) {
+  if (isBranch(props.value)) {
+    if (Array.isArray(props.value) && props.value.length === 0) {
+      return <ASTEmpty name={props.name} text="[]" />;
+    }
+    if (!Array.isArray(props.value) && Object.keys(props.value).length === 0) {
+      return <ASTEmpty name={props.name} text="{}" />;
+    }
+    return <ASTBranch {...props} value={props.value} />;
+  }
+
+  return <ASTLeaf name={props.name} value={props.value} />;
+}
+
+export function ASTTree({ onSelect, program }: ASTTreeProps) {
+  return (
+    <div className="ast-tree">
+      <ASTValue
+        depth={0}
+        name={null}
+        onSelect={onSelect}
+        path="ast"
+        value={program}
+      />
+    </div>
+  );
+}

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -12,6 +12,9 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import utooRabbitUrl from '../../../../assets/utoo-lint-mark-gpt.png';
+import { ASTWorkerClient } from '../features/ast/client';
+import type { ASTParseResult } from '../features/ast/protocol';
+import { ASTTree } from '../features/ast/tree';
 import { LintWorkerClient } from '../features/lint/client';
 import {
   diagnosticLabel,
@@ -30,12 +33,15 @@ import '../style.css';
 
 type EditorInstance = Parameters<OnMount>[0];
 type MonacoInstance = Parameters<OnMount>[1];
+type InspectorMode = 'ast' | 'rules';
 type RulesMode = 'recommended' | 'custom';
+type ASTPhase = 'idle' | 'running' | 'ready' | 'error';
 type RunPhase = 'idle' | 'running' | 'ready' | 'error';
 
 const EDITOR_THEME = 'utoo-dark';
 const DEFAULT_EDITOR_RATIO = 68;
 const DEFAULT_RULES_RATIO = 42;
+const INSPECTOR_MODES = ['rules', 'ast'] as const;
 
 interface RunState {
   phase: RunPhase;
@@ -44,7 +50,15 @@ interface RunState {
   elapsedMs?: number;
 }
 
+interface ASTState {
+  message?: string;
+  phase: ASTPhase;
+  result?: ASTParseResult;
+  revision: number;
+}
+
 const EMPTY_RUN_STATE: RunState = { phase: 'idle' };
+const EMPTY_AST_STATE: ASTState = { phase: 'idle', revision: 0 };
 
 function defineEditorTheme(monaco: MonacoInstance): void {
   monaco.editor.defineTheme(EDITOR_THEME, {
@@ -87,20 +101,26 @@ export default function PlaygroundPage() {
     useState<PlaygroundLanguage>('typescript');
   const [sources, setSources] =
     useState<Record<PlaygroundLanguage, string>>(INITIAL_SOURCES);
+  const [inspectorMode, setInspectorMode] =
+    useState<InspectorMode>('rules');
   const [rulesMode, setRulesMode] = useState<RulesMode>('custom');
   const [rulesSource, setRulesSource] = useState(INITIAL_RULES);
   const [runState, setRunState] = useState<RunState>(EMPTY_RUN_STATE);
+  const [astState, setASTState] = useState<ASTState>(EMPTY_AST_STATE);
   const editorRef = useRef<EditorInstance | null>(null);
   const monacoRef = useRef<MonacoInstance | null>(null);
+  const astClientRef = useRef<ASTWorkerClient | null>(null);
   const clientRef = useRef<LintWorkerClient | null>(null);
   const workspaceRef = useRef<HTMLElement | null>(null);
   const sidePanelRef = useRef<HTMLElement | null>(null);
   const languageTabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const latestASTRequestRef = useRef(0);
   const latestRequestRef = useRef(0);
   const [editorRatio, setEditorRatio] = useState(DEFAULT_EDITOR_RATIO);
   const [rulesRatio, setRulesRatio] = useState(DEFAULT_RULES_RATIO);
 
   if (!clientRef.current) clientRef.current = new LintWorkerClient();
+  if (!astClientRef.current) astClientRef.current = new ASTWorkerClient();
 
   const parsedRules = useMemo(() => parseRules(rulesSource), [rulesSource]);
   const source = sources[language];
@@ -171,8 +191,43 @@ export default function PlaygroundPage() {
   }, [execute]);
 
   useEffect(() => {
+    if (inspectorMode !== 'ast') return;
+
+    const requestId = ++latestASTRequestRef.current;
+    astClientRef.current?.cancelQueued();
+    setASTState({ phase: 'idle', revision: requestId });
+    const timeout = window.setTimeout(() => {
+      setASTState({ phase: 'running', revision: requestId });
+      void astClientRef.current
+        ?.parse(source, fileName)
+        .then((result) => {
+          if (requestId !== latestASTRequestRef.current) return;
+          setASTState({ phase: 'ready', result, revision: requestId });
+        })
+        .catch((error: unknown) => {
+          if (requestId !== latestASTRequestRef.current) return;
+          setASTState({
+            message: error instanceof Error ? error.message : 'AST parsing failed.',
+            phase: 'error',
+            revision: requestId,
+          });
+        });
+    }, 220);
+
     return () => {
+      window.clearTimeout(timeout);
+      if (latestASTRequestRef.current === requestId) {
+        latestASTRequestRef.current += 1;
+      }
+      astClientRef.current?.cancelQueued();
+    };
+  }, [fileName, inspectorMode, source]);
+
+  useEffect(() => {
+    return () => {
+      latestASTRequestRef.current += 1;
       latestRequestRef.current += 1;
+      astClientRef.current?.dispose();
       clientRef.current?.dispose();
     };
   }, []);
@@ -245,6 +300,23 @@ export default function PlaygroundPage() {
     editor.focus();
   };
 
+  const revealASTNode = (start: number, end: number) => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!editor || !model) return;
+
+    const startPosition = model.getPositionAt(start);
+    const endPosition = model.getPositionAt(end);
+    const range = {
+      endColumn: endPosition.column,
+      endLineNumber: endPosition.lineNumber,
+      startColumn: startPosition.column,
+      startLineNumber: startPosition.lineNumber,
+    };
+    editor.setSelection(range);
+    editor.revealRangeInCenter(range);
+  };
+
   const selectLanguage = (nextLanguage: PlaygroundLanguage) => {
     setRunState(EMPTY_RUN_STATE);
     setLanguage(nextLanguage);
@@ -276,6 +348,36 @@ export default function PlaygroundPage() {
     event.preventDefault();
     selectLanguage(LANGUAGES[nextIndex].id);
     languageTabRefs.current[nextIndex]?.focus();
+  };
+
+  const handleInspectorTabKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    let nextIndex: number;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (index + 1) % INSPECTOR_MODES.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (index - 1 + INSPECTOR_MODES.length) %
+          INSPECTOR_MODES.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = INSPECTOR_MODES.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    setInspectorMode(INSPECTOR_MODES[nextIndex]);
+    const tabs = event.currentTarget.parentElement?.querySelectorAll('button');
+    tabs?.[nextIndex]?.focus();
   };
 
   const fixableCount = diagnostics.filter(
@@ -480,61 +582,164 @@ export default function PlaygroundPage() {
           style={{ '--rules-ratio': `${rulesRatio}%` } as CSSProperties}
         >
           <section
-            aria-labelledby="rules-panel-title"
+            aria-label="Source inspector"
             className="rules-section"
             id="rules-panel"
           >
             <div className="panel-heading rules-heading">
-              <h2 className="panel-title" id="rules-panel-title">
-                Rules
-              </h2>
-              <div className="segmented-control">
+              <div
+                aria-label="Inspector view"
+                className="inspector-tabs"
+                role="tablist"
+              >
                 <button
-                  aria-pressed={rulesMode === 'recommended'}
-                  className={rulesMode === 'recommended' ? 'is-active' : undefined}
-                  onClick={() => {
-                    setRunState(EMPTY_RUN_STATE);
-                    setRulesMode('recommended');
-                  }}
+                  aria-controls="rules-config-panel"
+                  aria-selected={inspectorMode === 'rules'}
+                  className={inspectorMode === 'rules' ? 'is-active' : undefined}
+                  id="inspector-tab-rules"
+                  onClick={() => setInspectorMode('rules')}
+                  onKeyDown={(event) => handleInspectorTabKeyDown(event, 0)}
+                  role="tab"
+                  tabIndex={inspectorMode === 'rules' ? 0 : -1}
                   type="button"
                 >
-                  Recommended
+                  Rules
                 </button>
                 <button
-                  aria-pressed={rulesMode === 'custom'}
-                  className={rulesMode === 'custom' ? 'is-active' : undefined}
-                  onClick={() => {
-                    setRunState(EMPTY_RUN_STATE);
-                    setRulesMode('custom');
-                  }}
+                  aria-controls="ast-panel"
+                  aria-selected={inspectorMode === 'ast'}
+                  className={inspectorMode === 'ast' ? 'is-active' : undefined}
+                  id="inspector-tab-ast"
+                  onClick={() => setInspectorMode('ast')}
+                  onKeyDown={(event) => handleInspectorTabKeyDown(event, 1)}
+                  role="tab"
+                  tabIndex={inspectorMode === 'ast' ? 0 : -1}
                   type="button"
                 >
-                  Custom
+                  AST
                 </button>
               </div>
+
+              {inspectorMode === 'rules' ? (
+                <div className="segmented-control">
+                  <button
+                    aria-pressed={rulesMode === 'recommended'}
+                    className={
+                      rulesMode === 'recommended' ? 'is-active' : undefined
+                    }
+                    onClick={() => {
+                      setRunState(EMPTY_RUN_STATE);
+                      setRulesMode('recommended');
+                    }}
+                    type="button"
+                  >
+                    Recommended
+                  </button>
+                  <button
+                    aria-pressed={rulesMode === 'custom'}
+                    className={rulesMode === 'custom' ? 'is-active' : undefined}
+                    onClick={() => {
+                      setRunState(EMPTY_RUN_STATE);
+                      setRulesMode('custom');
+                    }}
+                    type="button"
+                  >
+                    Custom
+                  </button>
+                </div>
+              ) : (
+                <span className="ast-status">
+                  {astState.phase === 'idle' && 'Queued'}
+                  {astState.phase === 'running' && 'Parsing…'}
+                  {astState.phase === 'ready' &&
+                    `${astState.result?.elapsedMs.toFixed(1)} ms`}
+                  {astState.phase === 'error' && 'Parse failed'}
+                </span>
+              )}
             </div>
-            <textarea
-              aria-describedby={rulesDescriptionId}
-              aria-invalid={hasCustomRulesError || undefined}
-              aria-label="Rule configuration JSON"
-              className={`rules-editor ${hasCustomRulesError ? 'has-error' : ''}`}
-              disabled={rulesMode === 'recommended'}
-              onChange={(event) => {
-                setRunState(EMPTY_RUN_STATE);
-                setRulesSource(event.target.value);
-              }}
-              spellCheck={false}
-              value={rulesMode === 'recommended' ? INITIAL_RULES : rulesSource}
-            />
-            {hasCustomRulesError && (
-              <p className="config-error" id="rules-config-error" role="alert">
-                {parsedRules.message}
-              </p>
-            )}
-            {rulesMode === 'recommended' && (
-              <p className="rules-note" id="rules-mode-note">
-                Using the Playground&apos;s curated browser-safe rule set.
-              </p>
+
+            {inspectorMode === 'rules' ? (
+              <div
+                aria-labelledby="inspector-tab-rules"
+                className="rules-config-panel"
+                id="rules-config-panel"
+                role="tabpanel"
+              >
+                <textarea
+                  aria-describedby={rulesDescriptionId}
+                  aria-invalid={hasCustomRulesError || undefined}
+                  aria-label="Rule configuration JSON"
+                  className={`rules-editor ${hasCustomRulesError ? 'has-error' : ''}`}
+                  disabled={rulesMode === 'recommended'}
+                  onChange={(event) => {
+                    setRunState(EMPTY_RUN_STATE);
+                    setRulesSource(event.target.value);
+                  }}
+                  spellCheck={false}
+                  value={
+                    rulesMode === 'recommended' ? INITIAL_RULES : rulesSource
+                  }
+                />
+                {hasCustomRulesError && (
+                  <p
+                    className="config-error"
+                    id="rules-config-error"
+                    role="alert"
+                  >
+                    {parsedRules.message}
+                  </p>
+                )}
+                {rulesMode === 'recommended' && (
+                  <p className="rules-note" id="rules-mode-note">
+                    Using the Playground&apos;s curated browser-safe rule set.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div
+                aria-busy={
+                  astState.phase === 'idle' || astState.phase === 'running'
+                }
+                aria-labelledby="inspector-tab-ast"
+                className="ast-panel"
+                id="ast-panel"
+                role="tabpanel"
+              >
+                {astState.phase === 'error' && (
+                  <div className="empty-state error-state" role="alert">
+                    <strong>Unable to parse AST</strong>
+                    <span>{astState.message}</span>
+                  </div>
+                )}
+                {(astState.phase === 'idle' ||
+                  astState.phase === 'running') && (
+                  <div className="empty-state ast-loading-state">
+                    <span className="loading-icon" aria-hidden="true">
+                      ···
+                    </span>
+                    <strong>
+                      {astState.phase === 'idle'
+                        ? 'AST queued'
+                        : 'Parsing AST…'}
+                    </strong>
+                  </div>
+                )}
+                {astState.phase === 'ready' && astState.result && (
+                  <>
+                    {astState.result.diagnostics.length > 0 && (
+                      <div className="ast-diagnostic-note">
+                        {astState.result.diagnostics.length} parser diagnostic
+                        {astState.result.diagnostics.length === 1 ? '' : 's'}
+                      </div>
+                    )}
+                    <ASTTree
+                      key={astState.revision}
+                      onSelect={revealASTNode}
+                      program={astState.result.program}
+                    />
+                  </>
+                )}
+              </div>
             )}
           </section>
 

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -170,6 +170,7 @@ textarea:focus-visible {
 }
 
 .language-tabs button,
+.inspector-tabs button,
 .segmented-control button {
   border: 0;
   color: var(--muted);
@@ -187,6 +188,7 @@ textarea:focus-visible {
 }
 
 .language-tabs button:hover,
+.inspector-tabs button:hover,
 .segmented-control button:hover {
   color: var(--text);
 }
@@ -360,7 +362,7 @@ textarea:focus-visible {
 }
 
 .rules-section {
-  grid-template-rows: 40px minmax(0, 1fr) auto;
+  grid-template-rows: 40px minmax(0, 1fr);
 }
 
 .pane-splitter {
@@ -416,6 +418,24 @@ textarea:focus-visible {
   gap: 12px;
 }
 
+.inspector-tabs {
+  display: flex;
+  align-self: stretch;
+  gap: 18px;
+}
+
+.inspector-tabs button {
+  padding: 0;
+  border-bottom: 2px solid transparent;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.inspector-tabs button.is-active {
+  border-bottom-color: var(--accent);
+  color: var(--text-strong);
+}
+
 .segmented-control {
   align-self: stretch;
   gap: 12px;
@@ -430,6 +450,13 @@ textarea:focus-visible {
 .segmented-control button.is-active {
   border-bottom-color: var(--accent);
   color: var(--text);
+}
+
+.rules-config-panel {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: minmax(0, 1fr) auto;
 }
 
 .rules-editor {
@@ -464,6 +491,125 @@ textarea:focus-visible {
   border-top: 1px solid var(--line-muted);
   font-size: 11px;
   line-height: 1.45;
+}
+
+.ast-status {
+  color: var(--muted-subtle);
+  font-size: 11px;
+  font-weight: 450;
+  font-variant-numeric: tabular-nums;
+}
+
+.ast-panel {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  color: var(--text);
+  background: var(--canvas);
+  scrollbar-color: #484f58 transparent;
+  scrollbar-width: thin;
+}
+
+.ast-loading-state {
+  min-height: 100%;
+}
+
+.ast-diagnostic-note {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--line-muted);
+  color: var(--warning);
+  background: var(--surface);
+  font-size: 11px;
+}
+
+.ast-tree {
+  min-width: max-content;
+  padding: 10px 14px 18px;
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.ast-tree details {
+  width: max-content;
+  min-width: 100%;
+}
+
+.ast-tree summary {
+  padding: 1px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+  list-style: none;
+  white-space: pre;
+}
+
+.ast-tree summary::-webkit-details-marker {
+  display: none;
+}
+
+.ast-tree summary::before {
+  display: inline-block;
+  width: 1.1em;
+  color: var(--muted-subtle);
+  content: "\25B8";
+  transition: transform 120ms ease;
+}
+
+.ast-tree details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.ast-tree summary:hover,
+.ast-tree summary:focus-visible {
+  background: var(--surface-hover);
+}
+
+.ast-tree summary:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.ast-body {
+  margin-left: 0.65em;
+  padding-left: 0.95em;
+  border-left: 1px solid var(--line);
+}
+
+.ast-row {
+  padding-block: 1px;
+  padding-left: 1.1em;
+  white-space: pre;
+}
+
+.ast-type {
+  color: #79c0ff;
+}
+
+.ast-key {
+  color: #d2a8ff;
+}
+
+.ast-str {
+  color: #a5d6ff;
+}
+
+.ast-num {
+  color: #79c0ff;
+}
+
+.ast-bool,
+.ast-null {
+  color: #ff7b72;
+}
+
+.ast-span,
+.ast-meta,
+.ast-limit {
+  color: var(--muted-subtle);
 }
 
 .config-error {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@utoo/lint-wasm':
         specifier: workspace:*
         version: link:../../npm/@utoo/lint-wasm
+      '@yuku-parser/wasm':
+        specifier: 0.9.1
+        version: 0.9.1
       monaco-editor:
         specifier: 0.56.0
         version: 0.56.0
@@ -927,6 +930,12 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@yuku-parser/wasm@0.9.1':
+    resolution: {integrity: sha512-/LDyPG/jNGZ2OSvVR2PDODop2076FsFx6SGqIgAjLiVw4uLIMGUQ1R0GSfO6jdFPgvxIXZhqONdoh0A9VP8Eyg==}
+
+  '@yuku-toolchain/types@0.9.1':
+    resolution: {integrity: sha512-GhfAIaKmtC4fCKJVnzP6bdGhWZSd7U9Sk7/lexEfROQPDNzuFE9lZKrcIWqzgGVcIMqKvtvFxnfEIaZ5WiroyQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2164,6 +2173,9 @@ packages:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
 
+  yuku-ast@0.9.1:
+    resolution: {integrity: sha512-JN45kc3sxzv/bDGug063IsIHu6LTkL1vDQUL/m1zvIFBIvMRtYivyRp5LjtMbZtIWnNjV6jaAvHPA1f70yD6gg==}
+
 snapshots:
 
   '@babel/code-frame@7.22.5':
@@ -2925,6 +2937,13 @@ snapshots:
 
   '@xtuc/long@4.2.2':
     optional: true
+
+  '@yuku-parser/wasm@0.9.1':
+    dependencies:
+      '@yuku-toolchain/types': 0.9.1
+      yuku-ast: 0.9.1
+
+  '@yuku-toolchain/types@0.9.1': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -4049,3 +4068,7 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors@2.2.0: {}
+
+  yuku-ast@0.9.1:
+    dependencies:
+      '@yuku-toolchain/types': 0.9.1


### PR DESCRIPTION
## Summary

- add a Yuku-style AST inspector beside Rules for TypeScript, JavaScript, TSX, and JSX sources
- parse with public `@yuku-parser/wasm@0.9.1`, matching the repository's vendored Yuku revision, in a dedicated lazy Web Worker
- render a bounded, collapsible tree and select the corresponding Monaco source range when an AST node is clicked
- keep parser assets local with no runtime CDN dependency, and verify both lint and parser WASM assets in the static deployment audit

## Test Plan

- [x] `pnpm playground:typecheck`
- [x] `pnpm --filter @utoo/lint-playground test`
- [x] `pnpm --filter @utoo/lint-playground inspect`
- [x] `pnpm playground:build`
- [x] `pnpm audit --prod --audit-level high`
- [x] verify the parser WASM is not requested before opening AST
- [x] verify AST parsing, tree expansion, keyboard tab navigation, and source-range selection in Chrome
- [x] verify the page reports no browser runtime exceptions
