### PR TITLE
perf: resolve global references by node

### DIFF
--- a/src/rules/global_call_checks.zig
+++ b/src/rules/global_call_checks.zig
@@ -342,14 +342,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn isAlertName(name: []const u8) bool {

--- a/src/rules/global_is_checks.zig
+++ b/src/rules/global_is_checks.zig
@@ -156,12 +156,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/native_object_checks.zig
+++ b/src/rules/native_object_checks.zig
@@ -195,12 +195,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_alert.zig
+++ b/src/rules/no_alert.zig
@@ -122,14 +122,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn isForbiddenFunction(name: []const u8) bool {

--- a/src/rules/no_array_constructor.zig
+++ b/src/rules/no_array_constructor.zig
@@ -135,12 +135,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_async_promise_executor.zig
+++ b/src/rules/no_async_promise_executor.zig
@@ -99,12 +99,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_console.zig
+++ b/src/rules/no_console.zig
@@ -109,14 +109,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/no_eval.zig
+++ b/src/rules/no_eval.zig
@@ -194,12 +194,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_extra_boolean_cast.zig
+++ b/src/rules/no_extra_boolean_cast.zig
@@ -326,11 +326,7 @@ fn hasLogicalOrLowerPrecedence(tree: *const ast.Tree, index: ast.NodeIndex) bool
 }
 
 fn isUnresolvedReference(symbol_table: traverser.semantic.SymbolTable, node: ast.NodeIndex) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) return symbol_table.referenceSymbol(entry.id) == .none;
-    }
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/no_global_assign.zig
+++ b/src/rules/no_global_assign.zig
@@ -164,14 +164,8 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return true;
+    const reference = symbol_table.model.referenceOf(node) orelse return true;
+    return symbol_table.referenceSymbol(reference) == .none;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/no_global_is_finite.zig
+++ b/src/rules/no_global_is_finite.zig
@@ -114,12 +114,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_global_is_nan.zig
+++ b/src/rules/no_global_is_nan.zig
@@ -114,12 +114,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_implied_eval.zig
+++ b/src/rules/no_implied_eval.zig
@@ -148,12 +148,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_misleading_character_class.zig
+++ b/src/rules/no_misleading_character_class.zig
@@ -402,12 +402,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_new_func.zig
+++ b/src/rules/no_new_func.zig
@@ -156,12 +156,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_new_native_nonconstructor.zig
+++ b/src/rules/no_new_native_nonconstructor.zig
@@ -94,12 +94,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_new_object.zig
+++ b/src/rules/no_new_object.zig
@@ -87,12 +87,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_new_symbol.zig
+++ b/src/rules/no_new_symbol.zig
@@ -87,12 +87,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_new_wrappers.zig
+++ b/src/rules/no_new_wrappers.zig
@@ -95,12 +95,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_obj_calls.zig
+++ b/src/rules/no_obj_calls.zig
@@ -112,12 +112,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_object_constructor.zig
+++ b/src/rules/no_object_constructor.zig
@@ -104,12 +104,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_promise_executor_return.zig
+++ b/src/rules/no_promise_executor_return.zig
@@ -209,12 +209,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/no_regex_spaces.zig
+++ b/src/rules/no_regex_spaces.zig
@@ -181,14 +181,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 const SpaceRun = struct {

--- a/src/rules/no_restricted_globals.zig
+++ b/src/rules/no_restricted_globals.zig
@@ -171,14 +171,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/no_useless_backreference.zig
+++ b/src/rules/no_useless_backreference.zig
@@ -387,12 +387,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/object_constructor_checks.zig
+++ b/src/rules/object_constructor_checks.zig
@@ -128,12 +128,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/prefer_exponentiation_operator.zig
+++ b/src/rules/prefer_exponentiation_operator.zig
@@ -490,12 +490,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/prefer_named_capture_group.zig
+++ b/src/rules/prefer_named_capture_group.zig
@@ -240,12 +240,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/prefer_numeric_literals.zig
+++ b/src/rules/prefer_numeric_literals.zig
@@ -218,13 +218,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {

--- a/src/rules/prefer_object_has_own.zig
+++ b/src/rules/prefer_object_has_own.zig
@@ -182,14 +182,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/prefer_object_spread.zig
+++ b/src/rules/prefer_object_spread.zig
@@ -376,12 +376,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/prefer_promise_reject_errors.zig
+++ b/src/rules/prefer_promise_reject_errors.zig
@@ -263,14 +263,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/prefer_regex_literals.zig
+++ b/src/rules/prefer_regex_literals.zig
@@ -158,12 +158,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/promise_checks.zig
+++ b/src/rules/promise_checks.zig
@@ -451,14 +451,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/radix.zig
+++ b/src/rules/radix.zig
@@ -213,12 +213,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/react_jsx_no_undef.zig
+++ b/src/rules/react_jsx_no_undef.zig
@@ -90,12 +90,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/require_unicode_regexp.zig
+++ b/src/rules/require_unicode_regexp.zig
@@ -148,14 +148,7 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }
 
 fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {

--- a/src/rules/symbol_checks.zig
+++ b/src/rules/symbol_checks.zig
@@ -118,12 +118,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/rules/symbol_description.zig
+++ b/src/rules/symbol_description.zig
@@ -87,12 +87,5 @@ fn isUnresolvedReference(
     symbol_table: traverser.semantic.SymbolTable,
     node: ast.NodeIndex,
 ) bool {
-    var iter = symbol_table.iterReferences();
-    while (iter.next()) |entry| {
-        if (entry.reference.node == node) {
-            return symbol_table.referenceSymbol(entry.id) == .none;
-        }
-    }
-
-    return false;
+    return symbol_table.isUnresolvedReference(node);
 }

--- a/src/semantic_compat.zig
+++ b/src/semantic_compat.zig
@@ -111,6 +111,11 @@ pub const SymbolTable = struct {
         return self.model.reference(id).symbol;
     }
 
+    pub inline fn isUnresolvedReference(self: SymbolTable, node: ast.NodeIndex) bool {
+        const reference = self.model.referenceOf(node) orelse return false;
+        return self.model.reference(reference).symbol == .none;
+    }
+
     pub inline fn symbolDecls(self: SymbolTable, id: yuku_semantic.SymbolId) []const ast.NodeIndex {
         return self.model.decls(id);
     }


### PR DESCRIPTION
## Summary
- add an O(1) semantic node-to-reference check to the compatibility symbol table
- use it across 39 rules that identify unresolved globals such as `parseInt`, `RegExp`, `Promise`, `Symbol`, `console`, and `globalThis`
- remove the previous full-file semantic reference scan performed for every candidate node
- preserve `no-global-assign`'s existing fallback for nodes absent from the reference table

## Benchmarks
ReleaseFast, macOS arm64, `radix` only, with valid `parseInt(value, 10)` calls so diagnostics do not cap traversal.

| Corpus (1 thread) | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 20 files × 500 calls | 10.7 ms | 8.5 ms | 1.26× |
| 1 file × 5,000 calls | 14.9 ms | 4.5 ms | 3.31× |

Diagnostics were byte-for-byte identical. The same lookup path is shared by the other 38 updated rules.

## Validation
- `zig build test`
- rule snapshots: 11 checked, 0 failed
