### PR TITLE
docs: use a rounded homepage benchmark comparison

### DIFF
--- a/.dumi/overrides.css
+++ b/.dumi/overrides.css
@@ -723,16 +723,8 @@ body {
 }
 
 .utlint-benchmark-row--utoo > i::after {
-  width: max(1.12%, 7px);
+  width: max(1.43%, 7px);
   background: var(--utlint-brand);
-}
-
-.utlint-benchmark-row--oxlint > i::after {
-  width: 7.67%;
-}
-
-.utlint-benchmark-row--biome > i::after {
-  width: 8.23%;
 }
 
 .utlint-benchmark-row--eslint > i::after {

--- a/.dumi/overrides.css
+++ b/.dumi/overrides.css
@@ -727,6 +727,14 @@ body {
   background: var(--utlint-brand);
 }
 
+.utlint-benchmark-row--oxlint > i::after {
+  width: 5.71%;
+}
+
+.utlint-benchmark-row--biome > i::after {
+  width: 7.14%;
+}
+
 .utlint-benchmark-row--eslint > i::after {
   width: 100%;
   background: #555a5d;

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -44,11 +44,13 @@ export default defineConfig({
       mode: 'override',
       value: {
         'en-US': [
+          { title: 'Quick Start', link: '/quick-start' },
           { title: 'Configuration', link: '/configuration' },
           { title: 'Rules', link: '/rule-status' },
           { title: 'Migration', link: '/eslint-migration' },
         ],
         'zh-CN': [
+          { title: '快速开始', link: '/zh-CN/quick-start' },
           { title: '配置', link: '/zh-CN/configuration' },
           { title: '规则', link: '/zh-CN/rule-status' },
           { title: '迁移', link: '/zh-CN/eslint-migration' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,10 @@ hero:
   title: Find code problems faster.
   description: Native-speed linting for the JavaScript projects you already have—without replacing the workflow you already trust.
   actions:
-    - text: Read the docs
+    - text: Quick Start
       link: /configuration
-    - text: Open the Playground
-      link: /playground/
+    - text: GitHub
+      link: https://github.com/utooland/utoo-lint
 ---
 
 <section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,44 @@ hero:
       link: /playground/
 ---
 
+<section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
+  <header class="utlint-home-section-heading">
+    <span class="utlint-home-kicker">01 · Benchmark</span>
+    <h2 id="utlint-benchmark-title">About 70× faster than ESLint.</h2>
+    <p>
+      Measured with the same generated TypeScript corpus and the same 12 shared
+      rules. Every sample starts a fresh CLI process; results vary by project
+      and machine.
+    </p>
+    <a class="utlint-home-text-link" href="https://github.com/utooland/utoo-lint/tree/main/benchmarks">
+      See the methodology and run it yourself <span aria-hidden="true">→</span>
+    </a>
+  </header>
+  <figure class="utlint-benchmark-panel" aria-labelledby="utlint-benchmark-caption">
+    <header>
+      <div>
+        <span>Repository benchmark</span>
+        <strong>Relative wall-clock time</strong>
+      </div>
+      <span>Lower is better</span>
+    </header>
+    <div class="utlint-benchmark-chart">
+      <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
+        <span>utoo-lint</span><i aria-hidden="true"></i><strong>1×</strong>
+      </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
+        <span>ESLint</span><i aria-hidden="true"></i><strong>~70×</strong>
+      </div>
+    </div>
+    <figcaption id="utlint-benchmark-caption">
+      100 TypeScript files · 12 shared rules · fresh process per sample · rounded from repeated runs
+    </figcaption>
+  </figure>
+</section>
+
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · Migration</span>
+    <span class="utlint-home-kicker">02 · Migration</span>
     <h2 id="utlint-migration-title">Replace ESLint without the big-bang rewrite.</h2>
     <p>
       Migration is deliberately incremental. Generate a report first, move the
@@ -42,7 +77,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · Runtime</span>
+    <span class="utlint-home-kicker">03 · Runtime</span>
     <h2 id="utlint-architecture-title">One core. Native, Node and WebAssembly.</h2>
     <p>
       The Node wrapper handles trusted TypeScript configuration and project

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · Benchmark</span>
+    <span class="utlint-home-kicker">Benchmark</span>
     <h2 id="utlint-benchmark-title">About 70× faster than ESLint.</h2>
     <p>
       Measured with the same generated TypeScript corpus and the same 12 shared
@@ -54,7 +54,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · Migration</span>
+    <span class="utlint-home-kicker">Migration</span>
     <h2 id="utlint-migration-title">Replace ESLint without the big-bang rewrite.</h2>
     <p>
       Migration is deliberately incremental. Generate a report first, move the
@@ -83,7 +83,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">03 · Runtime</span>
+    <span class="utlint-home-kicker">Runtime</span>
     <h2 id="utlint-architecture-title">One core. Native, Node and WebAssembly.</h2>
     <p>
       The Node wrapper handles trusted TypeScript configuration and project

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,12 @@ hero:
       <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
         <span>utoo-lint</span><i aria-hidden="true"></i><strong>1×</strong>
       </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--oxlint">
+        <span>Oxlint</span><i aria-hidden="true"></i><strong>~4×</strong>
+      </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--biome">
+        <span>Biome</span><i aria-hidden="true"></i><strong>~5×</strong>
+      </div>
       <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
         <span>ESLint</span><i aria-hidden="true"></i><strong>~70×</strong>
       </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hero:
   description: Native-speed linting for the JavaScript projects you already have—without replacing the workflow you already trust.
   actions:
     - text: Quick Start
-      link: /configuration
+      link: /quick-start
     - text: GitHub
       link: https://github.com/utooland/utoo-lint
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,50 +11,9 @@ hero:
       link: /playground/
 ---
 
-<section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
-  <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · Benchmark</span>
-    <h2 id="utlint-benchmark-title">8.35 ms from a cold start.</h2>
-    <p>
-      The repository benchmark launches a fresh process for every run against
-      the same generated TypeScript corpus and the same 12 lint rules. These
-      results were recorded on Darwin arm64 on June 13, 2026.
-    </p>
-    <a class="utlint-home-text-link" href="https://github.com/utooland/utoo-lint/tree/main/benchmarks">
-      Read the methodology and run it yourself <span aria-hidden="true">→</span>
-    </a>
-  </header>
-  <figure class="utlint-benchmark-panel" aria-labelledby="utlint-benchmark-caption">
-    <header>
-      <div>
-        <span>Fresh CLI process</span>
-        <strong>Median wall-clock time</strong>
-      </div>
-      <span>Lower is better</span>
-    </header>
-    <div class="utlint-benchmark-chart">
-      <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
-        <span>utoo-lint</span><i aria-hidden="true"></i><strong>8.35 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--oxlint">
-        <span>Oxlint</span><i aria-hidden="true"></i><strong>57.35 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--biome">
-        <span>Biome</span><i aria-hidden="true"></i><strong>61.56 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
-        <span>ESLint</span><i aria-hidden="true"></i><strong>747.84 ms</strong>
-      </div>
-    </div>
-    <figcaption id="utlint-benchmark-caption">
-      100 TypeScript files · 12 shared rules · fresh process · median of repeated runs
-    </figcaption>
-  </figure>
-</section>
-
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · Migration</span>
+    <span class="utlint-home-kicker">01 · Migration</span>
     <h2 id="utlint-migration-title">Replace ESLint without the big-bang rewrite.</h2>
     <p>
       Migration is deliberately incremental. Generate a report first, move the
@@ -83,7 +42,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">03 · Runtime</span>
+    <span class="utlint-home-kicker">02 · Runtime</span>
     <h2 id="utlint-architecture-title">One core. Native, Node and WebAssembly.</h2>
     <p>
       The Node wrapper handles trusted TypeScript configuration and project

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -13,7 +13,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · 性能基准</span>
+    <span class="utlint-home-kicker">性能基准</span>
     <h2 id="utlint-benchmark-title">比 ESLint 快约 70 倍。</h2>
     <p>
       使用同一批生成的 TypeScript 文件和相同的 12 条共有规则进行测试。
@@ -53,7 +53,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · 渐进迁移</span>
+    <span class="utlint-home-kicker">渐进迁移</span>
     <h2 id="utlint-migration-title">不用一次性重写，也能迁移 ESLint。</h2>
     <p>
       迁移过程是渐进的。先生成报告，把 utoo-lint 已经原生实现的规则迁移过来；
@@ -81,7 +81,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">03 · 运行方式</span>
+    <span class="utlint-home-kicker">运行方式</span>
     <h2 id="utlint-architecture-title">同一个内核，运行在原生、Node 和 WebAssembly。</h2>
     <p>
       Node 包装层负责加载可信的 TypeScript 配置和发现项目文件；Zig 引擎接收

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -35,6 +35,12 @@ hero:
       <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
         <span>utoo-lint</span><i aria-hidden="true"></i><strong>1×</strong>
       </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--oxlint">
+        <span>Oxlint</span><i aria-hidden="true"></i><strong>~4×</strong>
+      </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--biome">
+        <span>Biome</span><i aria-hidden="true"></i><strong>~5×</strong>
+      </div>
       <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
         <span>ESLint</span><i aria-hidden="true"></i><strong>~70×</strong>
       </div>

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -11,50 +11,9 @@ hero:
       link: /playground/
 ---
 
-<section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
-  <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · 性能基准</span>
-    <h2 id="utlint-benchmark-title">冷启动只需 8.35 毫秒。</h2>
-    <p>
-      仓库中的基准测试会针对同一批生成的 TypeScript 文件和相同的 12 条
-      Lint 规则，每次启动一个全新的进程。以下结果于 2026 年 6 月 13 日在
-      Darwin arm64 环境中记录。
-    </p>
-    <a class="utlint-home-text-link" href="https://github.com/utooland/utoo-lint/tree/main/benchmarks">
-      阅读测试方法并亲自运行 <span aria-hidden="true">→</span>
-    </a>
-  </header>
-  <figure class="utlint-benchmark-panel" aria-labelledby="utlint-benchmark-caption">
-    <header>
-      <div>
-        <span>每次启动新的 CLI 进程</span>
-        <strong>实际耗时中位数</strong>
-      </div>
-      <span>数值越低越好</span>
-    </header>
-    <div class="utlint-benchmark-chart">
-      <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
-        <span>utoo-lint</span><i aria-hidden="true"></i><strong>8.35 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--oxlint">
-        <span>Oxlint</span><i aria-hidden="true"></i><strong>57.35 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--biome">
-        <span>Biome</span><i aria-hidden="true"></i><strong>61.56 ms</strong>
-      </div>
-      <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
-        <span>ESLint</span><i aria-hidden="true"></i><strong>747.84 ms</strong>
-      </div>
-    </div>
-    <figcaption id="utlint-benchmark-caption">
-      100 个 TypeScript 文件 · 12 条共有规则 · 全新进程 · 多次运行的中位数
-    </figcaption>
-  </figure>
-</section>
-
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · 渐进迁移</span>
+    <span class="utlint-home-kicker">01 · 渐进迁移</span>
     <h2 id="utlint-migration-title">不用一次性重写，也能迁移 ESLint。</h2>
     <p>
       迁移过程是渐进的。先生成报告，把 utoo-lint 已经原生实现的规则迁移过来；
@@ -82,7 +41,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">03 · 运行方式</span>
+    <span class="utlint-home-kicker">02 · 运行方式</span>
     <h2 id="utlint-architecture-title">同一个内核，运行在原生、Node 和 WebAssembly。</h2>
     <p>
       Node 包装层负责加载可信的 TypeScript 配置和发现项目文件；Zig 引擎接收

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -11,9 +11,43 @@ hero:
       link: /playground/
 ---
 
+<section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">
+  <header class="utlint-home-section-heading">
+    <span class="utlint-home-kicker">01 · 性能基准</span>
+    <h2 id="utlint-benchmark-title">比 ESLint 快约 70 倍。</h2>
+    <p>
+      使用同一批生成的 TypeScript 文件和相同的 12 条共有规则进行测试。
+      每个样本都会启动新的 CLI 进程；实际结果会因项目和机器而异。
+    </p>
+    <a class="utlint-home-text-link" href="https://github.com/utooland/utoo-lint/tree/main/benchmarks">
+      查看测试方法并亲自运行 <span aria-hidden="true">→</span>
+    </a>
+  </header>
+  <figure class="utlint-benchmark-panel" aria-labelledby="utlint-benchmark-caption">
+    <header>
+      <div>
+        <span>仓库基准测试</span>
+        <strong>相对实际耗时</strong>
+      </div>
+      <span>越低越好</span>
+    </header>
+    <div class="utlint-benchmark-chart">
+      <div class="utlint-benchmark-row utlint-benchmark-row--utoo">
+        <span>utoo-lint</span><i aria-hidden="true"></i><strong>1×</strong>
+      </div>
+      <div class="utlint-benchmark-row utlint-benchmark-row--eslint">
+        <span>ESLint</span><i aria-hidden="true"></i><strong>~70×</strong>
+      </div>
+    </div>
+    <figcaption id="utlint-benchmark-caption">
+      100 个 TypeScript 文件 · 12 条共有规则 · 每个样本启动新进程 · 多次运行后的近似值
+    </figcaption>
+  </figure>
+</section>
+
 <section class="utlint-home-section utlint-home-section--migration" aria-labelledby="utlint-migration-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">01 · 渐进迁移</span>
+    <span class="utlint-home-kicker">02 · 渐进迁移</span>
     <h2 id="utlint-migration-title">不用一次性重写，也能迁移 ESLint。</h2>
     <p>
       迁移过程是渐进的。先生成报告，把 utoo-lint 已经原生实现的规则迁移过来；
@@ -41,7 +75,7 @@ hero:
 
 <section class="utlint-home-section utlint-home-section--architecture" aria-labelledby="utlint-architecture-title">
   <header class="utlint-home-section-heading">
-    <span class="utlint-home-kicker">02 · 运行方式</span>
+    <span class="utlint-home-kicker">03 · 运行方式</span>
     <h2 id="utlint-architecture-title">同一个内核，运行在原生、Node 和 WebAssembly。</h2>
     <p>
       Node 包装层负责加载可信的 TypeScript 配置和发现项目文件；Zig 引擎接收

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -5,10 +5,10 @@ hero:
   title: 更快地发现代码问题。
   description: 为现有 JavaScript 工程带来原生级检查速度，不用推翻你已经熟悉的工作流。
   actions:
-    - text: 阅读文档
+    - text: 快速开始
       link: /zh-CN/configuration
-    - text: 打开 Playground
-      link: /playground/
+    - text: GitHub
+      link: https://github.com/utooland/utoo-lint
 ---
 
 <section class="utlint-home-section utlint-home-section--benchmark" aria-labelledby="utlint-benchmark-title">

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -6,7 +6,7 @@ hero:
   description: 为现有 JavaScript 工程带来原生级检查速度，不用推翻你已经熟悉的工作流。
   actions:
     - text: 快速开始
-      link: /zh-CN/configuration
+      link: /zh-CN/quick-start
     - text: GitHub
       link: https://github.com/utooland/utoo-lint
 ---

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,89 @@
+# Quick Start
+
+Install `utoo-lint`, run it on an existing JavaScript or TypeScript project,
+then add a typed project config when you are ready to choose rules and files.
+
+## Requirements
+
+The npm package requires Node.js 20 or later. It installs a prebuilt native
+binary for supported macOS, Linux, and Windows platforms, so using the package
+does not require a Zig toolchain.
+
+## Install
+
+Use the package manager already used by your project:
+
+```bash
+# pnpm
+pnpm add -D @utoo/lint
+
+# npm
+npm install --save-dev @utoo/lint
+
+# utoo
+ut install @utoo/lint -D
+```
+
+## Run Your First Check
+
+Point the CLI at a source directory. Without a config file, utoo-lint uses its
+built-in default rules.
+
+```bash
+pnpm exec utoo-lint src
+```
+
+With npm, use `npx utoo-lint src`. With utoo, use `utx @utoo/lint src`.
+
+## Add a Typed Config
+
+Create `utlint.config.ts` in the project root. The frontend preset provides a
+practical starting point for JavaScript, TypeScript, React, imports, and JSX
+accessibility rules.
+
+```ts
+import { defineConfig } from "@utoo/lint/config";
+import frontend from "@utoo/lint/configs/frontend";
+
+export default defineConfig({
+  ...frontend,
+  ignores: [...frontend.ignores, ".next", "storybook-static"],
+  rules: {
+    ...frontend.rules,
+    "no-console": "off"
+  }
+});
+```
+
+The preset includes its own `files` patterns, so the CLI can discover source
+files without a positional target:
+
+```bash
+pnpm exec utoo-lint
+```
+
+See [Configuration](/configuration) for flat config arrays, static JSON
+config, global ignores, rule options, and precedence.
+
+## Add Package Scripts
+
+Put repeatable lint commands in `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint": "utoo-lint src",
+    "lint:fix": "utoo-lint --fix src"
+  }
+}
+```
+
+Run them with your package manager, for example `pnpm lint` and
+`pnpm lint:fix`.
+
+## Next Steps
+
+- Review the complete [rule coverage](/rule-status).
+- Move an existing project with the [ESLint migration guide](/eslint-migration).
+- Learn how to document intentional exceptions with [suppression comments](/suppressions).
+- Try one file without installing anything in the [Playground](/playground/).

--- a/docs/quick-start.zh-CN.md
+++ b/docs/quick-start.zh-CN.md
@@ -1,0 +1,85 @@
+# 快速开始
+
+在现有 JavaScript 或 TypeScript 项目中安装并运行 `utoo-lint`，然后按需添加
+带类型的项目配置，用来选择规则和检查文件。
+
+## 环境要求
+
+npm 包要求 Node.js 20 或更高版本。它会在受支持的 macOS、Linux 和 Windows
+平台上安装预编译的原生二进制文件，因此使用 npm 包不需要 Zig 工具链。
+
+## 安装
+
+使用项目现有的包管理器：
+
+```bash
+# pnpm
+pnpm add -D @utoo/lint
+
+# npm
+npm install --save-dev @utoo/lint
+
+# utoo
+ut install @utoo/lint -D
+```
+
+## 第一次检查
+
+让 CLI 检查源码目录。没有配置文件时，utoo-lint 会使用内置默认规则。
+
+```bash
+pnpm exec utoo-lint src
+```
+
+使用 npm 时运行 `npx utoo-lint src`；使用 utoo 时运行
+`utx @utoo/lint src`。
+
+## 添加带类型的配置
+
+在项目根目录创建 `utlint.config.ts`。前端预设提供一套适用于 JavaScript、
+TypeScript、React、import 和 JSX 无障碍规则的实用起点。
+
+```ts
+import { defineConfig } from "@utoo/lint/config";
+import frontend from "@utoo/lint/configs/frontend";
+
+export default defineConfig({
+  ...frontend,
+  ignores: [...frontend.ignores, ".next", "storybook-static"],
+  rules: {
+    ...frontend.rules,
+    "no-console": "off"
+  }
+});
+```
+
+该预设自带 `files` 模式，因此 CLI 无需位置参数也能找到源码文件：
+
+```bash
+pnpm exec utoo-lint
+```
+
+如需了解扁平配置数组、静态 JSON 配置、全局忽略、规则选项和优先级，请阅读
+[配置文档](/zh-CN/configuration)。
+
+## 添加 package scripts
+
+在 `package.json` 中加入可重复执行的检查命令：
+
+```json
+{
+  "scripts": {
+    "lint": "utoo-lint src",
+    "lint:fix": "utoo-lint --fix src"
+  }
+}
+```
+
+使用项目的包管理器运行这些脚本，例如 `pnpm lint` 和 `pnpm lint:fix`。
+
+## 后续阅读
+
+- 查看完整的[规则覆盖情况](/zh-CN/rule-status)。
+- 按照 [ESLint 迁移指南](/zh-CN/eslint-migration)迁移现有项目。
+- 通过[抑制注释](/zh-CN/suppressions)记录有意保留的例外。
+- 无需安装，直接在 [Playground](/playground/) 中检查单个文件。

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -302,6 +302,10 @@ function verifyHomepageVisual(html) {
   ) {
     throw new Error('docs index is missing the rounded benchmark comparison');
   }
+
+  if (/\b0[123]\s*·/.test(html)) {
+    throw new Error('docs index still numbers homepage section labels');
+  }
 }
 
 function verifyHomepagePlaygroundLinks(html, heroCtaText) {

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -308,29 +308,38 @@ function verifyHomepageVisual(html) {
   }
 }
 
-function verifyHomepagePlaygroundLinks(html, heroCtaText) {
+function verifyHomepageActions(html, quickStartText, quickStartHref) {
   let linkCount = 0;
-  let heroCtaFound = false;
+  let quickStartFound = false;
+  let githubFound = false;
 
   for (const match of html.matchAll(/(<a\b[^>]*>)([\s\S]*?)<\/a>/gi)) {
     const text = match[2]
       .replace(/<[^>]*>/g, ' ')
       .replace(/\s+/g, ' ')
       .trim();
-    if (!/\bPlayground\b/i.test(text)) continue;
+    const href = getHtmlAttribute(match[1], 'href');
 
-    if (getHtmlAttribute(match[1], 'href') !== '/playground/') {
-      throw new Error(`${text} must be a native link to /playground/`);
+    if (/\bPlayground\b/i.test(text)) {
+      if (href !== '/playground/') {
+        throw new Error(`${text} must be a native link to /playground/`);
+      }
+      linkCount += 1;
     }
-    linkCount += 1;
-    heroCtaFound ||= text === heroCtaText;
+
+    quickStartFound ||= text === quickStartText && href === quickStartHref;
+    githubFound ||=
+      text === 'GitHub' && href === 'https://github.com/utooland/utoo-lint';
   }
 
-  if (!heroCtaFound) {
-    throw new Error('docs index is missing the native Playground hero CTA');
+  if (!quickStartFound) {
+    throw new Error('docs index is missing the localized Quick Start hero CTA');
   }
-  if (linkCount < 2) {
-    throw new Error('docs index is missing its native Playground links');
+  if (!githubFound) {
+    throw new Error('docs index is missing the GitHub hero CTA');
+  }
+  if (linkCount < 1) {
+    throw new Error('docs index is missing its native Playground link');
   }
 }
 
@@ -631,10 +640,10 @@ for (const spec of documentSpecs) {
 
   if (spec.homepage === 'en') {
     verifyHomepageVisual(html);
-    verifyHomepagePlaygroundLinks(html, 'Open the Playground');
+    verifyHomepageActions(html, 'Quick Start', '/configuration');
   } else if (spec.homepage === 'zh-CN') {
     verifyHomepageVisual(html);
-    verifyHomepagePlaygroundLinks(html, '打开 Playground');
+    verifyHomepageActions(html, '快速开始', '/zh-CN/configuration');
   }
 }
 

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -280,6 +280,8 @@ function verifyHomepageVisual(html) {
     'utlint-home-kicker',
     'utlint-home-section--benchmark',
     'utlint-benchmark-chart',
+    'utlint-benchmark-row--oxlint',
+    'utlint-benchmark-row--biome',
     'utlint-migration-boundary',
   ]) {
     if (!findOpeningTagByClass(html, requiredClass)) {
@@ -293,7 +295,11 @@ function verifyHomepageVisual(html) {
     }
   }
 
-  if (!html.includes('~70×')) {
+  if (
+    !['~4×', '~5×', '~70×'].every((comparison) =>
+      html.includes(comparison),
+    )
+  ) {
     throw new Error('docs index is missing the rounded benchmark comparison');
   }
 }

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -267,8 +267,6 @@ function verifyHomepageVisual(html) {
     'utlint-release-strip',
     'utlint-hero-command',
     'utlint-hero-evidence',
-    'utlint-home-section--benchmark',
-    'utlint-benchmark-chart',
   ]) {
     if (findOpeningTagByClass(html, removedClass)) {
       throw new Error(
@@ -280,6 +278,8 @@ function verifyHomepageVisual(html) {
   for (const requiredClass of [
     'utlint-gpu-logo',
     'utlint-home-kicker',
+    'utlint-home-section--benchmark',
+    'utlint-benchmark-chart',
     'utlint-migration-boundary',
   ]) {
     if (!findOpeningTagByClass(html, requiredClass)) {
@@ -291,6 +291,10 @@ function verifyHomepageVisual(html) {
     if (html.includes(result)) {
       throw new Error(`docs index still renders benchmark result ${result}`);
     }
+  }
+
+  if (!html.includes('~70×')) {
+    throw new Error('docs index is missing the rounded benchmark comparison');
   }
 }
 

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -32,6 +32,7 @@ async function collectFiles(directory) {
 async function verifyTranslationSources() {
   const stems = [
     'index',
+    'quick-start',
     'configuration',
     'eslint-migration',
     'rule-status',
@@ -73,7 +74,7 @@ async function verifyTranslationSources() {
     }
 
     if (
-      /(?:\]\(|href=["'])\/(?:configuration|rule-status|eslint-migration|suppressions|wasm)(?=[/#?"')])/i.test(
+      /(?:\]\(|href=["'])\/(?:quick-start|configuration|rule-status|eslint-migration|suppressions|wasm)(?=[/#?"')])/i.test(
         chinese,
       )
     ) {
@@ -492,6 +493,18 @@ const documentSpecs = [
     homepage: 'en',
   },
   {
+    file: 'quick-start/index.html',
+    title: 'Quick Start',
+    label: 'English quick start',
+    language: 'en',
+    currentPath: '/quick-start',
+    englishPath: '/quick-start',
+    chinesePath: '/zh-CN/quick-start',
+    switchHref: '/zh-CN/quick-start',
+    switchText: '中文',
+    colorThemeLabel: 'Color theme',
+  },
+  {
     file: 'configuration/index.html',
     title: 'Configuration',
     label: 'English configuration',
@@ -563,6 +576,18 @@ const documentSpecs = [
     switchText: 'English',
     colorThemeLabel: '颜色主题',
     homepage: 'zh-CN',
+  },
+  {
+    file: 'zh-CN/quick-start/index.html',
+    title: '快速开始',
+    label: 'Chinese quick start',
+    language: 'zh-CN',
+    currentPath: '/zh-CN/quick-start',
+    englishPath: '/quick-start',
+    chinesePath: '/zh-CN/quick-start',
+    switchHref: '/quick-start',
+    switchText: 'English',
+    colorThemeLabel: '颜色主题',
   },
   {
     file: 'zh-CN/configuration/index.html',
@@ -640,10 +665,10 @@ for (const spec of documentSpecs) {
 
   if (spec.homepage === 'en') {
     verifyHomepageVisual(html);
-    verifyHomepageActions(html, 'Quick Start', '/configuration');
+    verifyHomepageActions(html, 'Quick Start', '/quick-start');
   } else if (spec.homepage === 'zh-CN') {
     verifyHomepageVisual(html);
-    verifyHomepageActions(html, '快速开始', '/zh-CN/configuration');
+    verifyHomepageActions(html, '快速开始', '/zh-CN/quick-start');
   }
 }
 

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -267,6 +267,8 @@ function verifyHomepageVisual(html) {
     'utlint-release-strip',
     'utlint-hero-command',
     'utlint-hero-evidence',
+    'utlint-home-section--benchmark',
+    'utlint-benchmark-chart',
   ]) {
     if (findOpeningTagByClass(html, removedClass)) {
       throw new Error(
@@ -278,7 +280,6 @@ function verifyHomepageVisual(html) {
   for (const requiredClass of [
     'utlint-gpu-logo',
     'utlint-home-kicker',
-    'utlint-benchmark-chart',
     'utlint-migration-boundary',
   ]) {
     if (!findOpeningTagByClass(html, requiredClass)) {
@@ -287,8 +288,8 @@ function verifyHomepageVisual(html) {
   }
 
   for (const result of ['8.35 ms', '57.35 ms', '61.56 ms', '747.84 ms']) {
-    if (!html.includes(result)) {
-      throw new Error(`docs index is missing benchmark result ${result}`);
+    if (html.includes(result)) {
+      throw new Error(`docs index still renders benchmark result ${result}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep the benchmark section and full four-tool comparison chart on the English and Chinese homepages
- replace exact millisecond claims with rounded relative times: `1×`, `~4×`, `~5×`, and `~70×`
- lead with an approximate comparison against ESLint instead of a single-run cold-start number
- state that results vary by project and machine, while keeping the reproducible methodology link
- remove numeric prefixes from homepage section labels
- change the primary hero actions to Quick Start and GitHub; keep Playground in navigation and the local-try section
- add bilingual `/quick-start` and `/zh-CN/quick-start` guides covering installation, first run, typed configuration, and package scripts
- expose the localized Quick Start guide in the main navigation
- update site verification for the benchmark chart, section labels, translations, and CTA destinations

## Verification

- `pnpm site:build`
- `pnpm site:smoke`
- browser visual QA for `/`, `/zh-CN/`, `/quick-start`, and `/zh-CN/quick-start`
- browser click-through checks for both localized Quick Start hero actions
