### PR TITLE
fix: refine playground toolbar spacing

### DIFF
--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -524,59 +524,61 @@ export default function PlaygroundPage() {
               `Lint failed${runState.message ? `: ${runState.message}` : '.'}`}
           </span>
 
-          <span aria-hidden="true" className="toolbar-divider" />
-
-          <button
-            aria-label={fixButtonLabel}
-            className="fix-button"
-            disabled={isRetry ? !hasValidRules : !canFix}
-            onClick={() => void execute(isRetry ? 'lint' : 'fix')}
-            title={fixButtonLabel}
-            type="button"
-          >
-            {fixButtonText}
-          </button>
-
-          <label className="version-control">
-            <span className="visually-hidden">Utoo Lint version</span>
-            <select
-              aria-label="Utoo Lint version"
-              onChange={(event) => selectLintVersion(event.target.value)}
-              value={lintVersion}
+          <div className="control-actions">
+            <button
+              aria-label={fixButtonLabel}
+              className="fix-button"
+              disabled={isRetry ? !hasValidRules : !canFix}
+              onClick={() => void execute(isRetry ? 'lint' : 'fix')}
+              title={fixButtonLabel}
+              type="button"
             >
-              {LINT_VERSIONS.map((version) => (
-                <option key={version.id} value={version.id}>
-                  {version.label}
-                </option>
-              ))}
-            </select>
-          </label>
+              {fixButtonText}
+            </button>
 
-          <button
-            aria-label="Share this playground"
-            className="share-button"
-            onClick={() => void sharePlayground()}
-            type="button"
-          >
-            <span aria-live="polite">
-              {shareState === 'idle' && 'Share'}
-              {shareState === 'copied' && 'Copied'}
-              {shareState === 'error' && 'Copy failed'}
-            </span>
-          </button>
+            <label className="version-control">
+              <span className="version-control-label">Version</span>
+              <span className="version-select-wrap">
+                <select
+                  aria-label="Utoo Lint version"
+                  onChange={(event) => selectLintVersion(event.target.value)}
+                  value={lintVersion}
+                >
+                  {LINT_VERSIONS.map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.label}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
 
-          <a
-            aria-label="Open utoo-lint on GitHub (opens in a new tab)"
-            className="github-link"
-            href="https://github.com/utooland/utoo-lint"
-            target="_blank"
-            rel="noreferrer"
-          >
-            GitHub
-            <span aria-hidden="true" className="external-mark">
-              ↗
-            </span>
-          </a>
+            <button
+              aria-label="Share this playground"
+              className="share-button"
+              onClick={() => void sharePlayground()}
+              type="button"
+            >
+              <span aria-live="polite">
+                {shareState === 'idle' && 'Share'}
+                {shareState === 'copied' && 'Copied'}
+                {shareState === 'error' && 'Copy failed'}
+              </span>
+            </button>
+
+            <a
+              aria-label="Open utoo-lint on GitHub (opens in a new tab)"
+              className="github-link"
+              href="https://github.com/utooland/utoo-lint"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub
+              <span aria-hidden="true" className="external-mark">
+                ↗
+              </span>
+            </a>
+          </div>
         </section>
       </header>
 

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -247,6 +247,11 @@ select:focus-visible {
   background: rgba(255, 255, 255, 0.06);
 }
 
