### PR TITLE
feat: resolve classic ESLint extends chains

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -120,6 +120,17 @@ Flat-config output starts with a schema metadata entry, followed by the
 migrated entries. Matching entries are applied in array order, so a later value
 for the same rule retains ESLint's override behavior.
 
+Classic `.eslintrc`, `.eslintrc.json`, `.eslintrc.js`, and `.eslintrc.cjs`
+inputs are expanded with ESLint's classic config resolver before conversion.
+Relative paths, shareable config package names, `plugin:name/preset` references,
+and arrays of `extends` values retain their ESLint order. Nested inherited
+rules and overrides become ordered utoo config entries; `files`,
+`excludedFiles`, and `ignorePatterns` become the corresponding scoped selectors
+and global ignores. These patterns are rebased to the output config directory,
+including when an ancestor `.eslintrc` is discovered. Circular chains and missing configs stop migration with the
+extends chain or referring config in the error instead of producing partial
+output.
+
 The migrator translates the following reviewed aliases when their behavior has
 a native equivalent. These mappings are semantic compatibility decisions, not
 string-only renames: each source rule is checked against the target's
@@ -145,6 +156,10 @@ Use that JSON report to size the migration:
 - `unsupportedRules`: require a replacement, a new native rule, or temporary
   ESLint coverage.
 - `ignoredRules`: intentionally left outside `utoo-lint`, usually formatting.
+- `inheritedSources`: the resolved relative, package, plugin, or built-in config
+  sources that contributed to classic config migration.
+- `unsupportedInheritedRules`: unsupported rules paired with the inherited
+  source that introduced them.
 
 The command exits with status `1` when unsupported rules are found. That is a
 useful signal for automation; it does not mean the generated config is unusable.

--- a/docs/eslint-migration.zh-CN.md
+++ b/docs/eslint-migration.zh-CN.md
@@ -83,6 +83,8 @@ npx utoo-lint migrate eslint --print --report=json
 
 flat config 输出以一个 Schema 元数据配置项开始，后面依次是迁移后的配置项。匹配项按数组顺序应用，因此同一规则后出现的值仍会保留 ESLint 的覆盖行为。
 
+对于 `.eslintrc`、`.eslintrc.json`、`.eslintrc.js` 和 `.eslintrc.cjs`，迁移器会先使用 ESLint 的 classic config 解析器展开配置，再进行转换。相对路径、共享配置包名、`plugin:name/preset` 引用及 `extends` 数组都会保留 ESLint 的应用顺序。嵌套继承的规则和 overrides 会成为有序的 utoo 配置项；`files`、`excludedFiles` 和 `ignorePatterns` 会分别转换为对应的作用域选择器和全局忽略项。这些模式会相对输出配置目录重新定位，包括从祖先目录发现 `.eslintrc` 的情况。遇到循环链或缺失配置时，迁移会停止，并在错误中给出 extends 链或引用配置，而不会生成不完整输出。
+
 当下列经过审核的别名存在原生等价行为时，迁移器会进行转换。这些映射是语义兼容性决策，而不只是字符串重命名：每条源规则只有在与目标规则已经实现的行为及所支持的选项完成核对后，才会加入此表。
 
 | ESLint 规则 | utoo-lint 规则 |
@@ -102,6 +104,8 @@ flat config 输出以一个 Schema 元数据配置项开始，后面依次是迁
 - `supportedRules`：可以立即迁移到 `utoo-lint`。
 - `unsupportedRules`：需要替代规则、新的原生规则，或临时保留 ESLint 覆盖。
 - `ignoredRules`：有意留在 `utoo-lint` 之外，通常是格式化规则。
+- `inheritedSources`：在 classic config 迁移中实际参与的相对路径、共享包、插件或内置配置来源。
+- `unsupportedInheritedRules`：不受支持的继承规则，以及引入该规则的继承来源。
 
 发现不受支持的规则时，命令会以状态码 `1` 退出。这对自动化是有用信号，并不表示生成的配置不可使用。
 

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -1,7 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, extname, resolve as resolvePath } from "node:path";
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, relative, resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
+
+import { Legacy } from "@eslint/eslintrc";
+import eslintJs from "@eslint/js";
 
 import { Linter } from "../index.js";
 
@@ -9,6 +12,8 @@ const ESLINT_CONFIG_FILENAMES = [
   "eslint.config.js",
   "eslint.config.mjs",
   "eslint.config.cjs",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
   ".eslintrc.json",
   ".eslintrc"
 ];
@@ -28,6 +33,7 @@ const REVIEWED_RULE_ALIASES = new Map([
   ["@eslint-react/rules-of-hooks", "react-hooks/rules-of-hooks"]
 ]);
 const SCHEMA_URL = "https://raw.githubusercontent.com/utooland/utoo-lint/main/npm/utoo-lint/schema.json";
