### PR TITLE
perf: scope exhaustive deps callback scans

### DIFF
--- a/src/rules/alipay_ant_exhaustive_deps.zig
+++ b/src/rules/alipay_ant_exhaustive_deps.zig
@@ -71,8 +71,8 @@ pub fn runWithOptions(
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
         .reference_lookup = &reference_lookup,
-        .decl_symbols = &decl_symbols,
         .stable_symbols = &stable_symbols,
         .unstable_symbols = &unstable_symbols,
         .options = options,
@@ -157,8 +157,8 @@ const StableSymbolVisitor = struct {
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
     reference_lookup: *const ReferenceLookup,
-    decl_symbols: *const DeclSymbolMap,
     stable_symbols: *const SymbolSet,
     unstable_symbols: *const SymbolSet,
     options: Options,
@@ -277,11 +277,13 @@ const Visitor = struct {
             .allocator = self.allocator,
             .callback_span = ctx.tree.span(callback),
             .used = &used,
+            .symbol_table = self.symbol_table,
             .reference_lookup = self.reference_lookup,
             .stable_symbols = self.stable_symbols,
-            .decl_symbols = self.decl_symbols,
         };
-        try traverser.basic.traverse(DependencyVisitor, ctx.tree, &dep_visitor);
+        var callback_tree = ctx.tree.*;
+        callback_tree.root = callback;
+        try traverser.basic.traverse(DependencyVisitor, &callback_tree, &dep_visitor);
 
         if (duplicate) |name| {
             try self.reportFmt(
@@ -352,9 +354,9 @@ const DependencyVisitor = struct {
     allocator: Allocator,
     callback_span: ast.Span,
     used: *std.StringHashMap(ast.NodeIndex),
+    symbol_table: traverser.semantic.SymbolTable,
     reference_lookup: *const ReferenceLookup,
     stable_symbols: *const SymbolSet,
-    decl_symbols: *const DeclSymbolMap,
 
     pub fn enter_identifier_reference(
         self: *DependencyVisitor,
@@ -377,10 +379,8 @@ const DependencyVisitor = struct {
     }
 
     fn symbolDeclaredInsideCallback(self: *DependencyVisitor, tree: *const ast.Tree, symbol_id: SymbolId) bool {
-        var iter = self.decl_symbols.iterator();
-        while (iter.next()) |entry| {
-            if (entry.value_ptr.* != symbol_id) continue;
-            const span = tree.span(entry.key_ptr.*);
+        for (self.symbol_table.symbolDecls(symbol_id)) |declaration| {
+            const span = tree.span(declaration);
             if (span.start >= self.callback_span.start and span.end <= self.callback_span.end) return true;
         }
         return false;

--- a/tests/rules/alipay_ant_exhaustive_deps.zig
+++ b/tests/rules/alipay_ant_exhaustive_deps.zig
@@ -91,6 +91,28 @@ test "allows @alipay/ant/exhaustive-deps stable values" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.alipay_ant_exhaustive_deps.id));
 }
 
+test "isolates dependencies for each @alipay/ant/exhaustive-deps callback" {
+    const source =
+        \\function App({ first, second }) {
+        \\  useEffect(() => {
+        \\    const local = first;
+        \\    console.log(local);
+        \\  }, []);
+        \\  useEffect(() => {
+        \\    const local = second;
+        \\    console.log(local);
+        \\  }, []);
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "test.jsx", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.alipay_ant_exhaustive_deps.id));
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[0].message, "missing dependency: 'first'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.diagnostics[1].message, "missing dependency: 'second'") != null);
+}
+
 test "can disable @alipay/ant/exhaustive-deps" {
     const source =
         \\function App({ foo }) {


### PR DESCRIPTION
## Summary
- traverse only the current Hook callback when collecting dependencies instead of rewalking the entire file for every Hook
- look up declarations for the referenced symbol directly instead of scanning every declaration in the file
- add a regression test covering multiple callbacks with callback-local declarations

## Benchmarks
ReleaseFast, macOS arm64, `@alipay/ant/exhaustive-deps` only.

Stress corpus: 20 TSX files × 500 `useEffect` calls/file (15 post-change runs, 10 baseline runs):

| Mode | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| default threads | 98.3 ms | 8.9 ms | 11.0× |
| 1 thread | 481.0 ms | 21.0 ms | 22.9× |

Smaller corpus: 100 TSX files × 40 Hooks/file:

| Mode | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| default threads | 11.7 ms | 10.4 ms | 1.13× |
| 1 thread | 32.0 ms | 16.6 ms | 1.93× |

Diagnostics were byte-for-byte identical before and after on the stress corpus.

## Validation
- `zig build test`
- rule snapshots: 11 checked, 0 failed
