### PR TITLE
perf: locate comment-only lines by span

### DIFF
--- a/src/rules/max_lines_per_function.zig
+++ b/src/rules/max_lines_per_function.zig
@@ -115,28 +115,41 @@ fn isCommentOnlyLine(
     line_end: usize,
 ) bool {
     var saw_comment = false;
+    var cursor = line_start;
+    var comment_index = firstCommentEndingAfter(comments, line_start);
 
-    var index = line_start;
-    while (index < line_end) : (index += 1) {
-        if (std.ascii.isWhitespace(source[index])) continue;
-        if (!isInsideComment(comments, index, line_start, line_end)) return false;
+    while (comment_index < comments.len) : (comment_index += 1) {
+        const comment = comments[comment_index];
+        const start: usize = @intCast(comment.span.start);
+        const end: usize = @intCast(comment.span.end);
+        if (start >= line_end) break;
+        if (end <= cursor) continue;
+        const gap_end = @max(cursor, @min(start, line_end));
+        if (containsNonWhitespace(source[cursor..gap_end])) return false;
         saw_comment = true;
+        cursor = @max(cursor, @min(end, line_end));
     }
 
-    return saw_comment;
+    return saw_comment and !containsNonWhitespace(source[cursor..line_end]);
 }
 
-fn isInsideComment(
-    comments: []const ast.Comment,
-    index: usize,
-    line_start: usize,
-    line_end: usize,
-) bool {
-    for (comments) |comment| {
-        const start: usize = comment.span.start;
-        const end: usize = comment.span.end;
-        if (end <= line_start or start >= line_end) continue;
-        if (start <= index and index < end) return true;
+fn firstCommentEndingAfter(comments: []const ast.Comment, offset: usize) usize {
+    var low: usize = 0;
+    var high = comments.len;
+    while (low < high) {
+        const middle = low + (high - low) / 2;
+        if (comments[middle].span.end <= offset) {
+            low = middle + 1;
+        } else {
+            high = middle;
+        }
+    }
+    return low;
+}
+
+fn containsNonWhitespace(source: []const u8) bool {
+    for (source) |byte| {
+        if (!std.ascii.isWhitespace(byte)) return true;
     }
     return false;
 }

--- a/tests/rules/max_lines_per_function.zig
+++ b/tests/rules/max_lines_per_function.zig
@@ -63,6 +63,28 @@ test "supports skipBlankLines and skipComments" {
     try std.testing.expect(!helpers.hasRule(skipped_result, lint.rules.max_lines_per_function.id));
 }
 
+test "skipComments handles multiline comments without skipping inline code" {
+    const source =
+        \\function counted() {
+        \\  /* first
+        \\   * second
+        \\   */
+        \\  const value = 1; // inline comment
+        \\  return value;
+        \\}
+    ;
+
+    var options = baseOptions();
+    options.max_lines_per_function_max = 3;
+    options.max_lines_per_function_skip_comments = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.max_lines_per_function.id));
+    try std.testing.expect(hasMessage(result, "Function has too many lines (4). Maximum allowed is 3."));
+}
+
 test "skips IIFEs unless configured" {
     const source =
         \\(function () {


### PR DESCRIPTION
## Summary
- binary-search the first comment overlapping each function line
- validate only the gaps between overlapping comment spans instead of checking every byte against every comment in the file
- add coverage for multiline comments and inline code comments

## Benchmarks
ReleaseFast, macOS arm64, `max-lines-per-function` with `skipComments: true`, 20 runs, one thread. Both corpora produce no diagnostics.

| Corpus | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 10 files × 20 functions × 20 comments | 5.8 ms | 2.1 ms | 2.76× |
| 1 file × 100 functions × 50 comments | 54.2 ms | 1.9 ms | 28.5× |

Diagnostics were byte-for-byte identical.

## Validation
- new multiline/inline comment regression test
- `zig build test`
- rule snapshots: 11 checked, 0 failed
