### PR TITLE
feat: map equivalent ESLint migration aliases

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -120,19 +120,23 @@ Flat-config output starts with a schema metadata entry, followed by the
 migrated entries. Matching entries are applied in array order, so a later value
 for the same rule retains ESLint's override behavior.
 
-The migrator translates the following `@eslint-react` aliases when their
-behavior has a native equivalent:
+The migrator translates the following reviewed aliases when their behavior has
+a native equivalent. These mappings are semantic compatibility decisions, not
+string-only renames: each source rule is checked against the target's
+implemented behavior and supported options before it is added.
 
 | ESLint rule | utoo-lint rule |
 | --- | --- |
+| `no-native-reassign` | `no-global-assign` |
+| `@typescript-eslint/no-invalid-this` | `no-invalid-this` |
 | `@eslint-react/no-array-index-key` | `react/no-array-index-key` |
 | `@eslint-react/dom-no-find-dom-node` | `react/no-find-dom-node` |
 | `@eslint-react/dom-no-render-return-value` | `react/no-render-return-value` |
 | `@eslint-react/dom-no-void-elements-with-children` | `react/void-dom-elements-no-children` |
 | `@eslint-react/rules-of-hooks` | `react-hooks/rules-of-hooks` |
 
-Translated aliases are listed separately in the migration report. Other
-`@eslint-react` rules remain unsupported unless an explicit equivalent is added;
+Translated aliases are listed separately in the migration report. Other legacy
+or plugin rule IDs remain unsupported unless an explicit equivalent is added;
 the migrator does not infer mappings from similar names.
 
 Use that JSON report to size the migration:

--- a/docs/eslint-migration.zh-CN.md
+++ b/docs/eslint-migration.zh-CN.md
@@ -83,17 +83,19 @@ npx utoo-lint migrate eslint --print --report=json
 
 flat config 输出以一个 Schema 元数据配置项开始，后面依次是迁移后的配置项。匹配项按数组顺序应用，因此同一规则后出现的值仍会保留 ESLint 的覆盖行为。
 
-当下列 `@eslint-react` 别名存在原生等价行为时，迁移器会进行转换：
+当下列经过审核的别名存在原生等价行为时，迁移器会进行转换。这些映射是语义兼容性决策，而不只是字符串重命名：每条源规则只有在与目标规则已经实现的行为及所支持的选项完成核对后，才会加入此表。
 
 | ESLint 规则 | utoo-lint 规则 |
 | --- | --- |
+| `no-native-reassign` | `no-global-assign` |
+| `@typescript-eslint/no-invalid-this` | `no-invalid-this` |
 | `@eslint-react/no-array-index-key` | `react/no-array-index-key` |
 | `@eslint-react/dom-no-find-dom-node` | `react/no-find-dom-node` |
 | `@eslint-react/dom-no-render-return-value` | `react/no-render-return-value` |
 | `@eslint-react/dom-no-void-elements-with-children` | `react/void-dom-elements-no-children` |
 | `@eslint-react/rules-of-hooks` | `react-hooks/rules-of-hooks` |
 
-转换后的别名会在迁移报告中单独列出。其他 `@eslint-react` 规则只有在添加明确等价实现后才会受支持；迁移器不会因为名称相似就推断映射关系。
+转换后的别名会在迁移报告中单独列出。其他旧规则或插件规则 ID 只有在添加明确等价实现后才会受支持；迁移器不会因为名称相似就推断映射关系。
 
 使用 JSON 报告评估迁移规模：
 

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -16,7 +16,11 @@ const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const IGNORED_RULES = new Map([
   ["prettier/prettier", "formatting is outside utoo-lint"]
 ]);
