### PR TITLE
feat: implement no-unexpected-multiline

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -170,6 +170,7 @@ instead of being rewritten.
 | [`no-underscore-dangle`](https://eslint.org/docs/latest/rules/no-underscore-dangle) | Supports `allow`, `allowAfterThis`, `allowAfterSuper`, `allowAfterThisConstructor`, `allowFunctionParams`, `allowInArrayDestructuring`, `allowInObjectDestructuring`, `enforceInMethodNames`, and `enforceInClassFields` configuration |
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Supports `defaultAssignment` with precedence-, side-effect-, and comment-safe autofix |
+| [`no-unexpected-multiline`](https://eslint.org/docs/latest/rules/no-unexpected-multiline) | Reports confusing multiline calls, computed property access, tagged templates, and regexp-looking division chains |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unreachable-loop`](https://eslint.org/docs/latest/rules/no-unreachable-loop) | Supports loop body exit detection and `ignore` configuration |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -234,6 +234,7 @@ const BUILTIN_RULE_IDS = [
   "no-underscore-dangle",
   "no-undefined",
   "no-unneeded-ternary",
+  "no-unexpected-multiline",
   "no-unreachable",
   "no-unreachable-loop",
   "no-unsafe-finally",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -237,6 +237,7 @@ const BUILTIN_RULE_IDS = [
   "no-underscore-dangle",
   "no-undefined",
   "no-unneeded-ternary",
+  "no-unexpected-multiline",
   "no-unreachable",
   "no-unreachable-loop",
   "no-unsafe-finally",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2769,6 +2769,7 @@ pub const Options = struct {
     unicode_bom: bool = true,
     no_unneeded_ternary: bool = true,
     no_unneeded_ternary_default_assignment: bool = true,
+    no_unexpected_multiline: bool = true,
     no_unused_labels: bool = true,
     no_unreachable_loop: bool = true,
     no_unreachable_loop_ignore_while: bool = false,

--- a/src/main.zig
+++ b/src/main.zig
@@ -754,6 +754,8 @@ pub fn main(init: std.process.Init) !void {
             options.unicode_bom = false;
         } else if (std.mem.eql(u8, arg, "--no-unneeded-ternary=off")) {
             options.no_unneeded_ternary = false;
+        } else if (std.mem.eql(u8, arg, "--no-unexpected-multiline=off")) {
+            options.no_unexpected_multiline = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-labels=off")) {
             options.no_unused_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
@@ -2708,6 +2710,7 @@ fn printHelp() void {
         \\  --no-undefined=off        Disable no-undefined
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
+        \\  --no-unexpected-multiline=off Disable no-unexpected-multiline
         \\  --no-unused-labels=off   Disable no-unused-labels
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation

--- a/src/rules/no_unexpected_multiline.zig
+++ b/src/rules/no_unexpected_multiline.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-unexpected-multiline";
+
+const function_message = "Unexpected newline between function and ( of function call.";
+const property_message = "Unexpected newline between object and [ of property access.";
+const tagged_template_message = "Unexpected newline between template tag and template literal.";
+const division_message = "Unexpected newline between numerator and division operator.";
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    if (call.optional or call.arguments.len == 0) return;
+
+    const boundary = if (call.type_arguments != .null)
+        tree.span(call.type_arguments).end
+    else
+        tree.span(call.callee).end;
+    const call_end = tree.span(tree.extra(call.arguments)[0]).start;
+    const open_paren = findDelimiterOutsideComments(tree.source, boundary, call_end +| 1, '(') orelse return;
+    if (!containsLinebreak(tree.source, boundary, open_paren)) return;
+
+    try report(allocator, diagnostics, open_paren, function_message);
+}
+
+pub fn checkMemberExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    member: ast.MemberExpression,
+) Allocator.Error!void {
+    if (!member.computed or member.optional) return;
+
+    const boundary = tree.span(member.object).end;
+    const property_start = tree.span(member.property).start;
+    const open_bracket = findDelimiterOutsideComments(tree.source, boundary, property_start +| 1, '[') orelse return;
+    if (!containsLinebreak(tree.source, boundary, open_bracket)) return;
+
+    try report(allocator, diagnostics, open_bracket, property_message);
+}
+
+pub fn checkTaggedTemplateExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    tagged: ast.TaggedTemplateExpression,
+) Allocator.Error!void {
+    const boundary = if (tagged.type_arguments != .null)
+        tree.span(tagged.type_arguments).end
+    else
+        tree.span(tagged.tag).end;
+    const quasi_start = tree.span(tagged.quasi).start;
+    if (!containsLinebreak(tree.source, boundary, quasi_start)) return;
+
+    try report(allocator, diagnostics, quasi_start, tagged_template_message);
+}
+
+pub fn checkBinaryExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.BinaryExpression,
+) Allocator.Error!void {
+    if (expression.operator != .divide) return;
+
+    const left_binary = switch (tree.data(expression.left)) {
+        .binary_expression => |binary| binary,
+        else => return,
+    };
+    if (left_binary.operator != .divide) return;
+
+    const right_start: usize = @intCast(tree.span(expression.right).start);
+    if (right_start == 0 or right_start > tree.source.len or tree.source[right_start - 1] != '/') return;
+    if (!startsWithRegexFlagsIdentifier(tree.source, right_start)) return;
+
+    const numerator_end = tree.span(left_binary.left).end;
+    const denominator_start = tree.span(left_binary.right).start;
+    const first_slash = findDelimiterOutsideComments(tree.source, numerator_end, denominator_start, '/') orelse return;
+    if (!containsLinebreak(tree.source, numerator_end, first_slash)) return;
+
+    try report(allocator, diagnostics, first_slash, division_message);
+}
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    offset: u32,
+    message: []const u8,
+) Allocator.Error!void {
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        message,
+        .{ .start = offset, .end = offset + 1 },
+    );
+}
+
+fn containsLinebreak(source: []const u8, start: u32, end: u32) bool {
+    if (start >= end or end > source.len) return false;
+    return std.mem.indexOfAny(u8, source[start..end], "\r\n") != null;
+}
+
+fn findDelimiterOutsideComments(source: []const u8, start: u32, end: u32, delimiter: u8) ?u32 {
+    var index: usize = @intCast(start);
+    const limit = @min(@as(usize, @intCast(end)), source.len);
+
+    while (index < limit) {
+        if (source[index] == '/' and index + 1 < limit) {
+            if (source[index + 1] == '/') {
+                index += 2;
+                while (index < limit and source[index] != '\n' and source[index] != '\r') : (index += 1) {}
+                continue;
+            }
+            if (source[index + 1] == '*') {
+                index += 2;
+                while (index + 1 < limit and !(source[index] == '*' and source[index + 1] == '/')) : (index += 1) {}
+                index = @min(index + 2, limit);
+                continue;
+            }
+        }
+
+        if (source[index] == delimiter) return @intCast(index);
+        index += 1;
+    }
+
+    return null;
+}
+
+fn startsWithRegexFlagsIdentifier(source: []const u8, start: usize) bool {
+    if (start >= source.len or !isIdentifierByte(source[start])) return false;
+
+    var index = start;
+    while (index < source.len and isIdentifierByte(source[index])) : (index += 1) {
+        switch (source[index]) {
+            'g', 'i', 'm', 's', 'u', 'y' => {},
+            else => return false,
+        }
+    }
+    return index > start;
+}
+
+fn isIdentifierByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$';
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -227,6 +227,7 @@ pub const no_undef_init = @import("no_undef_init.zig");
 pub const no_underscore_dangle = @import("no_underscore_dangle.zig");
 pub const no_undefined = @import("no_undefined.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
+pub const no_unexpected_multiline = @import("no_unexpected_multiline.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_unsafe_optional_chaining = @import("no_unsafe_optional_chaining.zig");
@@ -3311,6 +3312,9 @@ const BasicVisitor = struct {
         if (self.options.no_constant_binary_expression) {
             try no_constant_binary_expression.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
+        if (self.options.no_unexpected_multiline) {
+            try no_unexpected_multiline.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression);
+        }
         if (self.options.eqeqeq) {
             try eqeqeq.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
                 .style = self.options.eqeqeq_style,
@@ -3439,6 +3443,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_unexpected_multiline) {
+            try no_unexpected_multiline.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
         if (self.options.promise_valid_params) {
             try promise_valid_params.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, call, self.options.promise_valid_params_exclude);
         }
@@ -3687,6 +3694,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.no_unexpected_multiline) {
+            try no_unexpected_multiline.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member);
+        }
         if (self.options.dot_notation and !self.options.typescript_eslint_dot_notation) {
             try dot_notation.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, member, index, .{
                 .allow_keywords = self.options.dot_notation_allow_keywords == .yes,
@@ -3752,6 +3762,18 @@ const BasicVisitor = struct {
         }
         if (self.options.complexity) {
             complexity.countMemberExpression(&self.complexity_state, member);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_tagged_template_expression(
+        self: *BasicVisitor,
+        tagged: ast.TaggedTemplateExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_unexpected_multiline) {
+            try no_unexpected_multiline.checkTaggedTemplateExpression(self.allocator, self.diagnostics, ctx.tree, tagged);
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -863,6 +863,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unexpected_multiline.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_labels.zig");
 }
 

--- a/tests/rules/no_unexpected_multiline.zig
+++ b/tests/rules/no_unexpected_multiline.zig
@@ -1,0 +1,164 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports confusing multiline calls property access and tagged templates" {
+    const source =
+        \\const call = fn
+        \\(value);
+        \\const property = object
+        \\[key];
+        \\const template = tag
+        \\`value`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.no_unexpected_multiline.id));
+    try std.testing.expectEqualStrings("Unexpected newline between function and ( of function call.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Unexpected newline between object and [ of property access.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("Unexpected newline between template tag and template literal.", ruleDiagnostic(result, 2).message);
+}
+
+test "reports regexp-looking multiline division" {
+    const source =
+        \\const value = numerator
+        \\/ denominator /g.test(input);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unexpected_multiline.id));
+    try std.testing.expectEqualStrings("Unexpected newline between numerator and division operator.", ruleDiagnostic(result, 0).message);
+}
+
+test "allows deliberate multiline expressions and optional chains" {
+    const source =
+        \\fn(
+        \\  value
+        \\);
+        \\object[
+        \\  key
+        \\];
+        \\tag `value`;
+        \\const optionalCall = object?.
+        \\  (value);
+        \\const optionalProperty = object?.
+        \\  [key];
+        \\const division = numerator / denominator /g;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unexpected_multiline.id));
+}
+
+test "matches multiline division flag edge cases" {
+    const source =
+        \\const spacedFlags = numerator
+        \\/ denominator / mgy;
+        \\const flagsOnNextLine = numerator
+        \\/ denominator /
+        \\gym;
+        \\const uppercaseFlags = numerator
+        \\/ denominator /GYM;
+        \\const ordinaryIdentifier = numerator
+        \\/ denominator /value;
+        \\const validFlags = numerator
+        \\/ denominator /gimuy.test(input);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.no_unexpected_multiline.id));
+}
+
+test "handles comments and TypeScript generic tagged templates" {
+    const source =
+        \\const call = fn /* a comment containing ( */
+        \\(value);
+        \\const valid = tag<
+        \\  string
+        \\>`value`;
+        \\const invalid = tag<string>/*
+        \\  comment
+        \\*/`value`;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_unexpected_multiline.id));
+}
+
+test "uses the opening delimiter as the diagnostic span" {
+    const source = "const value = fn\n  (argument);";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    const diagnostic = ruleDiagnostic(result, 0);
+    try std.testing.expectEqual(@as(u32, 19), diagnostic.span.start);
+    try std.testing.expectEqual(@as(u32, 20), diagnostic.span.end);
+}
+
+test "can disable no-unexpected-multiline" {
+    const source = "const value = fn\n(argument);";
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .no_unexpected_multiline = false,
+        .no_unused_vars = false,
+        .no_undef = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unexpected_multiline.id));
+}
+
+test "accepts ESLint-style no-unexpected-multiline configuration" {
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"off\"", .{});
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unexpected-multiline", config.value);
+    try std.testing.expect(!options.no_unexpected_multiline);
+}
+
+fn ruleDiagnostic(result: lint.Result, wanted_index: usize) lint.Diagnostic {
+    var found: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_unexpected_multiline.id)) continue;
+        if (found == wanted_index) return diagnostic;
+        found += 1;
+    }
+    unreachable;
+}


### PR DESCRIPTION
## Summary
- implement ESLint-compatible `no-unexpected-multiline` diagnostics for calls, computed properties, tagged templates, and regexp-looking division chains
- expose the rule through native options, CLI, npm migration support, and rule documentation
- cover ASI hazards, optional chains, comments, TypeScript generic tags, division flags, diagnostic spans, and config disabling

## Validation
- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `UTOO_LINT_BIN=... pnpm --dir npm/utoo-lint test`