### PR TITLE
perf: inspect loop-condition symbol uses directly

### DIFF
--- a/src/rules/no_unmodified_loop_condition.zig
+++ b/src/rules/no_unmodified_loop_condition.zig
@@ -124,13 +124,13 @@ fn isModified(
     symbol_table: semantic_compat.SymbolTable,
     condition: Condition,
 ) bool {
-    var references = symbol_table.iterReferences();
-    while (references.next()) |entry| {
-        if (symbol_table.referenceSymbol(entry.id) != condition.symbol) continue;
-        if (!symbol_table.isWriteReference(entry.id)) continue;
+    var uses = symbol_table.symbolUses(condition.symbol);
+    while (uses.next()) |reference| {
+        const reference_id = symbol_table.model.referenceOf(reference) orelse continue;
+        if (!symbol_table.isWriteReference(reference_id)) continue;
 
-        if (isInLoop(tree, condition.loop, entry.reference.node)) return true;
-        if (enclosingFunctionCalledInLoop(tree, symbol_table, condition.loop, entry.reference.node)) return true;
+        if (isInLoop(tree, condition.loop, reference)) return true;
+        if (enclosingFunctionCalledInLoop(tree, symbol_table, condition.loop, reference)) return true;
     }
 
     // Yuku does not model declaration initializers as references. ESLint counts


### PR DESCRIPTION
## Summary
- inspect the current condition symbol's semantic uses directly
- avoid scanning every reference in the file once per loop condition

## Benchmarks
ReleaseFast, macOS arm64, `no-unmodified-loop-condition` only.

| Corpus (1 thread) | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 20 files × 500 loops | 13.2 ms | 11.2 ms | 1.18× |
| 1 file × 5,000 loops | 17.4 ms | 9.3 ms | 1.87× |

Diagnostics were byte-for-byte identical.

## Validation
- `zig build test`
- rule snapshots: 11 checked, 0 failed
