### PR TITLE
feat(playground): align header with docs site

### DIFF
--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -146,6 +146,7 @@ export default function PlaygroundPage() {
   const monacoRef = useRef<MonacoInstance | null>(null);
   const astClientRef = useRef<ASTWorkerClient | null>(null);
   const clientRef = useRef<LintWorkerClient | null>(null);
+  const siteNavRef = useRef<HTMLElement | null>(null);
   const workspaceRef = useRef<HTMLElement | null>(null);
   const sidePanelRef = useRef<HTMLElement | null>(null);
   const shareResetTimerRef = useRef<number | undefined>(undefined);
@@ -260,6 +261,30 @@ export default function PlaygroundPage() {
       astClientRef.current?.cancelQueued();
     };
   }, [fileName, inspectorMode, source]);
+
+  useEffect(() => {
+    const navigation = siteNavRef.current;
+    const activeLink = navigation?.querySelector<HTMLElement>(
+      '[aria-current="page"]',
+    );
+    if (!navigation || !activeLink) return;
+
+    const keepActiveLinkVisible = () => {
+      const navigationRect = navigation.getBoundingClientRect();
+      const activeLinkRect = activeLink.getBoundingClientRect();
+
+      if (activeLinkRect.left < navigationRect.left) {
+        navigation.scrollLeft -= navigationRect.left - activeLinkRect.left;
+      } else if (activeLinkRect.right > navigationRect.right) {
+        navigation.scrollLeft += activeLinkRect.right - navigationRect.right;
+      }
+    };
+
+    keepActiveLinkVisible();
+    const resizeObserver = new ResizeObserver(keepActiveLinkVisible);
+    resizeObserver.observe(navigation);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -458,7 +483,11 @@ export default function PlaygroundPage() {
             <h1>utoo-lint</h1>
           </a>
 
-          <nav className="site-nav" aria-label="Main navigation">
+          <nav
+            aria-label="Main navigation"
+            className="site-nav"
+            ref={siteNavRef}
+          >
             <a href="/quick-start">Quick Start</a>
             <a href="/configuration">Configuration</a>
             <a href="/rule-status">Rules</a>

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -11,7 +11,7 @@ import type {
   CSSProperties,
   KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-import utooRabbitUrl from '../../../../assets/utoo-lint-mark-gpt.png';
+import utooRabbitUrl from '../../../../assets/utoo-lint-mark.svg';
 import { ASTWorkerClient } from '../features/ast/client';
 import type { ASTParseResult } from '../features/ast/protocol';
 import { ASTTree } from '../features/ast/tree';
@@ -445,101 +445,119 @@ export default function PlaygroundPage() {
 
   return (
     <main className="playground-shell">
-      <header className="topbar">
-        <div className="brand">
-          <span className="brand-mark" aria-hidden="true">
-            <img alt="" height={40} src={utooRabbitUrl} width={28} />
-          </span>
-          <div className="brand-title">
-            <h1>utoo-lint</h1>
-            <span className="brand-context">Playground</span>
-          </div>
-        </div>
-
-        <section className="controlbar" aria-label="Playground controls">
-          <label className="language-select-control">
-            <span className="visually-hidden">Language</span>
-            <span className="select-wrap">
-              <select
-                aria-controls="source-editor-panel"
-                onChange={(event) =>
-                  selectLanguage(event.target.value as PlaygroundLanguage)
-                }
-                value={language}
-              >
-                {LANGUAGES.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.label}
-                  </option>
-                ))}
-              </select>
-            </span>
-          </label>
-
-          <div className="run-summary" aria-hidden="true">
-            <span className="summary-count error-count">
-              <strong>{errorCount}</strong>{' '}
-              {errorCount === 1 ? 'error' : 'errors'}
-            </span>
-            <span className="summary-count warning-count">
-              <strong>{warningCount}</strong>{' '}
-              {warningCount === 1 ? 'warning' : 'warnings'}
-            </span>
-          </div>
-
-          <span
-            aria-atomic="true"
-            className="run-announcement"
-            role="status"
+      <header className="site-header">
+        <div className="site-header-content">
+          <a
+            aria-label="Back to the utoo-lint homepage"
+            className="brand"
+            href="/"
           >
-            {runState.phase === 'idle' && 'Lint queued.'}
-            {runState.phase === 'running' && 'Linting.'}
-            {runState.phase === 'ready' &&
-              `Lint complete. ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}, ${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}.`}
-            {runState.phase === 'error' &&
-              `Lint failed${runState.message ? `: ${runState.message}` : '.'}`}
-          </span>
+            <span className="brand-mark" aria-hidden="true">
+              <img alt="" height={40} src={utooRabbitUrl} width={28} />
+            </span>
+            <h1>utoo-lint</h1>
+          </a>
 
-          <div className="control-actions">
-            <button
-              aria-label={fixButtonLabel}
-              className="fix-button"
-              disabled={isRetry ? !hasValidRules : !canFix}
-              onClick={() => void execute(isRetry ? 'lint' : 'fix')}
-              title={fixButtonLabel}
-              type="button"
-            >
-              {fixButtonText}
-            </button>
+          <nav className="site-nav" aria-label="Main navigation">
+            <a href="/quick-start">Quick Start</a>
+            <a href="/configuration">Configuration</a>
+            <a href="/rule-status">Rules</a>
+            <a href="/eslint-migration">Migration</a>
+            <a aria-current="page" href="/playground/">
+              Playground
+            </a>
+          </nav>
 
-            <button
-              aria-label="Share this playground"
-              className="share-button"
-              onClick={() => void sharePlayground()}
-              type="button"
-            >
-              <span aria-live="polite">
-                {shareState === 'idle' && 'Share'}
-                {shareState === 'copied' && 'Copied'}
-                {shareState === 'error' && 'Copy failed'}
-              </span>
-            </button>
-
+          <div className="site-header-actions">
+            <a className="site-language-link" href="/zh-CN/">
+              中文
+            </a>
             <a
               aria-label="Open utoo-lint on GitHub (opens in a new tab)"
-              className="github-link"
+              className="site-github-link"
               href="https://github.com/utooland/utoo-lint"
               target="_blank"
               rel="noreferrer"
             >
-              GitHub
-              <span aria-hidden="true" className="external-mark">
-                ↗
-              </span>
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.49-2.7-1.08-2.7-1.08-.36-.93-.89-1.18-.89-1.18-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.88.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.63 7.63 0 0 1 8 3.72c.68 0 1.35.09 1.98.27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.08-1.87 3.75-3.66 3.95.29.25.54.74.54 1.5v2.22c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+              </svg>
+              <span className="visually-hidden">GitHub</span>
             </a>
           </div>
-        </section>
+        </div>
       </header>
+
+      <section className="controlbar" aria-label="Playground controls">
+        <label className="language-select-control">
+          <span className="visually-hidden">Language</span>
+          <span className="select-wrap">
+            <select
+              aria-controls="source-editor-panel"
+              onChange={(event) =>
+                selectLanguage(event.target.value as PlaygroundLanguage)
+              }
+              value={language}
+            >
+              {LANGUAGES.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </span>
+        </label>
+
+        <div className="run-summary" aria-hidden="true">
+          <span className="summary-count error-count">
+            <strong>{errorCount}</strong>{' '}
+            {errorCount === 1 ? 'error' : 'errors'}
+          </span>
+          <span className="summary-count warning-count">
+            <strong>{warningCount}</strong>{' '}
+            {warningCount === 1 ? 'warning' : 'warnings'}
+          </span>
+        </div>
+
+        <span
+          aria-atomic="true"
+          className="run-announcement"
+          role="status"
+        >
+          {runState.phase === 'idle' && 'Lint queued.'}
+          {runState.phase === 'running' && 'Linting.'}
+          {runState.phase === 'ready' &&
+            `Lint complete. ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}, ${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}.`}
+          {runState.phase === 'error' &&
+            `Lint failed${runState.message ? `: ${runState.message}` : '.'}`}
+        </span>
+
+        <div className="control-actions">
+          <button
+            aria-label={fixButtonLabel}
+            className="fix-button"
+            disabled={isRetry ? !hasValidRules : !canFix}
+            onClick={() => void execute(isRetry ? 'lint' : 'fix')}
+            title={fixButtonLabel}
+            type="button"
+          >
+            {fixButtonText}
+          </button>
+
+          <button
+            aria-label="Share this playground"
+            className="share-button"
+            onClick={() => void sharePlayground()}
+            type="button"
+          >
+            <span aria-live="polite">
+              {shareState === 'idle' && 'Share'}
+              {shareState === 'copied' && 'Copied'}
+              {shareState === 'error' && 'Copy failed'}
+            </span>
+          </button>
+        </div>
+      </section>
 
       <section
         className="workspace"

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -80,7 +80,7 @@ select:focus-visible {
 
 .playground-shell {
   display: grid;
-  grid-template-rows: 52px minmax(0, 1fr);
+  grid-template-rows: 76px 44px minmax(0, 1fr);
   width: 100%;
   height: 100vh;
   height: 100dvh;
@@ -88,16 +88,16 @@ select:focus-visible {
   background: var(--app);
 }
 
-.topbar {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: stretch;
+.site-header {
+  min-width: 0;
   border-bottom: 1px solid var(--line);
-  background: var(--surface);
+  background: rgba(21, 22, 22, 0.96);
 }
 
 .brand,
-.brand-title,
+.site-header-content,
+.site-nav,
+.site-header-actions,
 .controlbar,
 .control-actions,
 .run-summary,
@@ -110,51 +110,150 @@ select:focus-visible {
   align-items: center;
 }
 
+.site-header-content {
+  width: min(100%, 1280px);
+  height: 100%;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
 .brand {
-  min-width: 218px;
+  width: 184px;
+  height: 100%;
+  flex: none;
   gap: 10px;
-  padding: 0 16px;
-  border-right: 1px solid var(--line-muted);
+  color: inherit;
+  text-decoration: none;
+  transition: color 140ms ease;
+}
+
+.brand:hover {
+  color: var(--accent-hover);
 }
 
 .brand-mark {
   display: grid;
-  width: 22px;
-  height: 34px;
+  width: 24px;
+  height: 36px;
   flex: none;
   place-items: center;
 }
 
 .brand-mark img {
   display: block;
-  width: 21px;
-  height: 31px;
+  width: 23px;
+  height: 33px;
   object-fit: contain;
-}
-
-.brand-title {
-  min-width: 0;
-  gap: 10px;
 }
 
 .brand h1 {
   margin: 0;
-  color: var(--text-strong);
-  font-size: 14px;
-  font-weight: 650;
-  letter-spacing: -0.02em;
+  color: currentColor;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
 }
 
-.brand-context {
-  padding-left: 10px;
-  border-left: 1px solid var(--line);
+.site-nav {
+  height: 100%;
+  gap: 30px;
+}
+
+.site-nav a {
+  position: relative;
+  display: inline-flex;
+  height: 100%;
+  align-items: center;
+  color: #c3c6c4;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 140ms ease;
+}
+
+.site-nav a::after {
+  position: absolute;
+  right: 0;
+  bottom: 17px;
+  left: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: '';
+  opacity: 0;
+  transform: scaleX(0.6);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.site-nav a:hover,
+.site-nav a[aria-current='page'] {
+  color: var(--text-strong);
+}
+
+.site-nav a:hover::after,
+.site-nav a[aria-current='page']::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.site-header-actions {
+  height: 100%;
+  margin-left: auto;
+  gap: 10px;
+}
+
+.site-language-link,
+.site-github-link {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 450;
+  text-decoration: none;
+  transition:
+    border-color 140ms ease,
+    color 140ms ease,
+    background-color 140ms ease;
+}
+
+.site-language-link {
+  padding: 0 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.site-language-link:hover {
+  border-color: #414445;
+  color: var(--text-strong);
+  background: var(--surface-hover);
+}
+
+.site-github-link {
+  width: 34px;
+  border-radius: 7px;
+}
+
+.site-github-link:hover {
+  color: var(--text-strong);
+  background: var(--surface-hover);
+}
+
+.site-github-link svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .controlbar {
   min-width: 0;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
   padding: 0 10px 0 12px;
 }
 
@@ -249,8 +348,7 @@ select:focus-visible {
 }
 
 .fix-button,
-.share-button,
-.github-link {
+.share-button {
   display: inline-flex;
   min-height: 30px;
   flex: none;
@@ -304,21 +402,6 @@ select:focus-visible {
   border-color: #3a4047;
   color: var(--text-strong);
   background: var(--surface-raised);
-}
-
-.github-link {
-  gap: 5px;
-  padding: 0 7px;
-  color: var(--muted);
-}
-
-.github-link:hover {
-  color: var(--text-strong);
-}
-
-.external-mark {
-  color: var(--muted-subtle);
-  font-size: 10px;
 }
 
 .workspace {
@@ -836,7 +919,11 @@ select:focus-visible {
 
 @media (min-width: 901px) and (max-width: 1120px) {
   .brand {
-    min-width: 190px;
+    width: 160px;
+  }
+
+  .site-nav {
+    gap: 22px;
   }
 
   .segmented-label {
@@ -850,19 +937,25 @@ select:focus-visible {
   }
 
   .playground-shell {
-    grid-template-rows: auto auto;
+    grid-template-rows: auto auto auto;
     height: auto;
     min-height: 100vh;
   }
 
-  .brand {
-    min-width: 180px;
-    padding-inline: 12px;
+  .site-header-content {
+    min-height: 64px;
   }
 
-  .topbar,
+  .brand {
+    width: 150px;
+  }
+
   .controlbar {
-    min-height: 50px;
+    min-height: 44px;
+  }
+
+  .site-nav {
+    gap: 18px;
   }
 
   .workspace {
@@ -888,18 +981,46 @@ select:focus-visible {
   }
 }
 
-@media (max-width: 640px) {
-  .topbar {
-    grid-template-columns: 1fr;
+@media (max-width: 760px) {
+  .site-header-content {
+    min-height: 0;
+    flex-wrap: wrap;
   }
 
   .brand {
-    min-width: 0;
-    height: 50px;
-    border-right: 0;
-    border-bottom: 1px solid var(--line-muted);
+    width: auto;
+    height: 54px;
+    flex: 1;
   }
 
+  .site-header-actions {
+    height: 54px;
+  }
+
+  .site-nav {
+    width: calc(100% + 48px);
+    height: 42px;
+    min-width: 0;
+    flex: none;
+    order: 3;
+    margin: 0 -24px;
+    padding: 0 24px;
+    overflow-x: auto;
+    border-top: 1px solid var(--line-muted);
+    gap: 24px;
+    scrollbar-width: none;
+  }
+
+  .site-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .site-nav a::after {
+    bottom: 5px;
+  }
+}
+
+@media (max-width: 640px) {
   .controlbar {
     flex-wrap: wrap;
     gap: 0;
@@ -915,11 +1036,6 @@ select:focus-visible {
     gap: 5px;
   }
 
-  .github-link {
-    padding-right: 3px;
-    padding-left: 3px;
-  }
-
   .side-panel {
     grid-template-rows: 240px minmax(360px, auto);
   }
@@ -930,8 +1046,14 @@ select:focus-visible {
 }
 
 @media (max-width: 500px) {
-  .brand {
-    padding: 0 12px;
+  .site-header-content {
+    padding: 0 16px;
+  }
+
+  .site-nav {
+    width: calc(100% + 32px);
+    margin-inline: -16px;
+    padding-inline: 16px;
   }
 
   .controlbar {
@@ -944,10 +1066,6 @@ select:focus-visible {
 
   .control-actions {
     width: 100%;
-  }
-
-  .github-link {
-    margin-left: auto;
   }
 
   .segmented-label {

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -222,7 +222,11 @@ async function runSmoke(page, origin) {
     await page.waitForURL(`${origin}/playground/`);
     await waitForSettledPage(page);
     await page.getByRole('heading', { name: 'utoo-lint', level: 1 }).waitFor();
-    await page.locator('.brand-context', { hasText: 'Playground' }).waitFor();
+    await page
+      .locator('.site-nav a[aria-current="page"][href="/playground/"]', {
+        hasText: 'Playground',
+      })
+      .waitFor();
     await page.waitForFunction(
       () =>
         document
@@ -231,6 +235,16 @@ async function runSmoke(page, origin) {
       undefined,
       { timeout: 30_000 },
     );
+
+    stage = 'Playground navigation to home';
+    await page
+      .getByRole('link', { name: 'Back to the utoo-lint homepage' })
+      .click();
+    await page.waitForURL(`${origin}/`);
+    await waitForSettledPage(page);
+    await page
+      .getByRole('heading', { name: 'Find code problems faster.' })
+      .waitFor();
 
     // Let late worker/resource errors reach the event handlers before evaluating them.
     await page.waitForTimeout(250);

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -236,6 +236,24 @@ async function runSmoke(page, origin) {
       { timeout: 30_000 },
     );
 
+    // Let late worker/resource errors reach the event handlers before leaving
+    // the standalone Playground document.
+    await page.waitForTimeout(250);
+
+    stage = 'Narrow Playground navigation';
+    await page.setViewportSize({ height: 900, width: 320 });
+    await page.waitForFunction(() => {
+      const navigation = document.querySelector('.site-nav');
+      const activeLink = navigation?.querySelector('[aria-current="page"]');
+      if (!navigation || !activeLink) return false;
+      const navigationRect = navigation.getBoundingClientRect();
+      const activeLinkRect = activeLink.getBoundingClientRect();
+      return (
+        activeLinkRect.left >= navigationRect.left &&
+        activeLinkRect.right <= navigationRect.right
+      );
+    });
+
     stage = 'Playground navigation to home';
     await page
       .getByRole('link', { name: 'Back to the utoo-lint homepage' })
@@ -245,9 +263,6 @@ async function runSmoke(page, origin) {
     await page
       .getByRole('heading', { name: 'Find code problems faster.' })
       .waitFor();
-
-    // Let late worker/resource errors reach the event handlers before evaluating them.
-    await page.waitForTimeout(250);
   } catch (error) {
     assertionError = error;
   }


### PR DESCRIPTION
## Summary

- align the Playground header with the documentation site navigation and rabbit mark
- keep Playground highlighted while separating site navigation from editor controls
- add responsive navigation behavior from desktop down to the 320px minimum width
- update the production browser smoke test to verify the active navigation state and the brand link back to the homepage

## Testing

- pnpm playground:typecheck
- pnpm --filter @utoo/lint-playground test
- pnpm site:build
- pnpm site:smoke