### PR TITLE
perf: cache restrict-plus type environment

### DIFF
--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -780,6 +780,7 @@ pub fn runBasicWithOptionsPtr(
     defer visitor.max_statements_state.deinit(allocator);
     defer visitor.max_nested_callbacks_state.deinit(allocator);
     defer visitor.id_denylist_state.deinit(allocator);
+    defer visitor.typescript_eslint_restrict_plus_operands_state.deinit(allocator);
 
     try traverser.basic.traverse(BasicVisitor, tree, &visitor);
 }
@@ -1405,6 +1406,7 @@ const BasicVisitor = struct {
     max_nested_callbacks_state: max_nested_callbacks.State = .{},
     id_denylist_state: id_denylist.State = .{},
     init_declarations_state: init_declarations.State = .{},
+    typescript_eslint_restrict_plus_operands_state: typescript_eslint_restrict_plus_operands.State = .{},
 
     fn curlyOptions(self: *const BasicVisitor) curly.Options {
         return .{
@@ -3397,7 +3399,7 @@ const BasicVisitor = struct {
             try no_bitwise.checkBinaryExpressionWithOptions(self.allocator, self.diagnostics, ctx.tree, expression, index, self.noBitwiseOptions());
         }
         if (self.options.typescript_eslint_restrict_plus_operands) {
-            try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, .{
+            try typescript_eslint_restrict_plus_operands.checkBinaryExpression(self.allocator, self.diagnostics, ctx.tree, expression, index, &self.typescript_eslint_restrict_plus_operands_state, .{
                 .allow_number_and_string = self.options.typescript_eslint_restrict_plus_operands_allow_number_and_string,
             });
         }

--- a/src/rules/typescript_eslint_restrict_plus_operands.zig
+++ b/src/rules/typescript_eslint_restrict_plus_operands.zig
@@ -36,24 +36,37 @@ const ValueType = enum {
 
 const TypeEnv = std.StringHashMapUnmanaged(ValueType);
 
+pub const State = struct {
+    env: TypeEnv = .empty,
+    initialized: bool = false,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.env.deinit(allocator);
+    }
+
+    fn ensureInitialized(self: *State, allocator: Allocator, tree: *const ast.Tree) Allocator.Error!void {
+        if (self.initialized) return;
+        self.initialized = true;
+        var visitor = TypeEnvVisitor{ .allocator = allocator, .env = &self.env };
+        try traverser.basic.traverse(TypeEnvVisitor, tree, &visitor);
+    }
+};
+
 pub fn checkBinaryExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.BinaryExpression,
     index: ast.NodeIndex,
+    state: *State,
     options: Options,
 ) Allocator.Error!void {
     if (expression.operator != .add) return;
 
-    var env: TypeEnv = .empty;
-    defer env.deinit(allocator);
+    try state.ensureInitialized(allocator, tree);
 
-    var visitor = TypeEnvVisitor{ .allocator = allocator, .env = &env };
-    try traverser.basic.traverse(TypeEnvVisitor, tree, &visitor);
-
-    const left = inferExpressionType(tree, env, expression.left);
-    const right = inferExpressionType(tree, env, expression.right);
+    const left = inferExpressionType(tree, state.env, expression.left);
+    const right = inferExpressionType(tree, state.env, expression.right);
     if (left == .unknown_expression or right == .unknown_expression) return;
     if (isAllowedPair(left, right, options)) return;
 


### PR DESCRIPTION
## Summary

- build the restrict-plus-operands type environment once per file
- reuse it for every + expression instead of traversing the full AST repeatedly
- release the cached environment with the existing basic visitor state

## Performance

Webpack lib corpus, 718 JavaScript files, ReleaseFast, Apple M4. Medians from hyperfine (3 warmups, 15 runs):

- before: 120.0 ms mean
- after: 28.3 ms mean
- speedup: 4.24x

Both versions reported 0 diagnostics on the corpus, and the existing rule tests exercise multiple + expressions sharing annotated bindings.

## Validation

- zig build test
- rule snapshots: 11 checked, 0 failed
- ReleaseFast targeted hyperfine comparison