### PR TITLE
feat: implement no-magic-numbers

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -114,6 +114,7 @@ instead of being rewritten.
 | [`no-lonely-if`](https://eslint.org/docs/latest/rules/no-lonely-if) | Implemented with safe autofix |
 | [`no-loop-func`](https://eslint.org/docs/latest/rules/no-loop-func) | Implemented |
 | [`no-loss-of-precision`](https://eslint.org/docs/latest/rules/no-loss-of-precision) | Implemented |
+| [`no-magic-numbers`](https://eslint.org/docs/latest/rules/no-magic-numbers) | Supports `detectObjects`, `enforceConst`, `ignore`, `ignoreArrayIndexes`, `ignoreDefaultValues`, `ignoreClassFieldInitialValues`, `ignoreEnums`, `ignoreNumericLiteralTypes`, `ignoreReadonlyClassProperties`, and `ignoreTypeIndexes` |
 | [`no-mixed-spaces-and-tabs`](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs) | Supports `smart-tabs` configuration |
 | [`no-misleading-character-class`](https://eslint.org/docs/latest/rules/no-misleading-character-class) | Implemented |
 | [`no-multi-assign`](https://eslint.org/docs/latest/rules/no-multi-assign) | Supports `ignoreNonDeclaration` configuration and class field initializers |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -178,6 +178,7 @@ const BUILTIN_RULE_IDS = [
   "no-lonely-if",
   "no-loop-func",
   "no-loss-of-precision",
+  "no-magic-numbers",
   "no-mixed-spaces-and-tabs",
   "no-misleading-character-class",
   "no-multi-assign",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -181,6 +181,7 @@ const BUILTIN_RULE_IDS = [
   "no-lonely-if",
   "no-loop-func",
   "no-loss-of-precision",
+  "no-magic-numbers",
   "no-mixed-spaces-and-tabs",
   "no-misleading-character-class",
   "no-multi-assign",

--- a/src/core.zig
+++ b/src/core.zig
@@ -108,6 +108,94 @@ pub const NoInvalidThisCapIsConstructor = enum {
     no,
 };
 
+pub const max_no_magic_numbers_ignore_values = 64;
+pub const max_no_magic_numbers_bigint_len = 256;
+pub const max_no_magic_numbers_bigint_storage = 2048;
+
+pub const NoMagicNumbersIgnoreValues = struct {
+    const Kind = enum { number, bigint };
+
+    count: usize = 0,
+    kinds: [max_no_magic_numbers_ignore_values]Kind = undefined,
+    numbers: [max_no_magic_numbers_ignore_values]f64 = undefined,
+    bigint_offsets: [max_no_magic_numbers_ignore_values]u16 = undefined,
+    bigint_lengths: [max_no_magic_numbers_ignore_values]u16 = undefined,
+    bigint_storage: [max_no_magic_numbers_bigint_storage]u8 = undefined,
+    bigint_storage_len: usize = 0,
+
+    pub fn containsNumber(self: *const NoMagicNumbersIgnoreValues, value: f64) bool {
+        for (0..self.count) |index| {
+            if (self.kinds[index] == .number and self.numbers[index] == value) return true;
+        }
+        return false;
+    }
+
+    pub fn containsBigInt(self: *const NoMagicNumbersIgnoreValues, canonical: []const u8) bool {
+        for (0..self.count) |index| {
+            if (self.kinds[index] != .bigint) continue;
+            const start = self.bigint_offsets[index];
+            const stored = self.bigint_storage[start .. start + self.bigint_lengths[index]];
+            if (std.mem.eql(u8, stored, canonical)) return true;
+        }
+        return false;
+    }
+
+    pub fn appendNumber(self: *NoMagicNumbersIgnoreValues, value: f64) bool {
+        if (self.containsNumber(value)) return true;
+        if (self.count >= max_no_magic_numbers_ignore_values) return false;
+        self.kinds[self.count] = .number;
+        self.numbers[self.count] = value;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn appendBigInt(self: *NoMagicNumbersIgnoreValues, value: []const u8) bool {
+        var canonical_buffer: [max_no_magic_numbers_bigint_len]u8 = undefined;
+        const canonical = canonicalBigIntConfigValue(value, &canonical_buffer) orelse return false;
+        if (self.containsBigInt(canonical)) return true;
+        if (self.count >= max_no_magic_numbers_ignore_values) return false;
+        if (self.bigint_storage_len + canonical.len > self.bigint_storage.len) return false;
+        self.kinds[self.count] = .bigint;
+        @memcpy(self.bigint_storage[self.bigint_storage_len..][0..canonical.len], canonical);
+        self.bigint_offsets[self.count] = @intCast(self.bigint_storage_len);
+        self.bigint_lengths[self.count] = @intCast(canonical.len);
+        self.bigint_storage_len += canonical.len;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn appendCliValue(self: *NoMagicNumbersIgnoreValues, value: []const u8) bool {
+        if (std.mem.endsWith(u8, value, "n")) return self.appendBigInt(value);
+        const number = std.fmt.parseFloat(f64, value) catch return false;
+        return self.appendNumber(number);
+    }
+
+    fn canonicalBigIntConfigValue(value: []const u8, buffer: []u8) ?[]const u8 {
+        if (value.len < 2 or value[value.len - 1] != 'n') return null;
+        var digits = value[0 .. value.len - 1];
+        var negative = false;
+        if (digits[0] == '+' or digits[0] == '-') {
+            negative = digits[0] == '-';
+            digits = digits[1..];
+        }
+        if (digits.len == 0) return null;
+        for (digits) |digit| if (!std.ascii.isDigit(digit)) return null;
+
+        digits = std.mem.trimStart(u8, digits, "0");
+        if (digits.len == 0) digits = "0";
+        const length = digits.len + @intFromBool(negative and !std.mem.eql(u8, digits, "0"));
+        if (length > buffer.len) return null;
+
+        var offset: usize = 0;
+        if (negative and !std.mem.eql(u8, digits, "0")) {
+            buffer[0] = '-';
+            offset = 1;
+        }
+        @memcpy(buffer[offset..length], digits);
+        return buffer[0..length];
+    }
+};
+
 pub const CurlyStyle = enum {
     all,
     multi_line,
@@ -2722,6 +2810,17 @@ pub const Options = struct {
     no_lonely_if: bool = true,
     no_loop_func: bool = true,
     no_loss_of_precision: bool = true,
+    no_magic_numbers: bool = false,
+    no_magic_numbers_detect_objects: bool = false,
+    no_magic_numbers_enforce_const: bool = false,
+    no_magic_numbers_ignore: NoMagicNumbersIgnoreValues = .{},
+    no_magic_numbers_ignore_array_indexes: bool = false,
+    no_magic_numbers_ignore_default_values: bool = false,
+    no_magic_numbers_ignore_class_field_initial_values: bool = false,
+    no_magic_numbers_ignore_enums: bool = false,
+    no_magic_numbers_ignore_numeric_literal_types: bool = false,
+    no_magic_numbers_ignore_readonly_class_properties: bool = false,
+    no_magic_numbers_ignore_type_indexes: bool = false,
     no_multi_str: bool = true,
     no_multi_assign: bool = true,
     no_multi_assign_ignore_non_declaration: bool = false,
@@ -3609,6 +3708,18 @@ pub const Options = struct {
         if (std.mem.eql(u8, cli_name, "no-labels")) {
             self.no_labels_allow_loop = try noLabelsAllowLoopFromConfig(value);
             self.no_labels_allow_switch = try noLabelsAllowSwitchFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "no-magic-numbers")) {
+            self.no_magic_numbers_detect_objects = try boolRuleObjectOption(value, "detectObjects", false);
+            self.no_magic_numbers_enforce_const = try boolRuleObjectOption(value, "enforceConst", false);
+            self.no_magic_numbers_ignore = try noMagicNumbersIgnoreFromConfig(value);
+            self.no_magic_numbers_ignore_array_indexes = try boolRuleObjectOption(value, "ignoreArrayIndexes", false);
+            self.no_magic_numbers_ignore_default_values = try boolRuleObjectOption(value, "ignoreDefaultValues", false);
+            self.no_magic_numbers_ignore_class_field_initial_values = try boolRuleObjectOption(value, "ignoreClassFieldInitialValues", false);
+            self.no_magic_numbers_ignore_enums = try boolRuleObjectOption(value, "ignoreEnums", false);
+            self.no_magic_numbers_ignore_numeric_literal_types = try boolRuleObjectOption(value, "ignoreNumericLiteralTypes", false);
+            self.no_magic_numbers_ignore_readonly_class_properties = try boolRuleObjectOption(value, "ignoreReadonlyClassProperties", false);
+            self.no_magic_numbers_ignore_type_indexes = try boolRuleObjectOption(value, "ignoreTypeIndexes", false);
         }
         if (std.mem.eql(u8, cli_name, "no-mixed-spaces-and-tabs")) {
             self.no_mixed_spaces_and_tabs_smart_tabs = try noMixedSpacesAndTabsSmartTabsFromConfig(value);
@@ -5269,6 +5380,36 @@ pub const Options = struct {
             else => return error.UnsupportedRuleConfigValue,
         };
         return boolObjectOption(object, key, default);
+    }
+
+    fn noMagicNumbersIgnoreFromConfig(value: std.json.Value) RuleConfigError!NoMagicNumbersIgnoreValues {
+        var result: NoMagicNumbersIgnoreValues = .{};
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return result,
+        };
+        if (items.len < 2) return result;
+        const object = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const ignore_value = object.get("ignore") orelse return result;
+        const ignored = switch (ignore_value) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        for (ignored) |item| {
+            const appended = switch (item) {
+                .integer => |number| result.appendNumber(@floatFromInt(number)),
+                .float => |number| result.appendNumber(number),
+                .number_string => |raw| result.appendNumber(std.fmt.parseFloat(f64, raw) catch return error.UnsupportedRuleConfigValue),
+                .string => |bigint| result.appendBigInt(bigint),
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!appended) return error.UnsupportedRuleConfigValue;
+        }
+        return result;
     }
 
     fn reactNoUnusedPropTypesSkipShapePropsFromConfig(value: std.json.Value) RuleConfigError!bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -577,6 +577,57 @@ pub fn main(init: std.process.Init) !void {
             options.no_loop_func = false;
         } else if (std.mem.eql(u8, arg, "--no-loss-of-precision=off")) {
             options.no_loss_of_precision = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers=on")) {
+            options.no_magic_numbers = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers=off")) {
+            options.no_magic_numbers = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-detect-objects=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_detect_objects = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-detect-objects=off")) {
+            options.no_magic_numbers_detect_objects = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-enforce-const=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_enforce_const = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-enforce-const=off")) {
+            options.no_magic_numbers_enforce_const = false;
+        } else if (std.mem.startsWith(u8, arg, "--no-magic-numbers-ignore=")) {
+            parseNoMagicNumbersIgnore(arg["--no-magic-numbers-ignore=".len..], &options);
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-array-indexes=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_array_indexes = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-array-indexes=off")) {
+            options.no_magic_numbers_ignore_array_indexes = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-default-values=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_default_values = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-default-values=off")) {
+            options.no_magic_numbers_ignore_default_values = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-class-field-initial-values=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_class_field_initial_values = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-class-field-initial-values=off")) {
+            options.no_magic_numbers_ignore_class_field_initial_values = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-enums=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_enums = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-enums=off")) {
+            options.no_magic_numbers_ignore_enums = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-numeric-literal-types=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_numeric_literal_types = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-numeric-literal-types=off")) {
+            options.no_magic_numbers_ignore_numeric_literal_types = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-readonly-class-properties=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_readonly_class_properties = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-readonly-class-properties=off")) {
+            options.no_magic_numbers_ignore_readonly_class_properties = false;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-type-indexes=on")) {
+            options.no_magic_numbers = true;
+            options.no_magic_numbers_ignore_type_indexes = true;
+        } else if (std.mem.eql(u8, arg, "--no-magic-numbers-ignore-type-indexes=off")) {
+            options.no_magic_numbers_ignore_type_indexes = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-str=off")) {
             options.no_multi_str = false;
         } else if (std.mem.eql(u8, arg, "--no-multi-assign=off")) {
@@ -1542,6 +1593,25 @@ fn parseNoConsoleAllow(value: []const u8, options: *lint.Options) void {
         }
     }
     options.no_console_allow = allow;
+}
+
+fn parseNoMagicNumbersIgnore(value: []const u8, options: *lint.Options) void {
+    if (value.len == 0) {
+        std.debug.print("utoo-lint: --no-magic-numbers-ignore requires a comma-separated number list\n", .{});
+        std.process.exit(2);
+    }
+
+    var ignored: @TypeOf(options.no_magic_numbers_ignore) = .{};
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_value| {
+        const number = std.mem.trim(u8, raw_value, " \t\r\n");
+        if (number.len == 0 or !ignored.appendCliValue(number)) {
+            std.debug.print("utoo-lint: invalid or excessive --no-magic-numbers-ignore value: {s}\n", .{number});
+            std.process.exit(2);
+        }
+    }
+    options.no_magic_numbers = true;
+    options.no_magic_numbers_ignore = ignored;
 }
 
 fn parseNoEmptyFunctionAllow(value: []const u8, options: *lint.Options) void {
@@ -2671,6 +2741,18 @@ fn printHelp() void {
         \\  --max-statements-ignore-top-level-functions=on Ignore single top-level functions
         \\  --no-loop-func=off        Disable no-loop-func
         \\  --no-loss-of-precision=off Disable no-loss-of-precision
+        \\  --no-magic-numbers=on     Enable no-magic-numbers
+        \\  --no-magic-numbers=off    Disable no-magic-numbers
+        \\  --no-magic-numbers-detect-objects=on Check object properties and member assignments
+        \\  --no-magic-numbers-enforce-const=on Require const for direct numeric declarations
+        \\  --no-magic-numbers-ignore=0,1,-1,100n Ignore selected Number or BigInt values
+        \\  --no-magic-numbers-ignore-array-indexes=on Ignore valid array indexes
+        \\  --no-magic-numbers-ignore-default-values=on Ignore default values
+        \\  --no-magic-numbers-ignore-class-field-initial-values=on Ignore class field initial values
+        \\  --no-magic-numbers-ignore-enums=on Ignore TypeScript enum values
+        \\  --no-magic-numbers-ignore-numeric-literal-types=on Ignore numeric literal type aliases
+        \\  --no-magic-numbers-ignore-readonly-class-properties=on Ignore readonly class properties
+        \\  --no-magic-numbers-ignore-type-indexes=on Ignore TypeScript indexed access values
         \\  --no-multi-str=off        Disable no-multi-str
         \\  --no-multi-assign=off     Disable no-multi-assign
         \\  --no-multi-spaces=off     Disable no-multi-spaces

--- a/src/root.zig
+++ b/src/root.zig
@@ -164,7 +164,7 @@ fn lintSourceInternal(
         var semantic_result = semantic_compat.Result.init(&tree, semantic_model);
         try semantic_result.symbol_table.resolveAll(semantic_result.scope_tree);
         try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
-        try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
+        try rules.runBasicWithOptionsPtr(allocator, &diagnostics, &tree, path, &effective_options);
         if (with_io) {
             try rules.runSemanticWithIo(allocator, &diagnostics, &tree, io, path, semantic_result, effective_options);
         } else {
@@ -172,7 +172,7 @@ fn lintSourceInternal(
         }
     } else {
         try appendParserDiagnostics(allocator, &diagnostics, &tree, effective_options);
-        try rules.runBasic(allocator, &diagnostics, &tree, path, effective_options);
+        try rules.runBasicWithOptionsPtr(allocator, &diagnostics, &tree, path, &effective_options);
     }
 
     try suppressions.apply(allocator, &diagnostics, &suppressed_diagnostics, &tree);

--- a/src/rules/no_magic_numbers.zig
+++ b/src/rules/no_magic_numbers.zig
@@ -1,0 +1,414 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "no-magic-numbers";
+
+pub const Options = struct {
+    detect_objects: bool = false,
+    enforce_const: bool = false,
+    ignore: ?*const core.NoMagicNumbersIgnoreValues = null,
+    ignore_array_indexes: bool = false,
+    ignore_default_values: bool = false,
+    ignore_class_field_initial_values: bool = false,
+    ignore_enums: bool = false,
+    ignore_numeric_literal_types: bool = false,
+    ignore_readonly_class_properties: bool = false,
+    ignore_type_indexes: bool = false,
+};
+
+const Sign = enum {
+    none,
+    positive,
+    negative,
+
+    fn text(self: Sign) []const u8 {
+        return switch (self) {
+            .none => "",
+            .positive => "+",
+            .negative => "-",
+        };
+    }
+};
+
+const FullNumber = struct {
+    index: ast.NodeIndex,
+    depth: usize,
+    sign: Sign,
+};
+
+const Parent = struct {
+    index: ast.NodeIndex,
+    depth: usize,
+};
+
+pub fn checkNumericLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.NumericLiteral,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    const full = fullNumber(tree, index, ctx);
+    const unsigned_value = literal.value(tree);
+    const value = if (full.sign == .negative) -unsigned_value else unsigned_value;
+    const raw = tree.string(literal.raw);
+
+    if (options.ignore) |ignore| {
+        if (ignore.containsNumber(value)) return;
+    }
+    if (shouldIgnore(tree, ctx, full, .{ .number = value }, options)) return;
+    try checkParentAndReport(allocator, diagnostics, tree, ctx, full, raw, "", options);
+}
+
+pub fn checkBigIntLiteral(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    literal: ast.BigIntLiteral,
+    index: ast.NodeIndex,
+    ctx: *traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    const full = fullNumber(tree, index, ctx);
+    const raw = tree.string(literal.raw);
+
+    if (options.ignore) |ignore| {
+        var canonical_buffer: [core.max_no_magic_numbers_bigint_len]u8 = undefined;
+        if (canonicalBigInt(raw, full.sign == .negative, &canonical_buffer)) |canonical| {
+            if (ignore.containsBigInt(canonical)) return;
+        }
+    }
+    if (shouldIgnore(tree, ctx, full, .{ .bigint = raw }, options)) return;
+    try checkParentAndReport(allocator, diagnostics, tree, ctx, full, raw, "n", options);
+}
+
+const NumberValue = union(enum) {
+    number: f64,
+    bigint: []const u8,
+};
+
+fn shouldIgnore(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    full: FullNumber,
+    value: NumberValue,
+    options: Options,
+) bool {
+    const parent = structuralParent(tree, ctx, full.depth) orelse return false;
+
+    if (options.ignore_default_values and isDefaultValue(tree, parent, full.index)) return true;
+    if (options.ignore_class_field_initial_values and isClassFieldInitialValue(tree, parent, full.index)) return true;
+    if (options.ignore_enums and tree.data(parent.index) == .ts_enum_member) return true;
+    if (options.ignore_numeric_literal_types and isNumericLiteralType(tree, ctx, full.depth)) return true;
+    if (options.ignore_type_indexes and isTypeIndex(tree, ctx, full.depth)) return true;
+    if (options.ignore_readonly_class_properties and isReadonlyClassProperty(tree, parent)) return true;
+    if (isParseIntRadix(tree, parent, full.index)) return true;
+    if (isJsxNode(tree.data(parent.index))) return true;
+    if (options.ignore_array_indexes and isArrayIndex(tree, parent, full, value)) return true;
+    return false;
+}
+
+fn checkParentAndReport(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    full: FullNumber,
+    raw: []const u8,
+    suffix: []const u8,
+    options: Options,
+) Allocator.Error!void {
+    const parent = structuralParent(tree, ctx, full.depth) orelse return;
+
+    if (tree.data(parent.index) == .variable_declarator) {
+        if (!options.enforce_const) return;
+        const declaration = ancestorAfter(tree, ctx, parent.depth, false) orelse return;
+        const is_const = switch (tree.data(declaration.index)) {
+            .variable_declaration => |value| value.kind == .@"const",
+            else => false,
+        };
+        if (is_const) return;
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "Number constants declarations must use 'const'.",
+            tree.span(full.index),
+        );
+        return;
+    }
+
+    if (!options.detect_objects) {
+        switch (tree.data(parent.index)) {
+            .object_expression, .object_property => return,
+            .assignment_expression => |assignment| {
+                if (!isIdentifierReference(tree, unwrapTransparent(tree, assignment.left))) return;
+            },
+            else => {},
+        }
+    }
+
+    try core.addDiagnosticFmt(
+        allocator,
+        diagnostics,
+        .warning,
+        id,
+        tree.span(full.index),
+        "No magic number: {s}{s}{s}.",
+        .{ full.sign.text(), raw, suffix },
+    );
+}
+
+fn fullNumber(tree: *const ast.Tree, index: ast.NodeIndex, ctx: *traverser.basic.Ctx) FullNumber {
+    var depth: usize = 0;
+
+    while (ctx.path.ancestor(depth + 1)) |parent| {
+        switch (tree.data(parent)) {
+            .parenthesized_expression => {
+                depth += 1;
+                continue;
+            },
+            .unary_expression => |unary| {
+                if ((unary.operator == .positive or unary.operator == .negate) and
+                    unwrapTransparent(tree, unary.argument) == index)
+                {
+                    return .{
+                        .index = parent,
+                        .depth = depth + 1,
+                        .sign = if (unary.operator == .negate) .negative else .positive,
+                    };
+                }
+            },
+            else => {},
+        }
+        break;
+    }
+
+    return .{ .index = index, .depth = 0, .sign = .none };
+}
+
+fn structuralParent(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, depth: usize) ?Parent {
+    return ancestorAfter(tree, ctx, depth, false);
+}
+
+fn ancestorAfter(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    start_depth: usize,
+    skip_type_parentheses: bool,
+) ?Parent {
+    var depth = start_depth + 1;
+    while (ctx.path.ancestor(depth)) |index| : (depth += 1) {
+        switch (tree.data(index)) {
+            .parenthesized_expression, .chain_expression => continue,
+            .ts_parenthesized_type => if (skip_type_parentheses) continue,
+            else => {},
+        }
+        return .{ .index = index, .depth = depth };
+    }
+    return null;
+}
+
+fn isDefaultValue(tree: *const ast.Tree, parent: Parent, full: ast.NodeIndex) bool {
+    return switch (tree.data(parent.index)) {
+        .assignment_pattern => |pattern| unwrapTransparent(tree, pattern.right) == full,
+        else => false,
+    };
+}
+
+fn isClassFieldInitialValue(tree: *const ast.Tree, parent: Parent, full: ast.NodeIndex) bool {
+    return switch (tree.data(parent.index)) {
+        .property_definition => |property| unwrapTransparent(tree, property.value) == full,
+        else => false,
+    };
+}
+
+fn isReadonlyClassProperty(tree: *const ast.Tree, parent: Parent) bool {
+    return switch (tree.data(parent.index)) {
+        .property_definition => |property| property.readonly,
+        else => false,
+    };
+}
+
+fn isNumericLiteralType(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, full_depth: usize) bool {
+    var ancestor = ancestorAfter(tree, ctx, full_depth, true) orelse return false;
+    while (true) {
+        const parent = ancestorAfter(tree, ctx, ancestor.depth, true) orelse return false;
+        if (tree.data(parent.index) == .ts_union_type) {
+            ancestor = parent;
+            continue;
+        }
+        return tree.data(parent.index) == .ts_type_alias_declaration;
+    }
+}
+
+fn isTypeIndex(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, full_depth: usize) bool {
+    var ancestor = ancestorAfter(tree, ctx, full_depth, true) orelse return false;
+    while (true) {
+        const parent = ancestorAfter(tree, ctx, ancestor.depth, true) orelse return false;
+        switch (tree.data(parent.index)) {
+            .ts_union_type, .ts_intersection_type => ancestor = parent,
+            .ts_indexed_access_type => return true,
+            else => return false,
+        }
+    }
+}
+
+fn isParseIntRadix(tree: *const ast.Tree, parent: Parent, full: ast.NodeIndex) bool {
+    const call = switch (tree.data(parent.index)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len < 2 or unwrapTransparent(tree, arguments[1]) != full) return false;
+
+    const callee = unwrapTransparent(tree, call.callee);
+    if (identifierName(tree, callee)) |name| return std.mem.eql(u8, name, "parseInt");
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    const property = identifierName(tree, unwrapTransparent(tree, member.property)) orelse return false;
+    if (!std.mem.eql(u8, property, "parseInt")) return false;
+    const object = identifierName(tree, unwrapTransparent(tree, member.object)) orelse return false;
+    return std.mem.eql(u8, object, "Number");
+}
+
+fn isArrayIndex(
+    tree: *const ast.Tree,
+    parent: Parent,
+    full: FullNumber,
+    value: NumberValue,
+) bool {
+    const member = switch (tree.data(parent.index)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (!member.computed or unwrapTransparent(tree, member.property) != full.index) return false;
+
+    return switch (value) {
+        .number => |number| std.math.isFinite(number) and
+            number == @floor(number) and
+            number >= 0 and
+            number < 4294967295.0,
+        .bigint => |raw| bigintArrayIndex(raw, full.sign),
+    };
+}
+
+fn bigintArrayIndex(raw: []const u8, sign: Sign) bool {
+    const parsed = parseSmallBigInt(raw, 4294967295) orelse return false;
+    if (sign == .negative and parsed != 0) return false;
+    return parsed < 4294967295;
+}
+
+fn parseSmallBigInt(raw_with_suffix: []const u8, limit: u64) ?u64 {
+    var raw = raw_with_suffix;
+    if (raw.len > 0 and (raw[raw.len - 1] == 'n' or raw[raw.len - 1] == 'N')) raw = raw[0 .. raw.len - 1];
+    const radix: u8 = if (raw.len >= 2 and raw[0] == '0') switch (raw[1]) {
+        'x', 'X' => 16,
+        'o', 'O' => 8,
+        'b', 'B' => 2,
+        else => 10,
+    } else 10;
+    if (radix != 10) raw = raw[2..];
+
+    var value: u64 = 0;
+    var saw_digit = false;
+    for (raw) |char| {
+        if (char == '_') continue;
+        const digit = std.fmt.charToDigit(char, radix) catch return null;
+        saw_digit = true;
+        if (value > (limit -| digit) / radix) return null;
+        value = value * radix + digit;
+    }
+    return if (saw_digit) value else null;
+}
+
+fn canonicalBigInt(raw_with_suffix: []const u8, negative: bool, output: []u8) ?[]const u8 {
+    var raw = raw_with_suffix;
+    if (raw.len > 0 and (raw[raw.len - 1] == 'n' or raw[raw.len - 1] == 'N')) raw = raw[0 .. raw.len - 1];
+    const radix: u8 = if (raw.len >= 2 and raw[0] == '0') switch (raw[1]) {
+        'x', 'X' => 16,
+        'o', 'O' => 8,
+        'b', 'B' => 2,
+        else => 10,
+    } else 10;
+    if (radix != 10) raw = raw[2..];
+
+    var digits: [core.max_no_magic_numbers_bigint_len]u8 = [_]u8{0} ** core.max_no_magic_numbers_bigint_len;
+    var digits_len: usize = 1;
+    var saw_digit = false;
+
+    for (raw) |char| {
+        if (char == '_') continue;
+        const source_digit = std.fmt.charToDigit(char, radix) catch return null;
+        saw_digit = true;
+        var carry: u16 = source_digit;
+        for (digits[0..digits_len]) |*digit| {
+            const value: u16 = @as(u16, digit.*) * radix + carry;
+            digit.* = @intCast(value % 10);
+            carry = value / 10;
+        }
+        while (carry > 0) {
+            if (digits_len >= digits.len) return null;
+            digits[digits_len] = @intCast(carry % 10);
+            digits_len += 1;
+            carry /= 10;
+        }
+    }
+    if (!saw_digit) return null;
+    while (digits_len > 1 and digits[digits_len - 1] == 0) digits_len -= 1;
+
+    const is_zero = digits_len == 1 and digits[0] == 0;
+    const offset: usize = @intFromBool(negative and !is_zero);
+    if (digits_len + offset > output.len) return null;
+    if (offset == 1) output[0] = '-';
+    for (0..digits_len) |index| output[offset + index] = '0' + digits[digits_len - 1 - index];
+    return output[0 .. digits_len + offset];
+}
+
+fn isJsxNode(data: ast.NodeData) bool {
+    return std.mem.startsWith(u8, @tagName(std.meta.activeTag(data)), "jsx_");
+}
+
+fn isIdentifierReference(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return tree.data(index) == .identifier_reference;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            .chain_expression => |chain| current = chain.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+test "normalizes bigint values across radices" {
+    var buffer: [core.max_no_magic_numbers_bigint_len]u8 = undefined;
+    try std.testing.expectEqualStrings("171", canonicalBigInt("0xAB", false, &buffer).?);
+    try std.testing.expectEqualStrings("-8", canonicalBigInt("0b1000", true, &buffer).?);
+    try std.testing.expectEqualStrings("0", canonicalBigInt("0", true, &buffer).?);
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -170,6 +170,7 @@ pub const no_lone_blocks = @import("no_lone_blocks.zig");
 pub const no_lonely_if = @import("no_lonely_if.zig");
 pub const no_loop_func = @import("no_loop_func.zig");
 pub const no_loss_of_precision = @import("no_loss_of_precision.zig");
+pub const no_magic_numbers = @import("no_magic_numbers.zig");
 pub const no_mixed_spaces_and_tabs = @import("no_mixed_spaces_and_tabs.zig");
 pub const no_misleading_character_class = @import("no_misleading_character_class.zig");
 pub const no_multi_assign = @import("no_multi_assign.zig");
@@ -478,6 +479,21 @@ fn idMatchOptions(options: *const core.Options) id_match.Options {
     };
 }
 
+fn noMagicNumbersOptions(options: *const core.Options) no_magic_numbers.Options {
+    return .{
+        .detect_objects = options.no_magic_numbers_detect_objects,
+        .enforce_const = options.no_magic_numbers_enforce_const,
+        .ignore = &options.no_magic_numbers_ignore,
+        .ignore_array_indexes = options.no_magic_numbers_ignore_array_indexes,
+        .ignore_default_values = options.no_magic_numbers_ignore_default_values,
+        .ignore_class_field_initial_values = options.no_magic_numbers_ignore_class_field_initial_values,
+        .ignore_enums = options.no_magic_numbers_ignore_enums,
+        .ignore_numeric_literal_types = options.no_magic_numbers_ignore_numeric_literal_types,
+        .ignore_readonly_class_properties = options.no_magic_numbers_ignore_readonly_class_properties,
+        .ignore_type_indexes = options.no_magic_numbers_ignore_type_indexes,
+    };
+}
+
 fn reactPreferEs6ClassStyle(style: core.ReactPreferEs6ClassStyle) react_prefer_es6_class.Style {
     return switch (style) {
         .always => .always,
@@ -485,7 +501,7 @@ fn reactPreferEs6ClassStyle(style: core.ReactPreferEs6ClassStyle) react_prefer_e
     };
 }
 
-fn reactDisplayNameOptions(options: core.Options) react_display_name.Options {
+fn reactDisplayNameOptions(options: *const core.Options) react_display_name.Options {
     return .{
         .check_context_objects = options.react_display_name_check_context_objects,
         .ignore_transpiler_name = options.react_display_name_ignore_transpiler_name,
@@ -555,6 +571,16 @@ pub fn runBasic(
     tree: *const ast.Tree,
     file_path: []const u8,
     options: core.Options,
+) Allocator.Error!void {
+    return runBasicWithOptionsPtr(allocator, diagnostics, tree, file_path, &options);
+}
+
+pub fn runBasicWithOptionsPtr(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    file_path: []const u8,
+    options: *const core.Options,
 ) Allocator.Error!void {
     if (options.capitalized_comments) {
         try capitalized_comments.runWithOptions(allocator, diagnostics, tree, .{
@@ -1345,7 +1371,7 @@ const BasicVisitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     file_path: []const u8,
-    options: core.Options,
+    options: *const core.Options,
     react_button_has_type_state: react_button_has_type.State = .{},
     react_default_props_match_prop_types_state: react_default_props_match_prop_types.State = .{},
     react_display_name_state: react_display_name.State = .{},
@@ -1707,7 +1733,7 @@ const BasicVisitor = struct {
             try func_names.checkWithStyle(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, self.funcNamesStyle(function));
         }
         if (self.options.func_style) {
-            try func_style.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, funcStyleOptions(&self.options));
+            try func_style.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, funcStyleOptions(self.options));
         }
         if (self.options.prefer_arrow_callback) {
             try prefer_arrow_callback.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, index, ctx, .{
@@ -1716,13 +1742,13 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.camelcase) {
-            try camelcase.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, camelcaseOptions(&self.options));
+            try camelcase.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, camelcaseOptions(self.options));
         }
         if (self.options.id_length) {
-            try id_length.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idLengthOptions(&self.options));
+            try id_length.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idLengthOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idMatchOptions(&self.options));
+            try id_match.checkFunction(self.allocator, self.diagnostics, ctx.tree, function, idMatchOptions(self.options));
         }
         if (self.options.default_param_last) {
             try default_param_last.check(self.allocator, self.diagnostics, ctx.tree, function.params);
@@ -1838,13 +1864,13 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, class.id, false);
         }
         if (self.options.camelcase) {
-            try camelcase.checkClass(self.allocator, self.diagnostics, ctx.tree, class, camelcaseOptions(&self.options));
+            try camelcase.checkClass(self.allocator, self.diagnostics, ctx.tree, class, camelcaseOptions(self.options));
         }
         if (self.options.id_length) {
-            try id_length.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idLengthOptions(&self.options));
+            try id_length.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idLengthOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idMatchOptions(&self.options));
+            try id_match.checkClass(self.allocator, self.diagnostics, ctx.tree, class, idMatchOptions(self.options));
         }
         if (self.options.no_useless_constructor and !self.options.typescript_eslint_no_useless_constructor) {
             try no_useless_constructor.checkClass(self.allocator, self.diagnostics, ctx.tree, class);
@@ -2224,19 +2250,19 @@ const BasicVisitor = struct {
             try no_multi_assign.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator);
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkVariableDeclaratorWithOptions(self.allocator, self.diagnostics, ctx.tree, declarator, funcNameMatchingOptions(self.options));
         }
         if (self.options.func_style) {
-            try func_style.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, index, ctx, funcStyleOptions(&self.options));
+            try func_style.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, index, ctx, funcStyleOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, camelcaseOptions(&self.options));
+            try camelcase.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, camelcaseOptions(self.options));
         }
         if (self.options.id_length) {
-            try id_length.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idLengthOptions(&self.options));
+            try id_length.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idLengthOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idMatchOptions(&self.options));
+            try id_match.checkVariableDeclarator(self.allocator, self.diagnostics, ctx.tree, declarator, idMatchOptions(self.options));
         }
         if (self.options.react_no_children_prop) {
             react_no_children_prop.checkVariableDeclarator(ctx.tree, declarator, &self.react_no_children_prop_bindings);
@@ -2694,13 +2720,13 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, clause.param, false);
         }
         if (self.options.camelcase) {
-            try camelcase.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, camelcaseOptions(&self.options));
+            try camelcase.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, camelcaseOptions(self.options));
         }
         if (self.options.id_length) {
-            try id_length.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idLengthOptions(&self.options));
+            try id_length.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idLengthOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idMatchOptions(&self.options));
+            try id_match.checkCatchClause(self.allocator, self.diagnostics, ctx.tree, clause, idMatchOptions(self.options));
         }
         if (self.options.complexity) {
             complexity.increase(&self.complexity_state);
@@ -3114,6 +3140,37 @@ const BasicVisitor = struct {
         if (self.options.typescript_eslint_no_loss_of_precision) {
             try typescript_eslint_no_loss_of_precision.check(self.allocator, self.diagnostics, ctx.tree, literal, index);
         }
+        if (self.options.no_magic_numbers) {
+            try no_magic_numbers.checkNumericLiteral(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                literal,
+                index,
+                ctx,
+                noMagicNumbersOptions(self.options),
+            );
+        }
+        return .proceed;
+    }
+
+    pub fn enter_bigint_literal(
+        self: *BasicVisitor,
+        literal: ast.BigIntLiteral,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.no_magic_numbers) {
+            try no_magic_numbers.checkBigIntLiteral(
+                self.allocator,
+                self.diagnostics,
+                ctx.tree,
+                literal,
+                index,
+                ctx,
+                noMagicNumbersOptions(self.options),
+            );
+        }
         return .proceed;
     }
 
@@ -3136,7 +3193,7 @@ const BasicVisitor = struct {
             try max_nested_callbacks.enterArrowFunction(self.allocator, self.diagnostics, ctx.tree, index, &ctx.path, &self.max_nested_callbacks_state, self.maxNestedCallbacksOptions());
         }
         if (self.options.arrow_body_style) {
-            try arrow_body_style.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx, arrowBodyStyleOptions(&self.options));
+            try arrow_body_style.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, index, ctx, arrowBodyStyleOptions(self.options));
         }
         if (self.options.no_return_assign and expression.expression) {
             try no_return_assign.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, expression.body, .{
@@ -3158,13 +3215,13 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.camelcase) {
-            try camelcase.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, camelcaseOptions(&self.options));
+            try camelcase.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, camelcaseOptions(self.options));
         }
         if (self.options.id_length) {
-            try id_length.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idLengthOptions(&self.options));
+            try id_length.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idLengthOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idMatchOptions(&self.options));
+            try id_match.checkArrowFunction(self.allocator, self.diagnostics, ctx.tree, expression, idMatchOptions(self.options));
         }
         if (self.options.typescript_eslint_typedef and self.options.typescript_eslint_typedef_arrow_parameter) {
             try typescript_eslint_typedef.checkArrowFunctionParameters(self.allocator, self.diagnostics, ctx.tree, expression);
@@ -3253,7 +3310,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, funcNameMatchingOptions(self.options));
         }
         if (self.options.prefer_destructuring) {
             try prefer_destructuring.checkAssignmentExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, .{
@@ -3505,7 +3562,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkCallExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, call, funcNameMatchingOptions(self.options));
         }
         if (self.options.import_no_amd) {
             try import_no_amd.check(self.allocator, self.diagnostics, ctx.tree, call, index);
@@ -4163,7 +4220,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkObjectPropertyWithContextOptions(self.allocator, self.diagnostics, ctx.tree, property, index, ctx, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkObjectPropertyWithContextOptions(self.allocator, self.diagnostics, ctx.tree, property, index, ctx, funcNameMatchingOptions(self.options));
         }
         if (self.options.no_underscore_dangle) {
             try no_underscore_dangle.checkObjectPropertyWithOptions(self.allocator, self.diagnostics, ctx.tree, property, .{
@@ -4172,13 +4229,13 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.id_length) {
-            try id_length.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
+            try id_length.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(&self.options));
+            try camelcase.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
+            try id_match.checkObjectProperty(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(self.options));
         }
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterObjectProperty(self.allocator, ctx.tree, property, index, ctx.path.parent(), &self.react_no_unused_state_state);
@@ -4279,13 +4336,13 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.id_length) {
-            try id_length.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idLengthOptions(&self.options));
+            try id_length.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, camelcaseOptions(&self.options));
+            try camelcase.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idMatchOptions(&self.options));
+            try id_match.checkMethodDefinition(self.allocator, self.diagnostics, ctx.tree, method, idMatchOptions(self.options));
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkMethodDefinition(
@@ -4349,13 +4406,13 @@ const BasicVisitor = struct {
             try no_multi_assign.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property);
         }
         if (self.options.id_length) {
-            try id_length.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(&self.options));
+            try id_length.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(&self.options));
+            try camelcase.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(&self.options));
+            try id_match.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, idMatchOptions(self.options));
         }
         if (self.options.typescript_eslint_explicit_member_accessibility) {
             try typescript_eslint_explicit_member_accessibility.checkPropertyDefinition(
@@ -4390,7 +4447,7 @@ const BasicVisitor = struct {
             );
         }
         if (self.options.func_name_matching) {
-            try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, funcNameMatchingOptions(&self.options));
+            try func_name_matching.checkPropertyDefinitionWithOptions(self.allocator, self.diagnostics, ctx.tree, property, funcNameMatchingOptions(self.options));
         }
         if (self.options.react_no_typos) {
             try react_no_typos.checkPropertyDefinition(self.allocator, self.diagnostics, ctx.tree, property, ctx, self.react_no_typos_state);
@@ -4452,13 +4509,13 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
         if (self.options.id_length) {
-            try id_length.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+            try id_length.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
+            try camelcase.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
+            try id_match.checkImportSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(self.options));
         }
         return .proceed;
     }
