### PR TITLE
feat: implement no-useless-assignment

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -185,6 +185,7 @@ instead of being rewritten.
 | [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) | Implemented with optional `allowShortCircuit`, `allowTernary`, and `allowTaggedTemplates` behavior |
 | [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels) | Implemented with nested label shadowing and autofix |
 | [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) | Supports `vars`, `args`, `caughtErrors`, `ignoreRestSiblings`, `ignoreClassWithStaticInitBlock`, `ignoreUsingDeclarations`, `reportUsedIgnorePattern`, and common `argsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern`/`varsIgnorePattern` configuration |
+| [`no-useless-assignment`](https://eslint.org/docs/latest/rules/no-useless-assignment) | Implements control-flow-aware unused assignment analysis |
 | [`no-useless-backreference`](https://eslint.org/docs/latest/rules/no-useless-backreference) | Detects nested, forward, disjunctive, and negative-lookaround backreferences in regex literals and static `RegExp` constructors |
 | [`no-useless-call`](https://eslint.org/docs/latest/rules/no-useless-call) | Implemented |
 | [`no-useless-catch`](https://eslint.org/docs/latest/rules/no-useless-catch) | Implemented |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -249,6 +249,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-private-class-members",
   "no-unused-vars",
   "no-use-before-define",
+  "no-useless-assignment",
   "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -252,6 +252,7 @@ const BUILTIN_RULE_IDS = [
   "no-unused-private-class-members",
   "no-unused-vars",
   "no-use-before-define",
+  "no-useless-assignment",
   "no-useless-backreference",
   "no-useless-call",
   "no-useless-catch",

--- a/src/core.zig
+++ b/src/core.zig
@@ -2941,6 +2941,7 @@ pub const Options = struct {
     no_useless_call: bool = true,
     no_useless_concat: bool = true,
     no_useless_constructor: bool = true,
+    no_useless_assignment: bool = true,
     no_useless_catch: bool = true,
     no_useless_escape: bool = true,
     no_useless_escape_allow_regex_characters: NoUselessEscapeAllowRegexCharacters = .{},

--- a/src/main.zig
+++ b/src/main.zig
@@ -854,6 +854,8 @@ pub fn main(init: std.process.Init) !void {
             options.no_useless_concat = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-constructor=off")) {
             options.no_useless_constructor = false;
+        } else if (std.mem.eql(u8, arg, "--no-useless-assignment=off")) {
+            options.no_useless_assignment = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-catch=off")) {
             options.no_useless_catch = false;
         } else if (std.mem.eql(u8, arg, "--no-useless-escape=off")) {
@@ -2862,6 +2864,7 @@ fn printHelp() void {
         \\  --no-useless-call=off     Disable no-useless-call
         \\  --no-useless-concat=off   Disable no-useless-concat
         \\  --no-useless-constructor=off Disable no-useless-constructor
+        \\  --no-useless-assignment=off Disable no-useless-assignment
         \\  --no-useless-catch=off    Disable no-useless-catch
         \\  --no-useless-escape=off   Disable no-useless-escape
         \\  --no-useless-rename=off   Disable no-useless-rename

--- a/src/root.zig
+++ b/src/root.zig
@@ -302,6 +302,7 @@ fn hasSemanticRules(options: Options) bool {
         options.react_jsx_no_undef or
         options.react_no_forward_ref or
         options.no_unused_vars or
+        options.no_useless_assignment or
         options.no_useless_backreference or
         options.no_use_before_define or
         options.prefer_const or

--- a/src/rules/no_useless_assignment.zig
+++ b/src/rules/no_useless_assignment.zig
@@ -1,0 +1,788 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const semantic_compat = @import("../semantic_compat.zig");
+
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+const SymbolId = semantic_compat.traverser.semantic.SymbolId;
+const ReferenceId = semantic_compat.traverser.semantic.ReferenceId;
+const SymbolTable = semantic_compat.SymbolTable;
+
+pub const id = "no-useless-assignment";
+
+const NodeId = enum(u32) { none = std.math.maxInt(u32), _ };
+
+const Event = struct {
+    kind: enum { read, write },
+    node: ast.NodeIndex,
+    optional: bool = false,
+    reportable: bool = true,
+};
+
+const GraphNode = struct {
+    kind: enum { noop, read, write },
+    next: NodeId = .none,
+    alternate: NodeId = .none,
+    report_node: ast.NodeIndex = .null,
+    reportable: bool = false,
+};
+
+const Graph = struct {
+    allocator: Allocator,
+    nodes: std.ArrayList(GraphNode) = .empty,
+    candidates: std.ArrayList(NodeId) = .empty,
+
+    fn deinit(self: *Graph) void {
+        self.nodes.deinit(self.allocator);
+        self.candidates.deinit(self.allocator);
+    }
+
+    fn add(self: *Graph, node: GraphNode) Allocator.Error!NodeId {
+        const index: NodeId = @enumFromInt(self.nodes.items.len);
+        try self.nodes.append(self.allocator, node);
+        if (node.kind == .write) try self.candidates.append(self.allocator, index);
+        return index;
+    }
+
+    fn join(self: *Graph, first: NodeId, second: NodeId) Allocator.Error!NodeId {
+        if (first == second) return first;
+        return self.add(.{ .kind = .noop, .next = first, .alternate = second });
+    }
+
+    fn prependEvents(self: *Graph, events: []const Event, continuation: NodeId) Allocator.Error!NodeId {
+        var entry = continuation;
+        var index = events.len;
+        while (index > 0) {
+            index -= 1;
+            const event = events[index];
+            const event_node = try self.add(.{
+                .kind = switch (event.kind) {
+                    .read => .read,
+                    .write => .write,
+                },
+                .next = entry,
+                .report_node = event.node,
+                .reportable = event.kind == .write and event.reportable,
+            });
+            entry = if (event.optional) try self.join(event_node, entry) else event_node;
+        }
+        return entry;
+    }
+};
+
+const Controls = struct {
+    break_target: NodeId = .none,
+    continue_target: NodeId = .none,
+};
+
+const Builder = struct {
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    symbol_table: SymbolTable,
+    symbol: SymbolId,
+    code_path_root: ast.NodeIndex,
+    graph: Graph,
+
+    fn init(
+        allocator: Allocator,
+        tree: *const ast.Tree,
+        symbol_table: SymbolTable,
+        symbol: SymbolId,
+        code_path_root: ast.NodeIndex,
+    ) Builder {
+        return .{
+            .allocator = allocator,
+            .tree = tree,
+            .symbol_table = symbol_table,
+            .symbol = symbol,
+            .code_path_root = code_path_root,
+            .graph = .{ .allocator = allocator },
+        };
+    }
+
+    fn deinit(self: *Builder) void {
+        self.graph.deinit();
+    }
+
+    fn build(self: *Builder) Allocator.Error!NodeId {
+        return switch (self.tree.data(self.code_path_root)) {
+            .program => |program| self.buildStatements(self.tree.extra(program.body), .none, .{}, false),
+            .function => |function| self.buildFunctionBody(function.body),
+            .arrow_function_expression => |arrow| if (arrow.expression)
+                self.buildExpression(arrow.body, .none, false)
+            else
+                self.buildFunctionBody(arrow.body),
+            .static_block => |block| self.buildStatements(self.tree.extra(block.body), .none, .{}, false),
+            else => .none,
+        };
+    }
+
+    fn buildFunctionBody(self: *Builder, index: ast.NodeIndex) Allocator.Error!NodeId {
+        if (index == .null) return .none;
+        return switch (self.tree.data(index)) {
+            .function_body => |body| self.buildStatements(self.tree.extra(body.body), .none, .{}, false),
+            else => self.buildStatement(index, .none, .{}, false),
+        };
+    }
+
+    fn buildStatements(
+        self: *Builder,
+        statements: []const ast.NodeIndex,
+        continuation: NodeId,
+        controls: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        var entry = continuation;
+        var index = statements.len;
+        while (index > 0) {
+            index -= 1;
+            entry = try self.buildStatement(statements[index], entry, controls, suppress_writes);
+        }
+        return entry;
+    }
+
+    fn buildStatement(
+        self: *Builder,
+        index: ast.NodeIndex,
+        continuation: NodeId,
+        controls: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        if (index == .null) return continuation;
+        return switch (self.tree.data(index)) {
+            .block_statement => |block| self.buildStatements(self.tree.extra(block.body), continuation, controls, suppress_writes),
+            .function_body => |body| self.buildStatements(self.tree.extra(body.body), continuation, controls, suppress_writes),
+            .expression_statement => |statement| self.buildExpression(statement.expression, continuation, suppress_writes),
+            .variable_declaration => self.buildLinear(index, continuation, suppress_writes),
+            .if_statement => |statement| self.buildIf(statement, continuation, controls, suppress_writes),
+            .while_statement => |statement| self.buildWhile(statement, continuation, controls, suppress_writes),
+            .do_while_statement => |statement| self.buildDoWhile(statement, continuation, controls, suppress_writes),
+            .for_statement => |statement| self.buildFor(statement, continuation, controls, suppress_writes),
+            .for_in_statement => |statement| self.buildForIn(statement.left, statement.right, statement.body, continuation, controls, suppress_writes),
+            .for_of_statement => |statement| self.buildForIn(statement.left, statement.right, statement.body, continuation, controls, suppress_writes),
+            .return_statement => |statement| self.buildExpression(statement.argument, .none, suppress_writes),
+            .throw_statement => |statement| self.buildExpression(statement.argument, .none, suppress_writes),
+            .break_statement => if (controls.break_target != .none) controls.break_target else .none,
+            .continue_statement => if (controls.continue_target != .none) controls.continue_target else .none,
+            .labeled_statement => |statement| self.buildStatement(statement.body, continuation, .{
+                .break_target = continuation,
+                .continue_target = controls.continue_target,
+            }, suppress_writes),
+            .try_statement => |statement| self.buildTry(statement, continuation, controls, suppress_writes),
+            .catch_clause => |clause| self.buildStatement(clause.body, continuation, controls, suppress_writes),
+            .switch_statement => |statement| self.buildSwitch(statement, continuation, controls, suppress_writes),
+            .with_statement => |statement| self.buildExpression(
+                statement.object,
+                try self.buildStatement(statement.body, continuation, controls, suppress_writes),
+                suppress_writes,
+            ),
+            .function, .arrow_function_expression, .class => continuation,
+            else => self.buildLinear(index, continuation, suppress_writes),
+        };
+    }
+
+    fn buildIf(
+        self: *Builder,
+        statement: ast.IfStatement,
+        continuation: NodeId,
+        controls: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const consequent = try self.buildStatement(statement.consequent, continuation, controls, suppress_writes);
+        const alternate = if (statement.alternate == .null)
+            continuation
+        else
+            try self.buildStatement(statement.alternate, continuation, controls, suppress_writes);
+        const branch = try self.graph.join(consequent, alternate);
+        return self.buildExpression(statement.@"test", branch, suppress_writes);
+    }
+
+    fn buildWhile(
+        self: *Builder,
+        statement: ast.WhileStatement,
+        continuation: NodeId,
+        _: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const branch = try self.graph.add(.{ .kind = .noop, .alternate = continuation });
+        const test_entry = try self.buildExpression(statement.@"test", branch, suppress_writes);
+        const body = try self.buildStatement(statement.body, test_entry, .{
+            .break_target = continuation,
+            .continue_target = test_entry,
+        }, suppress_writes);
+        self.graph.nodes.items[@intFromEnum(branch)].next = body;
+        return test_entry;
+    }
+
+    fn buildDoWhile(
+        self: *Builder,
+        statement: ast.DoWhileStatement,
+        continuation: NodeId,
+        _: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const branch = try self.graph.add(.{ .kind = .noop, .alternate = continuation });
+        const test_entry = try self.buildExpression(statement.@"test", branch, suppress_writes);
+        const body = try self.buildStatement(statement.body, test_entry, .{
+            .break_target = continuation,
+            .continue_target = test_entry,
+        }, suppress_writes);
+        self.graph.nodes.items[@intFromEnum(branch)].next = body;
+        return body;
+    }
+
+    fn buildFor(
+        self: *Builder,
+        statement: ast.ForStatement,
+        continuation: NodeId,
+        _: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const branch = try self.graph.add(.{ .kind = .noop, .alternate = if (statement.@"test" == .null) .none else continuation });
+        const test_entry = if (statement.@"test" == .null)
+            branch
+        else
+            try self.buildExpression(statement.@"test", branch, suppress_writes);
+        const update_entry = try self.buildExpression(statement.update, test_entry, suppress_writes);
+        const body = try self.buildStatement(statement.body, update_entry, .{
+            .break_target = continuation,
+            .continue_target = update_entry,
+        }, suppress_writes);
+        self.graph.nodes.items[@intFromEnum(branch)].next = body;
+        return self.buildStatement(statement.init, test_entry, .{}, suppress_writes);
+    }
+
+    fn buildForIn(
+        self: *Builder,
+        left: ast.NodeIndex,
+        right: ast.NodeIndex,
+        body_index: ast.NodeIndex,
+        continuation: NodeId,
+        _: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const branch = try self.graph.add(.{ .kind = .noop, .alternate = continuation });
+        const body = try self.buildStatement(body_index, branch, .{
+            .break_target = continuation,
+            .continue_target = branch,
+        }, suppress_writes);
+        const iteration = try self.buildLinear(left, body, suppress_writes);
+        self.graph.nodes.items[@intFromEnum(branch)].next = iteration;
+        return self.buildExpression(right, branch, suppress_writes);
+    }
+
+    fn buildTry(
+        self: *Builder,
+        statement: ast.TryStatement,
+        continuation: NodeId,
+        controls: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const after_try = if (statement.finalizer == .null)
+            continuation
+        else
+            try self.buildStatement(statement.finalizer, continuation, controls, suppress_writes);
+        const handler = if (statement.handler == .null)
+            after_try
+        else
+            try self.buildStatement(statement.handler, after_try, controls, suppress_writes);
+        const block = try self.buildStatement(statement.block, after_try, controls, true);
+        return self.graph.join(block, handler);
+    }
+
+    fn buildSwitch(
+        self: *Builder,
+        statement: ast.SwitchStatement,
+        continuation: NodeId,
+        controls: Controls,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        const cases = self.tree.extra(statement.cases);
+        var fallthrough = continuation;
+        var choices = continuation;
+        var index = cases.len;
+        while (index > 0) {
+            index -= 1;
+            const case = switch (self.tree.data(cases[index])) {
+                .switch_case => |value| value,
+                else => continue,
+            };
+            const case_entry = try self.buildStatements(self.tree.extra(case.consequent), fallthrough, .{
+                .break_target = continuation,
+                .continue_target = controls.continue_target,
+            }, suppress_writes);
+            fallthrough = case_entry;
+            choices = try self.graph.join(case_entry, choices);
+        }
+        return self.buildExpression(statement.discriminant, choices, suppress_writes);
+    }
+
+    fn buildExpression(
+        self: *Builder,
+        index: ast.NodeIndex,
+        continuation: NodeId,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        if (index == .null) return continuation;
+        return switch (self.tree.data(index)) {
+            .logical_expression => |expression| blk: {
+                const right = try self.buildExpression(expression.right, continuation, suppress_writes);
+                const branch = try self.graph.join(right, continuation);
+                break :blk self.buildExpression(expression.left, branch, suppress_writes);
+            },
+            .conditional_expression => |expression| blk: {
+                const consequent = try self.buildExpression(expression.consequent, continuation, suppress_writes);
+                const alternate = try self.buildExpression(expression.alternate, continuation, suppress_writes);
+                const branch = try self.graph.join(consequent, alternate);
+                break :blk self.buildExpression(expression.@"test", branch, suppress_writes);
+            },
+            .sequence_expression => |expression| blk: {
+                var entry = continuation;
+                const expressions = self.tree.extra(expression.expressions);
+                var expression_index = expressions.len;
+                while (expression_index > 0) {
+                    expression_index -= 1;
+                    entry = try self.buildExpression(expressions[expression_index], entry, suppress_writes);
+                }
+                break :blk entry;
+            },
+            else => self.buildLinear(index, continuation, suppress_writes),
+        };
+    }
+
+    fn buildLinear(
+        self: *Builder,
+        index: ast.NodeIndex,
+        continuation: NodeId,
+        suppress_writes: bool,
+    ) Allocator.Error!NodeId {
+        if (index == .null) return continuation;
+        var events: std.ArrayList(Event) = .empty;
+        defer events.deinit(self.allocator);
+        try events.ensureTotalCapacity(
+            self.allocator,
+            self.symbol_table.model.uses(self.symbol).len * 3 +
+                self.symbol_table.symbolDecls(self.symbol).len * 2 + 8,
+        );
+
+        var collector = EventCollector{
+            .tree = self.tree,
+            .symbol_table = self.symbol_table,
+            .symbol = self.symbol,
+            .code_path_root = self.code_path_root,
+            .suppress_writes = suppress_writes,
+            .events = &events,
+        };
+        var subtree = self.tree.*;
+        subtree.root = index;
+        try traverser.basic.traverse(EventCollector, &subtree, &collector);
+        return self.graph.prependEvents(events.items, continuation);
+    }
+};
+
+const EventCollector = struct {
+    tree: *const ast.Tree,
+    symbol_table: SymbolTable,
+    symbol: SymbolId,
+    code_path_root: ast.NodeIndex,
+    suppress_writes: bool,
+    events: *std.ArrayList(Event),
+
+    pub fn enter_node(
+        self: *EventCollector,
+        _: ast.NodeData,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (self.delayedPatternAncestor(index) != null) return .proceed;
+        const reference_id = self.symbol_table.model.referenceOf(index) orelse return .proceed;
+        const reference = self.symbol_table.model.reference(reference_id);
+        if (reference.symbol != self.symbol or reference.flags.write) return .proceed;
+        self.events.appendAssumeCapacity(.{ .kind = .read, .node = index });
+        return .proceed;
+    }
+
+    pub fn enter_function(
+        self: *EventCollector,
+        _: ast.Function,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return if (index == self.code_path_root) .proceed else .skip;
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *EventCollector,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return if (index == self.code_path_root) .proceed else .skip;
+    }
+
+    pub fn enter_static_block(
+        self: *EventCollector,
+        _: ast.StaticBlock,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return if (index == self.code_path_root) .proceed else .skip;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *EventCollector,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (self.delayedPatternAncestor(index) != null) return .proceed;
+        if (expression.operator != .assign and self.patternHasWrite(expression.left)) {
+            self.events.appendAssumeCapacity(.{ .kind = .read, .node = firstWriteNode(self.tree, self.symbol_table, self.symbol, expression.left) orelse expression.left });
+        }
+        return .proceed;
+    }
+
+    pub fn exit_assignment_expression(
+        self: *EventCollector,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        if (self.delayedPatternAncestor(index) != null) return;
+        if (isPatternTarget(self.tree.data(expression.left)) and self.patternHasReference(expression.left)) {
+            self.appendPatternEvents(expression.left);
+        }
+    }
+
+    pub fn enter_update_expression(
+        self: *EventCollector,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (self.delayedPatternAncestor(index) != null) return .proceed;
+        if (self.patternHasWrite(expression.argument)) {
+            self.events.appendAssumeCapacity(.{ .kind = .read, .node = firstWriteNode(self.tree, self.symbol_table, self.symbol, expression.argument) orelse expression.argument });
+        }
+        return .proceed;
+    }
+
+    pub fn exit_update_expression(
+        self: *EventCollector,
+        expression: ast.UpdateExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        if (self.delayedPatternAncestor(index) != null) return;
+        if (firstWriteNode(self.tree, self.symbol_table, self.symbol, expression.argument)) |node| {
+            self.appendWrite(node, false);
+        }
+    }
+
+    pub fn exit_variable_declarator(
+        self: *EventCollector,
+        declarator: ast.VariableDeclarator,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        if (declarator.init == .null or self.delayedPatternAncestor(index) != null) return;
+        if (self.patternHasDeclaration(declarator.id) or self.patternHasReference(declarator.id)) {
+            self.appendPatternEvents(declarator.id);
+        }
+    }
+
+    fn appendPatternEvents(self: *EventCollector, pattern: ast.NodeIndex) void {
+        const declarations = self.symbol_table.symbolDecls(self.symbol);
+        const uses = self.symbol_table.model.uses(self.symbol);
+        var declaration_index: usize = 0;
+        var use_index: usize = 0;
+
+        while (true) {
+            while (declaration_index < declarations.len and !containsNode(self.tree, pattern, declarations[declaration_index])) declaration_index += 1;
+            while (use_index < uses.len and !containsNode(self.tree, pattern, self.symbol_table.model.reference(uses[use_index]).node)) use_index += 1;
+            if (declaration_index >= declarations.len and use_index >= uses.len) break;
+
+            const take_declaration = if (declaration_index >= declarations.len)
+                false
+            else if (use_index >= uses.len)
+                true
+            else
+                self.tree.span(declarations[declaration_index]).start <= self.tree.span(self.symbol_table.model.reference(uses[use_index]).node).start;
+
+            if (take_declaration) {
+                const node = declarations[declaration_index];
+                declaration_index += 1;
+                self.appendWrite(node, isInDefaultExpression(self.tree, self.symbol_table, pattern, node));
+                continue;
+            }
+
+            const reference_id = uses[use_index];
+            use_index += 1;
+            const reference = self.symbol_table.model.reference(reference_id);
+            const optional = isInDefaultExpression(self.tree, self.symbol_table, pattern, reference.node);
+            if (reference.flags.write) {
+                if (writeReadsOldValue(self.tree, self.symbol_table, reference.node)) {
+                    self.events.appendAssumeCapacity(.{ .kind = .read, .node = reference.node, .optional = optional });
+                }
+                self.appendWrite(reference.node, optional);
+            } else {
+                self.events.appendAssumeCapacity(.{ .kind = .read, .node = reference.node, .optional = optional });
+            }
+        }
+    }
+
+    fn appendWrite(self: *EventCollector, node: ast.NodeIndex, optional: bool) void {
+        self.events.appendAssumeCapacity(.{
+            .kind = .write,
+            .node = node,
+            .optional = optional,
+            .reportable = !self.suppress_writes,
+        });
+    }
+
+    fn patternHasWrite(self: *EventCollector, pattern: ast.NodeIndex) bool {
+        return firstWriteNode(self.tree, self.symbol_table, self.symbol, pattern) != null;
+    }
+
+    fn patternHasReference(self: *EventCollector, pattern: ast.NodeIndex) bool {
+        for (self.symbol_table.model.uses(self.symbol)) |reference_id| {
+            if (containsNode(self.tree, pattern, self.symbol_table.model.reference(reference_id).node)) return true;
+        }
+        return false;
+    }
+
+    fn patternHasDeclaration(self: *EventCollector, pattern: ast.NodeIndex) bool {
+        for (self.symbol_table.symbolDecls(self.symbol)) |declaration| {
+            if (containsNode(self.tree, pattern, declaration)) return true;
+        }
+        return false;
+    }
+
+    fn delayedPatternAncestor(self: *EventCollector, node: ast.NodeIndex) ?ast.NodeIndex {
+        var current = node;
+        while (self.symbol_table.parentOf(current)) |parent| {
+            switch (self.tree.data(parent)) {
+                .variable_declarator => |declarator| if (containsNode(self.tree, declarator.id, node)) return parent,
+                .assignment_expression => |expression| if (isPatternTarget(self.tree.data(expression.left)) and containsNode(self.tree, expression.left, node)) return parent,
+                else => {},
+            }
+            current = parent;
+        }
+        return null;
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: SymbolTable,
+) Allocator.Error!void {
+    var report_nodes: std.ArrayList(ast.NodeIndex) = .empty;
+    defer report_nodes.deinit(allocator);
+
+    var symbols = symbol_table.iterSymbols();
+    while (symbols.next()) |entry| {
+        const symbol = entry.symbol;
+        if (!symbol.flags.inValueSpace() or symbol.flags.exported) continue;
+        const declarations = symbol_table.symbolDecls(entry.id);
+        if (declarations.len == 0) continue;
+        if (isExportedByDirective(tree, tree.string(symbol.name)) or
+            isExportedBySpecifier(tree, symbol_table, entry.id)) continue;
+
+        const root = codePathRoot(tree, symbol_table, declarations[0]);
+        var has_local_read = false;
+        var has_external_read = false;
+        for (symbol_table.model.uses(entry.id)) |reference_id| {
+            const reference = symbol_table.model.reference(reference_id);
+            if (!isReadReference(tree, symbol_table, reference_id)) continue;
+            if (codePathRoot(tree, symbol_table, reference.node) == root) {
+                has_local_read = true;
+            } else {
+                has_external_read = true;
+            }
+        }
+        if (!has_local_read or has_external_read) continue;
+
+        var builder = Builder.init(allocator, tree, symbol_table, entry.id, root);
+        defer builder.deinit();
+        const graph_entry = try builder.build();
+        if (graph_entry == .none or builder.graph.candidates.items.len == 0) continue;
+
+        const reachable = try reachableNodes(allocator, builder.graph.nodes.items, graph_entry);
+        defer allocator.free(reachable);
+
+        for (builder.graph.candidates.items) |candidate| {
+            const node = builder.graph.nodes.items[@intFromEnum(candidate)];
+            if (!node.reportable or !reachable[@intFromEnum(candidate)]) continue;
+            if (try assignmentIsUsed(allocator, builder.graph.nodes.items, candidate)) continue;
+            try report_nodes.append(allocator, node.report_node);
+        }
+    }
+
+    std.mem.sort(ast.NodeIndex, report_nodes.items, tree, nodeLessThan);
+    for (report_nodes.items) |report_node| {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            "This assigned value is not used in subsequent statements.",
+            tree.span(report_node),
+        );
+    }
+}
+
+fn nodeLessThan(tree: *const ast.Tree, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+    return tree.span(left).start < tree.span(right).start;
+}
+
+fn reachableNodes(allocator: Allocator, nodes: []const GraphNode, entry: NodeId) Allocator.Error![]bool {
+    const reachable = try allocator.alloc(bool, nodes.len);
+    @memset(reachable, false);
+    var queue: std.ArrayList(NodeId) = .empty;
+    defer queue.deinit(allocator);
+    try queue.append(allocator, entry);
+    while (queue.pop()) |node_id| {
+        if (node_id == .none) continue;
+        const index = @intFromEnum(node_id);
+        if (reachable[index]) continue;
+        reachable[index] = true;
+        const node = nodes[index];
+        if (node.next != .none) try queue.append(allocator, node.next);
+        if (node.alternate != .none) try queue.append(allocator, node.alternate);
+    }
+    return reachable;
+}
+
+fn assignmentIsUsed(allocator: Allocator, nodes: []const GraphNode, assignment: NodeId) Allocator.Error!bool {
+    const visited = try allocator.alloc(bool, nodes.len);
+    defer allocator.free(visited);
+    @memset(visited, false);
+    visited[@intFromEnum(assignment)] = true;
+
+    var queue: std.ArrayList(NodeId) = .empty;
+    defer queue.deinit(allocator);
+    const start = nodes[@intFromEnum(assignment)];
+    if (start.next != .none) try queue.append(allocator, start.next);
+    if (start.alternate != .none) try queue.append(allocator, start.alternate);
+
+    while (queue.pop()) |node_id| {
+        if (node_id == .none) continue;
+        const index = @intFromEnum(node_id);
+        if (visited[index]) continue;
+        visited[index] = true;
+        const node = nodes[index];
+        if (node.kind == .read) return true;
+        if (node.kind == .write) continue;
+        if (node.next != .none) try queue.append(allocator, node.next);
+        if (node.alternate != .none) try queue.append(allocator, node.alternate);
+    }
+    return false;
+}
+
+fn firstWriteNode(
+    tree: *const ast.Tree,
+    symbol_table: SymbolTable,
+    symbol: SymbolId,
+    container: ast.NodeIndex,
+) ?ast.NodeIndex {
+    for (symbol_table.model.uses(symbol)) |reference_id| {
+        const reference = symbol_table.model.reference(reference_id);
+        if (reference.flags.write and containsNode(tree, container, reference.node)) return reference.node;
+    }
+    return null;
+}
+
+fn isReadReference(tree: *const ast.Tree, symbol_table: SymbolTable, reference_id: ReferenceId) bool {
+    const reference = symbol_table.model.reference(reference_id);
+    return !reference.flags.write or writeReadsOldValue(tree, symbol_table, reference.node);
+}
+
+fn writeReadsOldValue(tree: *const ast.Tree, symbol_table: SymbolTable, node: ast.NodeIndex) bool {
+    var current = node;
+    while (symbol_table.parentOf(current)) |parent| {
+        switch (tree.data(parent)) {
+            .update_expression => return true,
+            .assignment_expression => |expression| return expression.operator != .assign,
+            .parenthesized_expression, .ts_as_expression, .ts_satisfies_expression, .ts_non_null_expression, .ts_type_assertion => {},
+            else => return false,
+        }
+        current = parent;
+    }
+    return false;
+}
+
+fn isInDefaultExpression(
+    tree: *const ast.Tree,
+    symbol_table: SymbolTable,
+    pattern: ast.NodeIndex,
+    node: ast.NodeIndex,
+) bool {
+    var current = node;
+    while (current != pattern) {
+        const parent = symbol_table.parentOf(current) orelse return false;
+        switch (tree.data(parent)) {
+            .assignment_pattern => |assignment| if (containsNode(tree, assignment.right, node)) return true,
+            else => {},
+        }
+        current = parent;
+    }
+    return false;
+}
+
+fn codePathRoot(tree: *const ast.Tree, symbol_table: SymbolTable, node: ast.NodeIndex) ast.NodeIndex {
+    var current = node;
+    while (true) {
+        switch (tree.data(current)) {
+            .function, .arrow_function_expression, .static_block, .program => return current,
+            else => {},
+        }
+        current = symbol_table.parentOf(current) orelse return tree.root;
+    }
+}
+
+fn containsNode(tree: *const ast.Tree, container: ast.NodeIndex, node: ast.NodeIndex) bool {
+    if (container == .null or node == .null) return false;
+    const outer = tree.span(container);
+    const inner = tree.span(node);
+    return outer.start <= inner.start and inner.end <= outer.end;
+}
+
+fn isPatternTarget(data: ast.NodeData) bool {
+    return switch (data) {
+        .identifier_reference, .object_pattern, .array_pattern, .assignment_pattern, .binding_rest_element, .parenthesized_expression => true,
+        else => false,
+    };
+}
+
+fn isExportedByDirective(tree: *const ast.Tree, name: []const u8) bool {
+    var offset: usize = 0;
+    while (std.mem.indexOfPos(u8, tree.source, offset, "/*")) |start| {
+        const end = std.mem.indexOfPos(u8, tree.source, start + 2, "*/") orelse return false;
+        const comment = tree.source[start + 2 .. end];
+        if (std.mem.indexOf(u8, comment, "exported")) |keyword| {
+            var tokens = std.mem.tokenizeAny(u8, comment[keyword + "exported".len ..], " \t\r\n,;:");
+            while (tokens.next()) |token| if (std.mem.eql(u8, token, name)) return true;
+        }
+        offset = end + 2;
+    }
+    return false;
+}
+
+fn isExportedBySpecifier(tree: *const ast.Tree, symbol_table: SymbolTable, symbol: SymbolId) bool {
+    for (symbol_table.model.uses(symbol)) |reference_id| {
+        var current = symbol_table.model.reference(reference_id).node;
+        while (symbol_table.parentOf(current)) |parent| {
+            switch (tree.data(parent)) {
+                .export_specifier => return true,
+                .parenthesized_expression => {},
+                else => break,
+            }
+            current = parent;
+        }
+    }
+    return false;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -240,6 +240,7 @@ pub const no_useless_backreference = @import("no_useless_backreference.zig");
 pub const no_useless_call = @import("no_useless_call.zig");
 pub const no_useless_concat = @import("no_useless_concat.zig");
 pub const no_useless_constructor = @import("no_useless_constructor.zig");
+pub const no_useless_assignment = @import("no_useless_assignment.zig");
 pub const no_undef = @import("no_undef.zig");
 pub const no_unassigned_vars = @import("no_unassigned_vars.zig");
 pub const no_useless_catch = @import("no_useless_catch.zig");
@@ -840,6 +841,14 @@ fn runSemanticBeforeIo(
     }
     if (options.no_unmodified_loop_condition) {
         try no_unmodified_loop_condition.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+        );
+    }
+    if (options.no_useless_assignment) {
+        try no_useless_assignment.run(
             allocator,
             diagnostics,
             tree,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -919,6 +919,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/no_useless_assignment.zig");
+}
+
+comptime {
     _ = @import("rules/no_useless_catch.zig");
 }
 

--- a/tests/rules/no_useless_assignment.zig
+++ b/tests/rules/no_useless_assignment.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+fn count(source: []const u8, file_name: []const u8) !usize {
+    var options = lint.Options.allDisabled();
+    options.no_useless_assignment = true;
+    var result = try lint.lintSource(std.testing.allocator, source, file_name, options);
+    defer result.deinit(std.testing.allocator);
+    return helpers.countRule(result, lint.rules.no_useless_assignment.id);
+}
+
+test "reports overwritten and final assignments" {
+    try std.testing.expectEqual(@as(usize, 1), try count(
+        "let value = 'used'; console.log(value); value = 'unused';",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 2), try count(
+        "let value = 'used'; console.log(value); value = 1; value = 2;",
+        "fixture.js",
+    ));
+}
+
+test "reports assignments in source order" {
+    var options = lint.Options.allDisabled();
+    options.no_useless_assignment = true;
+    var result = try lint.lintSource(
+        std.testing.allocator,
+        "function f() { let outer = 0; if (cond) { let inner = 0; console.log(inner); inner = 1; inner = 2; } console.log(outer); outer = 1; }",
+        "fixture.js",
+        options,
+    );
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), result.diagnostics.len);
+    try std.testing.expect(result.diagnostics[0].span.start < result.diagnostics[1].span.start);
+    try std.testing.expect(result.diagnostics[1].span.start < result.diagnostics[2].span.start);
+}
+
+test "tracks branches and abrupt completion" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "function f() { let value = 1; if (cond) { value = 2; console.log(value); return; } console.log(value); }",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 1), try count(
+        "function f() { let value = 1; if (cond) { value = 2; return; } console.log(value); }",
+        "fixture.js",
+    ));
+}
+
+test "tracks loop-carried reads and updates" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "function f() { let value = 1; for (let i = 0; i < 10; i++) { console.log(value); value = 2; } }",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 1), try count(
+        "function f() { let value = 1; console.log(value); value++; }",
+        "fixture.js",
+    ));
+}
+
+test "tracks destructuring and optional defaults" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "const obj = { a: 1 }; let { a, b = (a = 2) } = obj; console.log(a, b);",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 2), try count(
+        "const obj = { a: 1 }; let { a, b = (a = 2) } = obj; a = 3; console.log(a, b);",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 1), try count(
+        "function f() { let x = 0; console.log(x); const { a = (x = 1) } = {}; x = 2; console.log(x); }",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "function f() { let x = 1; const { a = x } = {}; x = 2; console.log(x); }",
+        "fixture.js",
+    ));
+}
+
+test "is conservative across try blocks and nested code paths" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "let message = 'init'; try { message = call(); } catch {} console.log(message);",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "function f() { let value = 1; setTimeout(() => console.log(value)); value = 2; }",
+        "fixture.js",
+    ));
+}
+
+test "skips exported bindings and variables without reads" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "let value = 1; export { value }; console.log(value); value = 2;",
+        "fixture.js",
+    ));
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "let unused = 1; unused = 2;",
+        "fixture.js",
+    ));
+}
+
+test "counts JSX references as reads" {
+    try std.testing.expectEqual(@as(usize, 1), try count(
+        "function App() { let Component = 'unused'; Component = Used; return <Component />; }",
+        "fixture.jsx",
+    ));
+}
+
+test "uses the official message and is enabled by default" {
+    var options = lint.Options.allDisabled();
+    options.no_useless_assignment = true;
+    var result = try lint.lintSource(
+        std.testing.allocator,
+        "let value = 1; console.log(value); value = 2;",
+        "fixture.js",
+        options,
+    );
+    defer result.deinit(std.testing.allocator);
+
+    var saw_message = false;
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_useless_assignment.id) and
+            std.mem.eql(u8, diagnostic.message, "This assigned value is not used in subsequent statements."))
+        {
+            try std.testing.expectEqualStrings("value", "let value = 1; console.log(value); value = 2;"[diagnostic.span.start..diagnostic.span.end]);
+            saw_message = true;
+        }
+    }
+    try std.testing.expect(saw_message);
+    try std.testing.expect((lint.Options{}).no_useless_assignment);
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -111,6 +111,24 @@ test("applies no-magic-numbers Number and BigInt ignore values", () => {
   assert.equal(diagnostics[0].message, "No magic number: 9.");
 });
 
