### PR TITLE
fix: align playground version selector

### DIFF
--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -468,9 +468,9 @@ export default function PlaygroundPage() {
         </div>
 
         <section className="controlbar" aria-label="Playground controls">
-          <label className="language-select-control">
-            <span className="language-select-label">Language</span>
-            <span className="language-select-wrap">
+          <label className="select-control language-select-control">
+            <span className="select-label">Language</span>
+            <span className="select-wrap">
               <select
                 aria-controls="source-editor-panel"
                 onChange={(event) =>
@@ -536,9 +536,9 @@ export default function PlaygroundPage() {
               {fixButtonText}
             </button>
 
-            <label className="version-control">
-              <span className="version-control-label">Version</span>
-              <span className="version-select-wrap">
+            <label className="select-control version-control">
+              <span className="select-label">Version</span>
+              <span className="select-wrap">
                 <select
                   aria-label="Utoo Lint version"
                   onChange={(event) => selectLintVersion(event.target.value)}

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -153,7 +153,6 @@ select:focus-visible {
   margin-left: 24px;
 }
 
-.version-control,
 .share-button {
   display: inline-flex;
   min-height: 34px;
@@ -173,88 +172,16 @@ select:focus-visible {
     background-color 120ms ease;
 }
 
-.version-control {
-  position: relative;
-  min-width: 128px;
-  gap: 9px;
-  padding: 0 9px 0 10px;
-}
-
-.version-control-label {
-  color: var(--muted-subtle);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.version-select-wrap {
-  position: relative;
-  display: inline-flex;
-  min-width: 54px;
-  align-items: center;
-}
-
-.version-select-wrap::after {
-  position: absolute;
-  top: 50%;
-  right: 1px;
-  width: 5px;
-  height: 5px;
-  border-right: 1px solid var(--muted-subtle);
-  border-bottom: 1px solid var(--muted-subtle);
-  content: "";
-  pointer-events: none;
-  transform: translateY(-70%) rotate(45deg);
-}
-
-.version-control select {
-  width: 100%;
-  min-height: 32px;
-  padding: 0 17px 0 0;
-  appearance: none;
-  border: 0;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 10px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.version-control select:focus-visible {
-  outline: 0;
-}
-
-.version-control option {
-  color: var(--text);
-  background: var(--surface-raised);
-}
-
 .share-button {
   min-width: 58px;
   padding: 0 11px;
   cursor: pointer;
 }
 
-.version-control:hover,
-.version-control:focus-within,
 .share-button:hover {
   border-color: rgba(214, 225, 239, 0.2);
   color: var(--text-strong);
   background: rgba(255, 255, 255, 0.06);
-}
-
-.version-control:focus-within {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.version-control:hover select,
-.version-control:focus-within select {
-  color: var(--text-strong);
 }
 
 .share-button:active {
@@ -287,7 +214,7 @@ select:focus-visible {
   height: 100%;
 }
 
-.language-select-control {
+.select-control {
   position: relative;
   display: flex;
   height: 36px;
@@ -308,7 +235,7 @@ select:focus-visible {
   cursor: pointer;
 }
 
-.language-select-label {
+.select-label {
   color: var(--muted-subtle);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   font-size: 8px;
@@ -317,12 +244,12 @@ select:focus-visible {
   text-transform: uppercase;
 }
 
-.language-select-wrap {
+.select-wrap {
   position: relative;
   display: block;
 }
 
-.language-select-wrap::after {
+.select-wrap::after {
   position: absolute;
   top: 50%;
   right: 9px;
@@ -334,7 +261,7 @@ select:focus-visible {
   transform: translateY(-62%);
 }
 
-.language-select-control select {
+.select-control select {
   width: 128px;
   height: 28px;
   padding: 0 28px 0 9px;
@@ -351,12 +278,12 @@ select:focus-visible {
     background-color 120ms ease;
 }
 
-.language-select-control select:hover {
+.select-control select:hover {
   border-color: rgba(214, 225, 239, 0.22);
   background: var(--surface-hover);
 }
 
-.language-select-control option {
+.select-control option {
   color: var(--text);
   background: var(--surface-raised);
 }
@@ -1234,13 +1161,8 @@ select:focus-visible {
   }
 
   .fix-button,
-  .version-control,
   .share-button {
     min-height: 32px;
-  }
-
-  .version-control select {
-    min-height: 30px;
   }
 
   .panel-hint {


### PR DESCRIPTION
## Summary

- share one select-control structure between Language and Version
- make the Version dropdown match the Language control in sizing, spacing, border, typography, background, and focus treatment
- remove the duplicate version-specific selector styles

## Testing

- pnpm --filter @utoo/lint-playground test
- pnpm --filter @utoo/lint-playground typecheck
- pnpm playground:build
- visually compared computed control and select styles in the local Playground