### PR TITLE
feat: implement no-invalid-this

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -105,6 +105,7 @@ instead of being rewritten.
 | [`no-inline-comments`](https://eslint.org/docs/latest/rules/no-inline-comments) | Supports `ignorePattern` configuration with common regex-like patterns |
 | [`no-inner-declarations`](https://eslint.org/docs/latest/rules/no-inner-declarations) | Supports default `functions` mode and `both` mode for nested `var` declarations |
 | [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) | Implemented with optional `allowConstructorFlags` behavior |
+| [`no-invalid-this`](https://eslint.org/docs/latest/rules/no-invalid-this) | Supports strict functions, modules, constructors, explicit callback bindings, class fields/static blocks, TypeScript `this` parameters, JSDoc `@this`, and `capIsConstructor` |
 | [`no-irregular-whitespace`](https://eslint.org/docs/latest/rules/no-irregular-whitespace) | Implemented |
 | [`no-iterator`](https://eslint.org/docs/latest/rules/no-iterator) | Implemented |
 | [`no-label-var`](https://eslint.org/docs/latest/rules/no-label-var) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -169,6 +169,7 @@ const BUILTIN_RULE_IDS = [
   "no-inline-comments",
   "no-inner-declarations",
   "no-invalid-regexp",
+  "no-invalid-this",
   "no-irregular-whitespace",
   "no-iterator",
   "no-label-var",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -172,6 +172,7 @@ const BUILTIN_RULE_IDS = [
   "no-inline-comments",
   "no-inner-declarations",
   "no-invalid-regexp",
+  "no-invalid-this",
   "no-irregular-whitespace",
   "no-iterator",
   "no-label-var",

--- a/src/core.zig
+++ b/src/core.zig
@@ -103,6 +103,11 @@ pub const ClassMethodsUseThisIgnoreClassesWithImplements = enum {
     public_fields,
 };
 
+pub const NoInvalidThisCapIsConstructor = enum {
+    yes,
+    no,
+};
+
 pub const CurlyStyle = enum {
     all,
     multi_line,
@@ -2696,6 +2701,8 @@ pub const Options = struct {
     jsx_a11y_scope: bool = true,
     no_invalid_regexp: bool = true,
     no_invalid_regexp_allow_constructor_flags: NoInvalidRegexpAllowConstructorFlags = .{},
+    no_invalid_this: bool = false,
+    no_invalid_this_cap_is_constructor: NoInvalidThisCapIsConstructor = .yes,
     no_irregular_whitespace: bool = true,
     no_irregular_whitespace_skip_strings: bool = true,
     no_irregular_whitespace_skip_comments: bool = false,
@@ -3584,6 +3591,9 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "no-invalid-regexp")) {
             self.no_invalid_regexp_allow_constructor_flags = try noInvalidRegexpAllowConstructorFlagsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-invalid-this")) {
+            self.no_invalid_this_cap_is_constructor = if (try boolRuleObjectOption(value, "capIsConstructor", true)) .yes else .no;
         }
         if (std.mem.eql(u8, cli_name, "no-irregular-whitespace")) {
             self.no_irregular_whitespace_skip_strings = try noIrregularWhitespaceBoolOptionFromConfig(value, "skipStrings", true);
@@ -5245,6 +5255,19 @@ pub const Options = struct {
             .bool => |enabled| enabled,
             else => error.UnsupportedRuleConfigValue,
         };
+    }
+
+    fn boolRuleObjectOption(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return default,
+        };
+        if (items.len < 2) return default;
+        const object = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return boolObjectOption(object, key, default);
     }
 
     fn reactNoUnusedPropTypesSkipShapePropsFromConfig(value: std.json.Value) RuleConfigError!bool {
@@ -10660,6 +10683,17 @@ test "Options can apply ESLint-style rule config values" {
     try std.testing.expect(options.class_methods_use_this_except_methods.contains("#private"));
     try std.testing.expect(options.class_methods_use_this_ignore_override_methods);
     try std.testing.expectEqual(ClassMethodsUseThisIgnoreClassesWithImplements.public_fields, options.class_methods_use_this_ignore_classes_with_implements);
+
+    var no_invalid_this_config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"capIsConstructor\":false}]",
+        .{},
+    );
+    defer no_invalid_this_config.deinit();
+    try options.setByRuleConfigValue("no-invalid-this", no_invalid_this_config.value);
+    try std.testing.expect(options.no_invalid_this);
+    try std.testing.expectEqual(NoInvalidThisCapIsConstructor.no, options.no_invalid_this_cap_is_constructor);
 
     var consistent_return_config = try std.json.parseFromSlice(
         std.json.Value,

--- a/src/main.zig
+++ b/src/main.zig
@@ -550,6 +550,13 @@ pub fn main(init: std.process.Init) !void {
             options.jsx_a11y_scope = false;
         } else if (std.mem.eql(u8, arg, "--no-invalid-regexp=off")) {
             options.no_invalid_regexp = false;
+        } else if (std.mem.eql(u8, arg, "--no-invalid-this=on")) {
+            options.no_invalid_this = true;
+        } else if (std.mem.eql(u8, arg, "--no-invalid-this=off")) {
+            options.no_invalid_this = false;
+        } else if (std.mem.eql(u8, arg, "--no-invalid-this-cap-is-constructor=off")) {
+            options.no_invalid_this = true;
+            options.no_invalid_this_cap_is_constructor = .no;
         } else if (std.mem.eql(u8, arg, "--no-irregular-whitespace=off")) {
             options.no_irregular_whitespace = false;
         } else if (std.mem.eql(u8, arg, "--no-inline-comments=off")) {
@@ -2605,6 +2612,9 @@ fn printHelp() void {
         \\  --jsx-a11y-role-supports-aria-props=off Disable jsx-a11y/role-supports-aria-props
         \\  --jsx-a11y-scope=off      Disable jsx-a11y/scope
         \\  --no-invalid-regexp=off    Disable no-invalid-regexp
+        \\  --no-invalid-this=on       Enable no-invalid-this
+        \\  --no-invalid-this=off      Disable no-invalid-this
+        \\  --no-invalid-this-cap-is-constructor=off Do not treat capitalized functions as constructors
         \\  --no-irregular-whitespace=off Disable no-irregular-whitespace
         \\  --no-inline-comments=off   Disable no-inline-comments
         \\  --no-inner-declarations=off Disable no-inner-declarations

--- a/src/root.zig
+++ b/src/root.zig
@@ -269,6 +269,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_global_is_nan or
         options.no_implied_eval or
         options.no_import_assign or
+        options.no_invalid_this or
         options.alipay_ant_no_phantom_dependencies or
         options.import_default or
         options.import_export or

--- a/src/rules/no_invalid_this.zig
+++ b/src/rules/no_invalid_this.zig
@@ -1,0 +1,491 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const semantic_compat = @import("../semantic_compat.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-invalid-this";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    scope_tree: semantic_compat.ScopeTree,
+    symbol_table: semantic_compat.SymbolTable,
+    cap_is_constructor: bool,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .scope_tree = scope_tree,
+        .symbol_table = symbol_table,
+        .cap_is_constructor = cap_is_constructor,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const ContextStack = struct {
+    const capacity = 256;
+
+    values: [capacity]bool = undefined,
+    len: usize = 0,
+
+    fn push(self: *ContextStack, valid: bool) void {
+        if (self.len < capacity) self.values[self.len] = valid;
+        self.len += 1;
+    }
+
+    fn pop(self: *ContextStack) void {
+        if (self.len > 0) self.len -= 1;
+    }
+
+    fn current(self: *const ContextStack) bool {
+        // Suppress diagnostics for pathological nesting beyond local storage.
+        if (self.len == 0 or self.len > capacity) return true;
+        return self.values[self.len - 1];
+    }
+};
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    scope_tree: semantic_compat.ScopeTree,
+    symbol_table: semantic_compat.SymbolTable,
+    cap_is_constructor: bool,
+    contexts: ContextStack = .{},
+
+    pub fn enter_program(
+        self: *Visitor,
+        _: ast.Program,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.push(!ctx.tree.isModule());
+        return .proceed;
+    }
+
+    pub fn exit_program(
+        self: *Visitor,
+        _: ast.Program,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.contexts.pop();
+    }
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        const scope = self.scope_tree.getScope(self.symbol_table.scopeOf(index));
+        const valid = !scope.flags.strict or !isDefaultThisBinding(
+            ctx.tree,
+            function,
+            index,
+            ctx,
+            self.cap_is_constructor,
+        );
+        self.contexts.push(valid);
+        return .proceed;
+    }
+
+    pub fn exit_function(
+        self: *Visitor,
+        _: ast.Function,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.contexts.pop();
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.push(self.contexts.current());
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.contexts.pop();
+    }
+
+    pub fn enter_static_block(
+        self: *Visitor,
+        _: ast.StaticBlock,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        self.contexts.push(true);
+        return .proceed;
+    }
+
+    pub fn exit_static_block(
+        self: *Visitor,
+        _: ast.StaticBlock,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.contexts.pop();
+    }
+
+    pub fn enter_this_expression(
+        self: *Visitor,
+        _: ast.ThisExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!self.contexts.current()) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Unexpected 'this'.",
+                ctx.tree.span(index),
+            );
+        }
+        return .proceed;
+    }
+
+    pub fn exit_property_definition(
+        self: *Visitor,
+        _: ast.PropertyDefinition,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.contexts.pop();
+    }
+
+    pub fn exit_node(
+        self: *Visitor,
+        _: ast.NodeData,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        const parent_index = ctx.path.parent() orelse return;
+        const property = switch (ctx.tree.data(parent_index)) {
+            .property_definition => |property| property,
+            else => return,
+        };
+        // Computed keys evaluate in the outer context. The initializer is an
+        // implicit `this`-binding context, so start it only after the key.
+        if (property.key == index) self.contexts.push(true);
+    }
+};
+
+fn isDefaultThisBinding(
+    tree: *const ast.Tree,
+    function: ast.Function,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    cap_is_constructor: bool,
+) bool {
+    if (hasExplicitThisParameter(tree, function.params)) return false;
+    if (cap_is_constructor) {
+        if (functionName(tree, function.id)) |name| {
+            if (startsWithUpperCase(name)) return false;
+        }
+    }
+    if (hasJSDocThisTag(tree, index)) return false;
+
+    const is_anonymous = function.id == .null;
+    var current = index;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |parent_index| {
+        switch (tree.data(parent_index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != current) return true;
+                current = parent_index;
+                depth += 1;
+            },
+            .logical_expression, .conditional_expression => {
+                current = parent_index;
+                depth += 1;
+            },
+            .chain_expression => |chain| {
+                if (chain.expression != current) return true;
+                current = parent_index;
+                depth += 1;
+            },
+            .return_statement => {
+                const jump = returnedFromIife(tree, ctx, current, depth) orelse return true;
+                current = jump.call;
+                depth = jump.next_depth;
+            },
+            .arrow_function_expression => |arrow| {
+                if (arrow.body != current) return true;
+                const jump = calleeCallAbove(tree, ctx, parent_index, depth + 1) orelse return true;
+                current = jump.call;
+                depth = jump.next_depth;
+            },
+            .object_property => |property| return property.value != current,
+            .property_definition => |property| return property.value != current,
+            .method_definition => |method| return method.value != current,
+            .assignment_expression => |assignment| {
+                if (assignment.right != current) return true;
+                if (isMemberExpression(tree, assignment.left)) return false;
+                if (cap_is_constructor and is_anonymous) {
+                    if (identifierName(tree, assignment.left)) |name| return !startsWithUpperCase(name);
+                }
+                return true;
+            },
+            .assignment_pattern => |assignment| {
+                if (assignment.right != current) return true;
+                if (isMemberExpression(tree, assignment.left)) return false;
+                if (cap_is_constructor and is_anonymous) {
+                    if (identifierName(tree, assignment.left)) |name| return !startsWithUpperCase(name);
+                }
+                return true;
+            },
+            .variable_declarator => |declarator| {
+                if (declarator.init != current or !cap_is_constructor or !is_anonymous) return true;
+                const name = bindingName(tree, declarator.id) orelse return true;
+                return !startsWithUpperCase(name);
+            },
+            .member_expression => |member| {
+                if (member.object != current or !isBindCallApply(tree, member)) return true;
+                const jump = calleeCallAbove(tree, ctx, parent_index, depth + 1) orelse return true;
+                const call = switch (tree.data(jump.call)) {
+                    .call_expression => |call| call,
+                    else => return true,
+                };
+                const arguments = tree.extra(call.arguments);
+                return arguments.len < 1 or isNullOrUndefined(tree, arguments[0]);
+            },
+            .call_expression => |call| return isDefaultCallbackBinding(tree, call, current),
+            else => return true,
+        }
+    }
+    return true;
+}
+
+const IifeJump = struct {
+    call: ast.NodeIndex,
+    next_depth: usize,
+};
+
+fn returnedFromIife(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    current: ast.NodeIndex,
+    start_depth: usize,
+) ?IifeJump {
+    const statement = switch (tree.data(ctx.path.ancestor(start_depth).?)) {
+        .return_statement => |statement| statement,
+        else => return null,
+    };
+    if (statement.argument != current) return null;
+
+    var depth = start_depth + 1;
+    while (ctx.path.ancestor(depth)) |index| : (depth += 1) {
+        switch (tree.data(index)) {
+            .function => return calleeCallAbove(tree, ctx, index, depth + 1),
+            .arrow_function_expression => return calleeCallAbove(tree, ctx, index, depth + 1),
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn calleeCallAbove(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    initial: ast.NodeIndex,
+    start_depth: usize,
+) ?IifeJump {
+    var current = initial;
+    var depth = start_depth;
+    while (ctx.path.ancestor(depth)) |index| {
+        switch (tree.data(index)) {
+            .parenthesized_expression => |parenthesized| {
+                if (parenthesized.expression != current) return null;
+                current = index;
+                depth += 1;
+            },
+            .chain_expression => |chain| {
+                if (chain.expression != current) return null;
+                current = index;
+                depth += 1;
+            },
+            .call_expression => |call| {
+                if (call.callee != current) return null;
+                return .{ .call = index, .next_depth = depth + 1 };
+            },
+            else => return null,
+        }
+    }
+    return null;
+}
+
+fn isDefaultCallbackBinding(tree: *const ast.Tree, call: ast.CallExpression, current: ast.NodeIndex) bool {
+    const arguments = tree.extra(call.arguments);
+    const callee = unwrapTransparent(tree, call.callee);
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return true,
+    };
+    const method = memberName(tree, member) orelse return true;
+
+    if (isIdentifierNamed(tree, member.object, "Reflect") and std.mem.eql(u8, method, "apply")) {
+        return arguments.len != 3 or arguments[0] != current or isNullOrUndefined(tree, arguments[1]);
+    }
+    if (isArrayLikeName(identifierName(tree, unwrapTransparent(tree, member.object))) and
+        (std.mem.eql(u8, method, "from") or std.mem.eql(u8, method, "fromAsync")))
+    {
+        return arguments.len != 3 or arguments[1] != current or isNullOrUndefined(tree, arguments[2]);
+    }
+    if (isArrayCallbackMethod(method)) {
+        return arguments.len != 2 or arguments[0] != current or isNullOrUndefined(tree, arguments[1]);
+    }
+    return true;
+}
+
+fn hasExplicitThisParameter(tree: *const ast.Tree, params_index: ast.NodeIndex) bool {
+    if (params_index == .null) return false;
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |params| params,
+        else => return false,
+    };
+    for (tree.extra(params.items)) |item| {
+        const parameter = switch (tree.data(item)) {
+            .formal_parameter => |parameter| parameter.pattern,
+            else => item,
+        };
+        if (tree.data(parameter) == .ts_this_parameter) return true;
+    }
+    return false;
+}
+
+fn hasJSDocThisTag(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const function_start = tree.span(index).start;
+    var cursor = function_start;
+    var comment_index = tree.comments.len;
+    while (comment_index > 0) {
+        comment_index -= 1;
+        const comment = tree.comments[comment_index];
+        if (comment.span.end > cursor) continue;
+
+        const gap = tree.source[comment.span.end..cursor];
+        const trimmed = std.mem.trim(u8, gap, " \t\r\n");
+        if (trimmed.len != 0 and !(cursor == function_start and std.mem.eql(u8, trimmed, "return"))) break;
+        if (commentHasThisTag(tree.string(comment.value))) return true;
+        cursor = comment.span.start;
+    }
+    return false;
+}
+
+fn commentHasThisTag(comment: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, comment, '\n');
+    while (lines.next()) |line| {
+        var text = std.mem.trimStart(u8, line, " \t\r");
+        while (text.len > 0 and text[0] == '*') {
+            text = std.mem.trimStart(u8, text[1..], " \t");
+        }
+        if (std.mem.startsWith(u8, text, "@this")) return true;
+    }
+    return false;
+}
+
+fn isBindCallApply(tree: *const ast.Tree, member: ast.MemberExpression) bool {
+    const name = memberName(tree, member) orelse return false;
+    return std.mem.eql(u8, name, "bind") or std.mem.eql(u8, name, "call") or std.mem.eql(u8, name, "apply");
+}
+
+fn isArrayCallbackMethod(name: []const u8) bool {
+    const names = [_][]const u8{
+        "every",   "filter",  "find", "findIndex", "findLast", "findLastIndex",
+        "flatMap", "forEach", "map",  "some",
+    };
+    for (names) |candidate| if (std.mem.eql(u8, name, candidate)) return true;
+    return false;
+}
+
+fn isArrayLikeName(name: ?[]const u8) bool {
+    const value = name orelse return false;
+    return std.mem.endsWith(u8, value, "Array");
+}
+
+fn isNullOrUndefined(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .null_literal => true,
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "undefined"),
+        .unary_expression => |unary| unary.operator == .void,
+        else => false,
+    };
+}
+
+fn isMemberExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return tree.data(unwrapTransparent(tree, index)) == .member_expression;
+}
+
+fn memberName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, member.property))) {
+        .identifier_name => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn isIdentifierNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierName(tree, unwrapTransparent(tree, index)) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn functionName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn startsWithUpperCase(name: []const u8) bool {
+    if (name.len == 0) return false;
+    return if (name[0] < 0x80) std.ascii.isUpper(name[0]) else true;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, initial: ast.NodeIndex) ast.NodeIndex {
+    var index = initial;
+    while (true) {
+        index = switch (tree.data(index)) {
+            .parenthesized_expression => |parenthesized| parenthesized.expression,
+            .chain_expression => |chain| chain.expression,
+            .ts_as_expression => |expression| expression.expression,
+            .ts_satisfies_expression => |expression| expression.expression,
+            .ts_type_assertion => |expression| expression.expression,
+            .ts_non_null_expression => |expression| expression.expression,
+            else => return index,
+        };
+    }
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -161,6 +161,7 @@ pub const no_import_assign = @import("no_import_assign.zig");
 pub const no_inline_comments = @import("no_inline_comments.zig");
 pub const no_inner_declarations = @import("no_inner_declarations.zig");
 pub const no_invalid_regexp = @import("no_invalid_regexp.zig");
+pub const no_invalid_this = @import("no_invalid_this.zig");
 pub const no_irregular_whitespace = @import("no_irregular_whitespace.zig");
 pub const no_iterator = @import("no_iterator.zig");
 pub const no_label_var = @import("no_label_var.zig");
@@ -800,6 +801,16 @@ fn runSemanticBeforeIo(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.no_invalid_this) {
+        try no_invalid_this.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.scope_tree,
+            semantic_result.symbol_table,
+            options.no_invalid_this_cap_is_constructor == .yes,
+        );
+    }
     if (options.alipay_ant_exhaustive_deps and !options.react_hooks_exhaustive_deps) {
         try alipay_ant_exhaustive_deps.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -62,6 +62,10 @@ pub const SymbolTable = struct {
         return Reference.fromYuku(self.model.reference(id));
     }
 
+    pub inline fn scopeOf(self: SymbolTable, node: ast.NodeIndex) yuku_semantic.ScopeId {
+        return self.model.scopeOf(node);
+    }
+
     pub fn iterSymbols(self: SymbolTable) yuku_semantic.Semantic.SymbolIterator {
         return self.model.iterSymbols();
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -599,6 +599,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_invalid_this.zig");
+}
+
+comptime {
     _ = @import("rules/no_irregular_whitespace.zig");
 }
 

--- a/tests/rules/no_invalid_this.zig
+++ b/tests/rules/no_invalid_this.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const base_options = lint.Options{
+    .no_invalid_this = true,
+    .no_undef = false,
+    .no_unused_vars = false,
+    .parser_semantic_errors = false,
+};
+
+test "reports module top-level and strict default function bindings" {
+    const source =
+        \\this.value;
+        \\(() => this.value)();
+        \\function plain() { this.value; () => this.value; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", base_options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, lint.rules.no_invalid_this.id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_invalid_this.id)) {
+            try std.testing.expectEqualStrings("Unexpected 'this'.", diagnostic.message);
+        }
+    }
+}
+
+test "allows script top-level and non-strict functions" {
+    const source =
+        \\this.value;
+        \\(() => this.value)();
+        \\function plain() { this.value; () => this.value; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.cjs", base_options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "recognizes constructors properties explicit binding and callback thisArg" {
+    const source =
+        \\function Constructor() { this.value; }
+        \\const Assigned = function () { this.value; };
+        \\const object = { method: function () { this.value; }, shorthand() { this.value; } };
+        \\object.assigned = function () { this.value; };
+        \\(function () { this.value; }).call(object);
+        \\const bound = function () { this.value; }.bind(object);
+        \\Reflect.apply(function () { this.value; }, object, []);
+        \\Array.from([], function () { this.value; }, object);
+        \\items.forEach(function () { this.value; }, object);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", base_options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "reports nullish explicit bindings and supports capIsConstructor false" {
+    const source =
+        \\function Constructor() { this.value; }
+        \\const Assigned = function () { this.value; };
+        \\(function () { this.value; }).call(undefined);
+        \\const bound = function () { this.value; }.bind(null);
+        \\items.map(function () { this.value; }, void 0);
+        \\const dynamic = function () { this.value; }[binding](object);
+    ;
+
+    var options = base_options;
+    options.no_invalid_this_cap_is_constructor = .no;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "follows IIFE return destinations" {
+    const source =
+        \\const object = {
+        \\  method: (function () { return function () { this.value; }; })(),
+        \\  arrowFactory: (() => function () { this.value; })(),
+        \\};
+        \\target.method = (function () { return function () { this.value; }; })?.();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", base_options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "handles class fields static blocks and computed keys" {
+    const source =
+        \\class Example {
+        \\  [this.key] = 1;
+        \\  field = this.value;
+        \\  arrow = () => this.value;
+        \\  functionField = function () { this.value; };
+        \\  method() { this.value; }
+        \\  static { this.value; () => this.value; function nested() { this.value; } }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", base_options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "supports TypeScript this parameters and JSDoc this tags" {
+    const source =
+        \\function typed(this: Context) { this.value; }
+        \\callback(function (this: Context) { this.value; });
+        \\/** @this Context */ function documented() { this.value; }
+        \\callback(/* @this Context */ function () { this.value; });
+        \\function factory() { /** @this Context */ return function inner() { this.value; }; }
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", base_options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_this.id));
+}
+
+test "can disable no-invalid-this" {
+    var result = try lint.lintSource(std.testing.allocator, "this.value", "fixture.js", .{
+        .no_invalid_this = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_invalid_this.id));
+}


### PR DESCRIPTION
## Summary
- implement ESLint-compatible `no-invalid-this` strict-mode and binding analysis
- support constructors, property destinations, IIFE returns, bind/call/apply, callback `thisArg`, class fields/static blocks, TypeScript `this` parameters, and JSDoc `@this`
- add `capIsConstructor` config/CLI support and expose the rule through npm entry points

## Validation
- ESLint 10.0.1 conformance matrix: 444 applicable JS/TypeScript cases matched, 0 mismatches
- `zig fmt --check build.zig src tests`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `pnpm --dir npm/utoo-lint test` (86 tests plus TypeScript typecheck)