### PR TITLE
perf: skip empty configured rule checks

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -293,7 +293,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_object_constructor or
         options.no_promise_executor_return or
         options.no_redeclare or
-        options.no_restricted_globals or
+        (options.no_restricted_globals and options.no_restricted_globals_entries.count != 0) or
         options.no_regex_spaces or
         options.no_shadow or
         options.no_unassigned_vars or

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -1049,7 +1049,7 @@ fn runSemanticAfterIo(
         });
     }
 
-    if (options.no_restricted_globals) {
+    if (options.no_restricted_globals and options.no_restricted_globals_entries.count != 0) {
         try no_restricted_globals.run(allocator, diagnostics, tree, semantic_result.symbol_table, options.no_restricted_globals_entries);
     }
 
@@ -1551,10 +1551,10 @@ const BasicVisitor = struct {
         if (self.options.alipay_ant_no_negative_conditionals) {
             try alipay_ant_no_negative_conditionals.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index);
         }
-        if (self.options.id_denylist) {
+        if (self.options.id_denylist and self.options.id_denylist_names.count != 0) {
             try id_denylist.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index, &ctx.path, &self.id_denylist_state, &self.options.id_denylist_names);
         }
-        if (self.options.no_restricted_syntax) {
+        if (self.options.no_restricted_syntax and self.options.no_restricted_syntax_entries.count != 0) {
             try no_restricted_syntax.checkNode(self.allocator, self.diagnostics, ctx.tree, data, index, self.options.no_restricted_syntax_entries);
         }
         if (self.options.no_undefined) {
@@ -1618,7 +1618,7 @@ const BasicVisitor = struct {
         if (self.options.import_no_self_import) {
             try import_no_self_import.check(self.allocator, self.diagnostics, ctx.tree, program, self.file_path);
         }
-        if (self.options.no_restricted_imports) {
+        if (self.options.no_restricted_imports and self.options.no_restricted_imports_entries.count != 0) {
             try no_restricted_imports.check(self.allocator, self.diagnostics, ctx.tree, program, self.options.no_restricted_imports_entries);
         }
         if (self.options.react_no_deprecated) {
@@ -3597,7 +3597,7 @@ const BasicVisitor = struct {
                 .ignore_assignment_variables = self.options.promise_always_return_ignore_assignment_variables,
             });
         }
-        if (self.options.no_restricted_modules) {
+        if (self.options.no_restricted_modules and self.options.no_restricted_modules_entries.count != 0) {
             try no_restricted_modules.check(self.allocator, self.diagnostics, ctx.tree, call, index, self.options.no_restricted_modules_entries);
         }
         if (self.options.use_isnan) {
@@ -3821,7 +3821,7 @@ const BasicVisitor = struct {
         if (self.options.no_iterator) {
             try no_iterator.check(self.allocator, self.diagnostics, ctx.tree, member, index);
         }
-        if (self.options.no_restricted_properties) {
+        if (self.options.no_restricted_properties and self.options.no_restricted_properties_entries.count != 0) {
             try no_restricted_properties.checkMemberExpression(self.allocator, self.diagnostics, ctx.tree, member, index, self.options.no_restricted_properties_entries);
         }
         if (self.options.no_process_env) {
@@ -4289,7 +4289,7 @@ const BasicVisitor = struct {
         if (self.options.no_useless_computed_key) {
             try no_useless_computed_key.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern);
         }
-        if (self.options.no_restricted_properties) {
+        if (self.options.no_restricted_properties and self.options.no_restricted_properties_entries.count != 0) {
             try no_restricted_properties.checkObjectPattern(self.allocator, self.diagnostics, ctx.tree, pattern, self.options.no_restricted_properties_entries);
         }
         return .proceed;


### PR DESCRIPTION
## Summary

- skip configured-rule visitors when their entry lists are empty
- avoid semantic-model construction for no-restricted-globals with no configured globals
- cover id-denylist and restricted syntax/import/module/property rules with the same empty-config guard

## Performance

Webpack lib corpus, 718 JavaScript files, ReleaseFast, Apple M4. Means from hyperfine (3 warmups, 15 runs):

- no-restricted-properties: 124.7 ms -> 32.8 ms (3.80x faster)
- no-restricted-syntax: 143.7 ms -> 32.6 ms (4.41x faster)
- no-restricted-globals: 74.1 ms -> 38.5 ms (1.92x faster)

This is especially relevant to no-restricted-properties and id-denylist because their rule booleans default to enabled while their configured entry lists default to empty.

## Validation

- zig build test
- rule snapshots: 11 checked, 0 failed
- existing configured-rule tests remain green
- ReleaseFast targeted hyperfine comparisons