### PR TITLE
feat: add jest no-conditional-expect

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -258,6 +258,12 @@ instead of being rewritten.
 | [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | Implemented for fishlint's node resolver extensions, `smallfish:`/`minifish:` ignores, `commonjs`, `amd`, and common `ignore` pattern behavior |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | Implemented for relative imports resolved with fishlint's configured extensions |
 
+## Jest plugin rules
+
+| Rule | Status |
+| --- | --- |
+| [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | Implemented for conditionals, catch clauses, Promise catch callbacks, inline test callbacks, and named test callbacks |
+
 ## Promise plugin rules
 
 | Rule | Status |

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -257,6 +257,12 @@
 | [`import/no-unresolved`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md) | 已实现 fishlint 的 Node 解析器扩展名、`smallfish:`/`minifish:` 忽略、`commonjs`、`amd` 及常见 `ignore` 模式行为 |
 | [`import/no-self-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md) | 已实现对使用 fishlint 已配置扩展名解析的相对导入的检查 |
 
+## Jest 插件规则
+
+| 规则 | 状态 |
+| --- | --- |
+| [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | 已实现条件表达式、`catch` 子句、Promise `catch` 回调、内联测试回调及命名测试回调检查 |
+
 ## Promise 插件规则
 
 | 规则 | 状态 |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -311,6 +311,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-named-as-default-member",
   "import/no-unresolved",
   "import/no-self-import",
+  "jest/no-conditional-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -314,6 +314,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-named-as-default-member",
   "import/no-unresolved",
   "import/no-self-import",
+  "jest/no-conditional-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2550,6 +2550,38 @@ test("CLI --rules enables exactly the requested rules after project config", (t)
   assert.equal(readFileSync(sourcePath, "utf8"), "debugger;\nconsole.log(1);\nfoo();;\n");
 });
 
+test("project config and CLI --rules enable jest/no-conditional-expect", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-conditional-expect": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "conditional.test.js"),
+    "test('conditional', () => { if (enabled) expect(value).toBeDefined(); });\n"
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-conditional-expect", severity: "error" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-conditional-expect", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.deepEqual(isolatedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-conditional-expect", severity: "warning" }
+    ]);
+  }
+});
+
 test("CLI --rules preserves per-file options for the selected flat-config rule", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2759,6 +2759,7 @@ pub const Options = struct {
     import_no_unresolved_commonjs: bool = false,
     import_no_unresolved_ignore: ImportNoUnresolvedIgnorePatterns = .{},
     import_no_self_import: bool = true,
+    jest_no_conditional_expect: bool = true,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_alt_text_img: bool = true,
     jsx_a11y_alt_text_object: bool = true,
@@ -3343,6 +3344,10 @@ pub const Options = struct {
 
         if (std.mem.startsWith(u8, cli_name, "import/")) {
             return self.setByPrefixedRuleName("import_", cli_name["import/".len..], value);
+        }
+
+        if (std.mem.startsWith(u8, cli_name, "jest/")) {
+            return self.setByPrefixedRuleName("jest_", cli_name["jest/".len..], value);
         }
 
         if (std.mem.startsWith(u8, cli_name, "promise/")) {
@@ -10402,6 +10407,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.react_hooks_rules_of_hooks);
     try std.testing.expect(options.setByCliName("react-hooks/rules-of-hooks", true));
     try std.testing.expect(options.react_hooks_rules_of_hooks);
+
+    try std.testing.expect(!options.jest_no_conditional_expect);
+    try std.testing.expect(options.setByCliName("jest/no-conditional-expect", true));
+    try std.testing.expect(options.jest_no_conditional_expect);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -280,6 +280,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_no_named_as_default or
         options.import_no_named_as_default_member or
         options.import_no_unresolved or
+        options.jest_no_conditional_expect or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_no_conditional_expect.zig
+++ b/src/rules/jest_no_conditional_expect.zig
@@ -1,0 +1,312 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+const SymbolId = traverser.semantic.SymbolId;
+const SymbolSet = std.AutoHashMap(SymbolId, void);
+
+pub const id = "jest/no-conditional-expect";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var callback_symbols = SymbolSet.init(allocator);
+    defer callback_symbols.deinit();
+
+    var collector = CallbackCollector{
+        .symbol_table = symbol_table,
+        .callback_symbols = &callback_symbols,
+    };
+    try traverser.basic.traverse(CallbackCollector, tree, &collector);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+        .callback_symbols = &callback_symbols,
+    };
+    defer visitor.function_callback_stack.deinit(allocator);
+    defer visitor.conditional_stack.deinit(allocator);
+
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const CallbackCollector = struct {
+    symbol_table: traverser.semantic.SymbolTable,
+    callback_symbols: *SymbolSet,
+
+    pub fn enter_call_expression(
+        self: *CallbackCollector,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isTestCall(ctx.tree, call)) return .proceed;
+
+        const arguments = ctx.tree.extra(call.arguments);
+        if (arguments.len < 2) return .proceed;
+
+        for (arguments[1..]) |argument| {
+            const identifier = unwrapTransparent(ctx.tree, argument);
+            switch (ctx.tree.data(identifier)) {
+                .identifier_reference => {},
+                else => continue,
+            }
+
+            const reference_id = self.symbol_table.model.referenceOf(identifier) orelse continue;
+            const symbol_id = self.symbol_table.referenceSymbol(reference_id);
+            if (symbol_id != .none) try self.callback_symbols.put(symbol_id, {});
+        }
+
+        return .proceed;
+    }
+};
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+    callback_symbols: *const SymbolSet,
+    function_callback_stack: std.ArrayList(bool) = .empty,
+    conditional_stack: std.ArrayList(ast.NodeIndex) = .empty,
+    test_call_depth: usize = 0,
+    callback_function_depth: usize = 0,
+    in_promise_catch: bool = false,
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        try self.enterFunction(functionSymbol(ctx.tree, self.symbol_table, index, parent, function.id));
+        return .proceed;
+    }
+
+    pub fn exit_function(self: *Visitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitFunction();
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        try self.enterFunction(functionSymbol(ctx.tree, self.symbol_table, index, parent, .null));
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.exitFunction();
+    }
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isTestCall(ctx.tree, call)) self.test_call_depth += 1;
+        if (isCatchCall(ctx.tree, call)) self.in_promise_catch = true;
+
+        if (isExpectCall(ctx.tree, call)) {
+            if (self.inTestCase() and self.conditional_stack.items.len > 0) {
+                try self.report(ctx.tree, index);
+            }
+            if (self.in_promise_catch) {
+                try self.report(ctx.tree, index);
+            }
+        }
+
+        return .proceed;
+    }
+
+    pub fn exit_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (isTestCall(ctx.tree, call)) self.test_call_depth -= 1;
+        if (isCatchCall(ctx.tree, call)) self.in_promise_catch = false;
+    }
+
+    pub fn enter_catch_clause(self: *Visitor, _: ast.CatchClause, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.enterConditional(index);
+    }
+
+    pub fn exit_catch_clause(self: *Visitor, _: ast.CatchClause, index: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitConditional(index);
+    }
+
+    pub fn enter_if_statement(self: *Visitor, _: ast.IfStatement, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.enterConditional(index);
+    }
+
+    pub fn exit_if_statement(self: *Visitor, _: ast.IfStatement, index: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitConditional(index);
+    }
+
+    pub fn enter_switch_statement(self: *Visitor, _: ast.SwitchStatement, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.enterConditional(index);
+    }
+
+    pub fn exit_switch_statement(self: *Visitor, _: ast.SwitchStatement, index: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitConditional(index);
+    }
+
+    pub fn enter_conditional_expression(self: *Visitor, _: ast.ConditionalExpression, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.enterConditional(index);
+    }
+
+    pub fn exit_conditional_expression(self: *Visitor, _: ast.ConditionalExpression, index: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitConditional(index);
+    }
+
+    pub fn enter_logical_expression(self: *Visitor, _: ast.LogicalExpression, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.enterConditional(index);
+    }
+
+    pub fn exit_logical_expression(self: *Visitor, _: ast.LogicalExpression, index: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        self.exitConditional(index);
+    }
+
+    fn enterFunction(self: *Visitor, symbol_id: ?SymbolId) Allocator.Error!void {
+        const is_callback = if (symbol_id) |symbol|
+            symbol != .none and self.callback_symbols.contains(symbol)
+        else
+            false;
+        try self.function_callback_stack.append(self.allocator, is_callback);
+        if (is_callback) self.callback_function_depth += 1;
+    }
+
+    fn exitFunction(self: *Visitor) void {
+        if (self.function_callback_stack.pop()) |was_callback| {
+            if (was_callback) self.callback_function_depth -= 1;
+        }
+    }
+
+    fn enterConditional(self: *Visitor, index: ast.NodeIndex) Allocator.Error!traverser.Action {
+        if (self.inTestCase()) try self.conditional_stack.append(self.allocator, index);
+        return .proceed;
+    }
+
+    fn exitConditional(self: *Visitor, index: ast.NodeIndex) void {
+        if (self.conditional_stack.items.len == 0) return;
+        if (self.conditional_stack.items[self.conditional_stack.items.len - 1] == index) {
+            _ = self.conditional_stack.pop();
+        }
+    }
+
+    fn inTestCase(self: *const Visitor) bool {
+        return self.test_call_depth > 0 or self.callback_function_depth > 0;
+    }
+
+    fn report(self: *Visitor, tree: *const ast.Tree, index: ast.NodeIndex) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            "Avoid calling `expect` conditionally.",
+            tree.span(index),
+        );
+    }
+};
+
+fn functionSymbol(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    parent: ast.NodeIndex,
+    id_node: ast.NodeIndex,
+) ?SymbolId {
+    if (id_node != .null) return symbol_table.symbolOf(id_node);
+
+    return switch (tree.data(parent)) {
+        .variable_declarator => |declarator| if (declarator.init == index) symbol_table.symbolOf(declarator.id) else null,
+        else => null,
+    };
+}
+
+fn isTestCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const source = nodeSource(tree, call.callee);
+    const roots = [_][]const u8{ "test", "xtest", "it", "fit", "xit" };
+
+    for (roots) |root| {
+        if (!std.mem.startsWith(u8, source, root)) continue;
+        if (source.len == root.len) return true;
+        return switch (source[root.len]) {
+            '.', '[', '(' => true,
+            else => false,
+        };
+    }
+    return false;
+}
+
+fn isCatchCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const name = propertyName(tree, member) orelse return false;
+    return std.mem.eql(u8, name, "catch");
+}
+
+fn isExpectCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const name = identifierReferenceName(tree, call.callee) orelse return false;
+    return std.mem.eql(u8, name, "expect");
+}
+
+fn identifierReferenceName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    if (index == .null) return null;
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.property == .null) return null;
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn nodeSource(tree: *const ast.Tree, index: ast.NodeIndex) []const u8 {
+    const span = tree.span(index);
+    if (span.start >= span.end or span.end > tree.source.len) return "";
+    return std.mem.trim(u8, tree.source[span.start..span.end], " \t\r\n");
+}

--- a/src/rules/jest_no_conditional_expect.zig
+++ b/src/rules/jest_no_conditional_expect.zig
@@ -77,7 +77,7 @@ const Visitor = struct {
     conditional_stack: std.ArrayList(ast.NodeIndex) = .empty,
     test_call_depth: usize = 0,
     callback_function_depth: usize = 0,
-    in_promise_catch: bool = false,
+    promise_catch_depth: usize = 0,
 
     pub fn enter_function(
         self: *Visitor,
@@ -121,15 +121,12 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         if (isTestCall(ctx.tree, call)) self.test_call_depth += 1;
-        if (isCatchCall(ctx.tree, call)) self.in_promise_catch = true;
+        if (isCatchCall(ctx.tree, call)) self.promise_catch_depth += 1;
 
-        if (isExpectCall(ctx.tree, call)) {
-            if (self.inTestCase() and self.conditional_stack.items.len > 0) {
-                try self.report(ctx.tree, index);
-            }
-            if (self.in_promise_catch) {
-                try self.report(ctx.tree, index);
-            }
+        if (isExpectCall(ctx.tree, call) and
+            ((self.inTestCase() and self.conditional_stack.items.len > 0) or self.promise_catch_depth > 0))
+        {
+            try self.report(ctx.tree, index);
         }
 
         return .proceed;
@@ -142,7 +139,7 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) void {
         if (isTestCall(ctx.tree, call)) self.test_call_depth -= 1;
-        if (isCatchCall(ctx.tree, call)) self.in_promise_catch = false;
+        if (isCatchCall(ctx.tree, call)) self.promise_catch_depth -= 1;
     }
 
     pub fn enter_catch_clause(self: *Visitor, _: ast.CatchClause, index: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -78,6 +78,7 @@ pub const import_no_named_as_default = @import("import_no_named_as_default.zig")
 pub const import_no_named_as_default_member = @import("import_no_named_as_default_member.zig");
 pub const import_no_unresolved = @import("import_no_unresolved.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
+pub const jest_no_conditional_expect = @import("jest_no_conditional_expect.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -996,6 +997,10 @@ fn runSemanticAfterIo(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.jest_no_conditional_expect) {
+        try jest_no_conditional_expect.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
     if (options.block_scoped_var) {
         try block_scoped_var.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -267,6 +267,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("rules/jest_no_conditional_expect.zig");
+}
+
+comptime {
     _ = @import("rules/jsx_a11y_alt_text.zig");
 }
 

--- a/tests/rules/jest_no_conditional_expect.zig
+++ b/tests/rules/jest_no_conditional_expect.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "reports conditional expects with useful locations" {
+    const source =
+        \\test("conditions", () => {
+        \\  if (first) {
+        \\    if (second) expect(value).toBe(1);
+        \\  }
+        \\  switch (kind) {
+        \\    case "value": expect(value).toBe(2); break;
+        \\  }
+        \\  ready ? expect(value).toBe(3) : noop();
+        \\  enabled && expect(value).toBe(4);
+        \\});
+        \\it.each``("tagged", () => {
+        \\  enabled || expect(value).toBe(5);
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, lint.rules.jest_no_conditional_expect.id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.jest_no_conditional_expect.id)) continue;
+        const reported = source[diagnostic.span.start..diagnostic.span.end];
+        try std.testing.expect(std.mem.startsWith(u8, reported, "expect("));
+        try std.testing.expectEqualStrings("Avoid calling `expect` conditionally.", diagnostic.message);
+    }
+}
+
+test "reports catch clauses and Promise catch callbacks" {
+    const catch_source =
+        \\it("catches", () => {
+        \\  try {
+        \\    work();
+        \\  } catch (error) {
+        \\    expect(error).toBeDefined();
+        \\  }
+        \\});
+    ;
+    var catch_result = try lint.lintSource(std.testing.allocator, catch_source, "fixture.js", optionsOnly());
+    defer catch_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(catch_result, lint.rules.jest_no_conditional_expect.id));
+
+    const promise_source =
+        \\Promise.resolve()
+        \\  .catch(error => expect(error).toBeDefined())
+        \\  .catch(error => expect(error).toBeDefined())
+        \\  .catch(error => expect(error).toBeDefined());
+    ;
+    var promise_result = try lint.lintSource(std.testing.allocator, promise_source, "fixture.js", optionsOnly());
+    defer promise_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(promise_result, lint.rules.jest_no_conditional_expect.id));
+}
+
+test "reports named test callbacks without confusing same-name bindings" {
+    const source =
+        \\function declaredCallback() {
+        \\  if (enabled) expect(value).toBe(1);
+        \\}
+        \\const arrowCallback = () => {
+        \\  enabled && expect(value).toBe(2);
+        \\};
+        \\function unrelated() {
+        \\  if (enabled) expect(value).toBe(3);
+        \\}
+        \\it("declared", declaredCallback);
+        \\test.each([[1]])("arrow", arrowCallback);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.jest_no_conditional_expect.id));
+}
+
+test "allows unconditional expects and conditions that do not contain expects" {
+    const source =
+        \\test("valid", async () => {
+        \\  if (enabled) value = 1;
+        \\  const next = enabled ? 1 : 2;
+        \\  enabled && update();
+        \\  try {
+        \\    await work();
+        \\  } catch (error) {
+        \\    recover(error);
+        \\  } finally {
+        \\    expect(value).toBe(next);
+        \\  }
+        \\  await work().catch(error => error);
+        \\  expect(value).toBeDefined();
+        \\});
+        \\if (outside) expect(value).toBeDefined();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jest_no_conditional_expect.id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "test('js', () => { if (ok) expect(value); });", .file_name = "fixture.js" },
+        .{ .source = "test('ts', () => { const ok: boolean = true; if (ok) expect(value); });", .file_name = "fixture.ts" },
+        .{ .source = "test('jsx', () => { if (ok) expect(<div />); });", .file_name = "fixture.jsx" },
+        .{ .source = "test('tsx', () => { const node: JSX.Element = <div />; if (ok) expect(node); });", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.jest_no_conditional_expect.id));
+    }
+}
+
+test "parses config and can disable jest/no-conditional-expect" {
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer parsed.deinit();
+
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("jest/no-conditional-expect", parsed.value);
+    try std.testing.expect(options.jest_no_conditional_expect);
+
+    options.jest_no_conditional_expect = false;
+    var result = try lint.lintSource(
+        std.testing.allocator,
+        "test('disabled', () => { if (ok) expect(value); });",
+        "fixture.js",
+        options,
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jest_no_conditional_expect.id));
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_conditional_expect = true;
+    return options;
+}

--- a/tests/rules/jest_no_conditional_expect.zig
+++ b/tests/rules/jest_no_conditional_expect.zig
@@ -53,7 +53,18 @@ test "reports catch clauses and Promise catch callbacks" {
     ;
     var promise_result = try lint.lintSource(std.testing.allocator, promise_source, "fixture.js", optionsOnly());
     defer promise_result.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(promise_result, lint.rules.jest_no_conditional_expect.id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(promise_result, lint.rules.jest_no_conditional_expect.id));
+
+    const overlapping_source =
+        \\test("overlap", () => {
+        \\  Promise.reject().catch(error => {
+        \\    if (error) expect(error).toBeDefined();
+        \\  });
+        \\});
+    ;
+    var overlapping_result = try lint.lintSource(std.testing.allocator, overlapping_source, "fixture.js", optionsOnly());
+    defer overlapping_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(overlapping_result, lint.rules.jest_no_conditional_expect.id));
 }
 
 test "reports named test callbacks without confusing same-name bindings" {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- implement native `jest/no-conditional-expect` diagnostics for Jest test callbacks, conditional constructs, catch clauses, and Promise catch callbacks
- resolve named helper callbacks by semantic binding and support JavaScript, TypeScript, JSX, TSX, `test.each()`, and tagged `it.each` forms
- register project-config, `--rules`, ESM/CommonJS wrapper, and rule-status support

Closes #1152

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test` (2040/2040 tests passed)
- `zig build`
- `pnpm --dir npm/utoo-lint test` (104/104 package tests and type checks passed)
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- `pnpm docs:build`
- `./scripts/package-npm.sh`
- `pnpm --dir npm/utoo-lint pack`