### PR TITLE
feat: implement no-unmodified-loop-condition

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -173,6 +173,7 @@ instead of being rewritten.
 | [`no-undefined`](https://eslint.org/docs/latest/rules/no-undefined) | Implemented for identifier references and binding names |
 | [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) | Supports `defaultAssignment` with precedence-, side-effect-, and comment-safe autofix |
 | [`no-unexpected-multiline`](https://eslint.org/docs/latest/rules/no-unexpected-multiline) | Reports confusing multiline calls, computed property access, tagged templates, and regexp-looking division chains |
+| [`no-unmodified-loop-condition`](https://eslint.org/docs/latest/rules/no-unmodified-loop-condition) | Implemented |
 | [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) | Implemented with hoisted declaration handling |
 | [`no-unreachable-loop`](https://eslint.org/docs/latest/rules/no-unreachable-loop) | Supports loop body exit detection and `ignore` configuration |
 | [`no-unsafe-finally`](https://eslint.org/docs/latest/rules/no-unsafe-finally) | Implemented with local loop, switch, and label exit handling |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -237,6 +237,7 @@ const BUILTIN_RULE_IDS = [
   "no-undefined",
   "no-unneeded-ternary",
   "no-unexpected-multiline",
+  "no-unmodified-loop-condition",
   "no-unreachable",
   "no-unreachable-loop",
   "no-unsafe-finally",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -240,6 +240,7 @@ const BUILTIN_RULE_IDS = [
   "no-undefined",
   "no-unneeded-ternary",
   "no-unexpected-multiline",
+  "no-unmodified-loop-condition",
   "no-unreachable",
   "no-unreachable-loop",
   "no-unsafe-finally",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2823,6 +2823,7 @@ pub const Options = struct {
     no_unneeded_ternary: bool = true,
     no_unneeded_ternary_default_assignment: bool = true,
     no_unexpected_multiline: bool = true,
+    no_unmodified_loop_condition: bool = false,
     no_unused_labels: bool = true,
     no_unreachable_loop: bool = true,
     no_unreachable_loop_ignore_while: bool = false,

--- a/src/main.zig
+++ b/src/main.zig
@@ -777,6 +777,10 @@ pub fn main(init: std.process.Init) !void {
             options.no_unneeded_ternary = false;
         } else if (std.mem.eql(u8, arg, "--no-unexpected-multiline=off")) {
             options.no_unexpected_multiline = false;
+        } else if (std.mem.eql(u8, arg, "--no-unmodified-loop-condition=on")) {
+            options.no_unmodified_loop_condition = true;
+        } else if (std.mem.eql(u8, arg, "--no-unmodified-loop-condition=off")) {
+            options.no_unmodified_loop_condition = false;
         } else if (std.mem.eql(u8, arg, "--no-unused-labels=off")) {
             options.no_unused_labels = false;
         } else if (std.mem.eql(u8, arg, "--no-unsafe-finally=off")) {
@@ -2763,6 +2767,8 @@ fn printHelp() void {
         \\  --unicode-bom=off         Disable unicode-bom
         \\  --no-unneeded-ternary=off Disable no-unneeded-ternary
         \\  --no-unexpected-multiline=off Disable no-unexpected-multiline
+        \\  --no-unmodified-loop-condition=on Enable no-unmodified-loop-condition
+        \\  --no-unmodified-loop-condition=off Disable no-unmodified-loop-condition
         \\  --no-unused-labels=off   Disable no-unused-labels
         \\  --no-unsafe-finally=off   Disable no-unsafe-finally
         \\  --no-unsafe-negation=off  Disable no-unsafe-negation

--- a/src/root.zig
+++ b/src/root.zig
@@ -270,6 +270,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_implied_eval or
         options.no_import_assign or
         options.no_invalid_this or
+        options.no_unmodified_loop_condition or
         options.alipay_ant_no_phantom_dependencies or
         options.import_default or
         options.import_export or

--- a/src/rules/no_unmodified_loop_condition.zig
+++ b/src/rules/no_unmodified_loop_condition.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const semantic_compat = @import("../semantic_compat.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+const SymbolId = semantic_compat.traverser.semantic.SymbolId;
+
+pub const id = "no-unmodified-loop-condition";
+
+const Condition = struct {
+    node: ast.NodeIndex,
+    name: ast.String,
+    symbol: SymbolId,
+    group: ast.NodeIndex = .null,
+    loop: ast.NodeIndex,
+    modified: bool = false,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: semantic_compat.SymbolTable,
+) Allocator.Error!void {
+    var conditions: std.ArrayList(Condition) = .empty;
+    defer conditions.deinit(allocator);
+
+    var references = symbol_table.iterReferences();
+    while (references.next()) |entry| {
+        if (entry.reference.kind != .value) continue;
+        const symbol = symbol_table.referenceSymbol(entry.id);
+        if (symbol == .none) continue;
+
+        if (try toLoopCondition(tree, symbol_table, entry.reference.node, entry.reference.name, symbol)) |condition| {
+            try conditions.append(allocator, condition);
+        }
+    }
+
+    if (conditions.items.len == 0) return;
+
+    for (conditions.items) |*condition| {
+        condition.modified = isModified(tree, symbol_table, condition.*);
+    }
+
+    for (conditions.items) |condition| {
+        if (!condition.modified and condition.group == .null) {
+            try report(allocator, diagnostics, tree, condition);
+        }
+    }
+
+    var checked_groups = std.AutoHashMap(ast.NodeIndex, void).init(allocator);
+    defer checked_groups.deinit();
+
+    for (conditions.items) |condition| {
+        if (condition.group == .null or checked_groups.contains(condition.group)) continue;
+        try checked_groups.put(condition.group, {});
+
+        var all_unmodified = true;
+        for (conditions.items) |group_condition| {
+            if (group_condition.group == condition.group and group_condition.modified) {
+                all_unmodified = false;
+                break;
+            }
+        }
+        if (!all_unmodified) continue;
+
+        for (conditions.items) |group_condition| {
+            if (group_condition.group == condition.group) {
+                try report(allocator, diagnostics, tree, group_condition);
+            }
+        }
+    }
+}
+
+fn toLoopCondition(
+    tree: *const ast.Tree,
+    symbol_table: semantic_compat.SymbolTable,
+    reference_node: ast.NodeIndex,
+    name: ast.String,
+    symbol: SymbolId,
+) Allocator.Error!?Condition {
+    var group: ast.NodeIndex = .null;
+    var child = reference_node;
+    var maybe_node = symbol_table.parentOf(child);
+
+    while (maybe_node) |node| {
+        const data = tree.data(node);
+
+        if (isSentinel(data)) {
+            if (loopTest(data)) |test_node| {
+                if (test_node == child) {
+                    return .{
+                        .node = reference_node,
+                        .name = name,
+                        .symbol = symbol,
+                        .group = group,
+                        .loop = node,
+                    };
+                }
+            }
+            break;
+        }
+
+        switch (data) {
+            .binary_expression, .conditional_expression => {
+                if (containsDynamicExpression(tree, node)) break;
+                group = node;
+            },
+            else => {},
+        }
+
+        child = node;
+        maybe_node = symbol_table.parentOf(node);
+    }
+
+    return null;
+}
+
+fn isModified(
+    tree: *const ast.Tree,
+    symbol_table: semantic_compat.SymbolTable,
+    condition: Condition,
+) bool {
+    var references = symbol_table.iterReferences();
+    while (references.next()) |entry| {
+        if (symbol_table.referenceSymbol(entry.id) != condition.symbol) continue;
+        if (!symbol_table.isWriteReference(entry.id)) continue;
+
+        if (isInLoop(tree, condition.loop, entry.reference.node)) return true;
+        if (enclosingFunctionCalledInLoop(tree, symbol_table, condition.loop, entry.reference.node)) return true;
+    }
+
+    // Yuku does not model declaration initializers as references. ESLint counts
+    // initialized `var` declarations as writes, so synthesize those modifiers.
+    for (symbol_table.symbolDecls(condition.symbol)) |declaration| {
+        if (isInitializedVarDeclaration(tree, symbol_table, declaration) and
+            isInLoop(tree, condition.loop, declaration))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+fn isInitializedVarDeclaration(
+    tree: *const ast.Tree,
+    symbol_table: semantic_compat.SymbolTable,
+    declaration: ast.NodeIndex,
+) bool {
+    var child = declaration;
+    var declarator_index: ast.NodeIndex = .null;
+    var declarator: ast.VariableDeclarator = undefined;
+    while (symbol_table.parentOf(child)) |parent| {
+        const parent_data = tree.data(parent);
+        switch (parent_data) {
+            .variable_declarator => |value| {
+                declarator_index = parent;
+                declarator = value;
+                break;
+            },
+            else => if (parent_data.isDeclaration()) return false,
+        }
+        child = parent;
+    }
+    if (declarator_index == .null) return false;
+    if (declarator.init == .null) return false;
+
+    const declaration_index = symbol_table.parentOf(declarator_index) orelse return false;
+    return switch (tree.data(declaration_index)) {
+        .variable_declaration => |value| value.kind == .@"var",
+        else => false,
+    };
+}
+
+fn enclosingFunctionCalledInLoop(
+    tree: *const ast.Tree,
+    symbol_table: semantic_compat.SymbolTable,
+    loop: ast.NodeIndex,
+    modifier: ast.NodeIndex,
+) bool {
+    var maybe_node: ?ast.NodeIndex = modifier;
+    while (maybe_node) |node| {
+        switch (tree.data(node)) {
+            .function => |function| {
+                if (function.type == .function_declaration and function.id != .null) {
+                    const function_symbol = symbol_table.symbolOf(function.id) orelse return false;
+                    var uses = symbol_table.symbolUses(function_symbol);
+                    while (uses.next()) |use| {
+                        if (isInLoop(tree, loop, use)) return true;
+                    }
+                    return false;
+                }
+            },
+            else => {},
+        }
+        maybe_node = symbol_table.parentOf(node);
+    }
+    return false;
+}
+
+fn isInLoop(tree: *const ast.Tree, loop: ast.NodeIndex, node: ast.NodeIndex) bool {
+    const loop_span = tree.span(loop);
+    const node_span = tree.span(node);
+    if (node_span.start < loop_span.start or node_span.end > loop_span.end) return false;
+
+    return switch (tree.data(loop)) {
+        .for_statement => |statement| statement.init == .null or !containsNode(tree, statement.init, node),
+        else => true,
+    };
+}
+
+fn containsNode(tree: *const ast.Tree, container: ast.NodeIndex, node: ast.NodeIndex) bool {
+    const outer = tree.span(container);
+    const inner = tree.span(node);
+    return outer.start <= inner.start and inner.end <= outer.end;
+}
+
+fn loopTest(data: ast.NodeData) ?ast.NodeIndex {
+    return switch (data) {
+        .while_statement => |statement| statement.@"test",
+        .do_while_statement => |statement| statement.@"test",
+        .for_statement => |statement| statement.@"test",
+        else => null,
+    };
+}
+
+fn isSentinel(data: ast.NodeData) bool {
+    if (data.isStatement() or data.isDeclaration()) return true;
+    return switch (data) {
+        .call_expression,
+        .class,
+        .function,
+        .member_expression,
+        .new_expression,
+        .yield_expression,
+        => true,
+        else => false,
+    };
+}
+
+fn containsDynamicExpression(tree: *const ast.Tree, root: ast.NodeIndex) bool {
+    var scanner = DynamicExpressionScanner{};
+    var subtree = tree.*;
+    subtree.root = root;
+    traverser.basic.traverse(DynamicExpressionScanner, &subtree, &scanner) catch return true;
+    return scanner.found;
+}
+
+const DynamicExpressionScanner = struct {
+    found: bool = false,
+
+    pub fn enter_node(
+        self: *DynamicExpressionScanner,
+        data: ast.NodeData,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        switch (data) {
+            .call_expression,
+            .member_expression,
+            .new_expression,
+            .tagged_template_expression,
+            .yield_expression,
+            => {
+                self.found = true;
+                return .stop;
+            },
+            .arrow_function_expression => return .skip,
+            .function => |function| {
+                if (function.type == .function_expression or function.type == .ts_empty_body_function_expression) return .skip;
+            },
+            .class => |class_node| {
+                if (class_node.type == .class_expression) return .skip;
+            },
+            else => {},
+        }
+        return .proceed;
+    }
+};
+
+fn report(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    condition: Condition,
+) Allocator.Error!void {
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(condition.node),
+        "'{s}' is not modified in this loop.",
+        .{tree.string(condition.name)},
+    );
+}
+
+test "recognizes dynamic groups" {
+    var tree = try parser.parse(std.testing.allocator, "var foo, obj; while (foo === obj.bar) {}", .{});
+    defer tree.deinit();
+
+    var scanner = DynamicExpressionScanner{};
+    try traverser.basic.traverse(DynamicExpressionScanner, &tree, &scanner);
+    try std.testing.expect(scanner.found);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -230,6 +230,7 @@ pub const no_underscore_dangle = @import("no_underscore_dangle.zig");
 pub const no_undefined = @import("no_undefined.zig");
 pub const no_unneeded_ternary = @import("no_unneeded_ternary.zig");
 pub const no_unexpected_multiline = @import("no_unexpected_multiline.zig");
+pub const no_unmodified_loop_condition = @import("no_unmodified_loop_condition.zig");
 pub const no_unsafe_finally = @import("no_unsafe_finally.zig");
 pub const no_unsafe_negation = @import("no_unsafe_negation.zig");
 pub const no_unsafe_optional_chaining = @import("no_unsafe_optional_chaining.zig");
@@ -809,6 +810,14 @@ fn runSemanticBeforeIo(
             semantic_result.scope_tree,
             semantic_result.symbol_table,
             options.no_invalid_this_cap_is_constructor == .yes,
+        );
+    }
+    if (options.no_unmodified_loop_condition) {
+        try no_unmodified_loop_condition.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
         );
     }
     if (options.alipay_ant_exhaustive_deps and !options.react_hooks_exhaustive_deps) {

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -66,6 +66,18 @@ pub const SymbolTable = struct {
         return self.model.scopeOf(node);
     }
 
+    pub inline fn symbolOf(self: SymbolTable, node: ast.NodeIndex) ?yuku_semantic.SymbolId {
+        return self.model.symbolOf(node);
+    }
+
+    pub inline fn parentOf(self: SymbolTable, node: ast.NodeIndex) ?ast.NodeIndex {
+        return self.model.parentOf(node);
+    }
+
+    pub inline fn isWriteReference(self: SymbolTable, id: yuku_semantic.ReferenceId) bool {
+        return self.model.reference(id).flags.write;
+    }
+
     pub fn iterSymbols(self: SymbolTable) yuku_semantic.Semantic.SymbolIterator {
         return self.model.iterSymbols();
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -875,6 +875,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_unmodified_loop_condition.zig");
+}
+
+comptime {
     _ = @import("rules/no_unused_labels.zig");
 }
 

--- a/tests/rules/no_unmodified_loop_condition.zig
+++ b/tests/rules/no_unmodified_loop_condition.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const base_options = lint.Options{
+    .no_unmodified_loop_condition = true,
+    .no_undef = false,
+    .no_unused_vars = false,
+    .parser_semantic_errors = false,
+};
+
+test "accepts official ESLint valid cases" {
+    const cases = [_][]const u8{
+        "var foo = 0; while (foo) { ++foo; }",
+        "let foo = 0; while (foo) { ++foo; }",
+        "var foo = 0; while (foo) { foo += 1; }",
+        "var foo = 0; while (foo++) { }",
+        "var foo = 0; while (foo = next()) { }",
+        "var foo = 0; while (ok(foo)) { }",
+        "var foo = 0, bar = 0; while (++foo < bar) { }",
+        "var foo = 0, obj = {}; while (foo === obj.bar) { }",
+        "var foo = 0, f = {}, bar = {}; while (foo === f(bar)) { }",
+        "var foo = 0, f = {}; while (foo === f()) { }",
+        "var foo = 0, tag = 0; while (foo === tag`abc`) { }",
+        "function* f() { var foo = 0; while (yield foo) { } }",
+        "function* f() { var foo = 0; while (foo === (yield)) { } }",
+        "var foo = 0; while (foo.ok) { }",
+        "var foo = 0; while (foo) { update(); } function update() { ++foo; }",
+        "var foo = 0, bar = 9; while (foo < bar) { foo += 1; }",
+        "var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
+        "var foo = 0, bar = 0; while (foo && bar) { ++foo; ++bar; }",
+        "var foo = 0, bar = 0; while (foo || bar) { ++foo; ++bar; }",
+        "var foo = 0; do { ++foo; } while (foo);",
+        "var foo = 0; do { } while (foo++);",
+        "for (var foo = 0; foo; ++foo) { }",
+        "for (var foo = 0; foo;) { ++foo }",
+        "var foo = 0, bar = 0; for (bar; foo;) { ++foo }",
+        "var foo; if (foo) { }",
+        "var a = [1, 2, 3]; var len = a.length; for (var i = 0; i < len - 1; i++) {}",
+        "var foo; while (foo) { var [foo] = values; }",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", base_options);
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unmodified_loop_condition.id));
+    }
+}
+
+test "reports official ESLint invalid cases" {
+    const Case = struct { source: []const u8, count: usize };
+    const cases = [_]Case{
+        .{ .source = "var foo = 0; while (foo) { } foo = 1;", .count = 1 },
+        .{ .source = "var foo = 0; while (!foo) { } foo = 1;", .count = 1 },
+        .{ .source = "var foo = 0; while (foo != null) { } foo = 1;", .count = 1 },
+        .{ .source = "var foo = 0, bar = 9; while (foo < bar) { } foo = 1;", .count = 2 },
+        .{ .source = "var foo = 0, bar = 0; while (foo && bar) { ++bar; } foo = 1;", .count = 1 },
+        .{ .source = "var foo = 0, bar = 0; while (foo && bar) { ++foo; } foo = 1;", .count = 1 },
+        .{ .source = "var a, b, c; while (a < c && b < c) { ++a; } foo = 1;", .count = 2 },
+        .{ .source = "var foo = 0; while (foo ? 1 : 0) { } foo = 1;", .count = 1 },
+        .{ .source = "var foo = 0; while (foo) { update(); } function update(foo) { ++foo; }", .count = 1 },
+        .{ .source = "var foo; do { } while (foo);", .count = 1 },
+        .{ .source = "for (var foo = 0; foo < 10; ) { } foo = 1;", .count = 1 },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", base_options);
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.count, helpers.countRule(result, lint.rules.no_unmodified_loop_condition.id));
+    }
+}
+
+test "uses the official message and supports configuration" {
+    var result = try lint.lintSource(
+        std.testing.allocator,
+        "var foo; while (foo) {}",
+        "fixture.js",
+        base_options,
+    );
+    defer result.deinit(std.testing.allocator);
+
+    var found = false;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_unmodified_loop_condition.id)) continue;
+        try std.testing.expectEqualStrings("'foo' is not modified in this loop.", diagnostic.message);
+        found = true;
+    }
+    try std.testing.expect(found);
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-unmodified-loop-condition", .{ .string = "error" });
+    try std.testing.expect(options.no_unmodified_loop_condition);
+}
+
+test "is disabled by default" {
+    var result = try lint.lintSource(std.testing.allocator, "var foo; while (foo) {}", "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_unmodified_loop_condition.id));
+}


### PR DESCRIPTION
## Summary
- implement ESLint-compatible `no-unmodified-loop-condition` using resolved symbols and write references
- preserve binary/conditional grouping, dynamic-expression exclusions, `for` initializer handling, and named function modification tracking
- expose the rule through native options, CLI, npm wrappers, WASM configuration, and rule status docs

## Validation
- `zig fmt --check build.zig src tests`
- `zig build test` (11 snapshots, 0 failed)
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test` (86 tests plus typecheck)
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- ESLint 10.0.1 differential suite: 40 edge cases, 0 mismatches
- upstream ESLint valid/invalid fixtures ported as Zig tests