+const MIGRATION_SOURCE = Symbol("migrationSource");
 const JAVASCRIPT_CONFIG_LOADER_SCRIPT = `
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -188,10 +194,15 @@ function migrateEslintConfig(options) {
 
   const eslintConfig = loadEslintConfig(sourcePath, options.cwd);
   const supportedRuleIds = new Set(new Linter().getRules().keys());
-  const entries = normalizeConfigEntries(eslintConfig);
+  const migrationInput = migrationInputFromConfig(
+    eslintConfig,
+    sourcePath,
+    realpathSync(dirname(options.output))
+  );
+  const entries = migrationInput.entries;
   const migratedEntries = [];
   const supportedRules = [];
-  const unsupportedRules = [];
+  let unsupportedRules = [];
   const ignoredRules = [];
   const translatedRules = [];
 
@@ -206,9 +217,11 @@ function migrateEslintConfig(options) {
         }
         if (!supportedRuleIds.has(migratedRuleId)) {
           if (isRuleDisabled(ruleConfig)) {
+            unsupportedRules = removeDisabledUnsupportedRule(unsupportedRules, ruleId, entry);
             continue;
           }
-          unsupportedRules.push(ruleId);
+          const source = entry[MIGRATION_SOURCE];
+          unsupportedRules.push({ ruleId, scope: migrationRuleScope(entry), source });
           continue;
         }
         rules[migratedRuleId] = migratableRuleConfig(ruleConfig);
@@ -221,7 +234,7 @@ function migrateEslintConfig(options) {
     migratedEntries.push(migratableConfigEntry(entry, rules));
   }
 
-  const config = Array.isArray(eslintConfig)
+  const config = Array.isArray(eslintConfig) || migratedEntries.length > 1
     ? [{ $schema: SCHEMA_URL }, ...migratedEntries]
     : { $schema: SCHEMA_URL, ...(migratedEntries[0] ?? { rules: {} }) };
 
@@ -231,12 +244,364 @@ function migrateEslintConfig(options) {
       source: sourcePath,
       output: options.print ? null : options.output,
       supportedRules: uniqueSorted(supportedRules),
-      unsupportedRules: uniqueSorted(unsupportedRules),
+      unsupportedRules: uniqueSorted(unsupportedRules.map((rule) => rule.ruleId)),
       ignoredRules: uniqueByRuleId(ignoredRules),
       translatedRules: uniqueTranslatedRules(translatedRules),
+      inheritedSources: migrationInput.inheritedSources,
+      unsupportedInheritedRules: uniqueUnsupportedInheritedRules(
+        unsupportedRules
+          .filter((rule) => rule.source?.inherited)
+          .map((rule) => ({
+            ruleId: rule.ruleId,
+            sourceName: rule.source.name,
+            sourcePath: rule.source.filePath
+          }))
+      ),
       optionDroppedRules: []
     }
   };
+}
+
+function migrationInputFromConfig(eslintConfig, sourcePath, outputDirectory) {
+  if (!isClassicEslintConfig(eslintConfig, sourcePath)) {
+    return { entries: normalizeConfigEntries(eslintConfig), inheritedSources: [] };
+  }
+
+  const basePath = realpathSync(dirname(sourcePath));
+  const factory = new MigrationConfigArrayFactory({
+    cwd: basePath,
+    getEslintRecommendedConfig: () => eslintJs.configs.recommended,
+    getEslintAllConfig: () => eslintJs.configs.all
+  });
+
+  let configArray;
+  try {
+    configArray = factory.create(eslintConfig, {
+      basePath,
+      filePath: sourcePath,
+      name: sourcePath
+    });
+  } catch (error) {
+    throw new Error(`utoo-lint migrate eslint: unable to resolve classic config ${sourcePath}: ${error.message}`);
+  }
+
+  return migrationInputFromClassicConfigArray(configArray, basePath, outputDirectory);
+}
+
+function isClassicEslintConfig(eslintConfig, sourcePath) {
+  if (/^\.eslintrc(?:\.|$)/u.test(basename(sourcePath))) {
+    return true;
+  }
+  return Boolean(
+    eslintConfig &&
+    !Array.isArray(eslintConfig) &&
+    typeof eslintConfig === "object" &&
+    (eslintConfig.extends || eslintConfig.overrides || eslintConfig.ignorePatterns)
+  );
+}
+
+class MigrationConfigArrayFactory extends Legacy.ConfigArrayFactory {
+  activeSources = [];
+
+  _loadPlugin(name, context) {
+    return super._loadPlugin(name, {
+      ...context,
+      pluginBasePath: context.filePath ? dirname(context.filePath) : context.pluginBasePath
+    });
+  }
+
+  *_normalizeConfigData(configData, context) {
+    const source = classicContextSource(context);
+    const cycleIndex = this.activeSources.findIndex((active) => active.key === source.key);
+    if (cycleIndex !== -1) {
+      const chain = [...this.activeSources.slice(cycleIndex), source].map((active) => active.label).join(" -> ");
+      throw new Error(`Circular ESLint extends chain detected: ${chain}`);
+    }
+
+    this.activeSources.push(source);
+    try {
+      yield* super._normalizeConfigData(configData, context);
+    } finally {
+      this.activeSources.pop();
+    }
+  }
+}
+
+function classicContextSource(context) {
+  const label = classicSourceName(context.name ?? context.filePath ?? "inline config");
+  const key = label.startsWith("plugin:")
+    ? `plugin:${context.filePath ?? ""}:${label}`
+    : context.filePath
+      ? `file:${resolvePath(context.filePath)}`
+      : `name:${label}`;
+  return { key, label };
+}
+
+function migrationInputFromClassicConfigArray(configArray, basePath, outputDirectory) {
+  const entries = [];
+  const inheritedSources = [];
+  const records = [...configArray].map((element) => ({
+    element,
+    source: classicElementSource(element),
+    selector: rebaseClassicSelector(classicSelector(element.criteria), basePath, outputDirectory),
+    ignorePatterns: element.ignorePattern?.getPatternsRelativeTo(basePath) ?? []
+  }));
+  const scopedIgnores = new Map();
+
+  for (const record of records) {
+    if (record.element.criteria && record.ignorePatterns.length > 0) {
+      const key = classicOverrideChainKey(record.element);
+      scopedIgnores.set(key, uniquePatterns([...(scopedIgnores.get(key) ?? []), ...record.ignorePatterns]));
+    }
+  }
+
+  for (const { element, source, selector, ignorePatterns } of records) {
+    if (source.inherited) {
+      inheritedSources.push({ name: source.name, filePath: source.filePath });
+    }
+
+    const effectiveIgnorePatterns = (element.criteria
+      ? scopedIgnores.get(classicOverrideChainKey(element)) ?? []
+      : ignorePatterns).map((pattern) => rebaseClassicPattern(pattern, basePath, outputDirectory, true));
+    const rebasedIgnorePatterns = ignorePatterns.map(
+      (pattern) => rebaseClassicPattern(pattern, basePath, outputDirectory, true)
+    );
+    const hasRules = element.rules && typeof element.rules === "object";
+
+    if (rebasedIgnorePatterns.length > 0 && !element.criteria) {
+      entries.push(withMigrationSource({ ignores: rebasedIgnorePatterns }, source));
+    }
+
+    if (hasRules) {
+      const entry = { ...selector, rules: element.rules };
+      if (effectiveIgnorePatterns.length > 0 && element.criteria) {
+        entry.ignores = uniquePatterns([...(entry.ignores ?? []), ...effectiveIgnorePatterns]);
+      }
+      entries.push(withMigrationSource(entry, source));
+    } else if (rebasedIgnorePatterns.length > 0 && element.criteria) {
+      entries.push(withMigrationSource({ ...selector, ignores: [...(selector.ignores ?? []), ...rebasedIgnorePatterns] }, source));
+    }
+  }
+
+  return {
+    entries,
+    inheritedSources: uniqueInheritedSources(inheritedSources)
+  };
+}
+
+function classicOverrideChainKey(element) {
+  const segments = String(element.name ?? "").split(" » ");
+  let overrideIndex = -1;
+  for (let index = 0; index < segments.length; index += 1) {
+    if (/#overrides\[\d+\]/u.test(segments[index])) {
+      overrideIndex = index;
+    }
+  }
+  return overrideIndex === -1
+    ? `criteria:${classicCriteriaKey(element.criteria)}`
+    : `override:${segments.slice(0, overrideIndex + 1).join(" » ")}`;
+}
+
+function rebaseClassicSelector(selector, basePath, outputDirectory) {
+  return {
+    ...(selector.files ? {
+      files: selector.files.map((value) => Array.isArray(value)
+        ? value.map((pattern) => rebaseClassicPattern(pattern, basePath, outputDirectory))
+        : rebaseClassicPattern(value, basePath, outputDirectory))
+    } : {}),
+    ...(selector.ignores ? {
+      ignores: selector.ignores.map(
+        (pattern) => rebaseClassicPattern(pattern, basePath, outputDirectory, true)
+      )
+    } : {})
+  };
+}
+
+function rebaseClassicPattern(pattern, basePath, outputDirectory, preserveBasenameMatch = false) {
+  const negated = pattern.startsWith("!");
+  const unsignedPattern = negated ? pattern.slice(1) : pattern;
+  const rootAnchored = unsignedPattern.startsWith("/");
+  const value = rootAnchored ? unsignedPattern.slice(1) : unsignedPattern;
+  if (preserveBasenameMatch && !rootAnchored && !value.includes("/")) {
+    return pattern;
+  }
+
+  const absolutePattern = resolvePath(basePath, value);
+  const relativePattern = normalizeMigrationPath(relative(outputDirectory, absolutePattern));
+  const rebased = relativePattern === ".." || relativePattern.startsWith("../")
+    ? normalizeMigrationPath(absolutePattern)
+    : relativePattern || ".";
+  const anchoredPattern = rootAnchored && !rebased.includes("/") ? `/${rebased}` : rebased;
+  return negated ? `!${anchoredPattern}` : anchoredPattern;
+}
+
+function normalizeMigrationPath(path) {
+  return path.replaceAll("\\", "/");
+}
+
+function classicCriteriaKey(criteria) {
+  return JSON.stringify(classicSelector(criteria));
+}
+
+function classicSelector(criteria) {
+  if (!criteria) {
+    return {};
+  }
+
+  const includeGroups = [];
+  const ignores = [];
+  for (const patternGroup of criteria.patterns) {
+    includeGroups.push(uniquePatterns((patternGroup.includes ?? []).map(classicIncludePattern)));
+    ignores.push(...(patternGroup.excludes ?? []).map(classicExcludePattern));
+  }
+  const files = classicFileSelectors(includeGroups);
+
+  return {
+    ...(files.length > 0 ? { files } : {}),
+    ...(ignores.length > 0 ? { ignores: uniquePatterns(ignores) } : {})
+  };
+}
+
+function classicIncludePattern(matcher) {
+  return matcher.options?.matchBase && !matcher.pattern.includes("/")
+    ? `**/${matcher.pattern}`
+    : matcher.pattern;
+}
+
+function classicExcludePattern(matcher) {
+  return matcher.options?.matchBase === false && !matcher.pattern.includes("/")
+    ? `/${matcher.pattern}`
+    : matcher.pattern;
+}
+
+function classicFileSelectors(includeGroups) {
+  const groups = includeGroups.filter((group) => group.length > 0);
+  if (groups.length <= 1) {
+    return groups[0] ?? [];
+  }
+
+  let selectors = [[]];
+  for (const group of groups) {
+    selectors = selectors.flatMap((selector) => group.map((pattern) => [...selector, pattern]));
+  }
+  return selectors;
+}
+
+function uniquePatterns(patterns) {
+  return [...new Set(patterns)];
+}
+
+function migrationRuleScope(entry) {
+  if (!entry.files && !entry.ignores) {
+    return null;
+  }
+  return {
+    files: migratableFilePatterns(entry.files),
+    ignores: migratablePatterns(entry.ignores)
+  };
+}
+
+function removeDisabledUnsupportedRule(rules, ruleId, entry) {
+  const disabledScope = migrationRuleScope(entry);
+  return rules.filter(
+    (rule) => rule.ruleId !== ruleId || !disabledScopeCovers(rule.scope, disabledScope)
+  );
+}
+
+function disabledScopeCovers(enabledScope, disabledScope) {
+  if (disabledScope === null) {
+    return true;
+  }
+  if (enabledScope === null) {
+    return false;
+  }
+  if (
+    disabledScope.ignores.length > 0 &&
+    JSON.stringify(enabledScope.ignores) !== JSON.stringify(disabledScope.ignores)
+  ) {
+    return false;
+  }
+  return fileSelectorsCover(enabledScope.files, disabledScope.files);
+}
+
+function fileSelectorsCover(enabledFiles, disabledFiles) {
+  if (disabledFiles.length === 0) {
+    return true;
+  }
+  if (enabledFiles.length === 0) {
+    return false;
+  }
+
+  const enabledGroups = enabledFiles.map((selector) => Array.isArray(selector) ? selector : [selector]);
+  const disabledGroups = disabledFiles.map((selector) => Array.isArray(selector) ? selector : [selector]);
+  return enabledGroups.every((enabledGroup) => disabledGroups.some((disabledGroup) =>
+    disabledGroup.every((disabledPattern) => enabledGroup.some((enabledPattern) =>
+      globPatternCovers(enabledPattern, disabledPattern)
+    ))
+  ));
+}
+
+function globPatternCovers(enabledPattern, disabledPattern) {
+  if (enabledPattern === disabledPattern) {
+    return true;
+  }
+  const enabledSegments = enabledPattern.split("/");
+  const disabledSegments = disabledPattern.split("/");
+  return globSegmentsCover(enabledSegments, disabledSegments, 0, 0);
+}
+
+function globSegmentsCover(enabled, disabled, enabledIndex, disabledIndex) {
+  if (disabledIndex === disabled.length) {
+    return enabledIndex === enabled.length;
+  }
+  if (disabled[disabledIndex] === "**") {
+    if (disabledIndex === disabled.length - 1) {
+      return true;
+    }
+    for (let index = enabledIndex; index <= enabled.length; index += 1) {
+      if (globSegmentsCover(enabled, disabled, index, disabledIndex + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (enabledIndex === enabled.length || enabled[enabledIndex] === "**") {
+    return false;
+  }
+  return globSegmentCovers(enabled[enabledIndex], disabled[disabledIndex]) &&
+    globSegmentsCover(enabled, disabled, enabledIndex + 1, disabledIndex + 1);
+}
+
+function globSegmentCovers(enabledSegment, disabledSegment) {
+  if (enabledSegment === disabledSegment) {
+    return true;
+  }
+  if (/[?[{]/u.test(disabledSegment)) {
+    return false;
+  }
+  const expression = new RegExp(`^${disabledSegment
+    .split("*")
+    .map((part) => part.replace(/[.+?^${}()|[\]\\]/gu, "\\$&"))
+    .join(".*")}$`);
+  return expression.test(enabledSegment);
+}
+
+function classicElementSource(element) {
+  const name = classicSourceName(element.name ?? element.filePath ?? "inline config");
+  return {
+    inherited: String(element.name ?? "").includes(" » "),
+    name,
+    filePath: element.filePath || null
+  };
+}
+
+function classicSourceName(name) {
+  return String(name).split(" » ").at(-1).replace(/#overrides\[\d+\]$/u, "");
+}
+
+function withMigrationSource(entry, source) {
+  Object.defineProperty(entry, MIGRATION_SOURCE, { value: source });
+  return entry;
 }
 
 function findEslintConfig(cwd) {
@@ -297,7 +662,7 @@ function migratableConfigEntry(entry, rules) {
   if (typeof entry.name === "string") {
     migrated.name = entry.name;
   }
-  const files = migratablePatterns(entry.files);
+  const files = migratableFilePatterns(entry.files);
   if (files.length > 0) {
     migrated.files = files;
   }
@@ -309,6 +674,27 @@ function migratableConfigEntry(entry, rules) {
     migrated.rules = sortObjectByKey(rules);
   }
   return migrated;
+}
+
+function migratableFilePatterns(value) {
+  const result = [];
+  const seen = new Set();
+  for (const pattern of Array.isArray(value) ? value : [value]) {
+    const migrated = Array.isArray(pattern)
+      ? migratablePatterns(pattern)
+      : typeof pattern === "string"
+        ? pattern
+        : null;
+    if (migrated === null || (Array.isArray(migrated) && migrated.length === 0)) {
+      continue;
+    }
+    const key = JSON.stringify(migrated);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(migrated);
+    }
+  }
+  return result;
 }
 
 function migratablePatterns(value) {
@@ -364,6 +750,28 @@ function uniqueTranslatedRules(values) {
   return [...result.values()].sort((left, right) => left.sourceRuleId.localeCompare(right.sourceRuleId));
 }
 
+function uniqueInheritedSources(values) {
+  const result = new Map();
+  for (const value of values) {
+    result.set(`${value.name}\0${value.filePath ?? ""}`, value);
+  }
+  return [...result.values()].sort((left, right) =>
+    left.name.localeCompare(right.name) || String(left.filePath ?? "").localeCompare(String(right.filePath ?? ""))
+  );
+}
+
+function uniqueUnsupportedInheritedRules(values) {
+  const result = new Map();
+  for (const value of values) {
+    result.set(`${value.ruleId}\0${value.sourceName}\0${value.sourcePath ?? ""}`, value);
+  }
+  return [...result.values()].sort((left, right) =>
+    left.ruleId.localeCompare(right.ruleId) ||
+    left.sourceName.localeCompare(right.sourceName) ||
+    String(left.sourcePath ?? "").localeCompare(String(right.sourcePath ?? ""))
+  );
+}
+
 function writeReport(report, options, stream) {
   if (options.report === "json") {
     stream.write(JSON.stringify(report, null, 2) + "\n");
@@ -375,6 +783,9 @@ function writeReport(report, options, stream) {
     stream.write(`utoo-lint migrate eslint: wrote ${report.output}\n`);
   }
   stream.write(`utoo-lint migrate eslint: migrated ${report.supportedRules.length} supported rule(s)\n`);
+  if (report.inheritedSources.length > 0) {
+    stream.write(`utoo-lint migrate eslint: resolved ${report.inheritedSources.length} inherited config source(s): ${report.inheritedSources.map(formatInheritedSource).join(", ")}\n`);
+  }
   if (report.translatedRules.length > 0) {
     stream.write(`utoo-lint migrate eslint: translated ${report.translatedRules.length} rule alias(es): ${report.translatedRules.map((rule) => `${rule.sourceRuleId} -> ${rule.targetRuleId}`).join(", ")}\n`);
   }
@@ -384,6 +795,13 @@ function writeReport(report, options, stream) {
   if (report.unsupportedRules.length > 0) {
     stream.write(`utoo-lint migrate eslint: ${report.unsupportedRules.length} unsupported rule(s): ${report.unsupportedRules.join(", ")}\n`);
   }
+  if (report.unsupportedInheritedRules.length > 0) {
+    stream.write(`utoo-lint migrate eslint: unsupported inherited rule source(s): ${report.unsupportedInheritedRules.map((rule) => `${rule.ruleId} from ${formatInheritedSource({ name: rule.sourceName, filePath: rule.sourcePath })}`).join(", ")}\n`);
+  }
+}
+
+function formatInheritedSource(source) {
+  return source.filePath ? `${source.name} (${pathToFileURL(source.filePath).href})` : source.name;
 }
 
 function printMigrateHelp() {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -868,8 +868,9 @@ function runCli(args = [], options = {}) {
     extraArgs: parsed.passthroughArgs,
     preserveNativeDefaults: Boolean(parsed.options.noConfig)
   });
-  const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
-  const report = lintFiles(targets, cliOptions);
+  const usesDefaultTargets = parsed.targets.length === 0;
+  const targets = usesDefaultTargets ? defaultLintTargets(cliOptions) : parsed.targets;
+  const report = lintFiles(targets, { ...cliOptions, useDefaultConfigTargets: usesDefaultTargets });
   report.diagnostics = normalizeReportDiagnostics(report.diagnostics, cliOptions);
   report.exitCode = exitCodeForDiagnostics(report.diagnostics);
   const status = report.exitCode ?? exitCodeForDiagnostics(report.diagnostics);
@@ -1180,9 +1181,13 @@ function booleanFlagValue(arg) {
 
 function lintFiles(paths, options = {}) {
   options = withConfigCache(options);
+  const usesDefaultTargets = paths == null || options.useDefaultConfigTargets;
   const targets = lintTargetsForInput(paths, options);
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
-  const lintPaths = filteredLintPaths(targets, options);
+  let lintPaths = filteredLintPaths(targets, options);
+  if (usesDefaultTargets) {
+    lintPaths = filterDefaultConfigLintPaths(lintPaths, options);
+  }
   if (lintPaths.length === 0) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
@@ -1537,12 +1542,12 @@ function calculatedConfig(options = {}, filePath) {
   );
   return {
     ...configData,
-    rules: {
-      ...rulesFromConfig(options.baseConfig, filePath, options.cwd),
-      ...rulesFromFileConfig(options, filePath),
-      ...rulesFromConfig(options.overrideConfig, filePath, options.cwd),
-      ...rulesFromNativeRuleList(options.rules)
-    }
+    rules: mergeRuleConfigMaps(
+      rulesFromConfig(options.baseConfig, filePath, options.cwd),
+      rulesFromFileConfig(options, filePath),
+      rulesFromConfig(options.overrideConfig, filePath, options.cwd),
+      rulesFromNativeRuleList(options.rules)
+    )
   };
 }
 
@@ -1637,10 +1642,10 @@ function rulesFromConfig(config, filePath, cwd) {
     return {};
   }
   if (Array.isArray(config)) {
-    return config.reduce((rules, entry) => ({
-      ...rules,
-      ...rulesFromConfig(entry, filePath, cwd)
-    }), {});
+    return config.reduce(
+      (rules, entry) => mergeRuleConfigMaps(rules, rulesFromConfig(entry, filePath, cwd)),
+      {}
+    );
   }
   if (!configAppliesToFile(config, filePath, cwd)) {
     return {};
@@ -1693,10 +1698,62 @@ function defaultLintTargets(options = {}) {
     return ["."];
   }
 
-  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache));
+  const config = readConfig(configPath, options.cwd, options.configCache);
+  if (configHasUnscopedRules(config)) {
+    return ["."];
+  }
+
+  const targets = filePatternsFromConfig(config);
   return targets.length > 0
     ? targets.map((target) => resolveConfigPattern(target, dirname(configPath)))
     : ["."];
+}
+
+function filterDefaultConfigLintPaths(paths, options) {
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return paths;
+  }
+  const config = readConfig(configPath, options.cwd, options.configCache);
+  if (!configHasFileSelectors(config)) {
+    return paths;
+  }
+  const cwd = dirname(configPath);
+  return paths.filter((filePath) => configSelectsFile(config, filePath, cwd));
+}
+
+function configHasFileSelectors(config) {
+  if (Array.isArray(config)) {
+    return config.some(configHasFileSelectors);
+  }
+  return Boolean(config && typeof config === "object" && normalizeConfigFileSelectors(config.files).length > 0);
+}
+
+function configHasUnscopedRules(config) {
+  if (Array.isArray(config)) {
+    return config.some(configHasUnscopedRules);
+  }
+  return Boolean(
+    config &&
+    typeof config === "object" &&
+    normalizeConfigFileSelectors(config.files).length === 0 &&
+    config.rules &&
+    typeof config.rules === "object" &&
+    Object.keys(config.rules).length > 0
+  );
+}
+
+function configSelectsFile(config, filePath, cwd) {
+  if (Array.isArray(config)) {
+    return config.some((entry) => configSelectsFile(entry, filePath, cwd));
+  }
+  if (!config || typeof config !== "object") {
+    return false;
+  }
+  const selectors = normalizeConfigFileSelectors(config.files);
+  return selectors.length > 0
+    ? configAppliesToFile(config, filePath, cwd)
+    : configHasUnscopedRules(config) && configAppliesToFile(config, filePath, cwd);
 }
 
 function resolveConfigPattern(pattern, configDirectory) {
@@ -1722,13 +1779,32 @@ function configAppliesToFile(config, filePath, cwd) {
   }
 
   const normalized = normalizeIgnoredPath(filePath, cwd ?? process.cwd());
-  const files = normalizeConfigPatterns(config.files);
-  if (files.length > 0 && !files.some((pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern)))) {
+  const files = normalizeConfigFileSelectors(config.files);
+  if (files.length > 0 && !files.some((selector) => selector.every(
+    (pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern))
+  ))) {
     return false;
   }
 
   const ignores = normalizeIgnorePatterns(config.ignores);
   return !pathIgnoredByPatterns(normalized, ignores);
+}
+
+function normalizeConfigFileSelectors(patterns) {
+  if (!patterns) {
+    return [];
+  }
+  const values = Array.isArray(patterns) ? patterns : [patterns];
+  return values.flatMap((value) => {
+    if (typeof value === "string") {
+      return [[value]];
+    }
+    if (Array.isArray(value)) {
+      const selector = normalizeConfigPatterns(value);
+      return selector.length > 0 ? [selector] : [];
+    }
+    return [];
+  });
 }
 
 function normalizeConfigPatterns(patterns) {
@@ -1835,11 +1911,7 @@ function enabledRuleNames(rules) {
 }
 
 function runtimeRulesFromConfigs(...configs) {
-  const rules = {};
-  for (const config of configs) {
-    Object.assign(rules, runtimeRulesFromConfig(config));
-  }
-  return rules;
+  return mergeRuleConfigMaps(...configs.map(runtimeRulesFromConfig));
 }
 
 function materializedRulesFromConfigs(...configs) {
@@ -1851,10 +1923,10 @@ function runtimeRulesFromConfig(config) {
     return {};
   }
   if (Array.isArray(config)) {
-    return config.reduce((rules, entry) => ({
-      ...rules,
-      ...runtimeRulesFromConfig(entry)
-    }), {});
+    return config.reduce(
+      (rules, entry) => mergeRuleConfigMaps(rules, runtimeRulesFromConfig(entry)),
+      {}
+    );
   }
 
   const rules = {};
@@ -1862,6 +1934,26 @@ function runtimeRulesFromConfig(config) {
     rules[rule] = value;
   }
   return rules;
+}
+
+function mergeRuleConfigMaps(...ruleMaps) {
+  const result = {};
+  for (const rules of ruleMaps) {
+    for (const [ruleId, ruleConfig] of Object.entries(rules ?? {})) {
+      const previous = result[ruleId];
+      if (previous !== undefined && isSeverityOnlyRuleConfig(ruleConfig) && Array.isArray(previous) && previous.length > 1) {
+        const severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
+        result[ruleId] = [severity, ...previous.slice(1)];
+      } else {
+        result[ruleId] = ruleConfig;
+      }
+    }
+  }
+  return result;
+}
+
+function isSeverityOnlyRuleConfig(ruleConfig) {
+  return !Array.isArray(ruleConfig) || ruleConfig.length === 1;
 }
 
 function enabledRuleNamesFromConfigs(...configs) {
@@ -2053,7 +2145,7 @@ function parserOptionsForConfig(config, filePath, cwd) {
 
 function customRuleEntriesForConfig(config, rules, filePath, cwd) {
   const entries = new Map();
-  for (const [ruleId, ruleConfig] of ruleConfigEntries(config, filePath, cwd)) {
+  for (const [ruleId, ruleConfig] of Object.entries(rulesFromConfig(config, filePath, cwd))) {
     if (!rules.has(ruleId)) {
       continue;
     }
@@ -2108,19 +2200,6 @@ function matchingConfigEntries(config, filePath = undefined, cwd = undefined) {
     return [];
   }
   return [config];
-}
-
-function ruleConfigEntries(config, filePath = undefined, cwd = undefined) {
-  if (Array.isArray(config)) {
-    return config.flatMap((item) => ruleConfigEntries(item, filePath, cwd));
-  }
-  if (!config || typeof config !== "object" || !config.rules || typeof config.rules !== "object") {
-    return [];
-  }
-  if (!configAppliesToFile(config, filePath, cwd)) {
-    return [];
-  }
-  return Object.entries(config.rules);
 }
 
 function configWithoutCustomRules(config, rules) {
@@ -3423,10 +3502,7 @@ function mergeRuleTesterConfig(baseConfig, overrideConfig) {
   return {
     ...baseConfig,
     ...overrideConfig,
-    rules: {
-      ...(baseConfig.rules ?? {}),
-      ...(overrideConfig.rules ?? {})
-    }
+    rules: mergeRuleConfigMaps(baseConfig.rules, overrideConfig.rules)
   };
 }
 
@@ -4080,7 +4156,7 @@ function collectGlobFiles(target, cwd, patterns, expression, files) {
 
     const child = join(target, entry.name);
     if (entry.isDirectory()) {
-      if (!pathIgnoredByPatterns(normalizeIgnoredPath(child, cwd), patterns)) {
+      if (shouldTraverseDirectory(normalizeIgnoredPath(child, cwd), patterns)) {
         collectGlobFiles(child, cwd, patterns, expression, files);
       }
       continue;
@@ -4150,7 +4226,7 @@ function expandLintTarget(target, cwd, patterns) {
   if (stat.isFile()) {
     return isLintableFilePath(target) && !pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns) ? [target] : [];
   }
-  if (!stat.isDirectory() || pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+  if (!stat.isDirectory() || !shouldTraverseDirectory(normalizeIgnoredPath(target, cwd), patterns)) {
     return [];
   }
 
@@ -4168,7 +4244,7 @@ function collectLintableFiles(target, cwd, patterns, files) {
 
     const child = join(target, entry.name);
     if (entry.isDirectory()) {
-      if (!pathIgnoredByPatterns(normalizeIgnoredPath(child, cwd), patterns)) {
+      if (shouldTraverseDirectory(normalizeIgnoredPath(child, cwd), patterns)) {
         collectLintableFiles(child, cwd, patterns, files);
       }
       continue;
@@ -4301,7 +4377,7 @@ function normalizeIgnoredPath(filePath, cwd) {
 }
 
 function normalizeIgnoredPattern(pattern) {
-  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, "")).replace(/\/+$/, "");
+  return normalizePath(pattern.replace(/^!/, "")).replace(/\/+$/, "");
 }
 
 function pathIgnoredByPatterns(target, patterns) {
@@ -4315,10 +4391,55 @@ function pathIgnoredByPatterns(target, patterns) {
   return ignored;
 }
 
+function shouldTraverseDirectory(target, patterns) {
+  return !pathIgnoredByPatterns(target, patterns) || patterns.some(
+    (pattern) => pattern.startsWith("!") && negatedPatternMayMatchDescendant(target, pattern)
+  );
+}
+
+function negatedPatternMayMatchDescendant(target, pattern) {
+  pattern = normalizeIgnoredPattern(pattern);
+  if (pattern.startsWith("/")) {
+    pattern = pattern.slice(1);
+    if (target.startsWith("/")) {
+      target = target.slice(1);
+    }
+  }
+  if (!pattern.includes("/")) {
+    return true;
+  }
+
+  const directoryPattern = pattern.slice(0, pattern.lastIndexOf("/"));
+  if (hasGlobSyntax(directoryPattern)) {
+    const directoryExpression = new RegExp(`^${globPatternRegExpSource(directoryPattern)}(?:/.*)?$`);
+    if (directoryExpression.test(target)) {
+      return true;
+    }
+  }
+
+  const globIndex = pattern.search(/[*?[{]/u);
+  const staticPrefix = (globIndex === -1 ? pattern : pattern.slice(0, globIndex)).replace(/\/+$/u, "");
+  return !staticPrefix ||
+    staticPrefix === target ||
+    staticPrefix.startsWith(`${target}/`) ||
+    target.startsWith(`${staticPrefix}/`);
+}
+
 function matchesIgnorePattern(target, pattern) {
+  const anchored = pattern.startsWith("/");
+  if (anchored) {
+    pattern = pattern.slice(1);
+    if (target.startsWith("/")) {
+      target = target.slice(1);
+    }
+  }
   if (pattern.endsWith("/**")) {
-    const prefix = pattern.slice(0, -3);
-    return target === prefix || target.startsWith(`${prefix}/`) || target.includes(`/${prefix}/`);
+    const directoryPattern = pattern.slice(0, -3);
+    if (hasGlobSyntax(directoryPattern)) {
+      const expression = new RegExp(`^${globPatternRegExpSource(directoryPattern)}(?:/.*)?$`);
+      return expression.test(target);
+    }
+    return target === directoryPattern || target.startsWith(`${directoryPattern}/`);
   }
   if (pattern.startsWith("**/")) {
     const suffix = pattern.slice(3);
@@ -4327,10 +4448,14 @@ function matchesIgnorePattern(target, pattern) {
     }
   }
   if (!hasGlobSyntax(pattern)) {
+    if (anchored || pattern.includes("/")) {
+      return target === pattern || target.startsWith(`${pattern}/`);
+    }
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
-  const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
+  const prefix = anchored || pattern.includes("/") ? "^" : "(^|/)";
+  const expression = new RegExp(`${prefix}${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -774,7 +774,7 @@ function parserOptionsForConfig(config, filePath, cwd) {
 
 function customRuleEntriesForConfig(config, rules, filePath, cwd) {
   const entries = new Map();
-  for (const [ruleId, ruleConfig] of ruleConfigEntries(config, filePath, cwd)) {
+  for (const [ruleId, ruleConfig] of Object.entries(rulesFromConfig(config, filePath, cwd))) {
     if (!rules.has(ruleId)) {
       continue;
     }
@@ -829,19 +829,6 @@ function matchingConfigEntries(config, filePath = undefined, cwd = undefined) {
     return [];
   }
   return [config];
-}
-
-function ruleConfigEntries(config, filePath = undefined, cwd = undefined) {
-  if (Array.isArray(config)) {
-    return config.flatMap((item) => ruleConfigEntries(item, filePath, cwd));
-  }
-  if (!config || typeof config !== "object" || !config.rules || typeof config.rules !== "object") {
-    return [];
-  }
-  if (!configAppliesToFile(config, filePath, cwd)) {
-    return [];
-  }
-  return Object.entries(config.rules);
 }
 
 function configWithoutCustomRules(config, rules) {
@@ -2144,10 +2131,7 @@ function mergeRuleTesterConfig(baseConfig, overrideConfig) {
   return {
     ...baseConfig,
     ...overrideConfig,
-    rules: {
-      ...(baseConfig.rules ?? {}),
-      ...(overrideConfig.rules ?? {})
-    }
+    rules: mergeRuleConfigMaps(baseConfig.rules, overrideConfig.rules)
   };
 }
 
@@ -2773,8 +2757,9 @@ export function runCli(args = [], options = {}) {
     extraArgs: parsed.passthroughArgs,
     preserveNativeDefaults: Boolean(parsed.options.noConfig)
   });
-  const targets = parsed.targets.length > 0 ? parsed.targets : defaultLintTargets(cliOptions);
-  const report = lintFiles(targets, cliOptions);
+  const usesDefaultTargets = parsed.targets.length === 0;
+  const targets = usesDefaultTargets ? defaultLintTargets(cliOptions) : parsed.targets;
+  const report = lintFiles(targets, { ...cliOptions, useDefaultConfigTargets: usesDefaultTargets });
   report.diagnostics = normalizeReportDiagnostics(report.diagnostics, cliOptions);
   report.exitCode = exitCodeForDiagnostics(report.diagnostics);
   const status = report.exitCode ?? exitCodeForDiagnostics(report.diagnostics);
@@ -3085,9 +3070,13 @@ function booleanFlagValue(arg) {
 
 export function lintFiles(paths, options = {}) {
   options = withConfigCache(options);
+  const usesDefaultTargets = paths == null || options.useDefaultConfigTargets;
   const targets = lintTargetsForInput(paths, options);
   const ignoredDiagnostics = ignoredLintPathDiagnostics(targets, options);
-  const lintPaths = filteredLintPaths(targets, options);
+  let lintPaths = filteredLintPaths(targets, options);
+  if (usesDefaultTargets) {
+    lintPaths = filterDefaultConfigLintPaths(lintPaths, options);
+  }
   if (lintPaths.length === 0) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
@@ -3442,12 +3431,12 @@ function calculatedConfig(options = {}, filePath) {
   );
   return {
     ...configData,
-    rules: {
-      ...rulesFromConfig(options.baseConfig, filePath, options.cwd),
-      ...rulesFromFileConfig(options, filePath),
-      ...rulesFromConfig(options.overrideConfig, filePath, options.cwd),
-      ...rulesFromNativeRuleList(options.rules)
-    }
+    rules: mergeRuleConfigMaps(
+      rulesFromConfig(options.baseConfig, filePath, options.cwd),
+      rulesFromFileConfig(options, filePath),
+      rulesFromConfig(options.overrideConfig, filePath, options.cwd),
+      rulesFromNativeRuleList(options.rules)
+    )
   };
 }
 
@@ -3542,10 +3531,10 @@ function rulesFromConfig(config, filePath, cwd) {
     return {};
   }
   if (Array.isArray(config)) {
-    return config.reduce((rules, entry) => ({
-      ...rules,
-      ...rulesFromConfig(entry, filePath, cwd)
-    }), {});
+    return config.reduce(
+      (rules, entry) => mergeRuleConfigMaps(rules, rulesFromConfig(entry, filePath, cwd)),
+      {}
+    );
   }
   if (!configAppliesToFile(config, filePath, cwd)) {
     return {};
@@ -3598,10 +3587,62 @@ function defaultLintTargets(options = {}) {
     return ["."];
   }
 
-  const targets = filePatternsFromConfig(readConfig(configPath, options.cwd, options.configCache));
+  const config = readConfig(configPath, options.cwd, options.configCache);
+  if (configHasUnscopedRules(config)) {
+    return ["."];
+  }
+
+  const targets = filePatternsFromConfig(config);
   return targets.length > 0
     ? targets.map((target) => resolveConfigPattern(target, dirname(configPath)))
     : ["."];
+}
+
+function filterDefaultConfigLintPaths(paths, options) {
+  const configPath = configPathForOptions(options);
+  if (!configPath) {
+    return paths;
+  }
+  const config = readConfig(configPath, options.cwd, options.configCache);
+  if (!configHasFileSelectors(config)) {
+    return paths;
+  }
+  const cwd = dirname(configPath);
+  return paths.filter((filePath) => configSelectsFile(config, filePath, cwd));
+}
+
+function configHasFileSelectors(config) {
+  if (Array.isArray(config)) {
+    return config.some(configHasFileSelectors);
+  }
+  return Boolean(config && typeof config === "object" && normalizeConfigFileSelectors(config.files).length > 0);
+}
+
+function configHasUnscopedRules(config) {
+  if (Array.isArray(config)) {
+    return config.some(configHasUnscopedRules);
+  }
+  return Boolean(
+    config &&
+    typeof config === "object" &&
+    normalizeConfigFileSelectors(config.files).length === 0 &&
+    config.rules &&
+    typeof config.rules === "object" &&
+    Object.keys(config.rules).length > 0
+  );
+}
+
+function configSelectsFile(config, filePath, cwd) {
+  if (Array.isArray(config)) {
+    return config.some((entry) => configSelectsFile(entry, filePath, cwd));
+  }
+  if (!config || typeof config !== "object") {
+    return false;
+  }
+  const selectors = normalizeConfigFileSelectors(config.files);
+  return selectors.length > 0
+    ? configAppliesToFile(config, filePath, cwd)
+    : configHasUnscopedRules(config) && configAppliesToFile(config, filePath, cwd);
 }
 
 function resolveConfigPattern(pattern, configDirectory) {
@@ -3627,13 +3668,32 @@ function configAppliesToFile(config, filePath, cwd) {
   }
 
   const normalized = normalizeIgnoredPath(filePath, cwd ?? process.cwd());
-  const files = normalizeConfigPatterns(config.files);
-  if (files.length > 0 && !files.some((pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern)))) {
+  const files = normalizeConfigFileSelectors(config.files);
+  if (files.length > 0 && !files.some((selector) => selector.every(
+    (pattern) => matchesConfigFilePattern(normalized, normalizeIgnoredPattern(pattern))
+  ))) {
     return false;
   }
 
   const ignores = normalizeIgnorePatterns(config.ignores);
   return !pathIgnoredByPatterns(normalized, ignores);
+}
+
+function normalizeConfigFileSelectors(patterns) {
+  if (!patterns) {
+    return [];
+  }
+  const values = Array.isArray(patterns) ? patterns : [patterns];
+  return values.flatMap((value) => {
+    if (typeof value === "string") {
+      return [[value]];
+    }
+    if (Array.isArray(value)) {
+      const selector = normalizeConfigPatterns(value);
+      return selector.length > 0 ? [selector] : [];
+    }
+    return [];
+  });
 }
 
 function normalizeConfigPatterns(patterns) {
@@ -3740,11 +3800,7 @@ function enabledRuleNames(rules) {
 }
 
 function runtimeRulesFromConfigs(...configs) {
-  const rules = {};
-  for (const config of configs) {
-    Object.assign(rules, runtimeRulesFromConfig(config));
-  }
-  return rules;
+  return mergeRuleConfigMaps(...configs.map(runtimeRulesFromConfig));
 }
 
 function materializedRulesFromConfigs(...configs) {
@@ -3756,10 +3812,10 @@ function runtimeRulesFromConfig(config) {
     return {};
   }
   if (Array.isArray(config)) {
-    return config.reduce((rules, entry) => ({
-      ...rules,
-      ...runtimeRulesFromConfig(entry)
-    }), {});
+    return config.reduce(
+      (rules, entry) => mergeRuleConfigMaps(rules, runtimeRulesFromConfig(entry)),
+      {}
+    );
   }
 
   const rules = {};
@@ -3767,6 +3823,26 @@ function runtimeRulesFromConfig(config) {
     rules[rule] = value;
   }
   return rules;
+}
+
+function mergeRuleConfigMaps(...ruleMaps) {
+  const result = {};
+  for (const rules of ruleMaps) {
+    for (const [ruleId, ruleConfig] of Object.entries(rules ?? {})) {
+      const previous = result[ruleId];
+      if (previous !== undefined && isSeverityOnlyRuleConfig(ruleConfig) && Array.isArray(previous) && previous.length > 1) {
+        const severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
+        result[ruleId] = [severity, ...previous.slice(1)];
+      } else {
+        result[ruleId] = ruleConfig;
+      }
+    }
+  }
+  return result;
+}
+
+function isSeverityOnlyRuleConfig(ruleConfig) {
+  return !Array.isArray(ruleConfig) || ruleConfig.length === 1;
 }
 
 function enabledRuleNamesFromConfigs(...configs) {
@@ -4083,7 +4159,7 @@ function collectGlobFiles(target, cwd, patterns, expression, files) {
 
     const child = join(target, entry.name);
     if (entry.isDirectory()) {
-      if (!pathIgnoredByPatterns(normalizeIgnoredPath(child, cwd), patterns)) {
+      if (shouldTraverseDirectory(normalizeIgnoredPath(child, cwd), patterns)) {
         collectGlobFiles(child, cwd, patterns, expression, files);
       }
       continue;
@@ -4153,7 +4229,7 @@ function expandLintTarget(target, cwd, patterns) {
   if (stat.isFile()) {
     return isLintableFilePath(target) && !pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns) ? [target] : [];
   }
-  if (!stat.isDirectory() || pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+  if (!stat.isDirectory() || !shouldTraverseDirectory(normalizeIgnoredPath(target, cwd), patterns)) {
     return [];
   }
 
@@ -4171,7 +4247,7 @@ function collectLintableFiles(target, cwd, patterns, files) {
 
     const child = join(target, entry.name);
     if (entry.isDirectory()) {
-      if (!pathIgnoredByPatterns(normalizeIgnoredPath(child, cwd), patterns)) {
+      if (shouldTraverseDirectory(normalizeIgnoredPath(child, cwd), patterns)) {
         collectLintableFiles(child, cwd, patterns, files);
       }
       continue;
@@ -4304,7 +4380,7 @@ function normalizeIgnoredPath(filePath, cwd) {
 }
 
 function normalizeIgnoredPattern(pattern) {
-  return normalizePath(pattern.replace(/^!/, "").replace(/^\//, "")).replace(/\/+$/, "");
+  return normalizePath(pattern.replace(/^!/, "")).replace(/\/+$/, "");
 }
 
 function pathIgnoredByPatterns(target, patterns) {
@@ -4318,10 +4394,55 @@ function pathIgnoredByPatterns(target, patterns) {
   return ignored;
 }
 
+function shouldTraverseDirectory(target, patterns) {
+  return !pathIgnoredByPatterns(target, patterns) || patterns.some(
+    (pattern) => pattern.startsWith("!") && negatedPatternMayMatchDescendant(target, pattern)
+  );
+}
+
+function negatedPatternMayMatchDescendant(target, pattern) {
+  pattern = normalizeIgnoredPattern(pattern);
+  if (pattern.startsWith("/")) {
+    pattern = pattern.slice(1);
+    if (target.startsWith("/")) {
+      target = target.slice(1);
+    }
+  }
+  if (!pattern.includes("/")) {
+    return true;
+  }
+
+  const directoryPattern = pattern.slice(0, pattern.lastIndexOf("/"));
+  if (hasGlobSyntax(directoryPattern)) {
+    const directoryExpression = new RegExp(`^${globPatternRegExpSource(directoryPattern)}(?:/.*)?$`);
+    if (directoryExpression.test(target)) {
+      return true;
+    }
+  }
+
+  const globIndex = pattern.search(/[*?[{]/u);
+  const staticPrefix = (globIndex === -1 ? pattern : pattern.slice(0, globIndex)).replace(/\/+$/u, "");
+  return !staticPrefix ||
+    staticPrefix === target ||
+    staticPrefix.startsWith(`${target}/`) ||
+    target.startsWith(`${staticPrefix}/`);
+}
+
 function matchesIgnorePattern(target, pattern) {
+  const anchored = pattern.startsWith("/");
+  if (anchored) {
+    pattern = pattern.slice(1);
+    if (target.startsWith("/")) {
+      target = target.slice(1);
+    }
+  }
   if (pattern.endsWith("/**")) {
-    const prefix = pattern.slice(0, -3);
-    return target === prefix || target.startsWith(`${prefix}/`) || target.includes(`/${prefix}/`);
+    const directoryPattern = pattern.slice(0, -3);
+    if (hasGlobSyntax(directoryPattern)) {
+      const expression = new RegExp(`^${globPatternRegExpSource(directoryPattern)}(?:/.*)?$`);
+      return expression.test(target);
+    }
+    return target === directoryPattern || target.startsWith(`${directoryPattern}/`);
   }
   if (pattern.startsWith("**/")) {
     const suffix = pattern.slice(3);
@@ -4330,10 +4451,14 @@ function matchesIgnorePattern(target, pattern) {
     }
   }
   if (!hasGlobSyntax(pattern)) {
+    if (anchored || pattern.includes("/")) {
+      return target === pattern || target.startsWith(`${pattern}/`);
+    }
     return target === pattern || target.endsWith(`/${pattern}`) || target.startsWith(`${pattern}/`);
   }
 
-  const expression = new RegExp(`(^|/)${globPatternRegExpSource(pattern)}$`);
+  const prefix = anchored || pattern.includes("/") ? "^" : "(^|/)";
+  const expression = new RegExp(`${prefix}${globPatternRegExpSource(pattern)}$`);
   return expression.test(target);
 }
 

--- a/npm/utoo-lint/package.json
+++ b/npm/utoo-lint/package.json
@@ -87,6 +87,8 @@
     "@utoo/lint-win32-x64": "workspace:*"
   },
   "dependencies": {
+    "@eslint/eslintrc": "2.1.4",
+    "@eslint/js": "8.57.1",
     "jiti": "2.7.0"
   },
   "publishConfig": {

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -37,7 +37,18 @@
             {
               "type": "array",
               "items": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                ]
               }
             }
           ]

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
@@ -686,6 +686,661 @@ test("migrator preserves flat config scopes, global ignores, and override order"
       { filePath: specialPath, ruleId: "no-debugger", severity: "warning" }
     ]
   );
+});
+
+test("migrator resolves classic relative package plugin and nested extends in order", (t) => {
+  const project = createProject(t);
+  const relativeConfig = write(
+    join(project, "relative.cjs"),
+    'module.exports = { rules: { "no-alert": "warn" } };\n'
+  );
+  const companyDirectory = join(project, "node_modules", "eslint-config-company");
+  const companyConfig = write(
+    join(companyDirectory, "index.cjs"),
+    [
+      "module.exports = {",
+      '  extends: "./nested.json",',
+      '  ignorePatterns: ["vendor/**"],',
+      '  rules: { "no-debugger": "error" },',
+      "  overrides: [{",
+      '    files: ["test/**/*.js"],',
+      '    excludedFiles: ["test/fixtures/**"],',
+      '    rules: { "no-console": "off", "example/inherited": "error" }',
+      "  }]",
+      "};",
+      ""
+    ].join("\n")
+  );
+  const nestedConfig = write(
+    join(companyDirectory, "nested.json"),
+    JSON.stringify({ rules: { "no-console": "warn" } })
+  );
+  write(
+    join(companyDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-company", main: "index.cjs" })
+  );
+  const pluginDirectory = join(project, "node_modules", "eslint-plugin-demo");
+  const pluginConfig = write(
+    join(pluginDirectory, "index.cjs"),
+    'module.exports = { configs: { recommended: { rules: { "no-var": "error" } } } };\n'
+  );
+  write(
+    join(pluginDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-plugin-demo", main: "index.cjs" })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      extends: ["./relative.cjs", "company", "plugin:demo/recommended"],
+      rules: { "no-debugger": "off" }
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).slice(1), [
+    { rules: { "no-alert": "warn" } },
+    { rules: { "no-console": "warn" } },
+    { ignores: ["vendor/**"] },
+    { rules: { "no-debugger": "error" } },
+    {
+      files: ["test/**/*.js"],
+      ignores: ["test/fixtures/**"],
+      rules: { "no-console": "off" }
+    },
+    { rules: { "no-var": "error" } },
+    { rules: { "no-debugger": "off" } }
+  ]);
+
+  const report = JSON.parse(result.stderr);
+  assert.deepEqual(report.unsupportedRules, ["example/inherited"]);
+  assert.deepEqual(report.inheritedSources, [
+    { name: "./nested.json", filePath: realpathSync(nestedConfig) },
+    { name: "./relative.cjs", filePath: realpathSync(relativeConfig) },
+    { name: "eslint-config-company", filePath: realpathSync(companyConfig) },
+    { name: "plugin:demo/recommended", filePath: realpathSync(pluginConfig) }
+  ]);
+  assert.deepEqual(report.unsupportedInheritedRules, [
+    {
+      ruleId: "example/inherited",
+      sourceName: "eslint-config-company",
+      sourcePath: realpathSync(companyConfig)
+    }
+  ]);
+});
+
+test("migrator resolves plugins from the extending shareable config", (t) => {
+  const project = createProject(t);
+  const configDirectory = join(project, "node_modules", "eslint-config-local-plugin");
+  const configPath = write(
+    join(configDirectory, "index.cjs"),
+    'module.exports = { extends: "plugin:private/recommended" };\n'
+  );
+  write(
+    join(configDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-local-plugin", main: "index.cjs" })
+  );
+  const pluginDirectory = join(configDirectory, "node_modules", "eslint-plugin-private");
+  const pluginPath = write(
+    join(pluginDirectory, "index.cjs"),
+    'module.exports = { configs: { recommended: { rules: { "no-alert": "error" } } } };\n'
+  );
+  write(
+    join(pluginDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-plugin-private", main: "index.cjs" })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({ extends: "local-plugin" })
+  );
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const { $schema, ...migratedConfig } = JSON.parse(migration.stdout);
+  assert.equal($schema.endsWith("/schema.json"), true);
+  assert.deepEqual(migratedConfig, { rules: { "no-alert": "error" } });
+  assert.deepEqual(JSON.parse(migration.stderr).inheritedSources, [
+    { name: "eslint-config-local-plugin", filePath: realpathSync(configPath) },
+    { name: "plugin:private/recommended", filePath: realpathSync(pluginPath) }
+  ]);
+});
+
+test("migrator discovers CommonJS eslintrc files and resolves their extends", (t) => {
+  const project = createProject(t);
+  const baseConfig = write(
+    join(project, "base.json"),
+    JSON.stringify({ rules: { "no-console": "warn" } })
+  );
+  write(
+    join(project, ".eslintrc.cjs"),
+    'module.exports = { extends: "./base.json", rules: { "no-debugger": "error" } };\n'
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).slice(1), [
+    { rules: { "no-console": "warn" } },
+    { rules: { "no-debugger": "error" } }
+  ]);
+  assert.deepEqual(JSON.parse(result.stderr).inheritedSources, [
+    { name: "./base.json", filePath: realpathSync(baseConfig) }
+  ]);
+});
+
+test("migrator rebases classic selectors to a descendant output directory", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [{
+        files: "packages/app/**/*.js",
+        excludedFiles: "packages/app/generated/**",
+        rules: { "no-console": "error" }
+      }]
+    })
+  );
+  const appDirectory = join(project, "packages", "app");
+  mkdirSync(appDirectory, { recursive: true });
+  const outputPath = join(appDirectory, "utlint.config.json");
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--output=${outputPath}`],
+    { cwd: appDirectory, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const { $schema, ...migratedConfig } = JSON.parse(readFileSync(outputPath, "utf8"));
+  assert.equal($schema.endsWith("/schema.json"), true);
+  assert.deepEqual(migratedConfig, {
+    files: ["**/*.js"],
+    ignores: ["generated/**"],
+    rules: { "no-console": "error" }
+  });
+
+  const matchingSource = write(join(appDirectory, "src", "index.js"), "console.log('matched');\n");
+  write(join(appDirectory, "generated", "invalid.js"), "const = ;\n");
+  const options = { cwd: appDirectory, binary: testBinary(), encoding: "utf8" };
+
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json"], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: matchingSource, ruleId: "no-console" }]
+    );
+  }
+});
+
+test("migrator preserves rebased absolute and negated classic ignores", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      ignorePatterns: [
+        "dist/**",
+        "!dist/keep.js",
+        "packages/app/build/**",
+        "!packages/app/build/keep.js",
+        "packages/app/foo*/**",
+        "!packages/app/foo[12]/keep.js"
+      ],
+      rules: { "no-console": "error" }
+    })
+  );
+  const appDirectory = join(project, "packages", "app");
+  mkdirSync(appDirectory, { recursive: true });
+  const outputPath = join(appDirectory, "utlint.config.json");
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--output=${outputPath}`],
+    { cwd: appDirectory, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const migratedConfig = JSON.parse(readFileSync(outputPath, "utf8"));
+  const ignoreEntry = migratedConfig.find((entry) => entry.ignores);
+  assert.deepEqual(ignoreEntry.ignores, [
+    join(realpathSync(project), "dist", "**"),
+    `!${join(realpathSync(project), "dist", "keep.js")}`,
+    "build/**",
+    "!build/keep.js",
+    "foo*/**",
+    "!foo[12]/keep.js"
+  ]);
+
+  const ignoredSource = write(join(project, "dist", "drop.js"), "console.log('ignored');\n");
+  const keptSource = write(join(project, "dist", "keep.js"), "console.log('kept');\n");
+  const canonicalIgnoredSource = realpathSync(ignoredSource);
+  const canonicalKeptSource = realpathSync(keptSource);
+  write(join(appDirectory, "build", "drop.js"), "console.log('ignored');\n");
+  const defaultKeptSource = write(join(appDirectory, "build", "keep.js"), "console.log('kept');\n");
+  write(join(appDirectory, "foo1", "drop.js"), "console.log('ignored');\n");
+  const globKeptSource = write(join(appDirectory, "foo1", "keep.js"), "console.log('kept');\n");
+  const options = { cwd: appDirectory, binary: testBinary(), encoding: "utf8" };
+
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json", `--config=${outputPath}`, canonicalIgnoredSource, canonicalKeptSource], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics
+        .filter(({ ruleId }) => ruleId)
+        .map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: canonicalKeptSource, ruleId: "no-console" }]
+    );
+
+    const defaultLint = execute(["--json", `--config=${outputPath}`], options);
+    assert.equal(defaultLint.status, 1, `${name}: ${defaultLint.stderr}\n${defaultLint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(defaultLint.stdout).diagnostics
+        .filter(({ ruleId }) => ruleId)
+        .map(({ filePath, ruleId }) => ({ filePath, ruleId }))
+        .sort((left, right) => left.filePath.localeCompare(right.filePath)),
+      [
+        { filePath: defaultKeptSource, ruleId: "no-console" },
+        { filePath: globKeptSource, ruleId: "no-console" }
+      ].sort((left, right) => left.filePath.localeCompare(right.filePath))
+    );
+  }
+});
+
+test("migrator preserves AND semantics for nested classic override extends", (t) => {
+  const project = createProject(t);
+  const packageDirectory = join(project, "node_modules", "eslint-config-scoped");
+  write(
+    join(packageDirectory, "index.json"),
+    JSON.stringify({
+      overrides: [{
+        files: ["**/*.js", "**/*.cjs"],
+        excludedFiles: "**/generated/**",
+        rules: { "no-console": "error" }
+      }]
+    })
+  );
+  write(
+    join(packageDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-scoped", main: "index.json" })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [{
+        files: ["src/**", "lib/**"],
+        extends: "scoped"
+      }]
+    })
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const { $schema, ...config } = JSON.parse(result.stdout);
+  assert.equal($schema.endsWith("/schema.json"), true);
+  assert.deepEqual(config, {
+    files: [
+      ["src/**", "**/*.js"],
+      ["src/**", "**/*.cjs"],
+      ["lib/**", "**/*.js"],
+      ["lib/**", "**/*.cjs"]
+    ],
+    ignores: ["**/generated/**"],
+    rules: { "no-console": "error" }
+  });
+
+  write(join(project, "utlint.config.json"), result.stdout);
+  const matchingSource = write(join(project, "src", "index.js"), "console.log('matched');\n");
+  write(join(project, "src", "invalid.ts"), "const = ;\n");
+  write(join(project, "src", "generated", "invalid.js"), "const = ;\n");
+  write(join(project, "test", "invalid.js"), "const = ;\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json"], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    const report = JSON.parse(lint.stdout);
+    assert.deepEqual(report.filePaths, [matchingSource]);
+    assert.deepEqual(
+      report.diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: matchingSource, ruleId: "no-console" }]
+    );
+  }
+});
+
+test("migrator preserves inherited rule options and classic basename override globs", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "base.json"),
+    JSON.stringify({ rules: { "no-console": ["error", { allow: ["warn"] }] } })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      extends: "./base.json",
+      rules: { "no-console": "warn" },
+      overrides: [
+        { files: "*.js", rules: { "no-debugger": "warn" } },
+        { files: "./*.cjs", rules: { "no-alert": "warn" } },
+        { files: "**/*.js", excludedFiles: "test/*.js", rules: { "no-alert": "error" } }
+      ]
+    })
+  );
+  const outputPath = join(project, "utlint.config.json");
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, `--output=${outputPath}`],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  assert.deepEqual(JSON.parse(readFileSync(outputPath, "utf8")).slice(1), [
+    { rules: { "no-console": ["error", { allow: ["warn"] }] } },
+    { rules: { "no-console": "warn" } },
+    { files: ["**/*.js"], rules: { "no-debugger": "warn" } },
+    { files: ["*.cjs"], rules: { "no-alert": "warn" } },
+    { files: ["**/*.js"], ignores: ["test/*.js"], rules: { "no-alert": "error" } }
+  ]);
+
+  const nestedJavaScript = write(join(project, "src", "index.js"), "console.warn('ok');\ndebugger;\n");
+  const rootCommonJS = write(join(project, "index.cjs"), "alert('root');\n");
+  const nestedCommonJS = write(join(project, "src", "index.cjs"), "alert('nested');\n");
+  const rootTest = write(join(project, "test", "example.js"), "alert('excluded');\n");
+  const nestedTest = write(join(project, "src", "test", "example.js"), "alert('included');\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const lint = execute(["--json", nestedJavaScript, rootCommonJS, nestedCommonJS, rootTest, nestedTest], options);
+    assert.equal(lint.status, 1, lint.stderr);
+    const diagnostics = JSON.parse(lint.stdout).diagnostics
+      .map(({ filePath, ruleId, severity }) => ({ filePath, ruleId, severity }))
+      .sort((left, right) => left.filePath.localeCompare(right.filePath));
+    assert.deepEqual(
+      diagnostics,
+      [
+        { filePath: nestedJavaScript, ruleId: "no-debugger", severity: "warning" },
+        { filePath: rootCommonJS, ruleId: "no-alert", severity: "warning" },
+        { filePath: nestedTest, ruleId: "no-alert", severity: "error" }
+      ].sort((left, right) => left.filePath.localeCompare(right.filePath))
+    );
+  }
+});
+
+test("migrated unscoped rules keep project-wide default lint coverage", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      rules: { "no-console": "error" },
+      overrides: [{ files: "tests/**/*.js", rules: { "no-alert": "error" } }]
+    })
+  );
+  const outputPath = join(project, "utlint.config.json");
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, `--output=${outputPath}`],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const sourcePath = write(join(project, "src", "app.ts"), "console.log('covered');\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json"], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: sourcePath, ruleId: "no-console" }]
+    );
+  }
+});
+
+test("migrator propagates inherited scoped ignores to child override rules", (t) => {
+  const project = createProject(t);
+  const packageDirectory = join(project, "node_modules", "eslint-config-ignore-generated");
+  write(
+    join(packageDirectory, "index.json"),
+    JSON.stringify({
+      ignorePatterns: ["generated.js"],
+      rules: { "no-console": "error" }
+    })
+  );
+  write(
+    join(packageDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-ignore-generated", main: "index.json" })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [
+        {
+          files: "src/**/*.js",
+          extends: "ignore-generated",
+          rules: { "no-debugger": "error" }
+        },
+        {
+          files: "src/**/*.js",
+          rules: { "no-alert": "error" }
+        }
+      ]
+    })
+  );
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  assert.deepEqual(JSON.parse(migration.stdout).slice(1), [
+    {
+      files: ["src/**/*.js"],
+      ignores: ["generated.js"],
+      rules: { "no-console": "error" }
+    },
+    {
+      files: ["src/**/*.js"],
+      ignores: ["generated.js"],
+      rules: { "no-debugger": "error" }
+    },
+    {
+      files: ["src/**/*.js"],
+      rules: { "no-alert": "error" }
+    }
+  ]);
+
+  write(join(project, "utlint.config.json"), migration.stdout);
+  const generatedSource = write(
+    join(project, "src", "generated.js"),
+    "console.log('ignored in first chain');\ndebugger;\nalert('active sibling');\n"
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json", generatedSource], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: generatedSource, ruleId: "no-alert" }]
+    );
+  }
+});
+
+test("migrator isolates ignores between nested sibling override chains", (t) => {
+  const project = createProject(t);
+  const ignoredPackageDirectory = join(project, "node_modules", "eslint-config-nested-ignore");
+  write(
+    join(ignoredPackageDirectory, "index.json"),
+    JSON.stringify({ ignorePatterns: ["generated.js"], rules: { "no-console": "error" } })
+  );
+  write(
+    join(ignoredPackageDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-nested-ignore", main: "index.json" })
+  );
+  const nestedPackageDirectory = join(project, "node_modules", "eslint-config-nested-overrides");
+  write(
+    join(nestedPackageDirectory, "index.json"),
+    JSON.stringify({
+      overrides: [
+        {
+          files: "**/*.test.js",
+          extends: "nested-ignore",
+          rules: { "no-debugger": "error" }
+        },
+        {
+          files: "**/*.js",
+          rules: { "no-alert": "error" }
+        }
+      ]
+    })
+  );
+  write(
+    join(nestedPackageDirectory, "package.json"),
+    JSON.stringify({ name: "eslint-config-nested-overrides", main: "index.json" })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [{ files: "src/**", extends: "nested-overrides" }]
+    })
+  );
+  const outputPath = join(project, "utlint.config.json");
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, `--output=${outputPath}`],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const generatedSource = write(join(project, "src", "generated.js"), "alert('active sibling');\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json", generatedSource], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: generatedSource, ruleId: "no-alert" }]
+    );
+  }
+});
+
+test("migrator does not report inherited unsupported rules disabled by the child", (t) => {
+  const project = createProject(t);
+  const baseConfig = write(
+    join(project, "base.json"),
+    JSON.stringify({
+      rules: {
+        "example/disabled-by-child": "error",
+        "example/still-enabled": "error"
+      }
+    })
+  );
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      extends: "./base.json",
+      rules: { "example/disabled-by-child": "off" }
+    })
+  );
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 1, migration.stderr);
+  const report = JSON.parse(migration.stderr);
+  assert.deepEqual(report.unsupportedRules, ["example/still-enabled"]);
+  assert.deepEqual(report.unsupportedInheritedRules, [{
+    ruleId: "example/still-enabled",
+    sourceName: "./base.json",
+    sourcePath: realpathSync(baseConfig)
+  }]);
+});
+
+test("migrator applies scoped unsupported-rule disables by coverage", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [
+        { files: "src/**/*.js", rules: { "example/disabled-broadly": "error" } },
+        { files: "**/*.ts", rules: { "example/still-enabled": "error" } },
+        { files: "**/*.js", rules: { "example/disabled-broadly": "off" } },
+        { files: "src/**/*.ts", rules: { "example/still-enabled": "off" } }
+      ]
+    })
+  );
+
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, "--print", "--report=json"],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 1, migration.stderr);
+  const report = JSON.parse(migration.stderr);
+  assert.deepEqual(report.unsupportedRules, ["example/still-enabled"]);
+  assert.deepEqual(report.unsupportedInheritedRules, []);
+});
+
+test("migrator reports circular and unresolvable classic extends", (t) => {
+  const cycleProject = createProject(t);
+  const cycleConfig = write(
+    join(cycleProject, ".eslintrc.json"),
+    JSON.stringify({ extends: "./cycle-a.json" })
+  );
+  write(
+    join(cycleProject, "cycle-a.json"),
+    JSON.stringify({ extends: "./cycle-b.json" })
+  );
+  write(
+    join(cycleProject, "cycle-b.json"),
+    JSON.stringify({ extends: "./cycle-a.json" })
+  );
+
+  const cycle = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${cycleConfig}`, "--print"],
+    { cwd: cycleProject, encoding: "utf8" }
+  );
+  assert.equal(cycle.status, 2, cycle.stderr);
+  assert.equal(cycle.stdout, "");
+  assert.match(cycle.stderr, /Circular ESLint extends chain detected: \.\/cycle-a\.json -> \.\/cycle-b\.json -> \.\/cycle-a\.json/u);
+
+  const missingProject = createProject(t);
+  const missingConfig = write(
+    join(missingProject, ".eslintrc.json"),
+    JSON.stringify({ extends: "missing-shareable" })
+  );
+  const missing = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${missingConfig}`, "--print"],
+    { cwd: missingProject, encoding: "utf8" }
+  );
+  assert.equal(missing.status, 2, missing.stderr);
+  assert.equal(missing.stdout, "");
+  assert.match(missing.stderr, /Failed to load config "missing-shareable" to extend from/u);
+  assert.match(missing.stderr, /Referenced from:/u);
 });
 
 test("migrator config stdout does not corrupt its serialized input", (t) => {
@@ -1659,6 +2314,32 @@ test("flat config rule options are applied to the matching files", (t) => {
   assert.equal(result.status, 1, result.stderr);
   assert.doesNotMatch(result.stderr, /src\/index\.ts/);
   assert.match(result.stderr, /test\/index\.ts/);
+});
+
+test("ESM and CommonJS flat config nested file selectors use AND semantics", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify([
+      { rules: { "no-console": "off" } },
+      { files: [["src/**", "**/*.js"]], rules: { "no-console": "error" } }
+    ])
+  );
+  const matchingSource = write(join(project, "src", "index.js"), "console.log(1);\n");
+  const wrongExtension = write(join(project, "src", "index.ts"), "console.log(1);\n");
+  const wrongDirectory = write(join(project, "test", "index.js"), "console.log(1);\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", matchingSource, wrongExtension, wrongDirectory], options);
+    const report = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 1, result.stderr);
+    assert.deepEqual(
+      report.diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [{ filePath: matchingSource, ruleId: "no-console" }]
+    );
+  }
 });
 
 test("flat config autofixes only files whose matched config enables the rule", (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
     devDependencies:
       dumi:
         specifier: 2.4.49
-        version: 2.4.49(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+        version: 2.4.49(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       playwright:
         specifier: 1.62.1
         version: 1.62.1
@@ -114,6 +114,12 @@ importers:
 
   npm/utoo-lint:
     dependencies:
+      '@eslint/eslintrc':
+        specifier: 2.1.4
+        version: 2.1.4
+      '@eslint/js':
+        specifier: 8.57.1
+        version: 8.57.1
       jiti:
         specifier: 2.7.0
         version: 2.7.0
@@ -981,6 +987,10 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@eslint/js@10.0.1':
     resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -989,6 +999,10 @@ packages:
     peerDependenciesMeta:
       eslint:
         optional: true
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -3983,6 +3997,10 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -4302,6 +4320,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -6808,6 +6830,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
 
@@ -6984,6 +7010,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -8012,9 +8042,25 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.3.2
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))':
     optionalDependencies:
       eslint: 10.4.1(jiti@2.7.0)
+
+  '@eslint/js@8.57.1': {}
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -9372,10 +9418,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-utoopack@4.7.8(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
+  '@umijs/bundler-utoopack@4.7.8(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
     dependencies:
       '@umijs/bundler-utils': 4.7.8
-      '@umijs/bundler-webpack': 4.7.8(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-webpack': 4.7.8(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@utoo/pack': 1.5.11(less-loader@11.1.0(less@4.1.3)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)))(less@4.1.3)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
@@ -9405,11 +9451,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@umijs/bundler-vite@4.7.8(@types/node@26.3.0)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.4.31)(rollup@4.63.1)(sass@1.103.1)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
+  '@umijs/bundler-vite@4.7.8(@types/node@26.3.0)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.4.31)(rollup@4.63.1)(sass@1.103.1)(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
     dependencies:
       '@svgr/core': 6.5.1
       '@umijs/bundler-utils': 4.7.8
-      '@umijs/bundler-webpack': 4.7.8(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-webpack': 4.7.8(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/utils': 4.7.8
       '@vitejs/plugin-react': 5.2.0(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.103.1)(terser@5.49.0))
       core-js: 3.34.0
@@ -9442,7 +9488,7 @@ snapshots:
       - webpack-plugin-serve
       - yaml
 
-  '@umijs/bundler-webpack@4.7.8(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
+  '@umijs/bundler-webpack@4.7.8(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
     dependencies:
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
@@ -9452,7 +9498,7 @@ snapshots:
       '@umijs/bundler-utils': 4.7.8
       '@umijs/case-sensitive-paths-webpack-plugin': 1.0.1
       '@umijs/mfsu': 4.7.8
-      '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@0.20.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/utils': 4.7.8
       cors: 2.8.6
       css-loader: 6.7.1(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
@@ -9571,7 +9617,7 @@ snapshots:
       '@umijs/utils': 4.7.8
       tsx: 3.12.2
 
-  '@umijs/preset-umi@4.7.8(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
+  '@umijs/preset-umi@4.7.8(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
     dependencies:
       '@iconify/utils': 2.1.1
       '@stagewise/toolbar': 0.6.2
@@ -9581,9 +9627,9 @@ snapshots:
       '@umijs/bundler-esbuild': 4.7.8
       '@umijs/bundler-mako': 0.11.10(postcss@8.4.31)(sass@1.103.1)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/bundler-utils': 4.7.8
-      '@umijs/bundler-utoopack': 4.7.8(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
-      '@umijs/bundler-vite': 4.7.8(@types/node@26.3.0)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.4.31)(rollup@4.63.1)(sass@1.103.1)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
-      '@umijs/bundler-webpack': 4.7.8(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-utoopack': 4.7.8(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-vite': 4.7.8(@types/node@26.3.0)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.4.31)(rollup@4.63.1)(sass@1.103.1)(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-webpack': 4.7.8(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/core': 4.7.8
       '@umijs/did-you-know': 1.0.4
       '@umijs/history': 5.3.1
@@ -9640,7 +9686,7 @@ snapshots:
       - webpack-plugin-serve
       - yaml
 
-  '@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
+  '@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@0.20.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -9653,6 +9699,8 @@ snapshots:
       schema-utils: 3.3.0
       source-map: 0.7.6
       webpack: 5.109.2(lightningcss@1.22.1)(postcss@8.4.31)
+    optionalDependencies:
+      type-fest: 0.20.2
 
   '@umijs/renderer-react@4.7.8(patch_hash=e7c268e2f439046ec5bd5bac17ab8441dac5680813fa2a66d92fad9f72793011)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9935,6 +9983,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
 
   acorn@8.17.0: {}
 
@@ -10925,7 +10977,7 @@ snapshots:
 
   dumi-assets-types@2.4.14: {}
 
-  dumi@2.4.49(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)):
+  dumi@2.4.49(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)):
     dependencies:
       '@ant-design/icons-svg': 4.5.0
       '@makotot/ghostui': 2.0.0(react@18.3.1)
@@ -10990,7 +11042,7 @@ snapshots:
       sass: 1.103.1
       sitemap: 7.1.3
       sucrase: 3.35.1
-      umi: 4.7.8(@babel/core@7.29.7)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      umi: 4.7.8(@babel/core@7.29.7)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       unified: 10.1.2
       unist-util-visit: 4.1.2
       unist-util-visit-parents: 5.1.3
@@ -11369,6 +11421,12 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
 
@@ -11769,6 +11827,10 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
 
   globalthis@1.0.4:
     dependencies:
@@ -14770,6 +14832,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@3.1.1: {}
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -14948,6 +15012,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.20.2: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -15026,13 +15092,13 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
-  umi@4.7.8(@babel/core@7.29.7)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)):
+  umi@4.7.8(@babel/core@7.29.7)(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31)):
     dependencies:
       '@babel/runtime': 7.23.6
       '@umijs/bundler-utils': 4.7.8
-      '@umijs/bundler-webpack': 4.7.8(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/bundler-webpack': 4.7.8(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/core': 4.7.8
-      '@umijs/preset-umi': 4.7.8(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
+      '@umijs/preset-umi': 4.7.8(@types/node@26.3.0)(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@4.63.1)(sass@1.103.1)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@7.0.2)(webpack@5.109.2(lightningcss@1.22.1)(postcss@8.4.31))
       '@umijs/renderer-react': 4.7.8(patch_hash=e7c268e2f439046ec5bd5bac17ab8441dac5680813fa2a66d92fad9f72793011)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@umijs/server': 4.7.8
       '@umijs/test': 4.7.8(@babel/core@7.29.7)


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Closes #1151.

- resolve classic ESLint `extends` chains with ESLint's official legacy config resolver
- preserve relative, shareable-package, plugin-preset, nested override, file, and ignore semantics in migration output
- report inherited config sources and unsupported inherited rules, with actionable cycle and resolution errors
- support ESLint flat-config AND selectors in the utoo config schema and both Node entry points


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- [x] `pnpm --dir npm/utoo-lint test`
- [x] `pnpm docs:build`
- [x] `npm pack --dry-run --ignore-scripts` from `npm/utoo-lint`
