### PR TITLE
fix: complete eslint migration review follow-ups

### DIFF
--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -127,9 +127,12 @@ and arrays of `extends` values retain their ESLint order. Nested inherited
 rules and overrides become ordered utoo config entries; `files`,
 `excludedFiles`, and `ignorePatterns` become the corresponding scoped selectors
 and global ignores. These patterns are rebased to the output config directory,
-including when an ancestor `.eslintrc` is discovered. Circular chains and missing configs stop migration with the
-extends chain or referring config in the error instead of producing partial
-output.
+including when an ancestor `.eslintrc` is discovered. Literal-choice extglobs
+such as `**/*.@(js|ts)` are expanded to native selector alternatives. Extglob
+forms that cannot be represented safely stop migration with an actionable error
+instead of silently changing file coverage. Circular chains and missing configs
+likewise stop migration with the extends chain or referring config in the error
+instead of producing partial output.
 
 The migrator translates the following reviewed aliases when their behavior has
 a native equivalent. These mappings are semantic compatibility decisions, not

--- a/docs/eslint-migration.zh-CN.md
+++ b/docs/eslint-migration.zh-CN.md
@@ -83,7 +83,7 @@ npx utoo-lint migrate eslint --print --report=json
 
 flat config 输出以一个 Schema 元数据配置项开始，后面依次是迁移后的配置项。匹配项按数组顺序应用，因此同一规则后出现的值仍会保留 ESLint 的覆盖行为。
 
-对于 `.eslintrc`、`.eslintrc.json`、`.eslintrc.js` 和 `.eslintrc.cjs`，迁移器会先使用 ESLint 的 classic config 解析器展开配置，再进行转换。相对路径、共享配置包名、`plugin:name/preset` 引用及 `extends` 数组都会保留 ESLint 的应用顺序。嵌套继承的规则和 overrides 会成为有序的 utoo 配置项；`files`、`excludedFiles` 和 `ignorePatterns` 会分别转换为对应的作用域选择器和全局忽略项。这些模式会相对输出配置目录重新定位，包括从祖先目录发现 `.eslintrc` 的情况。遇到循环链或缺失配置时，迁移会停止，并在错误中给出 extends 链或引用配置，而不会生成不完整输出。
+对于 `.eslintrc`、`.eslintrc.json`、`.eslintrc.js` 和 `.eslintrc.cjs`，迁移器会先使用 ESLint 的 classic config 解析器展开配置，再进行转换。相对路径、共享配置包名、`plugin:name/preset` 引用及 `extends` 数组都会保留 ESLint 的应用顺序。嵌套继承的规则和 overrides 会成为有序的 utoo 配置项；`files`、`excludedFiles` 和 `ignorePatterns` 会分别转换为对应的作用域选择器和全局忽略项。这些模式会相对输出配置目录重新定位，包括从祖先目录发现 `.eslintrc` 的情况。`**/*.@(js|ts)` 这类仅包含字面选项的 extglob 会展开为原生选择器备选项；无法安全表示的 extglob 会给出可操作的错误并停止迁移，避免静默改变文件范围。遇到循环链或缺失配置时，迁移同样会停止，并在错误中给出 extends 链或引用配置，而不会生成不完整输出。
 
 当下列经过审核的别名存在原生等价行为时，迁移器会进行转换。这些映射是语义兼容性决策，而不只是字符串重命名：每条源规则只有在与目标规则已经实现的行为及所支持的选项完成核对后，才会加入此表。
 