-const RULE_ALIASES = new Map([
+// Add aliases only after reviewing the source rule against the target rule's
+// implemented behavior and supported options.
+const REVIEWED_RULE_ALIASES = new Map([
+  ["no-native-reassign", "no-global-assign"],
+  ["@typescript-eslint/no-invalid-this", "no-invalid-this"],
   ["@eslint-react/no-array-index-key", "react/no-array-index-key"],
   ["@eslint-react/dom-no-find-dom-node", "react/no-find-dom-node"],
   ["@eslint-react/dom-no-render-return-value", "react/no-render-return-value"],
@@ -195,7 +199,7 @@ function migrateEslintConfig(options) {
     const rules = {};
     if (entry.rules && typeof entry.rules === "object") {
       for (const [ruleId, ruleConfig] of Object.entries(entry.rules)) {
-        const migratedRuleId = RULE_ALIASES.get(ruleId) ?? ruleId;
+        const migratedRuleId = REVIEWED_RULE_ALIASES.get(ruleId) ?? ruleId;
         if (IGNORED_RULES.has(ruleId)) {
           ignoredRules.push({ ruleId, reason: IGNORED_RULES.get(ruleId) });
           continue;

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -795,14 +795,67 @@ test("migrator translates reviewed @eslint-react aliases", (t) => {
   ]);
 });
 
-test("migrator does not infer @eslint-react aliases without equivalent rules", (t) => {
+test("migrator preserves enabled disabled and option-bearing reviewed aliases", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, "eslint.config.mjs"),
+    [
+      "export default [",
+      "  { rules: {",
+      '    "no-native-reassign": ["warn", { exceptions: ["Object"] }],',
+      '    "@typescript-eslint/no-invalid-this": ["error", { capIsConstructor: false }]',
+      "  } },",
+      '  { files: ["test/**/*.ts"], rules: {',
+      '    "no-native-reassign": 0,',
+      '    "@typescript-eslint/no-invalid-this": "off"',
+      "  } }",
+      "];",
+      ""
+    ].join("\n")
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const config = JSON.parse(result.stdout);
+  assert.deepEqual(config.slice(1), [
+    {
+      rules: {
+        "no-global-assign": ["warn", { exceptions: ["Object"] }],
+        "no-invalid-this": ["error", { capIsConstructor: false }]
+      }
+    },
+    {
+      files: ["test/**/*.ts"],
+      rules: {
+        "no-global-assign": 0,
+        "no-invalid-this": "off"
+      }
+    }
+  ]);
+  const report = JSON.parse(result.stderr);
+  assert.deepEqual(report.supportedRules, ["no-global-assign", "no-invalid-this"]);
+  assert.deepEqual(report.unsupportedRules, []);
+  assert.deepEqual(report.translatedRules, [
+    { sourceRuleId: "@typescript-eslint/no-invalid-this", targetRuleId: "no-invalid-this" },
+    { sourceRuleId: "no-native-reassign", targetRuleId: "no-global-assign" }
+  ]);
+});
+
+test("migrator does not infer unreviewed aliases without equivalent rules", (t) => {
   const project = createProject(t);
   const eslintConfig = write(
     join(project, ".eslintrc.json"),
     JSON.stringify({
       rules: {
         "@eslint-react/no-missing-key": "error",
-        "@eslint-react/dom-no-render": "warn"
+        "@eslint-react/dom-no-render": "warn",
+        "@typescript-eslint/no-invalid-this-extra": "error",
+        "no-native-reassignment": "warn"
       }
     })
   );
@@ -819,7 +872,9 @@ test("migrator does not infer @eslint-react aliases without equivalent rules", (
   assert.deepEqual(report.translatedRules, []);
   assert.deepEqual(report.unsupportedRules, [
     "@eslint-react/dom-no-render",
-    "@eslint-react/no-missing-key"
+    "@eslint-react/no-missing-key",
+    "@typescript-eslint/no-invalid-this-extra",
+    "no-native-reassignment"
   ]);
 });
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Translate `no-native-reassign` to `no-global-assign` and `@typescript-eslint/no-invalid-this` to `no-invalid-this` during ESLint migration.
- Preserve enabled and disabled severities plus supported rule options, and record both aliases in migration reports.
- Document that the explicit alias table contains reviewed semantic compatibility decisions rather than inferred string renames.

Closes #1150

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `pnpm --dir npm/utoo-lint test`
- `pnpm docs:build`
- Compared `@typescript-eslint/no-invalid-this` behavior with the 8.61.0 oracle for TypeScript `this` parameters and `capIsConstructor: false`.
- Verified `no-native-reassign` replacement and `exceptions` compatibility against the official ESLint rule documentation.
