### PR TITLE
feat: add react no-direct-mutation-state

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -320,6 +320,7 @@ instead of being rewritten.
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | Implemented |
 | [`react/no-danger-with-children`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md) | Implemented |
 | [`react/no-deprecated`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md) | Implemented |
+| [`react/no-direct-mutation-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md) | Implemented |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | Implemented |
 | [`react/no-forward-ref`](https://eslint-react.xyz/docs/rules/no-forward-ref) | Opt-in React 19 diagnostic; recognizes named, aliased, default, and namespace imports from `react` |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | Implemented |

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -319,6 +319,7 @@
 | [`react/no-danger`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md) | 已实现 |
 | [`react/no-danger-with-children`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md) | 已实现 |
 | [`react/no-deprecated`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md) | 已实现 |
+| [`react/no-direct-mutation-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md) | 已实现 |
 | [`react/no-find-dom-node`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) | 已实现 |
 | [`react/no-forward-ref`](https://eslint-react.xyz/docs/rules/no-forward-ref) | 可选择启用的 React 19 诊断；识别来自 `react` 的具名、别名、默认和命名空间导入 |
 | [`react/no-is-mounted`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) | 已实现 |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -355,6 +355,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-danger",
   "react/no-danger-with-children",
   "react/no-deprecated",
+  "react/no-direct-mutation-state",
   "react/no-find-dom-node",
   "react/no-forward-ref",
   "react/no-is-mounted",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -358,6 +358,7 @@ const BUILTIN_RULE_IDS = [
   "react/no-danger",
   "react/no-danger-with-children",
   "react/no-deprecated",
+  "react/no-direct-mutation-state",
   "react/no-find-dom-node",
   "react/no-forward-ref",
   "react/no-is-mounted",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -1557,6 +1557,29 @@ test("a flat config does not leak native default rules that it never enables", a
   assert.equal(results[0].messages.length, 0);
 });
 
+test("ESM and CommonJS register and disable unselected react/no-direct-mutation-state", async (t) => {
+  const ruleId = "react/no-direct-mutation-state";
+  for (const LinterImplementation of [Linter, CommonJSLinter]) {
+    assert.equal(new LinterImplementation().getRules().has(ruleId), true);
+  }
+
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "no-console": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "index.js"),
+    "class View extends React.Component { update() { this.state.count = 1; } }\n"
+  );
+
+  for (const ESLintImplementation of [ESLint, CommonJSESLint]) {
+    const eslint = new ESLintImplementation({ cwd: project, binary: testBinary() });
+    const [result] = await eslint.lintFiles([sourcePath]);
+    assert.equal(result.messages.length, 0);
+  }
+});
+
 test("flat config rule options are applied to the matching files", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -3083,6 +3083,7 @@ pub const Options = struct {
     react_no_danger: bool = true,
     react_no_danger_with_children: bool = true,
     react_no_access_state_in_setstate: bool = true,
+    react_no_direct_mutation_state: bool = true,
     react_no_deprecated: bool = true,
     react_forbid_prop_types: bool = true,
     react_forbid_prop_types_forbid_any: bool = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1084,6 +1084,8 @@ pub fn main(init: std.process.Init) !void {
             options.react_no_danger_with_children = false;
         } else if (std.mem.eql(u8, arg, "--react-no-access-state-in-setstate=off")) {
             options.react_no_access_state_in_setstate = false;
+        } else if (std.mem.eql(u8, arg, "--react-no-direct-mutation-state=off")) {
+            options.react_no_direct_mutation_state = false;
         } else if (std.mem.eql(u8, arg, "--react-no-deprecated=off")) {
             options.react_no_deprecated = false;
         } else if (std.mem.eql(u8, arg, "--react-forbid-prop-types=off")) {
@@ -2930,6 +2932,7 @@ fn printHelp() void {
         \\  --react-no-danger=off     Disable react/no-danger
         \\  --react-no-danger-with-children=off Disable react/no-danger-with-children
         \\  --react-no-access-state-in-setstate=off Disable react/no-access-state-in-setstate
+        \\  --react-no-direct-mutation-state=off Disable react/no-direct-mutation-state
         \\  --react-no-deprecated=off Disable react/no-deprecated
         \\  --react-forbid-prop-types=off Disable react/forbid-prop-types
         \\  --react-no-array-index-key=off Disable react/no-array-index-key

--- a/src/rules/react_no_direct_mutation_state.zig
+++ b/src/rules/react_no_direct_mutation_state.zig
@@ -18,7 +18,7 @@ pub fn checkAssignmentExpression(
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
     const component = componentAncestor(tree, ctx) orelse return;
-    if (isAllowedConstructorAssignment(tree, ctx, component)) return;
+    if (isAllowedConstructorMutation(tree, ctx, component)) return;
 
     const member = switch (tree.data(expression.left)) {
         .member_expression => |member| member,
@@ -43,7 +43,8 @@ pub fn checkUpdateExpression(
     expression: ast.UpdateExpression,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
-    if (componentAncestor(tree, ctx) == null) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    if (isAllowedConstructorMutation(tree, ctx, component)) return;
     const root = stateRoot(tree, expression.argument) orelse return;
 
     try core.addDiagnostic(
@@ -86,7 +87,7 @@ fn componentAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.Node
     return null;
 }
 
-fn isAllowedConstructorAssignment(
+fn isAllowedConstructorMutation(
     tree: *const ast.Tree,
     ctx: *traverser.basic.Ctx,
     component: ast.NodeIndex,

--- a/src/rules/react_no_direct_mutation_state.zig
+++ b/src/rules/react_no_direct_mutation_state.zig
@@ -10,12 +10,27 @@ pub const id = "react/no-direct-mutation-state";
 
 const message = "Do not mutate state directly. Use setState().";
 
+const ConstructorState = struct {
+    component: ast.NodeIndex,
+    in_call_expression: bool = false,
+};
+
+pub const State = struct {
+    constructors: std.ArrayList(ConstructorState) = .empty,
+
+    pub fn deinit(self: *State, allocator: Allocator) void {
+        self.constructors.deinit(allocator);
+        self.* = .{};
+    }
+};
+
 pub fn checkAssignmentExpression(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
     expression: ast.AssignmentExpression,
     ctx: *traverser.basic.Ctx,
+    state: *const State,
 ) Allocator.Error!void {
     const left = unwrapTransparent(tree, expression.left);
     const member = switch (tree.data(left)) {
@@ -24,7 +39,7 @@ pub fn checkAssignmentExpression(
     };
     if (stateRoot(tree, left) == null) return;
     const component = componentAncestor(tree, ctx) orelse return;
-    if (isAllowedConstructorMutation(tree, ctx, component)) return;
+    if (shouldIgnoreConstructorMutation(component, state)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -42,10 +57,11 @@ pub fn checkUpdateExpression(
     tree: *const ast.Tree,
     expression: ast.UpdateExpression,
     ctx: *traverser.basic.Ctx,
+    state: *const State,
 ) Allocator.Error!void {
     const root = stateRoot(tree, expression.argument) orelse return;
     const component = componentAncestor(tree, ctx) orelse return;
-    if (isAllowedConstructorMutation(tree, ctx, component)) return;
+    if (shouldIgnoreConstructorMutation(component, state)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -55,6 +71,46 @@ pub fn checkUpdateExpression(
         message,
         tree.span(root),
     );
+}
+
+pub fn enterMethodDefinition(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) Allocator.Error!void {
+    if (method.kind != .constructor) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    if (tree.data(component) != .class) return;
+    try state.constructors.append(allocator, .{ .component = component });
+}
+
+pub fn exitMethodDefinition(
+    tree: *const ast.Tree,
+    method: ast.MethodDefinition,
+    ctx: *traverser.basic.Ctx,
+    state: *State,
+) void {
+    if (method.kind != .constructor) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    if (state.constructors.items.len == 0) return;
+    const current = state.constructors.items[state.constructors.items.len - 1];
+    if (current.component == component) _ = state.constructors.pop();
+}
+
+pub fn enterCallExpression(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, state: *State) void {
+    if (state.constructors.items.len == 0) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    const constructor = activeConstructor(component, state) orelse return;
+    constructor.in_call_expression = true;
+}
+
+pub fn exitCallExpression(tree: *const ast.Tree, ctx: *traverser.basic.Ctx, state: *State) void {
+    if (state.constructors.items.len == 0) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    const constructor = activeConstructor(component, state) orelse return;
+    constructor.in_call_expression = false;
 }
 
 fn stateRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
@@ -88,24 +144,21 @@ fn componentAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.Node
     return null;
 }
 
-fn isAllowedConstructorMutation(
-    tree: *const ast.Tree,
-    ctx: *traverser.basic.Ctx,
-    component: ast.NodeIndex,
-) bool {
-    if (tree.data(component) != .class) return false;
-
-    var inside_call = false;
-    var depth: usize = 1;
-    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
-        if (ancestor == component) return false;
-        switch (tree.data(ancestor)) {
-            .call_expression => inside_call = true,
-            .method_definition => |method| return method.kind == .constructor and !inside_call,
-            else => {},
-        }
+fn shouldIgnoreConstructorMutation(component: ast.NodeIndex, state: *const State) bool {
+    for (state.constructors.items) |constructor| {
+        if (constructor.component == component) return !constructor.in_call_expression;
     }
     return false;
+}
+
+fn activeConstructor(component: ast.NodeIndex, state: *State) ?*ConstructorState {
+    var index = state.constructors.items.len;
+    while (index > 0) {
+        index -= 1;
+        const constructor = &state.constructors.items[index];
+        if (constructor.component == component) return constructor;
+    }
+    return null;
 }
 
 fn isCreateClassObject(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {

--- a/src/rules/react_no_direct_mutation_state.zig
+++ b/src/rules/react_no_direct_mutation_state.zig
@@ -1,0 +1,188 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react/no-direct-mutation-state";
+
+const message = "Do not mutate state directly. Use setState().";
+
+pub fn checkAssignmentExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.AssignmentExpression,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    const component = componentAncestor(tree, ctx) orelse return;
+    if (isAllowedConstructorAssignment(tree, ctx, component)) return;
+
+    const member = switch (tree.data(expression.left)) {
+        .member_expression => |member| member,
+        else => return,
+    };
+    if (stateRoot(tree, expression.left) == null) return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        message,
+        tree.span(member.object),
+    );
+}
+
+pub fn checkUpdateExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.UpdateExpression,
+    ctx: *traverser.basic.Ctx,
+) Allocator.Error!void {
+    if (componentAncestor(tree, ctx) == null) return;
+    const root = stateRoot(tree, expression.argument) orelse return;
+
+    try core.addDiagnostic(
+        allocator,
+        diagnostics,
+        .@"error",
+        id,
+        message,
+        tree.span(root),
+    );
+}
+
+fn stateRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        const member = switch (tree.data(current)) {
+            .member_expression => |member| member,
+            else => return null,
+        };
+        if (tree.data(member.object) == .member_expression) {
+            current = member.object;
+            continue;
+        }
+        if (!isThisExpression(tree, member.object)) return null;
+        const property = identifierPropertyName(tree, member.property) orelse return null;
+        return if (std.mem.eql(u8, property, "state")) current else null;
+    }
+    return null;
+}
+
+fn componentAncestor(tree: *const ast.Tree, ctx: *traverser.basic.Ctx) ?ast.NodeIndex {
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .class => |class| return if (isReactComponentClass(tree, class)) ancestor else null,
+            .object_expression => if (isCreateClassObject(tree, ancestor, ctx.path.ancestor(depth + 1))) return ancestor,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn isAllowedConstructorAssignment(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    component: ast.NodeIndex,
+) bool {
+    if (tree.data(component) != .class) return false;
+
+    var inside_call = false;
+    var depth: usize = 1;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        if (ancestor == component) return false;
+        switch (tree.data(ancestor)) {
+            .call_expression => inside_call = true,
+            .method_definition => |method| return method.kind == .constructor and !inside_call,
+            else => {},
+        }
+    }
+    return false;
+}
+
+fn isCreateClassObject(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ?ast.NodeIndex) bool {
+    const parent = parent_index orelse return false;
+    const call = switch (tree.data(parent)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0 or arguments[0] != index) return false;
+    return isCreateClassCallee(tree, call.callee);
+}
+
+fn isCreateClassCallee(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const callee = unwrapTransparent(tree, index);
+    if (identifierReferenceName(tree, callee)) |name| {
+        return std.mem.eql(u8, name, "createReactClass");
+    }
+
+    const member = switch (tree.data(callee)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!identifierReferenceEquals(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = identifierPropertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "createClass");
+}
+
+fn isReactComponentClass(tree: *const ast.Tree, class: ast.Class) bool {
+    if (class.super_class == .null) return false;
+    const super_class = unwrapTransparent(tree, class.super_class);
+
+    if (identifierReferenceName(tree, super_class)) |name| {
+        return std.mem.eql(u8, name, "Component") or std.mem.eql(u8, name, "PureComponent");
+    }
+
+    const member = switch (tree.data(super_class)) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    if (member.computed) return false;
+    if (!identifierReferenceEquals(tree, unwrapTransparent(tree, member.object), "React")) return false;
+    const property = identifierPropertyName(tree, member.property) orelse return false;
+    return std.mem.eql(u8, property, "Component") or std.mem.eql(u8, property, "PureComponent");
+}
+
+fn isThisExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return tree.data(index) == .this_expression;
+}
+
+fn identifierPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn identifierReferenceEquals(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    const name = identifierReferenceName(tree, index) orelse return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/react_no_direct_mutation_state.zig
+++ b/src/rules/react_no_direct_mutation_state.zig
@@ -17,11 +17,12 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
-    const member = switch (tree.data(expression.left)) {
+    const left = unwrapTransparent(tree, expression.left);
+    const member = switch (tree.data(left)) {
         .member_expression => |member| member,
         else => return,
     };
-    if (stateRoot(tree, expression.left) == null) return;
+    if (stateRoot(tree, left) == null) return;
     const component = componentAncestor(tree, ctx) orelse return;
     if (isAllowedConstructorMutation(tree, ctx, component)) return;
 
@@ -31,7 +32,7 @@ pub fn checkAssignmentExpression(
         .@"error",
         id,
         message,
-        tree.span(member.object),
+        tree.span(unwrapTransparent(tree, member.object)),
     );
 }
 
@@ -57,17 +58,18 @@ pub fn checkUpdateExpression(
 }
 
 fn stateRoot(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.NodeIndex {
-    var current = index;
+    var current = unwrapTransparent(tree, index);
     while (current != .null) {
         const member = switch (tree.data(current)) {
             .member_expression => |member| member,
             else => return null,
         };
-        if (tree.data(member.object) == .member_expression) {
-            current = member.object;
+        const object = unwrapTransparent(tree, member.object);
+        if (tree.data(object) == .member_expression) {
+            current = object;
             continue;
         }
-        if (!isThisExpression(tree, member.object)) return null;
+        if (!isThisExpression(tree, object)) return null;
         const property = identifierPropertyName(tree, member.property) orelse return null;
         return if (std.mem.eql(u8, property, "state")) current else null;
     }

--- a/src/rules/react_no_direct_mutation_state.zig
+++ b/src/rules/react_no_direct_mutation_state.zig
@@ -17,14 +17,13 @@ pub fn checkAssignmentExpression(
     expression: ast.AssignmentExpression,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
-    const component = componentAncestor(tree, ctx) orelse return;
-    if (isAllowedConstructorMutation(tree, ctx, component)) return;
-
     const member = switch (tree.data(expression.left)) {
         .member_expression => |member| member,
         else => return,
     };
     if (stateRoot(tree, expression.left) == null) return;
+    const component = componentAncestor(tree, ctx) orelse return;
+    if (isAllowedConstructorMutation(tree, ctx, component)) return;
 
     try core.addDiagnostic(
         allocator,
@@ -43,9 +42,9 @@ pub fn checkUpdateExpression(
     expression: ast.UpdateExpression,
     ctx: *traverser.basic.Ctx,
 ) Allocator.Error!void {
+    const root = stateRoot(tree, expression.argument) orelse return;
     const component = componentAncestor(tree, ctx) orelse return;
     if (isAllowedConstructorMutation(tree, ctx, component)) return;
-    const root = stateRoot(tree, expression.argument) orelse return;
 
     try core.addDiagnostic(
         allocator,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -299,6 +299,7 @@ pub const react_jsx_uses_vars = @import("react_jsx_uses_vars.zig");
 pub const react_no_danger = @import("react_no_danger.zig");
 pub const react_no_danger_with_children = @import("react_no_danger_with_children.zig");
 pub const react_no_access_state_in_setstate = @import("react_no_access_state_in_setstate.zig");
+pub const react_no_direct_mutation_state = @import("react_no_direct_mutation_state.zig");
 pub const react_no_deprecated = @import("react_no_deprecated.zig");
 pub const react_forbid_prop_types = @import("react_forbid_prop_types.zig");
 pub const react_no_children_prop = @import("react_no_children_prop.zig");
@@ -3369,6 +3370,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.checkAssignmentExpression(self.allocator, ctx.tree, expression, ctx, &self.react_no_unused_state_state);
         }
+        if (self.options.react_no_direct_mutation_state) {
+            try react_no_direct_mutation_state.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx);
+        }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
         }
@@ -3512,7 +3516,7 @@ const BasicVisitor = struct {
 
     pub fn enter_update_expression(
         self: *BasicVisitor,
-        _: ast.UpdateExpression,
+        expression: ast.UpdateExpression,
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
@@ -3520,6 +3524,9 @@ const BasicVisitor = struct {
             try no_plusplus.checkWithOptions(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
                 .allow_for_loop_afterthoughts = self.options.no_plusplus_allow_for_loop_afterthoughts == .yes,
             });
+        }
+        if (self.options.react_no_direct_mutation_state) {
+            try react_no_direct_mutation_state.checkUpdateExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx);
         }
         return .proceed;
     }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -774,6 +774,7 @@ pub fn runBasicWithOptionsPtr(
     defer visitor.react_no_access_state_in_setstate_state.deinit(allocator);
     defer visitor.react_no_typos_state.deinit(allocator);
     defer visitor.react_no_unused_state_state.deinit(allocator);
+    defer visitor.react_no_direct_mutation_state_state.deinit(allocator);
     defer visitor.react_display_name_state.deinit(allocator);
     defer visitor.react_forbid_prop_types_state.deinit(allocator);
     defer visitor.react_default_props_match_prop_types_state.deinit(allocator);
@@ -1408,6 +1409,7 @@ const BasicVisitor = struct {
     react_no_multi_comp_state: react_no_multi_comp.State = .{},
     react_no_typos_state: react_no_typos.State = .{},
     react_no_unused_state_state: react_no_unused_state.State = .{},
+    react_no_direct_mutation_state_state: react_no_direct_mutation_state.State = .{},
     react_style_prop_object_bindings: react_style_prop_object.Bindings = .{},
     react_void_dom_elements_no_children_bindings: react_void_dom_elements_no_children.ReactBindings = .{},
     consistent_this_state: consistent_this.State = .{},
@@ -3371,7 +3373,7 @@ const BasicVisitor = struct {
             try react_no_unused_state.checkAssignmentExpression(self.allocator, ctx.tree, expression, ctx, &self.react_no_unused_state_state);
         }
         if (self.options.react_no_direct_mutation_state) {
-            try react_no_direct_mutation_state.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx);
+            try react_no_direct_mutation_state.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx, &self.react_no_direct_mutation_state_state);
         }
         if (self.options.react_forbid_prop_types) {
             try react_forbid_prop_types.checkAssignmentExpression(self.allocator, self.diagnostics, ctx.tree, expression, self.react_forbid_prop_types_state, self.reactForbidPropTypesOptions());
@@ -3526,7 +3528,7 @@ const BasicVisitor = struct {
             });
         }
         if (self.options.react_no_direct_mutation_state) {
-            try react_no_direct_mutation_state.checkUpdateExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx);
+            try react_no_direct_mutation_state.checkUpdateExpression(self.allocator, self.diagnostics, ctx.tree, expression, ctx, &self.react_no_direct_mutation_state_state);
         }
         return .proceed;
     }
@@ -3554,6 +3556,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.react_no_direct_mutation_state) {
+            react_no_direct_mutation_state.enterCallExpression(ctx.tree, ctx, &self.react_no_direct_mutation_state_state);
+        }
         if (self.options.no_unexpected_multiline) {
             try no_unexpected_multiline.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
         }
@@ -3735,6 +3740,9 @@ const BasicVisitor = struct {
         _: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) void {
+        if (self.options.react_no_direct_mutation_state) {
+            react_no_direct_mutation_state.exitCallExpression(ctx.tree, ctx, &self.react_no_direct_mutation_state_state);
+        }
         if (self.options.react_no_array_index_key) {
             react_no_array_index_key.exitCallExpression(ctx.tree, call, &self.react_no_array_index_key_state);
         }
@@ -4398,6 +4406,9 @@ const BasicVisitor = struct {
         if (self.options.react_no_unused_state) {
             try react_no_unused_state.enterMethodDefinition(self.allocator, ctx.tree, method, &self.react_no_unused_state_state);
         }
+        if (self.options.react_no_direct_mutation_state) {
+            try react_no_direct_mutation_state.enterMethodDefinition(self.allocator, ctx.tree, method, ctx, &self.react_no_direct_mutation_state_state);
+        }
         return .proceed;
     }
 
@@ -4405,10 +4416,13 @@ const BasicVisitor = struct {
         self: *BasicVisitor,
         method: ast.MethodDefinition,
         _: ast.NodeIndex,
-        _: *traverser.basic.Ctx,
+        ctx: *traverser.basic.Ctx,
     ) void {
         if (self.options.react_no_unused_state) {
             react_no_unused_state.exitMethodDefinition(method, &self.react_no_unused_state_state);
+        }
+        if (self.options.react_no_direct_mutation_state) {
+            react_no_direct_mutation_state.exitMethodDefinition(ctx.tree, method, ctx, &self.react_no_direct_mutation_state_state);
         }
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1120,6 +1120,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/react_no_direct_mutation_state.zig");
+}
+
+comptime {
     _ = @import("rules/react_no_deprecated.zig");
 }
 

--- a/tests/rules/react_no_direct_mutation_state.zig
+++ b/tests/rules/react_no_direct_mutation_state.zig
@@ -76,6 +76,7 @@ test "matches upstream alias computed nested and destructured behavior" {
         \\    this["state"].literal = true;
         \\    this[state].computed = true;
         \\    this.state["person"].name = "Grace";
+        \\    (this.state).parenthesized = true;
         \\    this.state = { replaced: true };
         \\  }
         \\}
@@ -96,7 +97,23 @@ test "matches upstream alias computed nested and destructured behavior" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+}
+
+test "preserves upstream TypeScript non-null assertion behavior" {
+    const source =
+        \\class View extends React.Component<{}, { count: number }> {
+        \\  update(): void {
+        \\    this.state!.count = 1;
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
 }
 
 test "accepts CLI and project rule configuration" {

--- a/tests/rules/react_no_direct_mutation_state.zig
+++ b/tests/rules/react_no_direct_mutation_state.zig
@@ -65,6 +65,34 @@ test "allows constructor initialization and setState but reports constructor cal
     try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
 }
 
+test "matches upstream nested call exit order in constructors" {
+    const allowed_source =
+        \\class View extends React.Component {
+        \\  constructor(props) {
+        \\    super(props);
+        \\    consume(sideEffect(), this.state.allowed = true);
+        \\  }
+        \\}
+    ;
+    var allowed = try lint.lintSource(std.testing.allocator, allowed_source, "allowed.js", ruleOptions());
+    defer allowed.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(allowed, "parse"));
+    try std.testing.expect(!helpers.hasRule(allowed, rule_id));
+
+    const reported_source =
+        \\class View extends React.Component {
+        \\  constructor(props) {
+        \\    super(props);
+        \\    consume(this.state.reported = true, sideEffect());
+        \\  }
+        \\}
+    ;
+    var reported = try lint.lintSource(std.testing.allocator, reported_source, "reported.js", ruleOptions());
+    defer reported.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(reported, "parse"));
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(reported, rule_id));
+}
+
 test "matches upstream alias computed nested and destructured behavior" {
     const source =
         \\class View extends React.Component {

--- a/tests/rules/react_no_direct_mutation_state.zig
+++ b/tests/rules/react_no_direct_mutation_state.zig
@@ -68,13 +68,11 @@ test "allows constructor initialization and setState but reports constructor cal
 test "matches upstream alias computed nested and destructured behavior" {
     const source =
         \\class View extends React.Component {
-        \\  update(state) {
+        \\  update() {
         \\    const that = this;
         \\    const { state: localState } = this;
         \\    that.state.aliased = true;
         \\    localState.destructured = true;
-        \\    this["state"].literal = true;
-        \\    this[state].computed = true;
         \\    this.state["person"].name = "Grace";
         \\    (this.state).parenthesized = true;
         \\    this.state = { replaced: true };
@@ -97,7 +95,29 @@ test "matches upstream alias computed nested and destructured behavior" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+}
+
+test "matches upstream computed state property-name behavior" {
+    const reported_source =
+        \\class Reported extends React.Component {
+        \\  update(state) { this[state].computed = true; }
+        \\}
+    ;
+    var reported = try lint.lintSource(std.testing.allocator, reported_source, "reported.js", ruleOptions());
+    defer reported.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(reported, "parse"));
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(reported, rule_id));
+
+    const allowed_source =
+        \\class Allowed extends React.Component {
+        \\  update() { this["state"].literal = true; }
+        \\}
+    ;
+    var allowed = try lint.lintSource(std.testing.allocator, allowed_source, "allowed.js", ruleOptions());
+    defer allowed.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(allowed, "parse"));
+    try std.testing.expect(!helpers.hasRule(allowed, rule_id));
 }
 
 test "preserves upstream TypeScript non-null assertion behavior" {

--- a/tests/rules/react_no_direct_mutation_state.zig
+++ b/tests/rules/react_no_direct_mutation_state.zig
@@ -1,0 +1,192 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.react_no_direct_mutation_state.id;
+
+test "reports direct state assignments and updates in React components" {
+    const source =
+        \\class View extends React.Component {
+        \\  update(value) {
+        \\    this.state.count = value;
+        \\    this.state.person.name = "Ada";
+        \\    this.state.count++;
+        \\    --this.state.count;
+        \\  }
+        \\}
+        \\class PureView extends PureComponent {
+        \\  update() {
+        \\    this.state.ready = true;
+        \\  }
+        \\}
+        \\const Legacy = createReactClass({
+        \\  render() {
+        \\    this.state.visible = true;
+        \\    return <div />;
+        \\  },
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+    const diagnostic = findDiagnostic(result) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(.@"error", diagnostic.severity);
+    try std.testing.expectEqualStrings("Do not mutate state directly. Use setState().", diagnostic.message);
+    try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+}
+
+test "allows constructor initialization and setState but reports constructor callbacks" {
+    const source =
+        \\class View extends React.Component {
+        \\  constructor(props) {
+        \\    super(props);
+        \\    this.state = { count: 0 };
+        \\    this.state.ready = true;
+        \\    this.state.count++;
+        \\    schedule(() => {
+        \\      this.state.count = 1;
+        \\    });
+        \\  }
+        \\  update() {
+        \\    this.setState({ count: 2 });
+        \\    this.setState((state) => ({ count: state.count + 1 }));
+        \\  }
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+}
+
+test "matches upstream alias computed nested and destructured behavior" {
+    const source =
+        \\class View extends React.Component {
+        \\  update(state) {
+        \\    const that = this;
+        \\    const { state: localState } = this;
+        \\    that.state.aliased = true;
+        \\    localState.destructured = true;
+        \\    this["state"].literal = true;
+        \\    this[state].computed = true;
+        \\    this.state["person"].name = "Grace";
+        \\    this.state = { replaced: true };
+        \\  }
+        \\}
+        \\class Plain {
+        \\  update() {
+        \\    this.state.value = 1;
+        \\  }
+        \\}
+        \\const Legacy = React.createClass({
+        \\  render() {
+        \\    const obj = { state: {} };
+        \\    obj.state.value = 1;
+        \\    return null;
+        \\  },
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.jsx", ruleOptions());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+}
+
+test "accepts CLI and project rule configuration" {
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.react_no_direct_mutation_state);
+
+    var config = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "[\"error\"]",
+        .{},
+    );
+    defer config.deinit();
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.react_no_direct_mutation_state);
+}
+
+test "parses and reports JS TS JSX and TSX fixtures" {
+    const Fixture = struct {
+        path: []const u8,
+        source: []const u8,
+    };
+    const fixtures = [_]Fixture{
+        .{
+            .path = "fixture.js",
+            .source =
+            \\class View extends React.Component {
+            \\  update() { this.state.count = 1; }
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.jsx",
+            .source =
+            \\class View extends React.Component {
+            \\  update() { this.state.count = 1; }
+            \\  render() { return <div />; }
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.ts",
+            .source =
+            \\class View extends React.Component<{}, { count: number }> {
+            \\  update(): void { this.state.count = 1; }
+            \\}
+            ,
+        },
+        .{
+            .path = "fixture.tsx",
+            .source =
+            \\class View extends React.Component<{}, { count: number }> {
+            \\  update(): void { this.state.count = 1; }
+            \\  render(): JSX.Element { return <div />; }
+            \\}
+            ,
+        },
+    };
+
+    for (fixtures) |fixture| {
+        var result = try lint.lintSource(std.testing.allocator, fixture.source, fixture.path, ruleOptions());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "can disable react/no-direct-mutation-state" {
+    const source =
+        \\class View extends React.Component {
+        \\  update() { this.state.count = 1; }
+        \\}
+    ;
+
+    var options = ruleOptions();
+    options.react_no_direct_mutation_state = false;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+fn ruleOptions() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.react_no_direct_mutation_state = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/react_no_direct_mutation_state.zig
+++ b/tests/rules/react_no_direct_mutation_state.zig
@@ -46,6 +46,8 @@ test "allows constructor initialization and setState but reports constructor cal
         \\    this.state = { count: 0 };
         \\    this.state.ready = true;
         \\    this.state.count++;
+        \\    this.onClick = () => { this.state.clicked = true; };
+        \\    consume(this.state.count = 2);
         \\    schedule(() => {
         \\      this.state.count = 1;
         \\    });


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Add native `react/no-direct-mutation-state` diagnostics for React class and `createReactClass` components.
- Match upstream constructor, call, alias, computed, nested, destructured, and update-expression behavior.
- Accept the rule through CLI and project configuration and document its implementation status.

Closes #1149

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- `pnpm playground:typecheck`
- Compared representative diagnostics and locations with `eslint-plugin-react@7.37.5`.
