### PR TITLE
feat: implement class-methods-use-this

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -13,6 +13,7 @@ instead of being rewritten.
 | [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) | Implemented |
 | [`camelcase`](https://eslint.org/docs/latest/rules/camelcase) | Supports declarations, imports, optional property checks, `ignoreDestructuring`, `ignoreImports`, lightweight `allow` patterns, and parses `ignoreGlobals` for migration compatibility |
 | [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) | Supports `always`, `never`, `ignoreInlineComments`, and `ignoreConsecutiveComments` configuration with autofix |
+| [`class-methods-use-this`](https://eslint.org/docs/latest/rules/class-methods-use-this) | Supports methods, accessors, function-valued class fields, `exceptMethods`, `enforceForClassFields`, `ignoreOverrideMethods`, and `ignoreClassesWithImplements` |
 | [`complexity`](https://eslint.org/docs/latest/rules/complexity) | Supports `max`, deprecated `maximum`, `classic` and `modified` variants, functions, arrow functions, and static blocks |
 | [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) | Implemented for mixed explicit value/bare returns and value-returning functions that can fall through |
 | [`consistent-this`](https://eslint.org/docs/latest/rules/consistent-this) | Supports configured aliases for direct `this` captures and same-scope deferred assignment checks |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -77,6 +77,7 @@ const BUILTIN_RULE_IDS = [
   "block-scoped-var",
   "camelcase",
   "capitalized-comments",
+  "class-methods-use-this",
   "complexity",
   "consistent-return",
   "consistent-this",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -80,6 +80,7 @@ const BUILTIN_RULE_IDS = [
   "block-scoped-var",
   "camelcase",
   "capitalized-comments",
+  "class-methods-use-this",
   "complexity",
   "consistent-return",
   "consistent-this",

--- a/src/core.zig
+++ b/src/core.zig
@@ -62,6 +62,47 @@ pub const ConsistentThisAliases = struct {
     }
 };
 
+pub const max_class_methods_use_this_except_methods = 32;
+pub const max_class_methods_use_this_except_method_len = 128;
+
+pub const ClassMethodsUseThisExceptMethodsError = error{
+    TooManyClassMethodsUseThisExceptMethods,
+    ClassMethodsUseThisExceptMethodTooLong,
+};
+
+pub const ClassMethodsUseThisExceptMethods = struct {
+    count: usize = 0,
+    lengths: [max_class_methods_use_this_except_methods]usize = undefined,
+    storage: [max_class_methods_use_this_except_methods][max_class_methods_use_this_except_method_len]u8 = undefined,
+
+    pub fn contains(self: *const ClassMethodsUseThisExceptMethods, name: []const u8) bool {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const ClassMethodsUseThisExceptMethods, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *ClassMethodsUseThisExceptMethods, name: []const u8) ClassMethodsUseThisExceptMethodsError!void {
+        if (self.count >= max_class_methods_use_this_except_methods) return error.TooManyClassMethodsUseThisExceptMethods;
+        if (name.len > max_class_methods_use_this_except_method_len) return error.ClassMethodsUseThisExceptMethodTooLong;
+        if (self.contains(name)) return;
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+    }
+};
+
+pub const ClassMethodsUseThisIgnoreClassesWithImplements = enum {
+    none,
+    all,
+    public_fields,
+};
+
 pub const CurlyStyle = enum {
     all,
     multi_line,
@@ -2386,6 +2427,11 @@ pub const Options = struct {
     capitalized_comments_mode: CapitalizedCommentsMode = .always,
     capitalized_comments_ignore_inline_comments: CapitalizedCommentsIgnoreInlineComments = .no,
     capitalized_comments_ignore_consecutive_comments: CapitalizedCommentsIgnoreConsecutiveComments = .no,
+    class_methods_use_this: bool = false,
+    class_methods_use_this_enforce_for_class_fields: bool = true,
+    class_methods_use_this_except_methods: ClassMethodsUseThisExceptMethods = .{},
+    class_methods_use_this_ignore_override_methods: bool = false,
+    class_methods_use_this_ignore_classes_with_implements: ClassMethodsUseThisIgnoreClassesWithImplements = .none,
     complexity: bool = true,
     complexity_max: usize = 20,
     complexity_variant: ComplexityVariant = .classic,
@@ -3268,6 +3314,13 @@ pub const Options = struct {
             self.capitalized_comments_mode = try capitalizedCommentsModeFromConfig(value);
             self.capitalized_comments_ignore_inline_comments = try capitalizedCommentsIgnoreInlineCommentsFromConfig(value);
             self.capitalized_comments_ignore_consecutive_comments = try capitalizedCommentsIgnoreConsecutiveCommentsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "class-methods-use-this")) {
+            const config = try classMethodsUseThisFromConfig(value);
+            self.class_methods_use_this_enforce_for_class_fields = config.enforce_for_class_fields;
+            self.class_methods_use_this_except_methods = config.except_methods;
+            self.class_methods_use_this_ignore_override_methods = config.ignore_override_methods;
+            self.class_methods_use_this_ignore_classes_with_implements = config.ignore_classes_with_implements;
         }
         if (std.mem.eql(u8, cli_name, "complexity")) {
             self.complexity_max = try complexityMaxFromConfig(value);
@@ -4363,6 +4416,60 @@ pub const Options = struct {
                     else => return error.UnsupportedRuleConfigValue,
                 };
                 result.allow.append(pattern) catch return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        return result;
+    }
+
+    const ClassMethodsUseThisConfig = struct {
+        enforce_for_class_fields: bool = true,
+        except_methods: ClassMethodsUseThisExceptMethods = .{},
+        ignore_override_methods: bool = false,
+        ignore_classes_with_implements: ClassMethodsUseThisIgnoreClassesWithImplements = .none,
+    };
+
+    fn classMethodsUseThisFromConfig(value: std.json.Value) RuleConfigError!ClassMethodsUseThisConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = ClassMethodsUseThisConfig{};
+        result.enforce_for_class_fields = try boolObjectOption(config, "enforceForClassFields", true);
+        result.ignore_override_methods = try boolObjectOption(config, "ignoreOverrideMethods", false);
+
+        if (config.get("exceptMethods")) |except_methods_value| {
+            const except_methods = switch (except_methods_value) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (except_methods) |except_method_value| {
+                const except_method = switch (except_method_value) {
+                    .string => |name| name,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                result.except_methods.append(except_method) catch return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        if (config.get("ignoreClassesWithImplements")) |ignore_value| {
+            const ignore = switch (ignore_value) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (std.mem.eql(u8, ignore, "all")) {
+                result.ignore_classes_with_implements = .all;
+            } else if (std.mem.eql(u8, ignore, "public-fields")) {
+                result.ignore_classes_with_implements = .public_fields;
+            } else {
+                return error.UnsupportedRuleConfigValue;
             }
         }
 
@@ -10538,6 +10645,21 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expectEqual(CapitalizedCommentsMode.never, options.capitalized_comments_mode);
     try std.testing.expectEqual(CapitalizedCommentsIgnoreInlineComments.yes, options.capitalized_comments_ignore_inline_comments);
     try std.testing.expectEqual(CapitalizedCommentsIgnoreConsecutiveComments.yes, options.capitalized_comments_ignore_consecutive_comments);
+
+    var class_methods_use_this_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"enforceForClassFields\":false,\"exceptMethods\":[\"render\",\"#private\"],\"ignoreOverrideMethods\":true,\"ignoreClassesWithImplements\":\"public-fields\"}]",
+        .{},
+    );
+    defer class_methods_use_this_config.deinit();
+    try options.setByRuleConfigValue("class-methods-use-this", class_methods_use_this_config.value);
+    try std.testing.expect(options.class_methods_use_this);
+    try std.testing.expect(!options.class_methods_use_this_enforce_for_class_fields);
+    try std.testing.expect(options.class_methods_use_this_except_methods.contains("render"));
+    try std.testing.expect(options.class_methods_use_this_except_methods.contains("#private"));
+    try std.testing.expect(options.class_methods_use_this_ignore_override_methods);
+    try std.testing.expectEqual(ClassMethodsUseThisIgnoreClassesWithImplements.public_fields, options.class_methods_use_this_ignore_classes_with_implements);
 
     var consistent_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -234,6 +234,20 @@ pub fn main(init: std.process.Init) !void {
             options.capitalized_comments_mode = .never;
         } else if (std.mem.eql(u8, arg, "--capitalized-comments-ignore-inline-comments=on")) {
             options.capitalized_comments_ignore_inline_comments = .yes;
+        } else if (std.mem.eql(u8, arg, "--class-methods-use-this=on")) {
+            options.class_methods_use_this = true;
+        } else if (std.mem.eql(u8, arg, "--class-methods-use-this=off")) {
+            options.class_methods_use_this = false;
+        } else if (std.mem.eql(u8, arg, "--class-methods-use-this-enforce-for-class-fields=off")) {
+            options.class_methods_use_this = true;
+            options.class_methods_use_this_enforce_for_class_fields = false;
+        } else if (std.mem.startsWith(u8, arg, "--class-methods-use-this-except-method=")) {
+            appendClassMethodsUseThisExceptMethod(arg["--class-methods-use-this-except-method=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--class-methods-use-this-ignore-override-methods=on")) {
+            options.class_methods_use_this = true;
+            options.class_methods_use_this_ignore_override_methods = true;
+        } else if (std.mem.startsWith(u8, arg, "--class-methods-use-this-ignore-classes-with-implements=")) {
+            parseClassMethodsUseThisIgnoreClassesWithImplements(arg["--class-methods-use-this-ignore-classes-with-implements=".len..], &options);
         } else if (std.mem.eql(u8, arg, "--complexity=off")) {
             options.complexity = false;
         } else if (std.mem.startsWith(u8, arg, "--complexity-max=")) {
@@ -1586,6 +1600,28 @@ fn appendCamelcaseAllow(value: []const u8, options: *lint.Options) void {
     options.camelcase = true;
 }
 
+fn appendClassMethodsUseThisExceptMethod(value: []const u8, options: *lint.Options) void {
+    options.class_methods_use_this_except_methods.append(value) catch {
+        std.debug.print("utoo-lint: invalid --class-methods-use-this-except-method value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+    options.class_methods_use_this = true;
+}
+
+fn parseClassMethodsUseThisIgnoreClassesWithImplements(value: []const u8, options: *lint.Options) void {
+    if (std.mem.eql(u8, value, "all")) {
+        options.class_methods_use_this_ignore_classes_with_implements = .all;
+    } else if (std.mem.eql(u8, value, "public-fields")) {
+        options.class_methods_use_this_ignore_classes_with_implements = .public_fields;
+    } else if (std.mem.eql(u8, value, "none")) {
+        options.class_methods_use_this_ignore_classes_with_implements = .none;
+    } else {
+        std.debug.print("utoo-lint: invalid --class-methods-use-this-ignore-classes-with-implements value: {s}\n", .{value});
+        std.process.exit(2);
+    }
+    options.class_methods_use_this = true;
+}
+
 fn appendNoRestrictedExportName(value: []const u8, options: *lint.Options) void {
     options.no_restricted_exports_names.append(value) catch {
         std.debug.print("utoo-lint: invalid --no-restricted-exports-name value: {s}\n", .{value});
@@ -2410,6 +2446,12 @@ fn printHelp() void {
         \\  --capitalized-comments=off Disable capitalized-comments
         \\  --capitalized-comments=never Require lowercase comment starts
         \\  --capitalized-comments-ignore-inline-comments=on Ignore inline comments
+        \\  --class-methods-use-this=on Enable class-methods-use-this
+        \\  --class-methods-use-this=off Disable class-methods-use-this
+        \\  --class-methods-use-this-enforce-for-class-fields=off Ignore function-valued class fields
+        \\  --class-methods-use-this-except-method=NAME Ignore a class method name
+        \\  --class-methods-use-this-ignore-override-methods=on Ignore TypeScript override methods
+        \\  --class-methods-use-this-ignore-classes-with-implements=MODE Ignore all or public-fields in implementing classes
         \\  --complexity=off          Disable complexity
         \\  --complexity-max=N        Set complexity maximum
         \\  --complexity-variant=modified Use modified switch complexity

--- a/src/rules/class_methods_use_this.zig
+++ b/src/rules/class_methods_use_this.zig
@@ -1,0 +1,393 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "class-methods-use-this";
+
+pub const Options = struct {
+    enforce_for_class_fields: bool = true,
+    except_methods: *const core.ClassMethodsUseThisExceptMethods,
+    ignore_override_methods: bool = false,
+    ignore_classes_with_implements: core.ClassMethodsUseThisIgnoreClassesWithImplements = .none,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    options: Options,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .options = options,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const ContextStack = struct {
+    const capacity = 256;
+
+    values: [capacity]bool = undefined,
+    len: usize = 0,
+
+    fn push(self: *ContextStack) void {
+        if (self.len < capacity) self.values[self.len] = false;
+        self.len += 1;
+    }
+
+    fn pop(self: *ContextStack) ?bool {
+        if (self.len == 0) return null;
+        self.len -= 1;
+        // Suppress diagnostics when pathological nesting exceeded storage.
+        if (self.len >= capacity) return true;
+        return self.values[self.len];
+    }
+
+    fn markUsed(self: *ContextStack) void {
+        if (self.len == 0 or self.len > capacity) return;
+        self.values[self.len - 1] = true;
+    }
+};
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    options: Options,
+    contexts: ContextStack = .{},
+
+    pub fn enter_function(
+        self: *Visitor,
+        _: ast.Function,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.push();
+        return .proceed;
+    }
+
+    pub fn exit_function(
+        self: *Visitor,
+        function: ast.Function,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        const uses_this = self.contexts.pop() orelse return;
+        if (uses_this) return;
+
+        const parent = directClassMemberParent(ctx.tree, ctx) orelse return;
+        switch (parent) {
+            .method_definition => |method| {
+                if (!self.includesMethod(ctx.tree, method, ctx)) return;
+                self.reportMethod(ctx.tree, method, function.async, function.generator) catch {};
+            },
+            .property_definition => |property| {
+                if (!self.includesProperty(ctx.tree, property, ctx)) return;
+                self.reportProperty(ctx.tree, property, function.async, function.generator) catch {};
+            },
+        }
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (directPropertyParent(ctx.tree, ctx) != null) self.contexts.push();
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        function: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        const property = directPropertyParent(ctx.tree, ctx) orelse return;
+        const uses_this = self.contexts.pop() orelse return;
+        if (uses_this or !self.includesProperty(ctx.tree, property, ctx)) return;
+        self.reportProperty(ctx.tree, property, function.async, false) catch {};
+    }
+
+    pub fn enter_static_block(
+        self: *Visitor,
+        _: ast.StaticBlock,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.push();
+        return .proceed;
+    }
+
+    pub fn exit_static_block(
+        self: *Visitor,
+        _: ast.StaticBlock,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        _ = self.contexts.pop();
+    }
+
+    pub fn enter_this_expression(
+        self: *Visitor,
+        _: ast.ThisExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.markUsed();
+        return .proceed;
+    }
+
+    pub fn enter_super(
+        self: *Visitor,
+        _: ast.Super,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.markUsed();
+        return .proceed;
+    }
+
+    pub fn exit_property_definition(
+        self: *Visitor,
+        _: ast.PropertyDefinition,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        _ = self.contexts.pop();
+    }
+
+    pub fn exit_node(
+        self: *Visitor,
+        _: ast.NodeData,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        const parent_index = ctx.path.parent() orelse return;
+        const property = switch (ctx.tree.data(parent_index)) {
+            .property_definition => |property| property,
+            else => return,
+        };
+        if (property.key == index) self.contexts.push();
+    }
+
+    fn includesMethod(
+        self: *const Visitor,
+        tree: *const ast.Tree,
+        method: ast.MethodDefinition,
+        ctx: *traverser.basic.Ctx,
+    ) bool {
+        if (method.static or method.kind == .constructor) return false;
+        return self.includesMember(tree, method.key, method.computed, method.override, method.accessibility, ctx);
+    }
+
+    fn includesProperty(
+        self: *const Visitor,
+        tree: *const ast.Tree,
+        property: ast.PropertyDefinition,
+        ctx: *traverser.basic.Ctx,
+    ) bool {
+        if (property.static or !self.options.enforce_for_class_fields) return false;
+        return self.includesMember(tree, property.key, property.computed, property.override, property.accessibility, ctx);
+    }
+
+    fn includesMember(
+        self: *const Visitor,
+        tree: *const ast.Tree,
+        key: ast.NodeIndex,
+        computed: bool,
+        override: bool,
+        accessibility: ast.Accessibility,
+        ctx: *traverser.basic.Ctx,
+    ) bool {
+        // ESLint intentionally applies configured exceptions only to non-computed members.
+        if (computed) return true;
+        if (self.options.ignore_override_methods and override) return false;
+
+        if (self.options.ignore_classes_with_implements != .none) {
+            if (nearestClass(tree, ctx)) |class| {
+                if (class.type == .class_declaration and class.implements.len > 0) {
+                    if (self.options.ignore_classes_with_implements == .all) return false;
+                    if (!isPrivateKey(tree, key) and (accessibility == .none or accessibility == .public)) return false;
+                }
+            }
+        }
+
+        return !exceptMethodsContains(self.options.except_methods, tree, key);
+    }
+
+    fn reportMethod(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        method: ast.MethodDefinition,
+        async_function: bool,
+        generator: bool,
+    ) Allocator.Error!void {
+        const kind = switch (method.kind) {
+            .get => "getter",
+            .set => "setter",
+            else => "method",
+        };
+        try self.report(tree, method.key, method.computed, kind, async_function, generator);
+    }
+
+    fn reportProperty(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        property: ast.PropertyDefinition,
+        async_function: bool,
+        generator: bool,
+    ) Allocator.Error!void {
+        try self.report(tree, property.key, property.computed, "method", async_function, generator);
+    }
+
+    fn report(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        key: ast.NodeIndex,
+        computed: bool,
+        kind: []const u8,
+        async_function: bool,
+        generator: bool,
+    ) Allocator.Error!void {
+        const name = staticMemberName(tree, key, computed);
+        const private_prefix = if (name != null and name.?.private) "private " else "";
+        const async_prefix = if (async_function) "async " else "";
+        const generator_prefix = if (generator) "generator " else "";
+        const span = tree.span(key);
+
+        if (name) |member_name| {
+            if (member_name.private) {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    span,
+                    "Expected 'this' to be used by class {s}{s}{s}{s} #{s}.",
+                    .{ private_prefix, async_prefix, generator_prefix, kind, member_name.value },
+                );
+            } else {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    span,
+                    "Expected 'this' to be used by class {s}{s}{s}{s} '{s}'.",
+                    .{ private_prefix, async_prefix, generator_prefix, kind, member_name.value },
+                );
+            }
+            return;
+        }
+
+        try core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            span,
+            "Expected 'this' to be used by class {s}{s}{s}{s}.",
+            .{ private_prefix, async_prefix, generator_prefix, kind },
+        );
+    }
+};
+
+const ClassMemberParent = union(enum) {
+    method_definition: ast.MethodDefinition,
+    property_definition: ast.PropertyDefinition,
+};
+
+fn directPropertyParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.PropertyDefinition {
+    return switch (directClassMemberParent(tree, ctx) orelse return null) {
+        .property_definition => |property| property,
+        .method_definition => null,
+    };
+}
+
+fn directClassMemberParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ClassMemberParent {
+    var child = ctx.path.ancestor(0) orelse return null;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent_index| : (depth += 1) {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != child) return null;
+                child = parent_index;
+            },
+            .method_definition => |method| return if (method.value == child)
+                .{ .method_definition = method }
+            else
+                null,
+            .property_definition => |property| return if (property.value == child)
+                .{ .property_definition = property }
+            else
+                null,
+            else => return null,
+        }
+    }
+    return null;
+}
+
+fn nearestClass(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.Class {
+    var ancestors = ctx.path.ancestors();
+    _ = ancestors.next();
+    while (ancestors.next()) |index| {
+        switch (tree.data(index)) {
+            .class => |class| return class,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn isPrivateKey(tree: *const ast.Tree, key: ast.NodeIndex) bool {
+    return tree.data(key) == .private_identifier;
+}
+
+fn exceptMethodsContains(
+    except_methods: *const core.ClassMethodsUseThisExceptMethods,
+    tree: *const ast.Tree,
+    key: ast.NodeIndex,
+) bool {
+    const name = staticMemberName(tree, key, false) orelse return false;
+    if (!name.private) return except_methods.contains(name.value);
+
+    for (0..except_methods.count) |index| {
+        const exception = except_methods.at(index);
+        if (exception.len == name.value.len + 1 and exception[0] == '#' and
+            std.mem.eql(u8, exception[1..], name.value)) return true;
+    }
+    return false;
+}
+
+const StaticMemberName = struct {
+    value: []const u8,
+    private: bool = false,
+};
+
+fn staticMemberName(tree: *const ast.Tree, key: ast.NodeIndex, computed: bool) ?StaticMemberName {
+    return switch (tree.data(key)) {
+        .identifier_name => |identifier| if (computed) null else .{ .value = tree.string(identifier.name) },
+        .private_identifier => |identifier| if (computed) null else .{ .value = tree.string(identifier.name), .private = true },
+        .string_literal => |literal| .{ .value = tree.string(literal.value) },
+        .numeric_literal => |literal| .{ .value = tree.string(literal.raw) },
+        .template_literal => |template| staticTemplateName(tree, template),
+        else => null,
+    };
+}
+
+fn staticTemplateName(tree: *const ast.Tree, template: ast.TemplateLiteral) ?StaticMemberName {
+    if (template.expressions.len != 0) return null;
+    const quasis = tree.extra(template.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| .{ .value = tree.string(element.cooked) },
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -20,6 +20,7 @@ pub const arrow_body_style = @import("arrow_body_style.zig");
 pub const block_scoped_var = @import("block_scoped_var.zig");
 pub const camelcase = @import("camelcase.zig");
 pub const capitalized_comments = @import("capitalized_comments.zig");
+pub const class_methods_use_this = @import("class_methods_use_this.zig");
 pub const complexity = @import("complexity.zig");
 pub const consistent_this = @import("consistent_this.zig");
 pub const consistent_return = @import("consistent_return.zig");
@@ -561,6 +562,14 @@ pub fn runBasic(
             },
             .ignore_inline_comments = options.capitalized_comments_ignore_inline_comments == .yes,
             .ignore_consecutive_comments = options.capitalized_comments_ignore_consecutive_comments == .yes,
+        });
+    }
+    if (options.class_methods_use_this) {
+        try class_methods_use_this.run(allocator, diagnostics, tree, .{
+            .enforce_for_class_fields = options.class_methods_use_this_enforce_for_class_fields,
+            .except_methods = &options.class_methods_use_this_except_methods,
+            .ignore_override_methods = options.class_methods_use_this_ignore_override_methods,
+            .ignore_classes_with_implements = options.class_methods_use_this_ignore_classes_with_implements,
         });
     }
     if (options.no_warning_comments) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -35,6 +35,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/class_methods_use_this.zig");
+}
+
+comptime {
     _ = @import("rules/complexity.zig");
 }
 

--- a/tests/rules/class_methods_use_this.zig
+++ b/tests/rules/class_methods_use_this.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports instance methods accessors and function-valued fields without this" {
+    const source =
+        \\class Example {
+        \\  method() {}
+        \\  get value() { return 1; }
+        \\  set value(next) { consume(next); }
+        \\  field = () => {};
+        \\  privateField = function () {};
+        \\  wrappedField = (() => {});
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .class_methods_use_this = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.class_methods_use_this.id));
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class method 'method'.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class getter 'value'.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class setter 'value'.", ruleDiagnostic(result, 2).message);
+}
+
+test "allows constructors static members and direct this or super usage" {
+    const source =
+        \\class Example extends Base {
+        \\  constructor() {}
+        \\  static utility() {}
+        \\  method() { return this.value; }
+        \\  inherited() { return super.value; }
+        \\  arrow() { return () => this.value; }
+        \\  field = () => this.value;
+        \\  functionField = function () { return this.value; };
+        \\  static staticField = () => {};
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .class_methods_use_this = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.class_methods_use_this.id));
+}
+
+test "isolates nested functions class fields and static blocks" {
+    const source =
+        \\class Example {
+        \\  nestedFunction() { function inner() { return this.value; } }
+        \\  nestedField() { return class Inner { field = this.value; }; }
+        \\  nestedStaticBlock() { return class Inner { static { this.value; } }; }
+        \\  computedField() { return class Inner { [this.key] = 1; }; }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .class_methods_use_this = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, lint.rules.class_methods_use_this.id));
+}
+
+test "supports exceptions field enforcement and override options" {
+    const source =
+        \\class Example extends Base {
+        \\  kept() {}
+        \\  field = () => {};
+        \\  override inherited() {}
+        \\}
+    ;
+
+    var options = lint.Options{
+        .class_methods_use_this = true,
+        .class_methods_use_this_enforce_for_class_fields = false,
+        .class_methods_use_this_ignore_override_methods = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    };
+    try options.class_methods_use_this_except_methods.append("kept");
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.class_methods_use_this.id));
+}
+
+test "supports implements exclusions for all and public members" {
+    const source =
+        \\interface Contract {}
+        \\class Example implements Contract {
+        \\  public exposed() {}
+        \\  protected inherited() {}
+        \\  private internal() {}
+        \\  #secret() {}
+        \\}
+    ;
+
+    var public_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .class_methods_use_this = true,
+        .class_methods_use_this_ignore_classes_with_implements = .public_fields,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer public_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(public_result, lint.rules.class_methods_use_this.id));
+
+    var all_result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", .{
+        .class_methods_use_this = true,
+        .class_methods_use_this_ignore_classes_with_implements = .all,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer all_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(all_result, lint.rules.class_methods_use_this.id));
+}
+
+test "reports private and computed methods with ESLint-compatible descriptions" {
+    const source =
+        \\class Example {
+        \\  #secret() {}
+        \\  [dynamic]() {}
+        \\  *generator() {}
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", .{
+        .class_methods_use_this = true,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class private method #secret.", ruleDiagnostic(result, 0).message);
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class method.", ruleDiagnostic(result, 1).message);
+    try std.testing.expectEqualStrings("Expected 'this' to be used by class generator method 'generator'.", ruleDiagnostic(result, 2).message);
+}
+
+test "can disable class-methods-use-this" {
+    var result = try lint.lintSource(std.testing.allocator, "class Example { method() {} }", "fixture.js", .{
+        .class_methods_use_this = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.class_methods_use_this.id));
+}
+
+fn ruleDiagnostic(result: lint.Result, ordinal: usize) lint.Diagnostic {
+    var seen: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.class_methods_use_this.id)) continue;
+        if (seen == ordinal) return diagnostic;
+        seen += 1;
+    }
+    unreachable;
+}


### PR DESCRIPTION
## Summary
- implement ESLint-compatible `class-methods-use-this` for methods, accessors, and function-valued class fields
- support `exceptMethods`, `enforceForClassFields`, `ignoreOverrideMethods`, and `ignoreClassesWithImplements`
- register CLI and npm migration surfaces and document the rule

## Verification
- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `UTOO_LINT_BIN=... pnpm --dir npm/utoo-lint test`