+test("applies control-flow-aware no-useless-assignment analysis", () => {
+  const result = linter.lint(
+    "let value = 1; console.log(value); value = 2;",
+    {
+      filePath: "assignment.js",
+      rules: { "no-useless-assignment": "error" },
+    },
+  );
+  const diagnostics = result.diagnostics.filter(
+    (item) => item.ruleId === "no-useless-assignment",
+  );
+  assert.equal(diagnostics.length, 1);
+  assert.equal(
+    diagnostics[0].message,
+    "This assigned value is not used in subsequent statements.",
+  );
+});
+
 test("applies autofixes and reports diagnostics against output", () => {
   const result = linter.lintAndFix("const value = 1;;;", {
     filePath: "fix.js",


### PR DESCRIPTION
## Summary
- add control-flow-aware no-useless-assignment analysis for branches, loops, abrupt completion, destructuring defaults, JSX references, and exports
- expose the rule through native, CLI, npm, and WASM surfaces
- add focused Zig and WASM regression coverage

## Validation
- ESLint v10.0.1 differential: 105/105 applicable official cases match diagnostic count, position, and order; 4 cases that directly mutate ESLint scope/reference state through test-only plugins are not applicable to the native engine
- 34 additional control-flow and destructuring differential cases match ESLint
- zig build test -j1
- ReleaseFast native build
- npm package: 86/86 tests plus typecheck
- raw WASM: 13/13 tests
- packaged WASM: 10/10 tests plus typecheck