@@ -4473,13 +4530,13 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
         if (self.options.id_length) {
-            try id_length.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+            try id_length.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
+            try camelcase.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
+            try id_match.checkImportDefaultSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(self.options));
         }
         return .proceed;
     }
@@ -4494,13 +4551,13 @@ const BasicVisitor = struct {
             try no_shadow_restricted_names.checkBinding(self.allocator, self.diagnostics, ctx.tree, specifier.local, false);
         }
         if (self.options.id_length) {
-            try id_length.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(&self.options));
+            try id_length.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idLengthOptions(self.options));
         }
         if (self.options.camelcase) {
-            try camelcase.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(&self.options));
+            try camelcase.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, camelcaseOptions(self.options));
         }
         if (self.options.id_match) {
-            try id_match.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(&self.options));
+            try id_match.checkImportNamespaceSpecifier(self.allocator, self.diagnostics, ctx.tree, specifier, idMatchOptions(self.options));
         }
         return .proceed;
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -631,6 +631,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_magic_numbers.zig");
+}
+
+comptime {
     _ = @import("rules/no_mixed_spaces_and_tabs.zig");
 }
 

--- a/tests/rules/no_magic_numbers.zig
+++ b/tests/rules/no_magic_numbers.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const base_options = lint.Options{
+    .no_magic_numbers = true,
+    .no_undef = false,
+    .no_unused_vars = false,
+    .parser_semantic_errors = false,
+};
+
+fn count(source: []const u8, file_name: []const u8, options: lint.Options) !usize {
+    var result = try lint.lintSource(std.testing.allocator, source, file_name, options);
+    defer result.deinit(std.testing.allocator);
+    return helpers.countRule(result, lint.rules.no_magic_numbers.id);
+}
+
+test "matches default JavaScript behavior" {
+    const valid = [_][]const u8{
+        "var x = parseInt(y, 10);",
+        "var x = Number.parseInt(y, -10);",
+        "const answer = +42;",
+        "var answer = -42;",
+        "var object = { answer: 42, 42: 'key' };",
+        "object.answer = 42;",
+        "var jsx = <input maxLength={10} />;",
+    };
+    for (valid) |source| try std.testing.expectEqual(@as(usize, 0), try count(source, "fixture.jsx", base_options));
+
+    const invalid = [_]struct { source: []const u8, expected: usize }{
+        .{ .source = "var value = 0 + 1 + -2;", .expected = 3 },
+        .{ .source = "value = 5; value += 6;", .expected = 2 },
+        .{ .source = "function seconds() { return -60; }", .expected = 1 },
+        .{ .source = "var jsx = <div values={[1, 2, 3]} />;", .expected = 3 },
+    };
+    for (invalid) |case| try std.testing.expectEqual(case.expected, try count(case.source, "fixture.jsx", base_options));
+}
+
+test "supports enforceConst and detectObjects" {
+    var options = base_options;
+    options.no_magic_numbers_enforce_const = true;
+    try std.testing.expectEqual(@as(usize, 1), try count("let answer = 42;", "fixture.js", options));
+    try std.testing.expectEqual(@as(usize, 0), try count("const answer = 42;", "fixture.js", options));
+
+    options = base_options;
+    options.no_magic_numbers_detect_objects = true;
+    try std.testing.expectEqual(@as(usize, 3), try count("var object = { 42: 42 }; object.answer = 43;", "fixture.js", options));
+}
+
+test "supports ignored Number and BigInt values" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"ignore\":[0,1,-2,\"100n\",\"-200n\"]}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = base_options;
+    try options.setByRuleConfigValue("no-magic-numbers", config.value);
+    try std.testing.expectEqual(@as(usize, 0), try count("f(0, 1, -2, 100n, -200n, 0x64n);", "fixture.js", options));
+    try std.testing.expectEqual(@as(usize, 3), try count("f(2, -100n, 200n);", "fixture.js", options));
+}
+
+test "parses every official object option" {
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\",{\"detectObjects\":true,\"enforceConst\":true,\"ignoreArrayIndexes\":true,\"ignoreDefaultValues\":true,\"ignoreClassFieldInitialValues\":true,\"ignoreEnums\":true,\"ignoreNumericLiteralTypes\":true,\"ignoreReadonlyClassProperties\":true,\"ignoreTypeIndexes\":true}]",
+        .{},
+    );
+    defer config.deinit();
+
+    var options = lint.Options{};
+    try options.setByRuleConfigValue("no-magic-numbers", config.value);
+    try std.testing.expect(options.no_magic_numbers);
+    try std.testing.expect(options.no_magic_numbers_detect_objects);
+    try std.testing.expect(options.no_magic_numbers_enforce_const);
+    try std.testing.expect(options.no_magic_numbers_ignore_array_indexes);
+    try std.testing.expect(options.no_magic_numbers_ignore_default_values);
+    try std.testing.expect(options.no_magic_numbers_ignore_class_field_initial_values);
+    try std.testing.expect(options.no_magic_numbers_ignore_enums);
+    try std.testing.expect(options.no_magic_numbers_ignore_numeric_literal_types);
+    try std.testing.expect(options.no_magic_numbers_ignore_readonly_class_properties);
+    try std.testing.expect(options.no_magic_numbers_ignore_type_indexes);
+}
+
+test "validates actual array index values" {
+    var options = base_options;
+    options.no_magic_numbers_ignore_array_indexes = true;
+
+    const valid = [_][]const u8{
+        "foo[-0]",  "foo[1]",     "foo[200.00]",      "foo[3e4]",   "foo[0xABC]", "foo[4294967294]",
+        "foo[-0n]", "foo[0xABn]", "foo[4294967294n]", "foo?.[777]",
+    };
+    for (valid) |source| try std.testing.expectEqual(@as(usize, 0), try count(source, "fixture.js", options));
+
+    const invalid = [_][]const u8{
+        "foo[-1]", "foo[1.5]", "foo[4294967295]", "foo[1e310]", "foo[-1n]", "foo[4294967295n]",
+    };
+    for (invalid) |source| try std.testing.expectEqual(@as(usize, 1), try count(source, "fixture.js", options));
+}
+
+test "supports defaults and class field initial values" {
+    var options = base_options;
+    options.no_magic_numbers_ignore_default_values = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("const f = ({ value = 123 }, other = -2) => {};", "fixture.js", options));
+    try std.testing.expectEqual(@as(usize, 2), try count("const f = ({ value = 1 + 2 }) => {};", "fixture.js", options));
+
+    options = base_options;
+    options.no_magic_numbers_ignore_class_field_initial_values = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("class C { foo = 2; static #bar = -3; }", "fixture.js", options));
+    try std.testing.expectEqual(@as(usize, 2), try count("class C { foo = 2 + 3; }", "fixture.js", options));
+}
+
+test "supports TypeScript-specific ignore options" {
+    var options = base_options;
+    options.no_magic_numbers_ignore_enums = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("enum E { A = 1000, B = -1, C = +2 }", "fixture.ts", options));
+
+    options = base_options;
+    options.no_magic_numbers_ignore_numeric_literal_types = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("type Value = 1 | -2 | (3);", "fixture.ts", options));
+    try std.testing.expectEqual(@as(usize, 1), try count("interface Value { item: 1; }", "fixture.ts", options));
+
+    options = base_options;
+    options.no_magic_numbers_ignore_readonly_class_properties = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("class C { readonly a = 1; static readonly b = -2; }", "fixture.ts", options));
+
+    options = base_options;
+    options.no_magic_numbers_ignore_type_indexes = true;
+    try std.testing.expectEqual(@as(usize, 0), try count("type Value = Source[((1 & -2) | 3) | 4];", "fixture.ts", options));
+    try std.testing.expectEqual(@as(usize, 4), try count("type Value = { [K in 0 | 1 | 2]: 3 };", "fixture.ts", options));
+}
+
+test "uses official messages and is disabled by default" {
+    var options = base_options;
+    options.no_magic_numbers_enforce_const = true;
+    var result = try lint.lintSource(std.testing.allocator, "let answer = 42; returnValue(7);", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    var saw_const = false;
+    var saw_magic = false;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_magic_numbers.id)) continue;
+        if (std.mem.eql(u8, diagnostic.message, "Number constants declarations must use 'const'.")) saw_const = true;
+        if (std.mem.eql(u8, diagnostic.message, "No magic number: 7.")) saw_magic = true;
+    }
+    try std.testing.expect(saw_const and saw_magic);
+
+    try std.testing.expectEqual(@as(usize, 0), try count("returnValue(7);", "fixture.js", .{
+        .no_undef = false,
+        .no_unused_vars = false,
+        .parser_semantic_errors = false,
+    }));
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -99,6 +99,18 @@ test("applies configured severity and UTF-16 ranges", () => {
   assert.equal(result.diagnosticsSource, "input");
 });
 
