### PR TITLE
feat: add safe no-var autofix

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -195,7 +195,7 @@ instead of being rewritten.
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | Supports `allowRegexCharacters` configuration and ESLint template escape handling |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | Supports autofix plus `ignoreDestructuring`, `ignoreImport`, and `ignoreExport` configuration |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | Implemented with comment-safe autofix for statement-list returns |
-| [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented |
+| [`no-var`](https://eslint.org/docs/latest/rules/no-var) | Implemented, with a scope-safe `var` to `let` autofix; multi-pass fixing can then apply `prefer-const` |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | Implemented with optional `allowAsStatement` behavior |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | Implemented with configurable `terms`, `location`, and common `decoration` behavior |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | Implemented |

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -194,7 +194,7 @@
 | [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) | 支持 `allowRegexCharacters` 配置及 ESLint 模板转义处理 |
 | [`no-useless-rename`](https://eslint.org/docs/latest/rules/no-useless-rename) | 支持自动修复，以及 `ignoreDestructuring`、`ignoreImport` 和 `ignoreExport` 配置 |
 | [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) | 已实现对语句列表中 return 语句的注释安全自动修复 |
-| [`no-var`](https://eslint.org/docs/latest/rules/no-var) | 已实现 |
+| [`no-var`](https://eslint.org/docs/latest/rules/no-var) | 已实现作用域安全的 `var` 到 `let` 自动修复；多轮修复随后可应用 `prefer-const` |
 | [`no-void`](https://eslint.org/docs/latest/rules/no-void) | 已实现可选的 `allowAsStatement` 行为 |
 | [`no-warning-comments`](https://eslint.org/docs/latest/rules/no-warning-comments) | 已实现可配置的 `terms`、`location` 和常见 `decoration` 行为 |
 | [`no-with`](https://eslint.org/docs/latest/rules/no-with) | 已实现 |

--- a/src/root.zig
+++ b/src/root.zig
@@ -299,6 +299,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_unassigned_vars or
         options.no_undef_init or
         options.no_undef or
+        options.no_var or
         options.react_jsx_no_undef or
         options.react_no_forward_ref or
         options.no_unused_vars or

--- a/src/rules/no_var.zig
+++ b/src/rules/no_var.zig
@@ -3,25 +3,368 @@ const parser = @import("parser");
 const core = @import("../core.zig");
 
 const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
 const Allocator = std.mem.Allocator;
+const SymbolId = traverser.semantic.SymbolId;
 
 pub const id = "no-var";
 
-pub fn check(
+pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .scope_tree = scope_tree,
+        .symbol_table = symbol_table,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_variable_declaration(
+        self: *Visitor,
+        declaration: ast.VariableDeclaration,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (declaration.kind != .@"var") return .proceed;
+        if (isDeclareGlobal(ctx.tree, self.symbol_table, index)) return .proceed;
+
+        const diagnostic_span = ctx.tree.span(index);
+        if (try canFix(
+            self.allocator,
+            ctx.tree,
+            declaration,
+            index,
+            self.scope_tree,
+            self.symbol_table,
+        )) {
+            if (varKeywordSpan(ctx.tree, declaration, diagnostic_span)) |fix_span| {
+                try core.addDiagnosticWithFix(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Use 'let' or 'const' instead of 'var'.",
+                    diagnostic_span,
+                    .{ .span = fix_span, .replacement = "let" },
+                );
+                return .proceed;
+            }
+        }
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Use 'let' or 'const' instead of 'var'.",
+            diagnostic_span,
+        );
+        return .proceed;
+    }
+};
+
+fn isDeclareGlobal(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) bool {
+    const parent = symbol_table.parentOf(index) orelse return false;
+    if (tree.data(parent) != .ts_module_block) return false;
+    const grandparent = symbol_table.parentOf(parent) orelse return false;
+    return tree.data(grandparent) == .ts_global_declaration;
+}
+
+fn canFix(
+    allocator: Allocator,
+    tree: *const ast.Tree,
     declaration: ast.VariableDeclaration,
     index: ast.NodeIndex,
-) Allocator.Error!void {
-    if (declaration.kind != .@"var") return;
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!bool {
+    const parent = symbol_table.parentOf(index) orelse return false;
+    if (tree.data(parent) == .switch_case) return false;
+    if (!hasSafeStatementPosition(tree, index, parent)) return false;
 
-    try core.addDiagnostic(
-        allocator,
-        diagnostics,
-        .warning,
-        id,
-        "Use 'let' or 'const' instead of 'var'.",
-        tree.span(index),
-    );
+    var symbols: std.ArrayList(SymbolId) = .empty;
+    defer symbols.deinit(allocator);
+
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |value| value,
+            else => continue,
+        };
+        try collectBindingSymbols(tree, symbol_table, declarator.id, &symbols, allocator);
+    }
+    if (symbols.items.len == 0) return false;
+
+    const scope_span = nearestScopeNodeSpan(tree, symbol_table, index) orelse return false;
+    const loop = enclosingLoop(tree, symbol_table, index);
+    const loop_assignee = isLoopAssignee(tree, index, parent);
+    if (loop != null and !loop_assignee and !isDeclarationInitialized(tree, declaration)) return false;
+
+    for (symbols.items) |symbol_id| {
+        const symbol = symbol_table.getSymbol(symbol_id);
+        if (scope_tree.getScope(symbol.scope).kind == .global) return false;
+        if (symbol_table.symbolDecls(symbol_id).len >= 2) return false;
+        if (std.mem.eql(u8, tree.string(symbol.name), "let")) return false;
+
+        const declaration_start = bindingDeclarationStart(tree, symbol_table, symbol_id) orelse return false;
+        var uses = symbol_table.symbolUses(symbol_id);
+        while (uses.next()) |reference_node| {
+            const reference_span = tree.span(reference_node);
+            if (!spanInside(reference_span, scope_span)) return false;
+            if (reference_span.start < declaration_start) return false;
+
+            if (loop != null) {
+                const reference_id = symbol_table.model.referenceOf(reference_node) orelse continue;
+                const reference = symbol_table.getReference(reference_id);
+                if (enclosingFunctionScope(scope_tree, reference.scope) != enclosingFunctionScope(scope_tree, symbol.scope)) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |value| value,
+            else => continue,
+        };
+        if (try hasReferenceInTdz(allocator, tree, symbol_table, declarator)) return false;
+    }
+
+    return true;
+}
+
+fn collectBindingSymbols(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    symbols: *std.ArrayList(SymbolId),
+    allocator: Allocator,
+) Allocator.Error!void {
+    if (index == .null) return;
+
+    switch (tree.data(index)) {
+        .binding_identifier => {
+            const symbol_id = symbol_table.symbolOf(index) orelse return;
+            for (symbols.items) |existing| {
+                if (existing == symbol_id) return;
+            }
+            try symbols.append(allocator, symbol_id);
+        },
+        .assignment_pattern => |pattern| try collectBindingSymbols(tree, symbol_table, pattern.left, symbols, allocator),
+        .binding_rest_element => |element| try collectBindingSymbols(tree, symbol_table, element.argument, symbols, allocator),
+        .array_pattern => |pattern| {
+            for (tree.extra(pattern.elements)) |element| {
+                try collectBindingSymbols(tree, symbol_table, element, symbols, allocator);
+            }
+            try collectBindingSymbols(tree, symbol_table, pattern.rest, symbols, allocator);
+        },
+        .object_pattern => |pattern| {
+            for (tree.extra(pattern.properties)) |property_index| {
+                const property = switch (tree.data(property_index)) {
+                    .binding_property => |value| value,
+                    else => continue,
+                };
+                try collectBindingSymbols(tree, symbol_table, property.value, symbols, allocator);
+            }
+            try collectBindingSymbols(tree, symbol_table, pattern.rest, symbols, allocator);
+        },
+        else => {},
+    }
+}
+
+fn hasSafeStatementPosition(tree: *const ast.Tree, index: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    return switch (tree.data(parent)) {
+        .program,
+        .function_body,
+        .block_statement,
+        .static_block,
+        .ts_module_block,
+        => true,
+        .for_statement => |statement| statement.init == index,
+        .for_in_statement => |statement| statement.left == index,
+        .for_of_statement => |statement| statement.left == index,
+        else => false,
+    };
+}
+
+fn isLoopAssignee(tree: *const ast.Tree, index: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    return switch (tree.data(parent)) {
+        .for_in_statement => |statement| statement.left == index,
+        .for_of_statement => |statement| statement.left == index,
+        else => false,
+    };
+}
+
+fn isDeclarationInitialized(tree: *const ast.Tree, declaration: ast.VariableDeclaration) bool {
+    for (tree.extra(declaration.declarators)) |declarator_index| {
+        const declarator = switch (tree.data(declarator_index)) {
+            .variable_declarator => |value| value,
+            else => return false,
+        };
+        if (declarator.init == .null) return false;
+    }
+    return true;
+}
+
+fn nearestScopeNodeSpan(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?ast.Span {
+    var current: ?ast.NodeIndex = index;
+    while (current) |node| : (current = symbol_table.parentOf(node)) {
+        switch (tree.data(node)) {
+            .program,
+            .function_body,
+            .block_statement,
+            .switch_statement,
+            .for_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .static_block,
+            .ts_module_block,
+            => return tree.span(node),
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn enclosingLoop(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?ast.NodeIndex {
+    var current = symbol_table.parentOf(index);
+    while (current) |node| : (current = symbol_table.parentOf(node)) {
+        switch (tree.data(node)) {
+            .for_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .while_statement,
+            .do_while_statement,
+            => return node,
+            .function,
+            .arrow_function_expression,
+            => return null,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn enclosingFunctionScope(
+    scope_tree: traverser.semantic.ScopeTree,
+    start: traverser.semantic.ScopeId,
+) traverser.semantic.ScopeId {
+    var current = start;
+    while (current != .none) {
+        const scope = scope_tree.getScope(current);
+        if (scope.kind == .function or scope.kind == .global) return current;
+        current = scope.parent;
+    }
+    return .root;
+}
+
+fn bindingDeclarationStart(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    symbol_id: SymbolId,
+) ?u32 {
+    const declarations = symbol_table.symbolDecls(symbol_id);
+    if (declarations.len == 0) return null;
+
+    var current: ?ast.NodeIndex = declarations[0];
+    while (current) |node| : (current = symbol_table.parentOf(node)) {
+        if (tree.data(node) == .variable_declarator) return tree.span(node).start;
+    }
+    return tree.span(declarations[0]).start;
+}
+
+fn hasReferenceInTdz(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    declarator: ast.VariableDeclarator,
+) Allocator.Error!bool {
+    if (declarator.init == .null) return false;
+
+    const id_span = tree.span(declarator.id);
+    const init_span = tree.span(declarator.init);
+    const function_initializer = switch (tree.data(declarator.init)) {
+        .function, .arrow_function_expression => true,
+        else => false,
+    };
+    var symbols: std.ArrayList(SymbolId) = .empty;
+    defer symbols.deinit(allocator);
+    try collectBindingSymbols(tree, symbol_table, declarator.id, &symbols, allocator);
+
+    for (symbols.items) |symbol_id| {
+        var uses = symbol_table.symbolUses(symbol_id);
+        while (uses.next()) |reference_node| {
+            const reference_span = tree.span(reference_node);
+            if (spanInside(reference_span, id_span)) return true;
+            if (!spanInside(reference_span, init_span)) continue;
+            if (!function_initializer) return true;
+        }
+    }
+    return false;
+}
+
+fn varKeywordSpan(tree: *const ast.Tree, declaration: ast.VariableDeclaration, span: ast.Span) ?ast.Span {
+    const declarators = tree.extra(declaration.declarators);
+    if (declarators.len == 0) return null;
+    const search_end = tree.span(declarators[0]).start;
+    if (span.start > search_end or search_end > tree.source.len) return null;
+
+    var offset: usize = @intCast(span.start);
+    const end: usize = @intCast(search_end);
+    while (offset + 3 <= end) : (offset += 1) {
+        if (!std.mem.eql(u8, tree.source[offset .. offset + 3], "var")) continue;
+        if (offset > 0 and isIdentifierByte(tree.source[offset - 1])) continue;
+        if (offset + 3 < tree.source.len and isIdentifierByte(tree.source[offset + 3])) continue;
+        if (insideComment(tree, @intCast(offset))) continue;
+        return .{ .start = @intCast(offset), .end = @intCast(offset + 3) };
+    }
+    return null;
+}
+
+fn insideComment(tree: *const ast.Tree, offset: u32) bool {
+    var low: usize = 0;
+    var high = tree.comments.len;
+    while (low < high) {
+        const middle = low + (high - low) / 2;
+        if (tree.comments[middle].span.end <= offset) {
+            low = middle + 1;
+        } else {
+            high = middle;
+        }
+    }
+    return low < tree.comments.len and
+        offset >= tree.comments[low].span.start and
+        offset < tree.comments[low].span.end;
+}
+
+fn isIdentifierByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '$' or byte >= 0x80;
+}
+
+fn spanInside(inner: ast.Span, outer: ast.Span) bool {
+    return inner.start >= outer.start and inner.end <= outer.end;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -998,6 +998,16 @@ fn runSemanticAfterIo(
         try block_scoped_var.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
+    if (options.no_var) {
+        try no_var.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.scope_tree,
+            semantic_result.symbol_table,
+        );
+    }
+
     const promise_check_options =
         options.no_async_promise_executor or
         options.no_promise_executor_return or
@@ -3020,9 +3030,6 @@ const BasicVisitor = struct {
                 &self.init_declarations_state,
                 self.initDeclarationsOptions(),
             );
-        }
-        if (self.options.no_var) {
-            try no_var.check(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
         if (self.options.vars_on_top) {
             try vars_on_top.check(self.allocator, self.diagnostics, ctx.tree, declaration, index, ctx);

--- a/tests/rules/no_undef_init.zig
+++ b/tests/rules/no_undef_init.zig
@@ -112,6 +112,7 @@ test "does not autofix undefined initializers when syntax must be preserved" {
         .eol_last = false,
         .no_unused_vars = false,
         .no_undef = false,
+        .no_var = false,
         .prefer_const = false,
         .parser_semantic_errors = false,
     });

--- a/tests/rules/no_var.zig
+++ b/tests/rules/no_var.zig
@@ -16,3 +16,236 @@ test "reports no-var for var declarations" {
 
     try std.testing.expect(helpers.hasRule(result, lint.rules.no_var.id));
 }
+
+test "autofixes safe declarations to let without prefer-const" {
+    const source =
+        \\function increment() {
+        \\  var value = 1;
+        \\  value += 1;
+        \\  var recursive = function () { return recursive; };
+        \\  recursive();
+        \\  return value;
+        \\}
+    ;
+    const expected =
+        \\function increment() {
+        \\  let value = 1;
+        \\  value += 1;
+        \\  let recursive = function () { return recursive; };
+        \\  recursive();
+        \\  return value;
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options(false));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_var.id));
+}
+
+test "multi-pass autofix uses const when prefer-const allows it" {
+    const source =
+        \\function read() {
+        \\  var value = 1;
+        \\  return value;
+        \\}
+    ;
+    const expected =
+        \\function read() {
+        \\  const value = 1;
+        \\  return value;
+        \\}
+    ;
+
+    var first = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options(true));
+    defer first.deinit(std.testing.allocator);
+
+    try std.testing.expect(first.fixed);
+    try std.testing.expect(first.passes >= 2);
+    try std.testing.expectEqualStrings(expected, first.output);
+
+    var second = try lint.lintSourceAndFix(std.testing.allocator, first.output, "fixture.js", options(true));
+    defer second.deinit(std.testing.allocator);
+    try std.testing.expect(!second.fixed);
+    try std.testing.expectEqualStrings(expected, second.output);
+}
+
+test "autofixes multiple declarators and loop declarations safely" {
+    const source =
+        \\function run(items) {
+        \\  var first = 1, second = 2;
+        \\  second += first;
+        \\  for (var index = 0; index < items.length; index++) consume(items[index]);
+        \\  for (var item of items) consume(item);
+        \\}
+    ;
+    const expected =
+        \\function run(items) {
+        \\  let first = 1, second = 2;
+        \\  second += first;
+        \\  for (let index = 0; index < items.length; index++) consume(items[index]);
+        \\  for (let item of items) consume(item);
+        \\}
+    ;
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options(false));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_var.id));
+}
+
+test "finds the var keyword after TypeScript modifiers and comments" {
+    const source = "declare /* var marker */ var value: number;";
+    const expected = "declare /* var marker */ let value: number;";
+
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.ts", options(false));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, lint.rules.no_var.id));
+}
+
+test "ignores var declarations in TypeScript global augmentation" {
+    const source =
+        \\export {};
+        \\declare global {
+        \\  var globalValue: number;
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options(false));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.no_var.id));
+}
+
+test "does not autofix declarations whose scope semantics could change" {
+    const cases = [_]struct { source: []const u8, path: []const u8 }{
+        .{
+            .source =
+            \\function escaped(ready) {
+            \\  if (ready) { var value = 1; }
+            \\  return value;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function redeclared() {
+            \\  var value = 1;
+            \\  var value = 2;
+            \\  return value;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function hoisted() {
+            \\  consume(value);
+            \\  var value = 1;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function closures() {
+            \\  const callbacks = [];
+            \\  for (var index = 0; index < 2; index++) callbacks.push(() => index);
+            \\  return callbacks;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function retained(ready) {
+            \\  while (ready) {
+            \\    var value;
+            \\    consume(value);
+            \\    value = 1;
+            \\  }
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function selfReference() {
+            \\  var value = value;
+            \\  return value;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function immediateSelfReference() {
+            \\  var value = (() => value)();
+            \\  return value;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function laterDeclarator() {
+            \\  var first = second, second = 1;
+            \\  return first;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source =
+            \\function destructuringDefault(source) {
+            \\  var { value = value } = source;
+            \\  return value;
+            \\}
+            ,
+            .path = "fixture.js",
+        },
+        .{
+            .source = "var globalValue = 1;",
+            .path = "fixture.cjs",
+        },
+        .{
+            .source = "if (ready) var statementValue = 1;",
+            .path = "fixture.js",
+        },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.path, options(false));
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(helpers.hasRule(result, lint.rules.no_var.id));
+        for (result.diagnostics) |diagnostic| {
+            if (std.mem.eql(u8, diagnostic.rule_id, lint.rules.no_var.id)) {
+                try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+            }
+        }
+    }
+}
+
+fn options(prefer_const: bool) lint.Options {
+    return .{
+        .capitalized_comments = false,
+        .curly = false,
+        .eol_last = false,
+        .no_console = false,
+        .no_plusplus = false,
+        .no_undef = false,
+        .no_unused_vars = false,
+        .one_var = false,
+        .prefer_const = prefer_const,
+        .parser_semantic_errors = false,
+    };
+}

--- a/tests/rules/one_var.zig
+++ b/tests/rules/one_var.zig
@@ -27,6 +27,7 @@ test "autofixes combined variable declarations into separate statements" {
     var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", .{
         .eol_last = false,
         .no_unused_vars = false,
+        .no_var = false,
         .prefer_const = false,
         .parser_semantic_errors = false,
     });
@@ -51,6 +52,7 @@ test "autofixes multiline declarations without discarding comments" {
         .capitalized_comments = false,
         .eol_last = false,
         .no_unused_vars = false,
+        .no_var = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);
@@ -123,6 +125,7 @@ test "does not autofix declarations outside statement lists" {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .no_var = false,
         .parser_semantic_errors = false,
     });
     defer result.deinit(std.testing.allocator);

--- a/tests/rules/sort_vars.zig
+++ b/tests/rules/sort_vars.zig
@@ -143,6 +143,7 @@ fn baseOptions() lint.Options {
         .eol_last = false,
         .no_undef = false,
         .no_unused_vars = false,
+        .no_var = false,
         .one_var = false,
         .prefer_const = false,
         .parser_semantic_errors = false,

--- a/tests/snapshots/specs/core/no-var/global-augmentation.options.json
+++ b/tests/snapshots/specs/core/no-var/global-augmentation.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "clean",
+  "diagnostic_count": 0,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/core/no-var/global-augmentation.ts
+++ b/tests/snapshots/specs/core/no-var/global-augmentation.ts
@@ -1,0 +1,4 @@
+export {};
+declare global {
+  var globalValue: number;
+}

--- a/tests/snapshots/specs/core/no-var/global-augmentation.ts.snap
+++ b/tests/snapshots/specs/core/no-var/global-augmentation.ts.snap
@@ -1,0 +1,22 @@
+---
+fixture: "tests/snapshots/specs/core/no-var/global-augmentation.ts"
+rule: "no-var"
+---
+
+# Input
+
+```ts
+export {};
+declare global {
+  var globalValue: number;
+}
+```
+
+# Diagnostics
+
+count: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/core/no-var/global.cjs
+++ b/tests/snapshots/specs/core/no-var/global.cjs
@@ -1,0 +1,1 @@
+var globalValue = 1;

--- a/tests/snapshots/specs/core/no-var/global.cjs.snap
+++ b/tests/snapshots/specs/core/no-var/global.cjs.snap
@@ -1,0 +1,30 @@
+---
+fixture: "tests/snapshots/specs/core/no-var/global.cjs"
+rule: "no-var"
+---
+
+# Input
+
+```cjs
+var globalValue = 1;
+```
+
+# Diagnostics
+
+count: 1
+
+## Diagnostic 1
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 0..20
+- start: 1:1
+- end: 1:21
+- source: "var globalValue = 1;"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/core/no-var/global.options.json
+++ b/tests/snapshots/specs/core/no-var/global.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 1,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/core/no-var/safe.js
+++ b/tests/snapshots/specs/core/no-var/safe.js
@@ -1,0 +1,6 @@
+var value = 1;
+function increment() {
+  var count = 0;
+  count += value;
+  return count;
+}

--- a/tests/snapshots/specs/core/no-var/safe.js.snap
+++ b/tests/snapshots/specs/core/no-var/safe.js.snap
@@ -1,0 +1,72 @@
+---
+fixture: "tests/snapshots/specs/core/no-var/safe.js"
+rule: "no-var"
+---
+
+# Input
+
+```js
+var value = 1;
+function increment() {
+  var count = 0;
+  count += value;
+  return count;
+}
+```
+
+# Diagnostics
+
+count: 2
+
+## Diagnostic 1
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 0..14
+- start: 1:1
+- end: 1:15
+- source: "var value = 1;"
+- fixes: 1
+
+### Fix 1.1
+
+- byte span: 0..3
+- start: 1:1
+- end: 1:4
+- source: "var"
+- replacement: "let"
+
+## Diagnostic 2
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 40..54
+- start: 3:3
+- end: 3:17
+- source: "var count = 0;"
+- fixes: 1
+
+### Fix 2.1
+
+- byte span: 40..43
+- start: 3:3
+- end: 3:6
+- source: "var"
+- replacement: "let"
+
+# First fix pass
+
+- fixed: true
+- applied diagnostics: 2
+- remaining diagnostics: 0
+
+```js
+let value = 1;
+function increment() {
+  let count = 0;
+  count += value;
+  return count;
+}
+```

--- a/tests/snapshots/specs/core/no-var/safe.options.json
+++ b/tests/snapshots/specs/core/no-var/safe.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 2,
+  "fixes": "required"
+}

--- a/tests/snapshots/specs/core/no-var/unsafe.js
+++ b/tests/snapshots/specs/core/no-var/unsafe.js
@@ -1,0 +1,25 @@
+function escaped(ready) {
+  if (ready) {
+    var value = 1;
+  }
+  return value;
+}
+
+function redeclared() {
+  var item = 1;
+  var item = 2;
+  return item;
+}
+
+function closures() {
+  const callbacks = [];
+  for (var index = 0; index < 2; index++) {
+    callbacks.push(() => index);
+  }
+  return callbacks;
+}
+
+function tdz() {
+  var result = result;
+  return result;
+}

--- a/tests/snapshots/specs/core/no-var/unsafe.js.snap
+++ b/tests/snapshots/specs/core/no-var/unsafe.js.snap
@@ -1,0 +1,98 @@
+---
+fixture: "tests/snapshots/specs/core/no-var/unsafe.js"
+rule: "no-var"
+---
+
+# Input
+
+```js
+function escaped(ready) {
+  if (ready) {
+    var value = 1;
+  }
+  return value;
+}
+
+function redeclared() {
+  var item = 1;
+  var item = 2;
+  return item;
+}
+
+function closures() {
+  const callbacks = [];
+  for (var index = 0; index < 2; index++) {
+    callbacks.push(() => index);
+  }
+  return callbacks;
+}
+
+function tdz() {
+  var result = result;
+  return result;
+}
+```
+
+# Diagnostics
+
+count: 5
+
+## Diagnostic 1
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 45..59
+- start: 3:5
+- end: 3:19
+- source: "var value = 1;"
+- fixes: 0
+
+## Diagnostic 2
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 109..122
+- start: 9:3
+- end: 9:16
+- source: "var item = 1;"
+- fixes: 0
+
+## Diagnostic 3
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 125..138
+- start: 10:3
+- end: 10:16
+- source: "var item = 2;"
+- fixes: 0
+
+## Diagnostic 4
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 210..223
+- start: 16:8
+- end: 16:21
+- source: "var index = 0"
+- fixes: 0
+
+## Diagnostic 5
+
+- rule: "no-var"
+- severity: "warning"
+- message: "Use 'let' or 'const' instead of 'var'."
+- byte span: 326..346
+- start: 23:3
+- end: 23:23
+- source: "var result = result;"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/core/no-var/unsafe.options.json
+++ b/tests/snapshots/specs/core/no-var/unsafe.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 5,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/core/no-var/valid.js
+++ b/tests/snapshots/specs/core/no-var/valid.js
@@ -1,0 +1,3 @@
+let mutable = 1;
+mutable += 1;
+const stable = mutable;

--- a/tests/snapshots/specs/core/no-var/valid.js.snap
+++ b/tests/snapshots/specs/core/no-var/valid.js.snap
@@ -1,0 +1,21 @@
+---
+fixture: "tests/snapshots/specs/core/no-var/valid.js"
+rule: "no-var"
+---
+
+# Input
+
+```js
+let mutable = 1;
+mutable += 1;
+const stable = mutable;
+```
+
+# Diagnostics
+
+count: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/core/no-var/valid.options.json
+++ b/tests/snapshots/specs/core/no-var/valid.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "clean",
+  "diagnostic_count": 0,
+  "fixes": "forbidden"
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- add a scope-aware `no-var` autofix that changes only semantically safe declarations to `let`
- preserve ESLint-compatible safety boundaries for globals, redeclarations, hoisting, TDZ references, loops, closures, switch cases, and statement positions
- let the existing multi-pass fixer apply `prefer-const` after the safe `var` to `let` conversion
- document the autofix and add focused unit and rule-snapshot coverage, including TypeScript global augmentations

Closes #1148

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `./scripts/package-npm.sh`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- `pnpm playground:typecheck`
- verified `--fix-dry-run --format=json` returns the proposed output without changing the input file hash
