### PR TITLE
perf: scan exported directives once

### DIFF
--- a/src/rules/no_useless_assignment.zig
+++ b/src/rules/no_useless_assignment.zig
@@ -583,13 +583,17 @@ pub fn run(
     var report_nodes: std.ArrayList(ast.NodeIndex) = .empty;
     defer report_nodes.deinit(allocator);
 
+    var exported_directive_names: std.ArrayList([]const u8) = .empty;
+    defer exported_directive_names.deinit(allocator);
+    try collectExportedDirectiveNames(allocator, tree.source, &exported_directive_names);
+
     var symbols = symbol_table.iterSymbols();
     while (symbols.next()) |entry| {
         const symbol = entry.symbol;
         if (!symbol.flags.inValueSpace() or symbol.flags.exported) continue;
         const declarations = symbol_table.symbolDecls(entry.id);
         if (declarations.len == 0) continue;
-        if (isExportedByDirective(tree, tree.string(symbol.name)) or
+        if (isExportedByDirective(exported_directive_names.items, tree.string(symbol.name)) or
             isExportedBySpecifier(tree, symbol_table, entry.id)) continue;
 
         const root = codePathRoot(tree, symbol_table, declarations[0]);
@@ -758,16 +762,26 @@ fn isPatternTarget(data: ast.NodeData) bool {
     };
 }
 
-fn isExportedByDirective(tree: *const ast.Tree, name: []const u8) bool {
+fn collectExportedDirectiveNames(
+    allocator: Allocator,
+    source: []const u8,
+    names: *std.ArrayList([]const u8),
+) Allocator.Error!void {
     var offset: usize = 0;
-    while (std.mem.indexOfPos(u8, tree.source, offset, "/*")) |start| {
-        const end = std.mem.indexOfPos(u8, tree.source, start + 2, "*/") orelse return false;
-        const comment = tree.source[start + 2 .. end];
+    while (std.mem.indexOfPos(u8, source, offset, "/*")) |start| {
+        const end = std.mem.indexOfPos(u8, source, start + 2, "*/") orelse return;
+        const comment = source[start + 2 .. end];
         if (std.mem.indexOf(u8, comment, "exported")) |keyword| {
             var tokens = std.mem.tokenizeAny(u8, comment[keyword + "exported".len ..], " \t\r\n,;:");
-            while (tokens.next()) |token| if (std.mem.eql(u8, token, name)) return true;
+            while (tokens.next()) |token| try names.append(allocator, token);
         }
         offset = end + 2;
+    }
+}
+
+fn isExportedByDirective(names: []const []const u8, name: []const u8) bool {
+    for (names) |candidate| {
+        if (std.mem.eql(u8, candidate, name)) return true;
     }
     return false;
 }

--- a/tests/rules/no_useless_assignment.zig
+++ b/tests/rules/no_useless_assignment.zig
@@ -100,6 +100,13 @@ test "skips exported bindings and variables without reads" {
     ));
 }
 
+test "skips bindings named by exported directives" {
+    try std.testing.expectEqual(@as(usize, 0), try count(
+        "/* exported value, other */ let value = 1; console.log(value); value = 2;",
+        "fixture.js",
+    ));
+}
+
 test "counts JSX references as reads" {
     try std.testing.expectEqual(@as(usize, 1), try count(
         "function App() { let Component = 'unused'; Component = Used; return <Component />; }",


### PR DESCRIPTION
## Summary

- scan ESLint exported directives once per file instead of once per symbol
- reuse the parsed directive names while evaluating no-useless-assignment
- add regression coverage for comma-separated exported names

## Performance

Webpack lib corpus, 718 JavaScript files, ReleaseFast, Apple M4. Medians from hyperfine (1 warmup, 5 runs):

- no-useless-assignment, automatic threads: 6379.3 ms -> 185.6 ms (34.4x faster)
- no-useless-assignment, one thread: 16241.3 ms -> 627.0 ms (25.9x faster)
- all 199 non-deprecated ESLint core rules, automatic threads: 2724.1 ms -> 1428.1 ms (1.90x faster)

Both targeted binaries reported the same 232 no-useless-assignment diagnostics on the corpus.

## Validation

- zig build test
- ReleaseFast build
- targeted and full-core hyperfine comparisons