--- a/npm/utoo-lint/bin/migrate.js
+++ b/npm/utoo-lint/bin/migrate.js
@@ -451,8 +451,12 @@ function classicSelector(criteria) {
   const includeGroups = [];
   const ignores = [];
   for (const patternGroup of criteria.patterns) {
-    includeGroups.push(uniquePatterns((patternGroup.includes ?? []).map(classicIncludePattern)));
-    ignores.push(...(patternGroup.excludes ?? []).map(classicExcludePattern));
+    includeGroups.push(uniquePatterns(
+      (patternGroup.includes ?? []).flatMap((matcher) => expandClassicExtglobs(classicIncludePattern(matcher)))
+    ));
+    ignores.push(...(patternGroup.excludes ?? []).flatMap(
+      (matcher) => expandClassicExtglobs(classicExcludePattern(matcher))
+    ));
   }
   const files = classicFileSelectors(includeGroups);
 
@@ -472,6 +476,36 @@ function classicExcludePattern(matcher) {
   return matcher.options?.matchBase === false && !matcher.pattern.includes("/")
     ? `/${matcher.pattern}`
     : matcher.pattern;
+}
+
+function expandClassicExtglobs(pattern) {
+  let expansions = [pattern];
+  while (expansions.some((value) => /@\([^()]*\)/u.test(value))) {
+    expansions = expansions.flatMap((value) => {
+      const match = /@\(([^()]*)\)/u.exec(value);
+      if (!match) {
+        return value;
+      }
+      const alternatives = match[1].split("|");
+      if (alternatives.some((alternative) => !alternative || /[*?[\]{}()]/u.test(alternative))) {
+        throw unsupportedClassicExtglobError(pattern);
+      }
+      return alternatives.map((alternative) =>
+        `${value.slice(0, match.index)}${alternative}${value.slice(match.index + match[0].length)}`
+      );
+    });
+  }
+  if (/[?+*!@]\(/u.test(expansions[0])) {
+    throw unsupportedClassicExtglobError(pattern);
+  }
+  return uniquePatterns(expansions);
+}
+
+function unsupportedClassicExtglobError(pattern) {
+  return new Error(
+    `utoo-lint migrate eslint: cannot migrate classic selector pattern "${pattern}": ` +
+    "only literal @(one|two) extglob alternatives are supported"
+  );
 }
 
 function classicFileSelectors(includeGroups) {
@@ -503,41 +537,51 @@ function migrationRuleScope(entry) {
 
 function removeDisabledUnsupportedRule(rules, ruleId, entry) {
   const disabledScope = migrationRuleScope(entry);
-  return rules.filter(
-    (rule) => rule.ruleId !== ruleId || !disabledScopeCovers(rule.scope, disabledScope)
-  );
+  const remaining = [];
+  for (const rule of rules) {
+    if (rule.ruleId !== ruleId) {
+      remaining.push(rule);
+      continue;
+    }
+    const scope = subtractDisabledScope(rule.scope, disabledScope);
+    if (scope !== undefined) {
+      remaining.push({ ...rule, scope });
+    }
+  }
+  return remaining;
 }
 
-function disabledScopeCovers(enabledScope, disabledScope) {
+function subtractDisabledScope(enabledScope, disabledScope) {
   if (disabledScope === null) {
-    return true;
+    return undefined;
   }
   if (enabledScope === null) {
-    return false;
+    return enabledScope;
   }
   if (
     disabledScope.ignores.length > 0 &&
     JSON.stringify(enabledScope.ignores) !== JSON.stringify(disabledScope.ignores)
   ) {
-    return false;
+    return enabledScope;
   }
-  return fileSelectorsCover(enabledScope.files, disabledScope.files);
+  if (disabledScope.files.length === 0) {
+    return undefined;
+  }
+  if (enabledScope.files.length === 0) {
+    return enabledScope;
+  }
+
+  const disabledGroups = disabledScope.files.map((selector) => Array.isArray(selector) ? selector : [selector]);
+  const files = enabledScope.files.filter((selector) => {
+    const enabledGroup = Array.isArray(selector) ? selector : [selector];
+    return !disabledGroups.some((disabledGroup) => selectorGroupCovers(enabledGroup, disabledGroup));
+  });
+  return files.length === 0 ? undefined : { ...enabledScope, files };
 }
 
-function fileSelectorsCover(enabledFiles, disabledFiles) {
-  if (disabledFiles.length === 0) {
-    return true;
-  }
-  if (enabledFiles.length === 0) {
-    return false;
-  }
-
-  const enabledGroups = enabledFiles.map((selector) => Array.isArray(selector) ? selector : [selector]);
-  const disabledGroups = disabledFiles.map((selector) => Array.isArray(selector) ? selector : [selector]);
-  return enabledGroups.every((enabledGroup) => disabledGroups.some((disabledGroup) =>
-    disabledGroup.every((disabledPattern) => enabledGroup.some((enabledPattern) =>
-      globPatternCovers(enabledPattern, disabledPattern)
-    ))
+function selectorGroupCovers(enabledGroup, disabledGroup) {
+  return disabledGroup.every((disabledPattern) => enabledGroup.some((enabledPattern) =>
+    globPatternCovers(enabledPattern, disabledPattern)
   ));
 }
 

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -1083,6 +1083,61 @@ test("migrator preserves inherited rule options and classic basename override gl
   }
 });
 
+test("migrator expands representable classic extglobs and rejects unsupported forms", (t) => {
+  const project = createProject(t);
+  const eslintConfig = write(
+    join(project, ".eslintrc.json"),
+    JSON.stringify({
+      overrides: [{ files: "**/*.@(js|ts)", rules: { "no-console": "error" } }]
+    })
+  );
+  const outputPath = join(project, "utlint.config.json");
+  const migration = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${eslintConfig}`, `--output=${outputPath}`],
+    { cwd: project, encoding: "utf8" }
+  );
+
+  assert.equal(migration.status, 0, migration.stderr);
+  const { $schema, ...migratedConfig } = JSON.parse(readFileSync(outputPath, "utf8"));
+  assert.equal($schema.endsWith("/schema.json"), true);
+  assert.deepEqual(migratedConfig, {
+    files: ["**/*.js", "**/*.ts"],
+    rules: { "no-console": "error" }
+  });
+
+  const javaScript = write(join(project, "src", "example.js"), "console.log('js');\n");
+  const typeScript = write(join(project, "src", "example.ts"), "console.log('ts');\n");
+  const jsx = write(join(project, "src", "example.jsx"), "console.log('jsx');\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+  for (const [name, execute] of [["ESM", runCli], ["CommonJS", commonJSRunCli]]) {
+    const lint = execute(["--json", javaScript, typeScript, jsx], options);
+    assert.equal(lint.status, 1, `${name}: ${lint.stderr}\n${lint.stdout}`);
+    assert.deepEqual(
+      JSON.parse(lint.stdout).diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })),
+      [
+        { filePath: javaScript, ruleId: "no-console" },
+        { filePath: typeScript, ruleId: "no-console" }
+      ]
+    );
+  }
+
+  const unsupportedConfig = write(
+    join(project, "unsupported.eslintrc.json"),
+    JSON.stringify({
+      overrides: [{ files: "**/*.!(test).js", rules: { "no-console": "error" } }]
+    })
+  );
+  const unsupported = spawnSync(
+    process.execPath,
+    [cliPath, "migrate", "eslint", `--from=${unsupportedConfig}`, "--print"],
+    { cwd: project, encoding: "utf8" }
+  );
+  assert.equal(unsupported.status, 2, unsupported.stderr);
+  assert.equal(unsupported.stdout, "");
+  assert.match(unsupported.stderr, /cannot migrate classic selector pattern .*only literal @\(one\|two\)/u);
+});
+
 test("migrated unscoped rules keep project-wide default lint coverage", (t) => {
   const project = createProject(t);
   const eslintConfig = write(
@@ -1285,8 +1340,14 @@ test("migrator applies scoped unsupported-rule disables by coverage", (t) => {
       overrides: [
         { files: "src/**/*.js", rules: { "example/disabled-broadly": "error" } },
         { files: "**/*.ts", rules: { "example/still-enabled": "error" } },
+        {
+          files: ["src/**/*.jsx", "test/**/*.jsx"],
+          rules: { "example/disabled-in-parts": "error" }
+        },
         { files: "**/*.js", rules: { "example/disabled-broadly": "off" } },
-        { files: "src/**/*.ts", rules: { "example/still-enabled": "off" } }
+        { files: "src/**/*.ts", rules: { "example/still-enabled": "off" } },
+        { files: "src/**/*.jsx", rules: { "example/disabled-in-parts": "off" } },
+        { files: "test/**/*.jsx", rules: { "example/disabled-in-parts": "off" } }
       ]
     })
   );


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Follow-up to #1168 for #1151.

- accumulate disjoint scoped rule disables before reporting unsupported rules
- expand representable classic extglobs and reject forms that would silently change file coverage
- document the classic extglob migration behavior in English and Chinese


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- [x] `pnpm --dir npm/utoo-lint test`
- [x] `pnpm docs:build`
- [x] `npm pack --dry-run --ignore-scripts` from `npm/utoo-lint`