+test("applies no-magic-numbers Number and BigInt ignore values", () => {
+  const result = linter.lint("call(7, 8n, 9);", {
+    filePath: "numbers.js",
+    rules: { "no-magic-numbers": ["error", { ignore: [7, "8n"] }] },
+  });
+  const diagnostics = result.diagnostics.filter(
+    (item) => item.ruleId === "no-magic-numbers",
+  );
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].message, "No magic number: 9.");
+});
+
 test("applies autofixes and reports diagnostics against output", () => {
   const result = linter.lintAndFix("const value = 1;;;", {
     filePath: "fix.js",


### PR DESCRIPTION
## Summary
- implement ESLint-compatible `no-magic-numbers` for Number and BigInt literals
- support all ten ESLint v10.0.1 options plus native CLI/config integration
- keep the public basic-rule runner compatible while avoiding a full `Options` copy in the internal visitor path
- expose the rule through npm, WASM, and the status documentation

## Validation
- ESLint v10.0.1 official RuleTester data: 205 cases, 0 parse skips, 0 diagnostic mismatches
- additional JavaScript differential set: 69 cases, 0 mismatches
- additional TypeScript differential set: 39 cases, 0 mismatches
- `zig build test -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test` (86 tests plus typecheck)
- `zig build test-wasm` (12 tests)
- `pnpm --dir npm/@utoo/lint-wasm test` (10 tests)
- `pnpm --dir npm/@utoo/lint-wasm test:types`