### PR TITLE
perf: reuse caught-error reference lookup

### DIFF
--- a/src/rules/preserve_caught_error.zig
+++ b/src/rules/preserve_caught_error.zig
@@ -202,7 +202,7 @@ const Visitor = struct {
         const callee_index = unwrapTransparent(tree, callee);
         const name = identifierReferenceName(tree, callee_index) orelse return false;
         if (!isBuiltInErrorName(name)) return false;
-        return isUnresolvedReference(self.symbol_table, callee_index);
+        return (self.reference_lookup.get(callee_index) orelse return false) == .none;
     }
 
     fn addDiagnostic(
@@ -333,19 +333,6 @@ fn isBuiltInErrorName(name: []const u8) bool {
         std.mem.eql(u8, name, "TypeError") or
         std.mem.eql(u8, name, "URIError") or
         std.mem.eql(u8, name, "AggregateError");
-}
-
-fn isUnresolvedReference(
-    symbol_table: traverser.semantic.SymbolTable,
-    node: ast.NodeIndex,
-) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-    return false;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {


### PR DESCRIPTION
## Summary
- reuse the rule's existing node-to-symbol lookup to identify unresolved built-in Error constructors
- remove the full semantic-reference scan performed for every throw

## Benchmarks
ReleaseFast, macOS arm64, `preserve-caught-error` only.

| Corpus (1 thread) | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 20 files × 500 catch/rethrow blocks | 14.4 ms | 13.0 ms | 1.11× |
| 1 file × 5,000 catch/rethrow blocks | 17.2 ms | 7.1 ms | 2.42× |

Diagnostics were byte-for-byte identical.

## Validation
- `zig build test`
- rule snapshots: 11 checked, 0 failed
