### PR TITLE
feat: refine playground UI and sharing

### DIFF
--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -55,9 +55,12 @@ const { AST_SOURCE_LENGTH_MAX } = await import(
   pathToFileURL(join(outputDirectory, 'ast', 'protocol.js')).href
 );
 const {
+  createPlaygroundShareUrl,
   fileNameForLanguage,
   INITIAL_SOURCES,
+  parsePlaygroundShareUrl,
   RECOMMENDED_RULES,
+  removePlaygroundShareState,
 } = await import(
   pathToFileURL(join(outputDirectory, 'playground', 'model.js')).href
 );
@@ -299,4 +302,54 @@ test('fixes every diagnostic in each default Playground fixture', async () => {
     assert.equal(ast.program.start, 0);
     assert.equal(ast.program.end, source.length);
   }
+});
+
+test('round-trips Playground state through a share URL', () => {
+  const payload = {
+    language: 'tsx',
+    rulesMode: 'custom',
+    rulesSource: '{"react/jsx-key":"error"}',
+    source: "const greeting = '你好，🐰';",
+    version: 1,
+  };
+  const shareUrl = createPlaygroundShareUrl(
+    'https://example.test/playground/?theme=dark',
+    payload,
+  );
+
+  assert.match(shareUrl, /#playground=[\w-]+$/u);
+  assert.deepEqual(parsePlaygroundShareUrl(shareUrl), payload);
+  assert.equal(new URL(shareUrl).searchParams.get('theme'), 'dark');
+});
+
+test('ignores malformed or unsupported Playground share state', () => {
+  assert.equal(
+    parsePlaygroundShareUrl('https://example.test/#playground=not-base64'),
+    undefined,
+  );
+
+  const unsupported = Buffer.from(
+    JSON.stringify({
+      language: 'typescript',
+      rulesMode: 'custom',
+      rulesSource: '{}',
+      source: 'const value = 1;',
+      version: 2,
+    }),
+  ).toString('base64url');
+  assert.equal(
+    parsePlaygroundShareUrl(
+      `https://example.test/#playground=${unsupported}`,
+    ),
+    undefined,
+  );
+});
+
+test('removes stale Playground state without changing other URL data', () => {
+  assert.equal(
+    removePlaygroundShareState(
+      'https://example.test/playground/?theme=dark#playground=old&panel=ast',
+    ),
+    'https://example.test/playground/?theme=dark#panel=ast',
+  );
 });

--- a/apps/playground/src/features/playground/model.ts
+++ b/apps/playground/src/features/playground/model.ts
@@ -28,6 +28,21 @@ export const LANGUAGES = [
 ] as const;
 
 export type PlaygroundLanguage = (typeof LANGUAGES)[number]['id'];
+export type PlaygroundRulesMode = 'recommended' | 'custom';
+
+export interface PlaygroundSharePayload {
+  language: PlaygroundLanguage;
+  rulesMode: PlaygroundRulesMode;
+  rulesSource: string;
+  source: string;
+  version: 1;
+}
+
+const SHARE_HASH_KEY = 'playground';
+const SHARE_PAYLOAD_VERSION = 1;
+const MAX_ENCODED_SHARE_LENGTH = 512_000;
+const MAX_SHARED_RULES_LENGTH = 50_000;
+const MAX_SHARED_SOURCE_LENGTH = 250_000;
 
 export const INITIAL_SOURCES: Record<PlaygroundLanguage, string> = {
   typescript: `function greet(name: string) {
@@ -74,6 +89,90 @@ export const RECOMMENDED_RULES = {
 } satisfies Record<string, RuleConfig>;
 
 export const INITIAL_RULES = JSON.stringify(RECOMMENDED_RULES, null, 2);
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+
+  for (let index = 0; index < bytes.length; index += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 32_768));
+  }
+
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/u, '');
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(`${base64}${padding}`);
+  const bytes = Uint8Array.from(binary, (character) =>
+    character.charCodeAt(0),
+  );
+  return new TextDecoder().decode(bytes);
+}
+
+function isPlaygroundLanguage(value: unknown): value is PlaygroundLanguage {
+  return LANGUAGES.some((language) => language.id === value);
+}
+
+function isPlaygroundSharePayload(
+  value: unknown,
+): value is PlaygroundSharePayload {
+  if (value === null || typeof value !== 'object') return false;
+
+  const payload = value as Partial<PlaygroundSharePayload>;
+  return (
+    payload.version === SHARE_PAYLOAD_VERSION &&
+    isPlaygroundLanguage(payload.language) &&
+    (payload.rulesMode === 'recommended' || payload.rulesMode === 'custom') &&
+    typeof payload.rulesSource === 'string' &&
+    payload.rulesSource.length <= MAX_SHARED_RULES_LENGTH &&
+    typeof payload.source === 'string' &&
+    payload.source.length <= MAX_SHARED_SOURCE_LENGTH
+  );
+}
+
+export function createPlaygroundShareUrl(
+  currentUrl: string,
+  payload: PlaygroundSharePayload,
+): string {
+  if (!isPlaygroundSharePayload(payload)) {
+    throw new RangeError('Playground content is too large to share in a URL.');
+  }
+
+  const url = new URL(currentUrl);
+  const encoded = encodeBase64Url(JSON.stringify(payload));
+  url.hash = `${SHARE_HASH_KEY}=${encoded}`;
+  return url.toString();
+}
+
+export function parsePlaygroundShareUrl(
+  currentUrl: string,
+): PlaygroundSharePayload | undefined {
+  try {
+    const url = new URL(currentUrl);
+    const encoded = new URLSearchParams(url.hash.slice(1)).get(SHARE_HASH_KEY);
+    if (!encoded || encoded.length > MAX_ENCODED_SHARE_LENGTH) return undefined;
+
+    const payload: unknown = JSON.parse(decodeBase64Url(encoded));
+    return isPlaygroundSharePayload(payload) ? payload : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function removePlaygroundShareState(currentUrl: string): string {
+  const url = new URL(currentUrl);
+  const parameters = new URLSearchParams(url.hash.slice(1));
+  if (!parameters.has(SHARE_HASH_KEY)) return currentUrl;
+
+  parameters.delete(SHARE_HASH_KEY);
+  url.hash = parameters.toString();
+  return url.toString();
+}
 
 export function fileNameForLanguage(language: PlaygroundLanguage): string {
   return LANGUAGES.find((candidate) => candidate.id === language)?.fileName ?? 'index.ts';

--- a/apps/playground/src/pages/page.config.ts
+++ b/apps/playground/src/pages/page.config.ts
@@ -1,11 +1,11 @@
 import { definePageConfig } from '@evjs/ev';
 
 export default definePageConfig({
-  title: 'Playground | Utoo Lint',
+  title: 'utoo-lint Playground',
   meta: {
-    description: 'Playground of Utoo Lint',
+    description: 'Run utoo-lint in the browser and inspect diagnostics or AST output.',
     viewport: 'width=device-width, initial-scale=1',
-    'theme-color': '#080a0d',
+    'theme-color': '#111315',
   },
   render: 'csr',
 });

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -17,6 +17,7 @@ import type { ASTParseResult } from '../features/ast/protocol';
 import { ASTTree } from '../features/ast/tree';
 import { LintWorkerClient } from '../features/lint/client';
 import {
+  createPlaygroundShareUrl,
   diagnosticLabel,
   fileNameForLanguage,
   INITIAL_RULES,
@@ -24,8 +25,11 @@ import {
   LANGUAGES,
   monacoLanguageForLanguage,
   parseRules,
+  parsePlaygroundShareUrl,
   RECOMMENDED_RULES,
+  removePlaygroundShareState,
   type PlaygroundLanguage,
+  type PlaygroundRulesMode,
 } from '../features/playground/model';
 import '../features/playground/monaco';
 import { Splitter } from '../features/playground/splitter';
@@ -34,7 +38,6 @@ import '../style.css';
 type EditorInstance = Parameters<OnMount>[0];
 type MonacoInstance = Parameters<OnMount>[1];
 type InspectorMode = 'ast' | 'rules';
-type RulesMode = 'recommended' | 'custom';
 type ASTPhase = 'idle' | 'running' | 'ready' | 'error';
 type RunPhase = 'idle' | 'running' | 'ready' | 'error';
 type ShareState = 'idle' | 'copied' | 'error';
@@ -43,39 +46,15 @@ const EDITOR_THEME = 'utoo-dark';
 const DEFAULT_EDITOR_RATIO = 68;
 const DEFAULT_RULES_RATIO = 42;
 const INSPECTOR_MODES = ['rules', 'ast'] as const;
-const V030_WASM_URL = new URL(
+const LINT_WASM_URL = new URL(
   '../../../../npm/@utoo/lint-wasm/utoo-lint.wasm',
   import.meta.url,
 ).href;
-const LINT_VERSIONS = [
-  { id: '0.3.0', label: 'v0.3.0', wasmUrl: V030_WASM_URL },
-] as const;
-
-type LintVersionId = (typeof LINT_VERSIONS)[number]['id'];
-
-function getLintVersionDefinition(version: LintVersionId) {
-  return (
-    LINT_VERSIONS.find((candidate) => candidate.id === version) ??
-    LINT_VERSIONS[0]
-  );
-}
-
-function getInitialLintVersion(): LintVersionId {
-  if (typeof window === 'undefined') return LINT_VERSIONS[0].id;
-  const requestedVersion = new URLSearchParams(window.location.search).get(
-    'version',
-  );
-  const match = LINT_VERSIONS.find(
-    (candidate) => candidate.id === requestedVersion,
-  );
-  return match?.id ?? LINT_VERSIONS[0].id;
-}
 
 interface RunState {
   phase: RunPhase;
   result?: LintResult;
   message?: string;
-  elapsedMs?: number;
 }
 
 interface ASTState {
@@ -93,27 +72,27 @@ function defineEditorTheme(monaco: MonacoInstance): void {
     base: 'vs-dark',
     inherit: true,
     rules: [
-      { token: 'comment', foreground: '8B949E' },
-      { token: 'keyword', foreground: 'FF7B72' },
-      { token: 'number', foreground: '79C0FF' },
-      { token: 'string', foreground: 'A5D6FF' },
-      { token: 'type.identifier', foreground: 'D2A8FF' },
+      { token: 'comment', foreground: '727A85' },
+      { token: 'keyword', foreground: 'E58A82' },
+      { token: 'number', foreground: '79B8EA' },
+      { token: 'string', foreground: 'A9C98F' },
+      { token: 'type.identifier', foreground: 'C49ADD' },
     ],
     colors: {
-      'editor.background': '#101216',
-      'editor.foreground': '#D6DAE1',
-      'editorCursor.foreground': '#38BDF8',
-      'editorGutter.background': '#101216',
-      'editorIndentGuide.background1': '#232830',
-      'editorIndentGuide.activeBackground1': '#373E49',
-      'editorLineNumber.activeForeground': '#C7CDD6',
-      'editorLineNumber.foreground': '#626A76',
-      'editor.lineHighlightBackground': '#181B21',
-      'editor.selectionBackground': '#164B68',
-      'editor.inactiveSelectionBackground': '#15394C',
-      'editorWhitespace.foreground': '#2A3038',
-      'editorError.foreground': '#F85149',
-      'editorWarning.foreground': '#D29922',
+      'editor.background': '#141618',
+      'editor.foreground': '#D9DDE3',
+      'editorCursor.foreground': '#2BA7EE',
+      'editorGutter.background': '#141618',
+      'editorIndentGuide.background1': '#25292E',
+      'editorIndentGuide.activeBackground1': '#3A4047',
+      'editorLineNumber.activeForeground': '#C4C9D0',
+      'editorLineNumber.foreground': '#59616B',
+      'editor.lineHighlightBackground': '#191C1F',
+      'editor.selectionBackground': '#164A67',
+      'editor.inactiveSelectionBackground': '#183B4F',
+      'editorWhitespace.foreground': '#2B3035',
+      'editorError.foreground': '#FF716C',
+      'editorWarning.foreground': '#D6A956',
     },
   });
 }
@@ -124,18 +103,42 @@ function diagnosticButtonLabel(diagnostic: LintDiagnostic): string {
   return `${diagnostic.severity}: ${diagnostic.message} ${diagnostic.ruleId} ${location}${fixable}`;
 }
 
+function invalidateShareUrl(): void {
+  const currentUrl = window.location.href;
+  const nextUrl = removePlaygroundShareState(currentUrl);
+  if (nextUrl !== currentUrl) {
+    window.history.replaceState(null, '', nextUrl);
+  }
+}
+
 export default function PlaygroundPage() {
-  const [language, setLanguage] =
-    useState<PlaygroundLanguage>('typescript');
-  const [lintVersion, setLintVersion] = useState<LintVersionId>(
-    getInitialLintVersion,
+  const [initialSharePayload] = useState(() =>
+    typeof window === 'undefined'
+      ? undefined
+      : parsePlaygroundShareUrl(window.location.href),
   );
-  const [sources, setSources] =
-    useState<Record<PlaygroundLanguage, string>>(INITIAL_SOURCES);
+  const [language, setLanguage] =
+    useState<PlaygroundLanguage>(
+      initialSharePayload?.language ?? 'typescript',
+    );
+  const [sources, setSources] = useState<
+    Record<PlaygroundLanguage, string>
+  >(() =>
+    initialSharePayload
+      ? {
+          ...INITIAL_SOURCES,
+          [initialSharePayload.language]: initialSharePayload.source,
+        }
+      : INITIAL_SOURCES,
+  );
   const [inspectorMode, setInspectorMode] =
     useState<InspectorMode>('rules');
-  const [rulesMode, setRulesMode] = useState<RulesMode>('custom');
-  const [rulesSource, setRulesSource] = useState(INITIAL_RULES);
+  const [rulesMode, setRulesMode] = useState<PlaygroundRulesMode>(
+    initialSharePayload?.rulesMode ?? 'custom',
+  );
+  const [rulesSource, setRulesSource] = useState(
+    initialSharePayload?.rulesSource ?? INITIAL_RULES,
+  );
   const [runState, setRunState] = useState<RunState>(EMPTY_RUN_STATE);
   const [astState, setASTState] = useState<ASTState>(EMPTY_AST_STATE);
   const [shareState, setShareState] = useState<ShareState>('idle');
@@ -171,7 +174,6 @@ export default function PlaygroundPage() {
         return;
       }
 
-      const startedAt = performance.now();
       setRunState({ phase: 'running' });
 
       try {
@@ -187,12 +189,13 @@ export default function PlaygroundPage() {
                   ? parsedRules.rules
                   : {},
           },
-          getLintVersionDefinition(lintVersion).wasmUrl,
+          LINT_WASM_URL,
         );
 
         if (!result || requestId !== latestRequestRef.current) return;
 
         if (action === 'fix' && result.mode === 'fix' && result.fixed) {
+          invalidateShareUrl();
           setSources((current) => ({
             ...current,
             [language]: result.output,
@@ -202,18 +205,16 @@ export default function PlaygroundPage() {
         setRunState({
           phase: 'ready',
           result,
-          elapsedMs: performance.now() - startedAt,
         });
       } catch (error) {
         if (requestId !== latestRequestRef.current) return;
         setRunState({
           phase: 'error',
           message: error instanceof Error ? error.message : 'Lint failed.',
-          elapsedMs: performance.now() - startedAt,
         });
       }
     },
-    [fileName, language, lintVersion, parsedRules, rulesMode, source],
+    [fileName, language, parsedRules, rulesMode, source],
   );
 
   useEffect(() => {
@@ -357,39 +358,28 @@ export default function PlaygroundPage() {
   };
 
   const selectLanguage = (nextLanguage: PlaygroundLanguage) => {
+    invalidateShareUrl();
     setRunState(EMPTY_RUN_STATE);
     setLanguage(nextLanguage);
   };
 
-  const selectLintVersion = (nextVersion: string) => {
-    const definition = LINT_VERSIONS.find(
-      (candidate) => candidate.id === nextVersion,
-    );
-    if (!definition || definition.id === lintVersion) return;
-
-    setRunState(EMPTY_RUN_STATE);
-    setLintVersion(definition.id);
-    const url = new URL(window.location.href);
-    url.searchParams.set('version', definition.id);
-    window.history.replaceState(null, '', url);
-  };
-
   const sharePlayground = async () => {
-    const shareData = {
-      title: 'Playground | Utoo Lint',
-      text: 'Playground of Utoo Lint',
-      url: window.location.href,
-    };
-
     try {
-      if (navigator.share) {
-        await navigator.share(shareData);
-      } else {
-        await navigator.clipboard.writeText(shareData.url);
+      const shareUrl = createPlaygroundShareUrl(window.location.href, {
+        language,
+        rulesMode,
+        rulesSource,
+        source,
+        version: 1,
+      });
+      window.history.replaceState(null, '', shareUrl);
+
+      if (!navigator.clipboard) {
+        throw new Error('Clipboard access is unavailable.');
       }
+      await navigator.clipboard.writeText(shareUrl);
       setShareState('copied');
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return;
       setShareState('error');
     }
 
@@ -451,9 +441,7 @@ export default function PlaygroundPage() {
       : 'No safe autofixes available';
   const rulesDescriptionId = hasCustomRulesError
     ? 'rules-config-error'
-    : rulesMode === 'recommended'
-      ? 'rules-mode-note'
-      : undefined;
+    : undefined;
 
   return (
     <main className="playground-shell">
@@ -464,12 +452,13 @@ export default function PlaygroundPage() {
           </span>
           <div className="brand-title">
             <h1>utoo-lint</h1>
+            <span className="brand-context">Playground</span>
           </div>
         </div>
 
         <section className="controlbar" aria-label="Playground controls">
-          <label className="select-control language-select-control">
-            <span className="select-label">Language</span>
+          <label className="language-select-control">
+            <span className="visually-hidden">Language</span>
             <span className="select-wrap">
               <select
                 aria-controls="source-editor-panel"
@@ -488,19 +477,6 @@ export default function PlaygroundPage() {
           </label>
 
           <div className="run-summary" aria-hidden="true">
-            <span
-              className={`run-state-copy run-state-${runState.phase}`}
-            >
-              {runState.phase === 'idle' && 'Queued…'}
-              {runState.phase === 'running' && 'Linting…'}
-              {runState.phase === 'ready' && 'Ready'}
-              {runState.phase === 'error' && 'Run failed'}
-            </span>
-            {runState.phase === 'ready' && (
-              <span className="run-duration">
-                {runState.elapsedMs?.toFixed(1)} ms
-              </span>
-            )}
             <span className="summary-count error-count">
               <strong>{errorCount}</strong>{' '}
               {errorCount === 1 ? 'error' : 'errors'}
@@ -535,23 +511,6 @@ export default function PlaygroundPage() {
             >
               {fixButtonText}
             </button>
-
-            <label className="select-control version-control">
-              <span className="select-label">Version</span>
-              <span className="select-wrap">
-                <select
-                  aria-label="Utoo Lint version"
-                  onChange={(event) => selectLintVersion(event.target.value)}
-                  value={lintVersion}
-                >
-                  {LINT_VERSIONS.map((version) => (
-                    <option key={version.id} value={version.id}>
-                      {version.label}
-                    </option>
-                  ))}
-                </select>
-              </span>
-            </label>
 
             <button
               aria-label="Share this playground"
@@ -594,10 +553,8 @@ export default function PlaygroundPage() {
         >
           <div className="panel-heading">
             <div className="panel-heading-copy">
-              <span className="panel-kicker">Source</span>
               <span className="panel-title file-name">{fileName}</span>
             </div>
-            <span className="panel-hint">Live lint</span>
           </div>
           <div className="editor-frame">
             <Editor
@@ -605,6 +562,7 @@ export default function PlaygroundPage() {
               height="100%"
               language={monacoLanguage}
               onChange={(value) => {
+                invalidateShareUrl();
                 setRunState(EMPTY_RUN_STATE);
                 setSources((current) => ({
                   ...current,
@@ -702,6 +660,7 @@ export default function PlaygroundPage() {
                       rulesMode === 'recommended' ? 'is-active' : undefined
                     }
                     onClick={() => {
+                      invalidateShareUrl();
                       setRunState(EMPTY_RUN_STATE);
                       setRulesMode('recommended');
                     }}
@@ -713,6 +672,7 @@ export default function PlaygroundPage() {
                     aria-pressed={rulesMode === 'custom'}
                     className={rulesMode === 'custom' ? 'is-active' : undefined}
                     onClick={() => {
+                      invalidateShareUrl();
                       setRunState(EMPTY_RUN_STATE);
                       setRulesMode('custom');
                     }}
@@ -721,15 +681,7 @@ export default function PlaygroundPage() {
                     Custom
                   </button>
                 </div>
-              ) : (
-                <span className="ast-status">
-                  {astState.phase === 'idle' && 'Queued'}
-                  {astState.phase === 'running' && 'Parsing…'}
-                  {astState.phase === 'ready' &&
-                    `${astState.result?.elapsedMs.toFixed(1)} ms`}
-                  {astState.phase === 'error' && 'Parse failed'}
-                </span>
-              )}
+              ) : null}
             </div>
 
             {inspectorMode === 'rules' ? (
@@ -744,11 +696,12 @@ export default function PlaygroundPage() {
                   aria-invalid={hasCustomRulesError || undefined}
                   aria-label="utlint.json configuration"
                   className={`rules-editor ${hasCustomRulesError ? 'has-error' : ''}`}
-                  disabled={rulesMode === 'recommended'}
                   onChange={(event) => {
+                    invalidateShareUrl();
                     setRunState(EMPTY_RUN_STATE);
                     setRulesSource(event.target.value);
                   }}
+                  readOnly={rulesMode === 'recommended'}
                   spellCheck={false}
                   value={
                     rulesMode === 'recommended' ? INITIAL_RULES : rulesSource
@@ -761,11 +714,6 @@ export default function PlaygroundPage() {
                     role="alert"
                   >
                     {parsedRules.message}
-                  </p>
-                )}
-                {rulesMode === 'recommended' && (
-                  <p className="rules-note" id="rules-mode-note">
-                    Using the Playground&apos;s curated browser-safe rule set.
                   </p>
                 )}
               </div>
@@ -788,14 +736,7 @@ export default function PlaygroundPage() {
                 {(astState.phase === 'idle' ||
                   astState.phase === 'running') && (
                   <div className="empty-state ast-loading-state">
-                    <span className="loading-icon" aria-hidden="true">
-                      ···
-                    </span>
-                    <strong>
-                      {astState.phase === 'idle'
-                        ? 'AST queued'
-                        : 'Parsing AST…'}
-                    </strong>
+                    <strong>Parsing syntax tree…</strong>
                   </div>
                 )}
                 {astState.phase === 'ready' && astState.result && (
@@ -837,7 +778,6 @@ export default function PlaygroundPage() {
           >
             <div className="panel-heading">
               <div className="panel-heading-copy">
-                <span className="panel-kicker">Output</span>
                 <h2 className="panel-title" id="diagnostics-panel-title">
                   Diagnostics
                 </h2>
@@ -855,23 +795,13 @@ export default function PlaygroundPage() {
 
               {(runState.phase === 'idle' || runState.phase === 'running') && (
                 <div className="empty-state">
-                  <span className="loading-icon" aria-hidden="true">
-                    ···
-                  </span>
-                  <strong>
-                    {runState.phase === 'idle' ? 'Lint queued' : 'Linting…'}
-                  </strong>
-                  <span>Results will appear when the worker is ready.</span>
+                  <strong>Checking…</strong>
                 </div>
               )}
 
               {runState.phase === 'ready' && diagnostics.length === 0 && (
                 <div className="empty-state">
-                  <span className="success-icon" aria-hidden="true">
-                    ✓
-                  </span>
-                  <strong>No diagnostics</strong>
-                  <span>This file is clean for the selected rules.</span>
+                  <strong>No problems found</strong>
                 </div>
               )}
 

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -1,28 +1,29 @@
 :root {
-  color: #d6dae1;
-  background: #080a0d;
+  color: #d9dde3;
+  background: #111315;
   color-scheme: dark;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --app: #080a0d;
-  --canvas: #101216;
-  --surface: #181b21;
-  --surface-raised: #1d2128;
-  --surface-hover: #232830;
-  --line: rgba(214, 225, 239, 0.13);
-  --line-muted: rgba(214, 225, 239, 0.075);
-  --text: #d6dae1;
-  --text-strong: #f5f7fa;
-  --muted: #8f97a3;
-  --muted-subtle: #68717e;
-  --accent: #38bdf8;
-  --accent-muted: rgba(56, 189, 248, 0.14);
-  --success: #55c987;
-  --error: #ff6b65;
-  --warning: #e4b85c;
-  --splitter-size: 8px;
+  --app: #111315;
+  --canvas: #141618;
+  --surface: #191b1e;
+  --surface-raised: #202328;
+  --surface-hover: #1d2024;
+  --line: #2a2e33;
+  --line-muted: #23272b;
+  --text: #d9dde3;
+  --text-strong: #f3f5f7;
+  --muted: #9299a3;
+  --muted-subtle: #69717c;
+  --accent: #2ba7ee;
+  --accent-hover: #4ab6f4;
+  --success: #69c38d;
+  --error: #ff716c;
+  --warning: #d6a956;
+  --splitter-size: 7px;
 }
 
 * {
@@ -50,7 +51,9 @@ select {
 }
 
 button,
-a {
+a,
+select,
+textarea {
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -62,291 +65,7 @@ select:focus-visible {
   outline-offset: -2px;
 }
 
-.playground-shell {
-  display: grid;
-  grid-template-rows: 66px minmax(0, 1fr);
-  width: 100%;
-  height: 100vh;
-  height: 100dvh;
-  min-height: 660px;
-  background:
-    radial-gradient(circle at 18% -30%, rgba(56, 189, 248, 0.07), transparent 34%),
-    var(--app);
-}
-
-.topbar,
-.controlbar,
-.panel-heading,
-.run-summary,
-.brand,
-.brand-title,
-.diagnostic-meta,
-.segmented-control,
-.panel-hint {
-  display: flex;
-  align-items: center;
-}
-
-.topbar {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 28px;
-  padding: 0 20px;
-  border-bottom: 1px solid var(--line-muted);
-  background: rgba(11, 14, 18, 0.9);
-  backdrop-filter: blur(18px);
-}
-
-.brand {
-  min-width: 0;
-  gap: 11px;
-}
-
-.brand-mark {
-  display: grid;
-  width: 28px;
-  height: 40px;
-  flex: none;
-  place-items: center;
-}
-
-.brand-mark img {
-  display: block;
-  width: 26px;
-  height: 38px;
-  object-fit: contain;
-}
-
-.brand-title {
-  min-width: 0;
-  gap: 8px;
-}
-
-.brand h1 {
-  margin: 0;
-  color: var(--text-strong);
-  font-size: 15px;
-  font-weight: 680;
-  letter-spacing: -0.025em;
-}
-
-.github-link {
-  display: inline-flex;
-  min-height: 34px;
-  flex: none;
-  align-items: center;
-  gap: 4px;
-  margin-left: 2px;
-  padding: 0 5px;
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 500;
-  text-decoration: none;
-}
-
-.control-actions {
-  display: flex;
-  flex: none;
-  align-items: center;
-  gap: 14px;
-  margin-left: 24px;
-}
-
-.share-button {
-  display: inline-flex;
-  min-height: 34px;
-  flex: none;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  color: var(--muted);
-  background: rgba(255, 255, 255, 0.025);
-  font-size: 10px;
-  font-weight: 550;
-  text-decoration: none;
-  transition:
-    color 120ms ease,
-    border-color 120ms ease,
-    background-color 120ms ease;
-}
-
-.share-button {
-  min-width: 58px;
-  padding: 0 11px;
-  cursor: pointer;
-}
-
-.share-button:hover {
-  border-color: rgba(214, 225, 239, 0.2);
-  color: var(--text-strong);
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.share-button:active {
-  background: rgba(255, 255, 255, 0.025);
-}
-
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-  white-space: nowrap;
-}
-
-.external-mark {
-  color: var(--muted-subtle);
-  font-size: 10px;
-}
-
-.github-link:hover {
-  color: var(--text-strong);
-}
-
-.controlbar {
-  min-width: 0;
-  height: 100%;
-}
-
-.select-control {
-  position: relative;
-  display: flex;
-  height: 36px;
-  align-items: center;
-  align-self: center;
-  gap: 10px;
-  padding: 0 10px 0 12px;
-  border: 1px solid var(--line-muted);
-  border-radius: 5px;
-  background: rgba(255, 255, 255, 0.015);
-}
-
-.inspector-tabs button,
-.segmented-control button {
-  border: 0;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-}
-
-.select-label {
-  color: var(--muted-subtle);
-  font-size: 10px;
-  font-weight: 500;
-}
-
-.select-wrap {
-  position: relative;
-  display: block;
-}
-
-.select-wrap::after {
-  position: absolute;
-  top: 50%;
-  right: 9px;
-  color: var(--muted-subtle);
-  content: "⌄";
-  font-size: 12px;
-  line-height: 1;
-  pointer-events: none;
-  transform: translateY(-62%);
-}
-
-.select-control select {
-  width: 128px;
-  height: 28px;
-  padding: 0 28px 0 9px;
-  appearance: none;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  color: var(--text);
-  background: var(--surface-raised);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 550;
-  transition:
-    border-color 120ms ease,
-    background-color 120ms ease;
-}
-
-.select-control select:hover {
-  border-color: rgba(214, 225, 239, 0.22);
-  background: var(--surface-hover);
-}
-
-.select-control option {
-  color: var(--text);
-  background: var(--surface-raised);
-}
-
-.inspector-tabs button:hover,
-.segmented-control button:hover {
-  color: var(--text);
-}
-
-.run-summary {
-  min-width: 0;
-  gap: 14px;
-  margin-left: auto;
-  color: var(--muted);
-  font-size: 11px;
-  white-space: nowrap;
-}
-
-.run-state-copy {
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.run-state-idle,
-.run-state-running {
-  color: var(--text);
-}
-
-.run-state-copy::before {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  margin-right: 7px;
-  border-radius: 50%;
-  background: var(--muted-subtle);
-  content: "";
-  vertical-align: 1px;
-}
-
-.run-state-ready::before {
-  background: var(--success);
-  box-shadow: 0 0 0 3px rgba(85, 201, 135, 0.1);
-}
-
-.run-state-running::before {
-  background: var(--accent);
-}
-
-.run-state-error::before {
-  background: var(--error);
-}
-
-.run-state-error {
-  color: #ff7b72;
-}
-
-.run-duration {
-  color: var(--muted-subtle);
-  font-variant-numeric: tabular-nums;
-}
-
-.run-duration::before {
-  margin-right: 12px;
-  color: var(--muted-subtle);
-  content: "·";
-}
-
+.visually-hidden,
 .run-announcement {
   position: absolute;
   width: 1px;
@@ -359,69 +78,247 @@ select:focus-visible {
   white-space: nowrap;
 }
 
-.summary-count {
-  display: inline-flex;
+.playground-shell {
+  display: grid;
+  grid-template-rows: 52px minmax(0, 1fr);
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 600px;
+  background: var(--app);
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: stretch;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.brand,
+.brand-title,
+.controlbar,
+.control-actions,
+.run-summary,
+.summary-count,
+.panel-heading,
+.panel-heading-copy,
+.diagnostic-meta,
+.segmented-control {
+  display: flex;
   align-items: center;
-  gap: 6px;
+}
+
+.brand {
+  min-width: 218px;
+  gap: 10px;
+  padding: 0 16px;
+  border-right: 1px solid var(--line-muted);
+}
+
+.brand-mark {
+  display: grid;
+  width: 22px;
+  height: 34px;
+  flex: none;
+  place-items: center;
+}
+
+.brand-mark img {
+  display: block;
+  width: 21px;
+  height: 31px;
+  object-fit: contain;
+}
+
+.brand-title {
+  min-width: 0;
+  gap: 10px;
+}
+
+.brand h1 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.brand-context {
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 450;
+}
+
+.controlbar {
+  min-width: 0;
+  padding: 0 10px 0 12px;
+}
+
+.language-select-control {
+  position: relative;
+  display: flex;
+  height: 28px;
+  flex: none;
+  align-items: center;
+}
+
+.select-wrap {
+  position: relative;
+  display: block;
+}
+
+.select-wrap::after {
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  width: 4px;
+  height: 4px;
+  border-right: 1px solid var(--muted);
+  border-bottom: 1px solid var(--muted);
+  content: "";
+  pointer-events: none;
+  transform: translateY(-70%) rotate(45deg);
+}
+
+.language-select-control select {
+  width: 102px;
+  height: 28px;
+  padding: 0 18px 0 0;
+  appearance: none;
+  border: 0;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 550;
+  transition: color 120ms ease;
+}
+
+.language-select-control select:hover {
+  color: var(--text-strong);
+}
+
+.language-select-control select:focus-visible {
+  outline-width: 1px;
+  outline-offset: 2px;
+}
+
+.language-select-control option {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+
+.run-summary {
+  min-width: 0;
+  gap: 12px;
+  margin-left: 12px;
+  padding-left: 14px;
+  border-left: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.summary-count {
+  gap: 4px;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
 
 .summary-count strong {
-  color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 
-.summary-count::before {
-  width: 5px;
-  height: 5px;
-  border-radius: 1px;
-  background: currentColor;
-  content: "";
-}
-
-.error-count::before {
+.error-count strong {
   color: var(--error);
 }
 
-.warning-count::before {
+.warning-count strong {
   color: var(--warning);
 }
 
-.fix-button {
+.control-actions {
   min-width: 0;
-  min-height: 34px;
   flex: none;
-  padding: 0 12px;
-  border: 1px solid var(--line);
+  gap: 7px;
+  margin-left: auto;
+}
+
+.fix-button,
+.share-button,
+.github-link {
+  display: inline-flex;
+  min-height: 30px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
   border-radius: 4px;
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.045);
-  cursor: pointer;
   font-size: 11px;
   font-weight: 550;
-  box-shadow: inset 0 1px rgba(255, 255, 255, 0.025);
+  text-decoration: none;
   transition:
     color 120ms ease,
     border-color 120ms ease,
     background-color 120ms ease;
 }
 
+.fix-button {
+  min-width: 60px;
+  padding: 0 12px;
+  border: 1px solid #238dca;
+  color: #081117;
+  background: var(--accent);
+  cursor: pointer;
+}
+
 .fix-button:hover:not(:disabled) {
-  border-color: rgba(214, 225, 239, 0.2);
-  color: var(--text-strong);
-  background: rgba(255, 255, 255, 0.075);
+  border-color: var(--accent-hover);
+  background: var(--accent-hover);
 }
 
 .fix-button:active:not(:disabled) {
-  background: rgba(255, 255, 255, 0.025);
+  background: #238dca;
 }
 
 .fix-button:disabled {
+  border-color: var(--line);
   color: var(--muted-subtle);
   background: transparent;
-  border-color: transparent;
   cursor: default;
+}
+
+.share-button {
+  min-width: 58px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.share-button:hover {
+  border-color: #3a4047;
+  color: var(--text-strong);
+  background: var(--surface-raised);
+}
+
+.github-link {
+  gap: 5px;
+  padding: 0 7px;
+  color: var(--muted);
+}
+
+.github-link:hover {
+  color: var(--text-strong);
+}
+
+.external-mark {
+  color: var(--muted-subtle);
+  font-size: 10px;
 }
 
 .workspace {
@@ -430,14 +327,8 @@ select:focus-visible {
     minmax(480px, var(--editor-ratio, 68%)) var(--splitter-size)
     minmax(340px, 1fr);
   min-height: 0;
-  margin: 10px 12px 12px;
   overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 9px;
   background: var(--canvas);
-  box-shadow:
-    0 18px 50px rgba(0, 0, 0, 0.34),
-    0 1px 0 rgba(255, 255, 255, 0.035) inset;
 }
 
 .editor-panel,
@@ -450,13 +341,13 @@ select:focus-visible {
 
 .editor-panel {
   display: grid;
-  grid-template-rows: 44px minmax(0, 1fr);
+  grid-template-rows: 40px minmax(0, 1fr);
 }
 
 .panel-heading {
   justify-content: space-between;
-  min-height: 44px;
-  padding: 0 16px;
+  min-height: 40px;
+  padding: 0 13px;
   border-bottom: 1px solid var(--line);
   color: var(--text);
   background: var(--surface);
@@ -465,22 +356,8 @@ select:focus-visible {
 }
 
 .panel-heading-copy {
-  display: flex;
   min-width: 0;
-  align-items: center;
   gap: 9px;
-}
-
-.panel-kicker {
-  color: var(--muted-subtle);
-  font-size: 10px;
-  font-weight: 500;
-}
-
-.panel-kicker::after {
-  margin-left: 9px;
-  color: var(--line);
-  content: "/";
 }
 
 .panel-title {
@@ -494,24 +371,8 @@ select:focus-visible {
 .file-name {
   font-family:
     "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 550;
-}
-
-.panel-hint {
-  color: var(--muted-subtle);
-  font-size: 10px;
-  font-weight: 450;
-}
-
-.panel-hint::before {
-  width: 5px;
-  height: 5px;
-  margin-right: 7px;
-  border-radius: 50%;
-  background: var(--success);
-  box-shadow: 0 0 0 3px rgba(85, 201, 135, 0.08);
-  content: "";
 }
 
 .editor-frame {
@@ -533,7 +394,7 @@ select:focus-visible {
 }
 
 .rules-section {
-  grid-template-rows: 44px minmax(0, 1fr);
+  grid-template-rows: 40px minmax(0, 1fr);
 }
 
 .pane-splitter {
@@ -541,7 +402,7 @@ select:focus-visible {
   z-index: 2;
   min-width: 0;
   min-height: 0;
-  background: transparent;
+  background: var(--surface);
   cursor: default;
   touch-action: none;
   user-select: none;
@@ -549,7 +410,7 @@ select:focus-visible {
 
 .pane-splitter::before {
   position: absolute;
-  background: var(--line-muted);
+  background: var(--line);
   content: "";
   transition: background-color 120ms ease;
 }
@@ -561,7 +422,7 @@ select:focus-visible {
 .pane-splitter-vertical::before {
   top: 0;
   bottom: 0;
-  left: 4px;
+  left: 3px;
   width: 1px;
 }
 
@@ -570,7 +431,7 @@ select:focus-visible {
 }
 
 .pane-splitter-horizontal::before {
-  top: 4px;
+  top: 3px;
   right: 0;
   left: 0;
   height: 1px;
@@ -586,75 +447,80 @@ select:focus-visible {
 }
 
 .rules-heading {
-  padding-right: 14px;
-  padding-left: 0;
   gap: 12px;
+  padding-right: 12px;
+  padding-left: 0;
 }
 
 .inspector-tabs {
   display: flex;
   align-self: stretch;
-  gap: 0;
+}
+
+.inspector-tabs button,
+.segmented-control button {
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
 }
 
 .inspector-tabs button {
+  position: relative;
   display: inline-flex;
+  min-width: 74px;
   align-items: center;
-  min-width: 68px;
   justify-content: center;
-  padding: 0 15px;
+  padding: 0 14px;
   border-right: 1px solid var(--line-muted);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 550;
   transition:
     color 120ms ease,
     background-color 120ms ease;
 }
 
+.inspector-tabs button:hover,
+.segmented-control button:hover {
+  color: var(--text);
+}
+
 .inspector-tabs button.is-active {
   color: var(--text-strong);
   background: var(--canvas);
-  box-shadow: inset 0 2px var(--accent);
+}
+
+.inspector-tabs button.is-active::after {
+  position: absolute;
+  right: 12px;
+  bottom: -1px;
+  left: 12px;
+  height: 2px;
+  background: var(--accent);
+  content: "";
 }
 
 .segmented-control {
   align-self: stretch;
-  gap: 15px;
+  gap: 3px;
 }
 
 .segmented-label {
+  margin-right: 4px;
   color: var(--muted-subtle);
+  font-size: 10px;
+}
+
+.segmented-control button {
+  padding: 4px 7px;
+  border-radius: 3px;
   font-size: 10px;
   font-weight: 500;
 }
 
-.segmented-control button {
-  position: relative;
-  padding: 0 0 0 10px;
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.segmented-control button::before {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 4px;
-  height: 4px;
-  border: 1px solid var(--muted-subtle);
-  border-radius: 50%;
-  content: "";
-  transform: translateY(-50%);
-}
-
 .segmented-control button.is-active {
   color: var(--text-strong);
-}
-
-.segmented-control button.is-active::before {
-  border-color: var(--accent);
-  background: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-muted);
+  background: var(--surface-raised);
 }
 
 .rules-config-panel {
@@ -667,51 +533,36 @@ select:focus-visible {
 .rules-editor {
   width: 100%;
   min-height: 0;
-  padding: 16px;
+  padding: 15px 16px;
   resize: none;
   border: 0;
   color: var(--text);
   background: var(--canvas);
   font-family:
     "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.65;
-  scrollbar-color: #363d47 transparent;
+  scrollbar-color: #363c43 transparent;
   tab-size: 2;
 }
 
-.rules-editor:disabled {
-  color: #737c88;
-  background:
-    repeating-linear-gradient(
-      -45deg,
-      transparent,
-      transparent 10px,
-      rgba(255, 255, 255, 0.012) 10px,
-      rgba(255, 255, 255, 0.012) 11px
-    ),
-    var(--canvas);
-  cursor: not-allowed;
+.rules-editor:read-only {
+  color: #a8afb8;
+  cursor: default;
 }
 
 .rules-editor.has-error {
   box-shadow: inset 2px 0 var(--error);
 }
 
-.config-error,
-.rules-note {
+.config-error {
   margin: 0;
   padding: 8px 14px;
-  border-top: 1px solid var(--line-muted);
+  border-top: 1px solid #553033;
+  color: #ff918d;
+  background: #25191b;
   font-size: 11px;
   line-height: 1.45;
-}
-
-.ast-status {
-  color: var(--muted-subtle);
-  font-size: 11px;
-  font-weight: 450;
-  font-variant-numeric: tabular-nums;
 }
 
 .ast-panel {
@@ -720,7 +571,7 @@ select:focus-visible {
   overflow: auto;
   color: var(--text);
   background: var(--canvas);
-  scrollbar-color: #363d47 transparent;
+  scrollbar-color: #363c43 transparent;
   scrollbar-width: thin;
 }
 
@@ -733,9 +584,9 @@ select:focus-visible {
   top: 0;
   z-index: 1;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--line-muted);
+  border-bottom: 1px solid #544529;
   color: var(--warning);
-  background: var(--surface);
+  background: #211d16;
   font-size: 11px;
 }
 
@@ -744,8 +595,8 @@ select:focus-visible {
   padding: 12px 16px 20px;
   font-family:
     "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 13px;
-  line-height: 1.7;
+  font-size: 12px;
+  line-height: 1.75;
 }
 
 .ast-tree details {
@@ -755,7 +606,7 @@ select:focus-visible {
 
 .ast-tree summary {
   padding: 1px 4px;
-  border-radius: 3px;
+  border-radius: 2px;
   cursor: pointer;
   list-style: none;
   white-space: pre;
@@ -799,25 +650,22 @@ select:focus-visible {
   white-space: pre;
 }
 
-.ast-type {
-  color: #79c0ff;
+.ast-type,
+.ast-num {
+  color: #79b8ea;
 }
 
 .ast-key {
-  color: #d2a8ff;
+  color: #c49add;
 }
 
 .ast-str {
-  color: #a5d6ff;
-}
-
-.ast-num {
-  color: #79c0ff;
+  color: #a9c98f;
 }
 
 .ast-bool,
 .ast-null {
-  color: #ff7b72;
+  color: #e58a82;
 }
 
 .ast-span,
@@ -826,91 +674,66 @@ select:focus-visible {
   color: var(--muted-subtle);
 }
 
-.config-error {
-  color: #ff8d88;
-  background: #251719;
-}
-
-.rules-note {
-  color: var(--muted);
-  background: var(--surface-raised);
-}
-
 .diagnostics-section {
-  grid-template-rows: 44px minmax(0, 1fr) auto;
+  grid-template-rows: 40px minmax(0, 1fr) auto;
 }
 
 .diagnostic-total {
-  display: inline-grid;
-  min-width: 24px;
-  height: 20px;
-  place-items: center;
-  border: 1px solid var(--line);
-  border-radius: 3px;
-  color: var(--muted);
-  background: rgba(255, 255, 255, 0.02);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 9px;
+  min-width: 18px;
+  color: var(--muted-subtle);
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 10px;
   font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 .diagnostic-list {
   min-height: 0;
   overflow: auto;
   background: var(--canvas);
-  scrollbar-color: #363d47 transparent;
+  scrollbar-color: #363c43 transparent;
   scrollbar-width: thin;
 }
 
 .diagnostic-card {
   display: grid;
-  grid-template-columns: 10px minmax(0, 1fr);
-  gap: 12px;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 8px;
   width: 100%;
   margin: 0;
-  padding: 14px 16px 14px 14px;
+  padding: 11px 14px 12px;
   border: 0;
   border-bottom: 1px solid var(--line-muted);
   color: inherit;
   background: transparent;
   cursor: pointer;
   text-align: left;
-  transition:
-    background-color 120ms ease,
-    box-shadow 120ms ease;
+  transition: background-color 120ms ease;
 }
 
 .diagnostic-card:hover {
   background: var(--surface-hover);
 }
 
-.severity-error:hover {
-  box-shadow: inset 2px 0 var(--error);
-}
-
-.severity-warning:hover {
-  box-shadow: inset 2px 0 var(--warning);
-}
-
 .severity-symbol {
   display: block;
-  width: 7px;
-  height: 7px;
-  margin-top: 6px;
-  border-radius: 2px;
-  font-size: 0;
+  width: 16px;
+  margin-top: 1px;
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.45;
+  text-align: center;
 }
 
 .severity-error .severity-symbol {
-  background: var(--error);
-  box-shadow: 0 0 0 3px rgba(255, 107, 101, 0.1);
+  color: var(--error);
 }
 
 .severity-warning .severity-symbol {
-  border-radius: 1px;
-  background: var(--warning);
-  box-shadow: 0 0 0 3px rgba(228, 184, 92, 0.09);
-  transform: rotate(45deg);
+  color: var(--warning);
 }
 
 .diagnostic-content {
@@ -920,15 +743,15 @@ select:focus-visible {
 .diagnostic-message {
   display: block;
   color: var(--text);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 450;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .diagnostic-meta {
   flex-wrap: wrap;
-  gap: 9px;
-  margin-top: 6px;
+  gap: 8px;
+  margin-top: 5px;
   color: var(--muted-subtle);
   font-size: 10px;
 }
@@ -936,106 +759,88 @@ select:focus-visible {
 .diagnostic-meta code {
   max-width: 100%;
   overflow: hidden;
-  padding: 2px 4px;
-  border-radius: 3px;
-  color: var(--accent);
-  background: var(--accent-muted);
+  color: #67b8e8;
   font-family:
     "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   text-overflow: ellipsis;
 }
 
-.fixable-badge {
-  color: var(--muted);
-}
-
 .fixable-badge::before {
   margin-right: 8px;
-  color: var(--muted-subtle);
-  content: "·";
+  color: var(--line);
+  content: "/";
 }
 
 .empty-state {
   display: flex;
-  min-height: 150px;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
+  min-height: 120px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 18px 16px;
   color: var(--muted-subtle);
-  text-align: center;
 }
 
 .empty-state strong {
-  margin: 7px 0 3px;
-  color: var(--text);
-  font-size: 13px;
-  font-weight: 550;
-}
-
-.empty-state span:last-child {
-  max-width: 240px;
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.success-icon,
-.loading-icon {
+  margin: 0;
   color: var(--muted);
-  font-size: 15px;
+  font-size: 11px;
+  font-weight: 500;
 }
 
-.success-icon {
-  color: var(--success);
-}
-
-.loading-icon {
-  letter-spacing: 2px;
+.error-state {
+  flex-direction: column;
+  gap: 5px;
+  color: #ff918d;
 }
 
 .error-state strong,
 .error-state span {
-  color: #ff8d88;
+  color: #ff918d;
+}
+
+.error-state span {
+  font-size: 11px;
+  line-height: 1.5;
 }
 
 .notice-row {
   display: flex;
   gap: 4px;
-  padding: 8px 16px;
-  border-top: 1px solid var(--line-muted);
+  padding: 7px 14px;
+  border-top: 1px solid var(--line);
   color: var(--muted);
   background: var(--surface);
-  font-size: 11px;
+  font-size: 10px;
   line-height: 1.45;
 }
 
 .warning-notice {
   flex-direction: column;
-  color: #c69026;
-  background: #211b12;
+  color: #bda267;
+  background: #211d16;
 }
 
 .warning-notice strong {
-  color: #e3b341;
+  color: var(--warning);
 }
 
-@media (min-width: 901px) and (max-height: 659px) {
+@media (min-width: 901px) and (max-height: 599px) {
   body {
     overflow: auto;
   }
 
   .playground-shell {
-    height: 660px;
+    height: 600px;
   }
 }
 
-@media (min-width: 901px) and (max-width: 1100px) {
-  .segmented-label {
-    display: none;
+@media (min-width: 901px) and (max-width: 1120px) {
+  .brand {
+    min-width: 190px;
   }
 
-  .segmented-control {
-    gap: 10px;
+  .segmented-label {
+    display: none;
   }
 }
 
@@ -1050,49 +855,18 @@ select:focus-visible {
     min-height: 100vh;
   }
 
-  .topbar {
-    grid-template-columns: 1fr;
-    gap: 0;
-    padding: 0;
-  }
-
   .brand {
-    height: 58px;
-    padding: 0 12px;
-    border-bottom: 1px solid var(--line);
+    min-width: 180px;
+    padding-inline: 12px;
   }
 
+  .topbar,
   .controlbar {
-    height: auto;
-    flex-wrap: wrap;
-    padding: 0;
-  }
-
-  .language-select-control {
-    margin-left: 12px;
-  }
-
-  .run-summary {
-    min-height: 48px;
-    margin-right: 12px;
-  }
-
-  .control-actions {
-    width: 100%;
-    min-height: 48px;
-    gap: 12px;
-    margin-left: 0;
-    padding: 0 12px;
-    border-top: 1px solid var(--line-muted);
-  }
-
-  .github-link {
-    margin-left: auto;
+    min-height: 50px;
   }
 
   .workspace {
     grid-template-columns: 1fr;
-    margin: 8px;
   }
 
   .pane-splitter {
@@ -1102,7 +876,6 @@ select:focus-visible {
   .editor-panel {
     height: 58vh;
     min-height: 420px;
-    border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
@@ -1115,42 +888,36 @@ select:focus-visible {
   }
 }
 
-@media (max-width: 620px) {
-  .controlbar {
-    height: auto;
-    flex-wrap: wrap;
-    padding: 0;
+@media (max-width: 640px) {
+  .topbar {
+    grid-template-columns: 1fr;
   }
 
-  .language-select-control {
-    width: 100%;
-    height: 44px;
-    justify-content: space-between;
-    padding: 0 12px;
-    border-top: 0;
+  .brand {
+    min-width: 0;
+    height: 50px;
     border-right: 0;
-    border-bottom: 1px solid var(--line);
-    border-left: 0;
-    border-radius: 0;
-    margin-left: 0;
+    border-bottom: 1px solid var(--line-muted);
+  }
+
+  .controlbar {
+    flex-wrap: wrap;
+    gap: 0;
+    padding: 8px 10px;
   }
 
   .run-summary {
-    min-height: 44px;
+    gap: 9px;
     margin-left: 12px;
   }
 
+  .control-actions {
+    gap: 5px;
+  }
+
   .github-link {
-    min-height: 32px;
-  }
-
-  .fix-button,
-  .share-button {
-    min-height: 32px;
-  }
-
-  .panel-hint {
-    display: none;
+    padding-right: 3px;
+    padding-left: 3px;
   }
 
   .side-panel {
@@ -1162,28 +929,37 @@ select:focus-visible {
   }
 }
 
-@media (max-width: 430px) {
-  .control-actions {
-    flex-wrap: wrap;
-    row-gap: 8px;
-    padding-top: 8px;
-    padding-bottom: 8px;
+@media (max-width: 500px) {
+  .brand {
+    padding: 0 12px;
   }
 
-  .run-duration {
-    display: none;
+  .controlbar {
+    row-gap: 8px;
   }
 
   .run-summary {
-    gap: 7px;
+    margin-left: auto;
+  }
+
+  .control-actions {
+    width: 100%;
   }
 
   .github-link {
-    padding: 0 5px;
+    margin-left: auto;
   }
 
-  .github-link .external-mark {
+  .segmented-label {
     display: none;
+  }
+
+  .rules-heading {
+    gap: 6px;
+  }
+
+  .segmented-control button {
+    padding-inline: 5px;
   }
 }
 


### PR DESCRIPTION
## Summary

- reshape the Playground into a flatter, full-width developer workbench with a quieter toolbar and panel treatment
- remove redundant visible run states and the single-version selector while preserving accessible announcements and error feedback
- add share URLs that restore the active language, source, rules mode, and rules configuration
- discard stale share fragments after edits and handle malformed or unsupported shared state safely
- tighten responsive behavior and update page metadata to match the Playground

## Testing

- pnpm --filter @utoo/lint-playground test
- pnpm playground:typecheck
- pnpm --filter @utoo/lint-playground inspect
- pnpm playground:build