### PR TITLE
perf: look up click handler declarations directly

### DIFF
--- a/src/rules/alipay_ant_prefer_click_with_debounce.zig
+++ b/src/rules/alipay_ant_prefer_click_with_debounce.zig
@@ -11,7 +11,6 @@ pub const id = "@alipay/ant/prefer-click-with-debounce";
 const message = "异步点击事件(async function)必须防抖处理.";
 const SymbolId = traverser.semantic.SymbolId;
 const ReferenceLookup = std.AutoHashMap(ast.NodeIndex, SymbolId);
-const DeclSymbolMap = std.AutoHashMap(ast.NodeIndex, SymbolId);
 const DefinitionMap = std.AutoHashMap(ast.NodeIndex, ast.NodeIndex);
 
 pub fn run(
@@ -22,16 +21,6 @@ pub fn run(
 ) Allocator.Error!void {
     var reference_lookup = ReferenceLookup.init(allocator);
     defer reference_lookup.deinit();
-
-    var decl_symbols = DeclSymbolMap.init(allocator);
-    defer decl_symbols.deinit();
-
-    var symbol_iter = symbol_table.iterSymbols();
-    while (symbol_iter.next()) |entry| {
-        for (symbol_table.symbolDecls(entry.id)) |decl| {
-            try decl_symbols.put(decl, entry.id);
-        }
-    }
 
     var reference_iter = symbol_table.iterReferences();
     while (reference_iter.next()) |entry| {
@@ -50,8 +39,8 @@ pub fn run(
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
         .reference_lookup = &reference_lookup,
-        .decl_symbols = &decl_symbols,
         .definitions = &definitions,
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -89,8 +78,8 @@ const DefinitionVisitor = struct {
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
     reference_lookup: *const ReferenceLookup,
-    decl_symbols: *const DeclSymbolMap,
     definitions: *const DefinitionMap,
 
     pub fn enter_jsx_element(
@@ -148,10 +137,8 @@ const Visitor = struct {
         const symbol_id = self.reference_lookup.get(reference) orelse return null;
         if (symbol_id == .none) return null;
 
-        var iter = self.decl_symbols.iterator();
-        while (iter.next()) |entry| {
-            if (entry.value_ptr.* != symbol_id) continue;
-            return self.definitions.get(entry.key_ptr.*);
+        for (self.symbol_table.symbolDecls(symbol_id)) |declaration| {
+            if (self.definitions.get(declaration)) |definition| return definition;
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- use the semantic table's per-symbol declaration list for JSX click-handler resolution
- remove the reverse declaration map and the per-handler scan over every declaration in the file

## Benchmarks
ReleaseFast, macOS arm64, `@alipay/ant/prefer-click-with-debounce` only, 15 runs.

Stress corpus: 5 TSX files × 2,000 debounced handler definitions and JSX references/file, 1 thread:

- before: 34.8 ms
- after: 19.8 ms
- speedup: 1.76×

A smaller 20-file × 400-handler corpus improved from 18.2 ms to 15.9 ms in single-thread mode. Diagnostics were byte-for-byte identical.

## Validation
- `zig build test`
- rule snapshots: 11 checked, 0 failed