+.version-control:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .version-control:hover select,
 .version-control:focus-within select {
   color: var(--text-strong);
@@ -1252,6 +1257,13 @@ select:focus-visible {
 }
 
 @media (max-width: 430px) {
+  .control-actions {
+    flex-wrap: wrap;
+    row-gap: 8px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
   .run-duration {
     display: none;
   }

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -138,17 +138,25 @@ select:focus-visible {
   align-items: center;
   gap: 4px;
   margin-left: 2px;
-  padding: 0 8px;
+  padding: 0 5px;
   color: var(--muted);
   font-size: 11px;
   font-weight: 500;
   text-decoration: none;
 }
 
+.control-actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 14px;
+  margin-left: 24px;
+}
+
 .version-control,
 .share-button {
   display: inline-flex;
-  min-height: 30px;
+  min-height: 34px;
   flex: none;
   align-items: center;
   justify-content: center;
@@ -167,26 +175,44 @@ select:focus-visible {
 
 .version-control {
   position: relative;
-  min-width: 70px;
-  margin-left: 3px;
+  min-width: 128px;
+  gap: 9px;
+  padding: 0 9px 0 10px;
 }
 
-.version-control::after {
+.version-control-label {
+  color: var(--muted-subtle);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.version-select-wrap {
+  position: relative;
+  display: inline-flex;
+  min-width: 54px;
+  align-items: center;
+}
+
+.version-select-wrap::after {
   position: absolute;
   top: 50%;
-  right: 8px;
-  color: var(--muted-subtle);
-  content: "⌄";
-  font-size: 11px;
-  line-height: 1;
+  right: 1px;
+  width: 5px;
+  height: 5px;
+  border-right: 1px solid var(--muted-subtle);
+  border-bottom: 1px solid var(--muted-subtle);
+  content: "";
   pointer-events: none;
-  transform: translateY(-62%);
+  transform: translateY(-70%) rotate(45deg);
 }
 
 .version-control select {
   width: 100%;
-  min-height: 28px;
-  padding: 0 24px 0 8px;
+  min-height: 32px;
+  padding: 0 17px 0 0;
   appearance: none;
   border: 0;
   color: var(--muted);
@@ -198,9 +224,18 @@ select:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+.version-control select:focus-visible {
+  outline: 0;
+}
+
+.version-control option {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+
 .share-button {
-  min-width: 52px;
-  padding: 0 9px;
+  min-width: 58px;
+  padding: 0 11px;
   cursor: pointer;
 }
 
@@ -425,19 +460,11 @@ select:focus-visible {
   color: var(--warning);
 }
 
-.toolbar-divider {
-  width: 1px;
-  height: 16px;
-  flex: none;
-  margin-left: 12px;
-  background: var(--line);
-}
-
 .fix-button {
   min-width: 0;
-  min-height: 30px;
-  margin-left: 4px;
-  padding: 0 10px;
+  min-height: 34px;
+  flex: none;
+  padding: 0 12px;
   border: 1px solid var(--line);
   border-radius: 4px;
   color: var(--text);
@@ -1120,8 +1147,31 @@ select:focus-visible {
   }
 
   .controlbar {
-    height: 48px;
-    padding: 0 8px;
+    height: auto;
+    flex-wrap: wrap;
+    padding: 0;
+  }
+
+  .language-select-control {
+    margin-left: 12px;
+  }
+
+  .run-summary {
+    min-height: 48px;
+    margin-right: 12px;
+  }
+
+  .control-actions {
+    width: 100%;
+    min-height: 48px;
+    gap: 12px;
+    margin-left: 0;
+    padding: 0 12px;
+    border-top: 1px solid var(--line-muted);
+  }
+
+  .github-link {
+    margin-left: auto;
   }
 
   .workspace {
@@ -1166,6 +1216,7 @@ select:focus-visible {
     border-bottom: 1px solid var(--line);
     border-left: 0;
     border-radius: 0;
+    margin-left: 0;
   }
 
   .run-summary {
@@ -1173,17 +1224,11 @@ select:focus-visible {
     margin-left: 12px;
   }
 
-  .fix-button {
-    min-height: 32px;
-    margin-left: 6px;
-  }
-
   .github-link {
     min-height: 32px;
-    margin-right: 8px;
-    margin-left: 2px;
   }
 
+  .fix-button,
   .version-control,
   .share-button {
     min-height: 32px;


### PR DESCRIPTION
## Summary

- make the Utoo Lint version control read clearly as a labeled dropdown
- separate Fix all, Version, Share, and GitHub with stable spacing
- prevent action buttons from shrinking into each other
- move the action group to its own row below 900px

## Testing

- pnpm --filter @utoo/lint-playground typecheck
- pnpm playground:build
- manually verified at desktop and narrow viewport widths