### PR TITLE
feat: add jest/no-deprecated-functions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,7 +143,8 @@ does not execute or discover TypeScript. It searches for `utlint.config.json`
 and then the legacy JSON names. Use the npm CLI for `utlint.config.ts`; when
 invoking the raw binary directly, use `utlint.config.json`.
 
-The raw binary applies only the JSON config's `rules`. Config-driven
+The raw binary applies the JSON config's `rules` and supported shared
+`settings`. Config-driven
 `files` and `ignores` filtering, including choosing default lint targets, is an
 npm/Node wrapper feature. Pass lint targets explicitly when invoking the raw
 binary.
@@ -167,6 +168,18 @@ Use `utlint.config.json` for a static, runtime-independent config:
 The optional `$schema` property enables completion and validation in editors
 that support JSON Schema. JSON config cannot contain imports or computed
 values; use `utlint.config.ts` when those are required.
+
+Version-aware Jest rules detect the closest installed `jest` package by
+default and fall back to the latest supported major when no installation can
+be found. Set `settings.jest.version` when a repository uses multiple Jest
+versions or needs to pin the version used for linting:
+
+```json
+{
+  "settings": { "jest": { "version": "29.7.0" } },
+  "rules": { "jest/no-deprecated-functions": "error" }
+}
+```
 
 ESLint config files are a migration input, not the recommended long-term
 configuration format. Generate a native config with:

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -101,7 +101,7 @@ export default defineConfig(
 
 npm 封装层会执行 TypeScript 文件，将其结果转换为 JSON，再把该 JSON 传给原生二进制文件。原生二进制文件本身不会执行或查找 TypeScript 配置。它会查找 `utlint.config.json`，然后再查找旧版 JSON 文件名。对于 `utlint.config.ts`，请使用 npm CLI；直接调用原生二进制文件时，请使用 `utlint.config.json`。
 
-原生二进制文件只会应用 JSON 配置中的 `rules`。由配置驱动的 `files` 和 `ignores` 过滤，以及默认 lint 目标的选择，均由 npm/Node 封装层实现。直接调用原生二进制文件时，请显式传入 lint 目标。
+原生二进制文件会应用 JSON 配置中的 `rules` 以及受支持的共享 `settings`。由配置驱动的 `files` 和 `ignores` 过滤，以及默认 lint 目标的选择，均由 npm/Node 封装层实现。直接调用原生二进制文件时，请显式传入 lint 目标。
 
 ## JSON 配置
 
@@ -120,6 +120,15 @@ npm 封装层会执行 TypeScript 文件，将其结果转换为 JSON，再把�
 ```
 
 可选的 `$schema` 属性可以在支持 JSON Schema 的编辑器中启用补全和验证。JSON 配置不能包含导入或计算值；需要这些能力时，请使用 `utlint.config.ts`。
+
+需要感知版本的 Jest 规则默认会检测距离待检查文件最近的已安装 `jest` 包；未找到安装时会回退到当前支持的最新主版本。如果仓库使用多个 Jest 版本，或需要固定 lint 使用的版本，可显式设置 `settings.jest.version`：
+
+```json
+{
+  "settings": { "jest": { "version": "29.7.0" } },
+  "rules": { "jest/no-deprecated-functions": "error" }
+}
+```
 
 ESLint 配置文件仅作为迁移输入，不是推荐的长期配置格式。可使用以下命令生成原生配置：
 

--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -263,6 +263,7 @@ instead of being rewritten.
 | Rule | Status |
 | --- | --- |
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | Implemented for conditionals, catch clauses, Promise catch callbacks, inline test callbacks, and named test callbacks |
+| [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | Implemented with installed or configured Jest version detection and upstream autofixes |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -262,6 +262,7 @@
 | 规则 | 状态 |
 | --- | --- |
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | 已实现条件表达式、`catch` 子句、Promise `catch` 回调、内联测试回调及命名测试回调检查 |
+| [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | 已实现已安装或显式配置的 Jest 版本检测，并支持上游自动修复 |
 
 ## Promise 插件规则
 

--- a/npm/@utoo/lint-wasm/index.d.ts
+++ b/npm/@utoo/lint-wasm/index.d.ts
@@ -1,6 +1,16 @@
 export type RuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | false | true;
 export type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]];
 
+export interface JestPluginSettings {
+  version?: string | number;
+  [key: string]: unknown;
+}
+
+export interface SharedSettings {
+  jest?: JestPluginSettings;
+  [key: string]: unknown;
+}
+
 export interface LintFix {
   range: [number, number];
   text: string;
@@ -29,6 +39,7 @@ export interface LintOptions {
   filePath?: string;
   filename?: string;
   rules?: Record<string, RuleConfig>;
+  settings?: SharedSettings;
 }
 
 export interface LintResultBase {

--- a/npm/@utoo/lint-wasm/index.js
+++ b/npm/@utoo/lint-wasm/index.js
@@ -64,7 +64,8 @@ function createApi(instance) {
       version: ABI_VERSION,
       filePath: options.filePath ?? options.filename ?? "input.js",
       fix: fix ? "apply" : "none",
-      ...(options.rules === undefined ? {} : { rules: options.rules })
+      ...(options.rules === undefined ? {} : { rules: options.rules }),
+      ...(options.settings === undefined ? {} : { settings: options.settings })
     }));
     assertRequestSize(optionsBytes.length, MAX_OPTIONS_BYTES, "options", "1 MiB");
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -312,6 +312,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-unresolved",
   "import/no-self-import",
   "jest/no-conditional-expect",
+  "jest/no-deprecated-functions",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -459,6 +460,7 @@ const NATIVE_ONLY_RULE_IDS = [
 ];
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
+  "jest/no-deprecated-functions",
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"
@@ -1278,13 +1280,15 @@ function nativeConfigRunsForFiles(paths, options) {
     const fileConfigPath = options.noConfig ? undefined : configPathForFile(options, matchPath);
     const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath);
     hasConfigSource ||= configured;
-    let rules = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath).rules : undefined;
+    const calculated = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath) : {};
+    let rules = calculated.rules;
+    const settings = calculated.settings;
     if (configured && options.rules) {
       rules = selectedRulesWithConfigOptions(rules, options.rules);
     }
-    const signature = configured ? stableConfigSignature(rules) : "<native-defaults>";
+    const signature = configured ? stableConfigSignature({ rules, settings }) : "<native-defaults>";
     if (!groups.has(signature)) {
-      groups.set(signature, { paths: [], rules, configured });
+      groups.set(signature, { paths: [], rules, settings, configured });
     }
     groups.get(signature).paths.push(filePath);
   }
@@ -1314,7 +1318,10 @@ function nativeConfigRunsForFiles(paths, options) {
         config: undefined,
         noConfig: true,
         baseConfig: undefined,
-        overrideConfig: { rules: allDisabledNativeRules(group.rules) },
+        overrideConfig: {
+          rules: allDisabledNativeRules(group.rules),
+          ...(group.settings ? { settings: group.settings } : {})
+        },
         forceMaterializedConfig: true
       }
     };
@@ -1869,7 +1876,15 @@ function withTemporaryConfig(options, callback) {
   const rules = shouldMaterializeFileConfig
     ? materializedRulesFromConfigs(...configs)
     : runtimeRulesFromConfigs(...configs);
-  if (Object.keys(rules).length === 0) {
+  const settings = configs.reduce(
+    (result, config) => ({
+      ...result,
+      ...(configDataFromConfig(config, options.filePath ?? options.filename, options.cwd).settings ?? {})
+    }),
+    {}
+  );
+  const hasSettings = Object.keys(settings).length > 0;
+  if (Object.keys(rules).length === 0 && !hasSettings) {
     if (shouldMaterializeFileConfig) {
       return callback({
         ...options,
@@ -1881,7 +1896,7 @@ function withTemporaryConfig(options, callback) {
   }
   const enabledRules = enabledRuleNamesFromConfigs(...configs);
   const hasExplicitOffRules = Object.values(rules).some((value) => ruleConfigSeverity(value) === 0);
-  if (!shouldMaterializeFileConfig && !hasRuleOptions(rules) && !hasExplicitOffRules && !options.forceMaterializedConfig) {
+  if (!shouldMaterializeFileConfig && !hasSettings && !hasRuleOptions(rules) && !hasExplicitOffRules && !options.forceMaterializedConfig) {
     return callback({
       ...options,
       config: shouldMaterializeFileConfig ? undefined : options.config,
@@ -1893,7 +1908,7 @@ function withTemporaryConfig(options, callback) {
   const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
   const configPath = join(tmp, "utlint.config.json");
   try {
-    writeFileSync(configPath, JSON.stringify({ rules }));
+    writeFileSync(configPath, JSON.stringify({ rules, ...(hasSettings ? { settings } : {}) }));
     return callback({
       ...options,
       config: shouldMaterializeFileConfig ? configPath : options.config ?? configPath,

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -67,13 +67,23 @@ export interface PluginObject {
   [key: string]: unknown;
 }
 
+export interface JestPluginSettings {
+  version?: string | number;
+  [key: string]: unknown;
+}
+
+export interface SharedSettings {
+  jest?: JestPluginSettings;
+  [key: string]: unknown;
+}
+
 export interface ConfigObject {
   name?: string;
   files?: Array<string | string[]>;
   ignores?: string[];
   rules?: Record<string, RuleConfig>;
   plugins?: Record<string, PluginObject>;
-  settings?: Record<string, unknown>;
+  settings?: SharedSettings;
   languageOptions?: {
     parser?: unknown;
     parserOptions?: Record<string, unknown>;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -315,6 +315,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-unresolved",
   "import/no-self-import",
   "jest/no-conditional-expect",
+  "jest/no-deprecated-functions",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -462,6 +463,7 @@ const NATIVE_ONLY_RULE_IDS = [
 ];
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
+  "jest/no-deprecated-functions",
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"
@@ -3167,13 +3169,15 @@ function nativeConfigRunsForFiles(paths, options) {
     const fileConfigPath = options.noConfig ? undefined : configPathForFile(options, matchPath);
     const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath);
     hasConfigSource ||= configured;
-    let rules = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath).rules : undefined;
+    const calculated = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath) : {};
+    let rules = calculated.rules;
+    const settings = calculated.settings;
     if (configured && options.rules) {
       rules = selectedRulesWithConfigOptions(rules, options.rules);
     }
-    const signature = configured ? stableConfigSignature(rules) : "<native-defaults>";
+    const signature = configured ? stableConfigSignature({ rules, settings }) : "<native-defaults>";
     if (!groups.has(signature)) {
-      groups.set(signature, { paths: [], rules, configured });
+      groups.set(signature, { paths: [], rules, settings, configured });
     }
     groups.get(signature).paths.push(filePath);
   }
@@ -3203,7 +3207,10 @@ function nativeConfigRunsForFiles(paths, options) {
         config: undefined,
         noConfig: true,
         baseConfig: undefined,
-        overrideConfig: { rules: allDisabledNativeRules(group.rules) },
+        overrideConfig: {
+          rules: allDisabledNativeRules(group.rules),
+          ...(group.settings ? { settings: group.settings } : {})
+        },
         forceMaterializedConfig: true
       }
     };
@@ -3758,7 +3765,15 @@ function withTemporaryConfig(options, callback) {
   const rules = shouldMaterializeFileConfig
     ? materializedRulesFromConfigs(...configs)
     : runtimeRulesFromConfigs(...configs);
-  if (Object.keys(rules).length === 0) {
+  const settings = configs.reduce(
+    (result, config) => ({
+      ...result,
+      ...(configDataFromConfig(config, options.filePath ?? options.filename, options.cwd).settings ?? {})
+    }),
+    {}
+  );
+  const hasSettings = Object.keys(settings).length > 0;
+  if (Object.keys(rules).length === 0 && !hasSettings) {
     if (shouldMaterializeFileConfig) {
       return callback({
         ...options,
@@ -3770,7 +3785,7 @@ function withTemporaryConfig(options, callback) {
   }
   const enabledRules = enabledRuleNamesFromConfigs(...configs);
   const hasExplicitOffRules = Object.values(rules).some((value) => ruleConfigSeverity(value) === 0);
-  if (!shouldMaterializeFileConfig && !hasRuleOptions(rules) && !hasExplicitOffRules && !options.forceMaterializedConfig) {
+  if (!shouldMaterializeFileConfig && !hasSettings && !hasRuleOptions(rules) && !hasExplicitOffRules && !options.forceMaterializedConfig) {
     return callback({
       ...options,
       config: shouldMaterializeFileConfig ? undefined : options.config,
@@ -3782,7 +3797,7 @@ function withTemporaryConfig(options, callback) {
   const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-config-"));
   const configPath = join(tmp, "utlint.config.json");
   try {
-    writeFileSync(configPath, JSON.stringify({ rules }));
+    writeFileSync(configPath, JSON.stringify({ rules, ...(hasSettings ? { settings } : {}) }));
     return callback({
       ...options,
       config: shouldMaterializeFileConfig ? configPath : options.config ?? configPath,

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -28,6 +28,26 @@
             "$ref": "#/definitions/ruleSeverity"
           }
         },
+        "settings": {
+          "description": "Shared plugin settings.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "jest": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "version": {
+                  "description": "Jest version used by version-aware Jest rules.",
+                  "oneOf": [
+                    { "type": "integer", "minimum": 1 },
+                    { "type": "string", "pattern": "^[0-9]+(?:\\..*)?$" }
+                  ]
+                }
+              }
+            }
+          }
+        },
         "files": {
           "description": "File globs this config entry applies to.",
           "oneOf": [

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2582,6 +2582,91 @@ test("project config and CLI --rules enable jest/no-conditional-expect", (t) => 
   }
 });
 
+test("jest/no-deprecated-functions uses project settings, auto detection, and fixes", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({
+      settings: { jest: { version: "21.4.0" } },
+      rules: { "jest/no-deprecated-functions": "error" }
+    })
+  );
+  write(join(project, "node_modules", "jest", "package.json"), JSON.stringify({ version: "22.2.0" }));
+  const source = [
+    'require.requireActual("module");',
+    "jest.runTimersToTime(1000);",
+    'jest.genMockFromModule("module");',
+    ""
+  ].join("\n");
+  const sourcePath = write(join(project, "deprecated.test.js"), source);
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-deprecated-functions", severity: "error" }
+    ]);
+
+    const selected = execute(["--rules=jest/no-deprecated-functions", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-deprecated-functions", severity: "warning" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-deprecated-functions", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 2);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-deprecated-functions" && severity === "warning"
+    ));
+
+    const dryRun = execute(["--fix-dry-run", "--json", sourcePath], options);
+    const dryRunReport = JSON.parse(dryRun.stdout);
+    assert.equal(dryRun.status, 0, dryRun.stderr);
+    assert.equal(dryRunReport.outputs.length, 1);
+    assert.match(dryRunReport.outputs[0].output, /jest\.requireActual\("module"\)/);
+    assert.equal(readFileSync(sourcePath, "utf8"), source);
+
+    const fixed = execute(["--fix", "--json", sourcePath], options);
+    assert.equal(fixed.status, 0, fixed.stderr);
+    assert.match(readFileSync(sourcePath, "utf8"), /jest\.requireActual\("module"\)/);
+    writeFileSync(sourcePath, source);
+  }
+});
+
+test("flat config keeps Jest version settings scoped per file", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.ts"),
+    [
+      "export default [",
+      '  { files: ["old/**/*.js"], settings: { jest: { version: 21 } }, rules: { "jest/no-deprecated-functions": "error" } },',
+      '  { files: ["new/**/*.js"], settings: { jest: { version: 22 } }, rules: { "jest/no-deprecated-functions": "error" } }',
+      "];",
+      ""
+    ].join("\n")
+  );
+  const oldSource = write(join(project, "old", "fixture.js"), "jest.runTimersToTime(1000);\n");
+  const newSource = write(join(project, "new", "fixture.js"), "jest.runTimersToTime(1000);\n");
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", oldSource, newSource], options);
+    const report = JSON.parse(result.stdout);
+    assert.equal(result.status, 1, result.stderr);
+    assert.deepEqual(report.diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })), [
+      { filePath: newSource, ruleId: "jest/no-deprecated-functions" }
+    ]);
+  }
+});
+
 test("CLI --rules preserves per-file options for the selected flat-config rule", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2760,6 +2760,8 @@ pub const Options = struct {
     import_no_unresolved_ignore: ImportNoUnresolvedIgnorePatterns = .{},
     import_no_self_import: bool = true,
     jest_no_conditional_expect: bool = true,
+    jest_no_deprecated_functions: bool = true,
+    jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_alt_text_img: bool = true,
     jsx_a11y_alt_text_object: bool = true,
@@ -4191,6 +4193,27 @@ pub const Options = struct {
         }
     }
 
+    pub fn setJestVersionFromConfig(self: *Options, value: std.json.Value) RuleConfigError!void {
+        self.jest_version = switch (value) {
+            .integer => |version| if (version > 0 and version <= std.math.maxInt(u32))
+                @intCast(version)
+            else
+                return error.InvalidJestVersion,
+            .string => |version| blk: {
+                const separator = std.mem.indexOfScalar(u8, version, '.') orelse version.len;
+                const major = version[0..separator];
+                if (major.len == 0) return error.InvalidJestVersion;
+                for (major) |char| {
+                    if (!std.ascii.isDigit(char)) return error.InvalidJestVersion;
+                }
+                const parsed = std.fmt.parseUnsigned(u32, major, 10) catch return error.InvalidJestVersion;
+                if (parsed == 0) return error.InvalidJestVersion;
+                break :blk parsed;
+            },
+            else => return error.InvalidJestVersion,
+        };
+    }
+
     pub fn severityFromRuleConfigValue(value: std.json.Value) RuleConfigError!?Severity {
         return switch (value) {
             .bool => |enabled| if (enabled) .@"error" else null,
@@ -4224,6 +4247,7 @@ pub const Options = struct {
 
     pub const RuleConfigError = error{
         EmptyRuleConfigArray,
+        InvalidJestVersion,
         UnknownRule,
         UnsupportedRuleConfigValue,
     };
@@ -10411,6 +10435,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_conditional_expect);
     try std.testing.expect(options.setByCliName("jest/no-conditional-expect", true));
     try std.testing.expect(options.jest_no_conditional_expect);
+
+    try std.testing.expect(!options.jest_no_deprecated_functions);
+    try std.testing.expect(options.setByCliName("jest/no-deprecated-functions", true));
+    try std.testing.expect(options.jest_no_deprecated_functions);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,7 +163,9 @@ pub fn main(init: std.process.Init) !void {
                 std.process.exit(2);
             };
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
+            const jest_version = options.jest_version;
             options = lint.Options.allDisabled();
+            options.jest_version = jest_version;
             clearRuleSeverities(allocator, &rule_severities);
             try parseEnabledRules(allocator, arg["--rules=".len..], &options, &rule_severities);
         } else if (std.mem.eql(u8, arg, "--accessor-pairs=off")) {
@@ -1472,6 +1474,33 @@ fn loadConfigFile(
     };
 
     options.* = lint.Options.allDisabled();
+    if (root.get("settings")) |settings_value| {
+        const settings = switch (settings_value) {
+            .object => |object| object,
+            else => {
+                std.debug.print("utoo-lint: config {s} field \"settings\" must be an object\n", .{path});
+                std.process.exit(2);
+            },
+        };
+        if (settings.get("jest")) |jest_value| {
+            const jest = switch (jest_value) {
+                .object => |object| object,
+                else => {
+                    std.debug.print("utoo-lint: config {s} field \"settings.jest\" must be an object\n", .{path});
+                    std.process.exit(2);
+                },
+            };
+            if (jest.get("version")) |version| {
+                options.setJestVersionFromConfig(version) catch |err| {
+                    std.debug.print(
+                        "utoo-lint: invalid config {s} setting settings.jest.version: {s}\n",
+                        .{ path, @errorName(err) },
+                    );
+                    std.process.exit(2);
+                };
+            }
+        }
+    }
     const rules_value = root.get("rules") orelse return;
     const rules = switch (rules_value) {
         .object => |object| object,

--- a/src/root.zig
+++ b/src/root.zig
@@ -153,6 +153,17 @@ fn lintSourceInternal(
     if (isDefinitionFile(path) and effective_options.typescript_eslint_no_namespace_allow_definition_files) {
         effective_options.typescript_eslint_no_namespace = false;
     }
+    if (effective_options.jest_no_deprecated_functions and effective_options.jest_version == 0) {
+        if (comptime with_io) {
+            effective_options.jest_version = (try rules.jest_no_deprecated_functions.detectJestVersion(
+                allocator,
+                io,
+                path,
+            )) orelse rules.jest_no_deprecated_functions.latest_jest_version;
+        } else {
+            effective_options.jest_version = rules.jest_no_deprecated_functions.latest_jest_version;
+        }
+    }
 
     var tree = try parseSource(allocator, source, path);
     defer tree.deinit();

--- a/src/root.zig
+++ b/src/root.zig
@@ -292,6 +292,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_no_named_as_default_member or
         options.import_no_unresolved or
         options.jest_no_conditional_expect or
+        options.jest_no_deprecated_functions or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_no_deprecated_functions.zig
+++ b/src/rules/jest_no_deprecated_functions.zig
@@ -1,0 +1,188 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-deprecated-functions";
+pub const latest_jest_version: u32 = 30;
+
+const max_package_file_size = 1024 * 1024;
+
+const Deprecation = struct {
+    object: []const u8,
+    property: []const u8,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    jest_version: u32,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .jest_version = if (jest_version == 0) latest_jest_version else jest_version,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+pub fn detectJestVersion(allocator: Allocator, io: std.Io, file_path: []const u8) Allocator.Error!?u32 {
+    const absolute_file = if (std.fs.path.isAbsolute(file_path))
+        try allocator.dupe(u8, file_path)
+    else blk: {
+        const cwd = std.process.currentPathAlloc(io, allocator) catch {
+            break :blk try std.fs.path.resolve(allocator, &.{file_path});
+        };
+        defer allocator.free(cwd);
+        break :blk try std.fs.path.resolve(allocator, &.{ cwd, file_path });
+    };
+    defer allocator.free(absolute_file);
+
+    var current = try allocator.dupe(u8, std.fs.path.dirname(absolute_file) orelse ".");
+    defer allocator.free(current);
+
+    while (true) {
+        const package_path = try std.fs.path.join(allocator, &.{ current, "node_modules", "jest", "package.json" });
+        defer allocator.free(package_path);
+        if (readJestVersion(allocator, io, package_path)) |version| return version;
+
+        const parent = std.fs.path.dirname(current) orelse break;
+        if (std.mem.eql(u8, parent, current)) break;
+        const next = try allocator.dupe(u8, parent);
+        allocator.free(current);
+        current = next;
+    }
+
+    return null;
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    jest_version: u32,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const callee = unwrapTransparent(ctx.tree, call.callee);
+        const member = switch (ctx.tree.data(callee)) {
+            .member_expression => |value| value,
+            else => return .proceed,
+        };
+        if (member.object == .null or member.property == .null) return .proceed;
+
+        const object_name = identifierName(ctx.tree, member.object) orelse return .proceed;
+        const property_name = propertyName(ctx.tree, member) orelse return .proceed;
+        const replacement = deprecationFor(self.jest_version, object_name, property_name) orelse return .proceed;
+
+        const message = try std.fmt.allocPrint(
+            self.allocator,
+            "`{s}.{s}` has been deprecated in favor of `{s}.{s}`",
+            .{ object_name, property_name, replacement.object, replacement.property },
+        );
+        defer self.allocator.free(message);
+
+        const property_replacement = if (member.computed)
+            try std.fmt.allocPrint(self.allocator, "'{s}'", .{replacement.property})
+        else
+            replacement.property;
+        defer if (member.computed) self.allocator.free(property_replacement);
+
+        try core.addDiagnosticWithFixes(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            message,
+            ctx.tree.span(index),
+            &.{
+                .{ .span = ctx.tree.span(member.object), .replacement = replacement.object },
+                .{ .span = ctx.tree.span(member.property), .replacement = property_replacement },
+            },
+        );
+        return .proceed;
+    }
+};
+
+fn deprecationFor(version: u32, object: []const u8, property: []const u8) ?Deprecation {
+    if (version >= 15 and std.mem.eql(u8, object, "jest") and std.mem.eql(u8, property, "resetModuleRegistry")) {
+        return .{ .object = "jest", .property = "resetModules" };
+    }
+    if (version >= 17 and std.mem.eql(u8, object, "jest") and std.mem.eql(u8, property, "addMatchers")) {
+        return .{ .object = "expect", .property = "extend" };
+    }
+    if (version >= 21 and std.mem.eql(u8, object, "require") and std.mem.eql(u8, property, "requireMock")) {
+        return .{ .object = "jest", .property = "requireMock" };
+    }
+    if (version >= 21 and std.mem.eql(u8, object, "require") and std.mem.eql(u8, property, "requireActual")) {
+        return .{ .object = "jest", .property = "requireActual" };
+    }
+    if (version >= 22 and std.mem.eql(u8, object, "jest") and std.mem.eql(u8, property, "runTimersToTime")) {
+        return .{ .object = "jest", .property = "advanceTimersByTime" };
+    }
+    if (version >= 26 and std.mem.eql(u8, object, "jest") and std.mem.eql(u8, property, "genMockFromModule")) {
+        return .{ .object = "jest", .property = "createMockFromModule" };
+    }
+    return null;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    return if (member.computed)
+        switch (tree.data(member.property)) {
+            .string_literal => |literal| tree.string(literal.value),
+            else => null,
+        }
+    else switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |chain| current = chain.expression,
+            .parenthesized_expression => |parenthesized| current = parenthesized.expression,
+            else => return current,
+        }
+    }
+    return current;
+}
+
+fn readJestVersion(allocator: Allocator, io: std.Io, path: []const u8) ?u32 {
+    const directory_path = std.fs.path.dirname(path) orelse return null;
+    const basename = std.fs.path.basename(path);
+    var directory = std.Io.Dir.openDirAbsolute(io, directory_path, .{}) catch return null;
+    defer directory.close(io);
+    const source = directory.readFileAlloc(io, basename, allocator, .limited(max_package_file_size)) catch return null;
+    defer allocator.free(source);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch return null;
+    defer parsed.deinit();
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return null,
+    };
+    const version = switch (root.get("version") orelse return null) {
+        .string => |value| value,
+        else => return null,
+    };
+    const separator = std.mem.indexOfScalar(u8, version, '.') orelse version.len;
+    if (separator == 0) return null;
+    return std.fmt.parseUnsigned(u32, version[0..separator], 10) catch null;
+}

--- a/src/rules/jest_no_deprecated_functions.zig
+++ b/src/rules/jest_no_deprecated_functions.zig
@@ -16,15 +16,37 @@ const Deprecation = struct {
     property: []const u8,
 };
 
+const JestGlobal = enum {
+    expect,
+    jest,
+};
+
+const ImportedGlobals = std.StringHashMapUnmanaged(JestGlobal);
+
+const ObjectMatch = struct {
+    canonical: []const u8,
+    source: []const u8,
+    scope: traverser.semantic.ScopeId,
+};
+
 pub fn run(
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
     tree: *const ast.Tree,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
     jest_version: u32,
 ) Allocator.Error!void {
+    var imported_globals: ImportedGlobals = .empty;
+    defer imported_globals.deinit(allocator);
+    try collectImportedGlobals(allocator, tree, &imported_globals);
+
     var visitor = Visitor{
         .allocator = allocator,
         .diagnostics = diagnostics,
+        .scope_tree = scope_tree,
+        .symbol_table = symbol_table,
+        .imported_globals = &imported_globals,
         .jest_version = if (jest_version == 0) latest_jest_version else jest_version,
     };
     try traverser.basic.traverse(Visitor, tree, &visitor);
@@ -63,6 +85,9 @@ pub fn detectJestVersion(allocator: Allocator, io: std.Io, file_path: []const u8
 const Visitor = struct {
     allocator: Allocator,
     diagnostics: *core.DiagnosticList,
+    scope_tree: traverser.semantic.ScopeTree,
+    symbol_table: traverser.semantic.SymbolTable,
+    imported_globals: *const ImportedGlobals,
     jest_version: u32,
 
     pub fn enter_call_expression(
@@ -78,16 +103,29 @@ const Visitor = struct {
         };
         if (member.object == .null or member.property == .null) return .proceed;
 
-        const object_name = identifierName(ctx.tree, member.object) orelse return .proceed;
+        const object = self.matchObject(ctx.tree, member.object) orelse return .proceed;
         const property_name = propertyName(ctx.tree, member) orelse return .proceed;
-        const replacement = deprecationFor(self.jest_version, object_name, property_name) orelse return .proceed;
+        const replacement = deprecationFor(self.jest_version, object.canonical, property_name) orelse return .proceed;
+        const replacement_object = self.replacementObject(object, replacement.object);
 
         const message = try std.fmt.allocPrint(
             self.allocator,
             "`{s}.{s}` has been deprecated in favor of `{s}.{s}`",
-            .{ object_name, property_name, replacement.object, replacement.property },
+            .{ object.source, property_name, replacement_object orelse replacement.object, replacement.property },
         );
         defer self.allocator.free(message);
+
+        if (replacement_object == null) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                message,
+                ctx.tree.span(index),
+            );
+            return .proceed;
+        }
 
         const property_replacement = if (member.computed)
             try std.fmt.allocPrint(self.allocator, "'{s}'", .{replacement.property})
@@ -103,13 +141,115 @@ const Visitor = struct {
             message,
             ctx.tree.span(index),
             &.{
-                .{ .span = ctx.tree.span(member.object), .replacement = replacement.object },
+                .{ .span = ctx.tree.span(member.object), .replacement = replacement_object.? },
                 .{ .span = ctx.tree.span(member.property), .replacement = property_replacement },
             },
         );
         return .proceed;
     }
+
+    fn matchObject(self: *const Visitor, tree: *const ast.Tree, index: ast.NodeIndex) ?ObjectMatch {
+        const object = unwrapTransparent(tree, index);
+        const source_name = identifierName(tree, object) orelse return null;
+        const reference_id = self.symbol_table.model.referenceOf(object) orelse return null;
+        const reference = self.symbol_table.getReference(reference_id);
+        const symbol_id = self.symbol_table.referenceSymbol(reference_id);
+
+        if (symbol_id == .none) {
+            if (!std.mem.eql(u8, source_name, "jest") and !std.mem.eql(u8, source_name, "require")) return null;
+            return .{
+                .canonical = source_name,
+                .source = source_name,
+                .scope = reference.scope,
+            };
+        }
+
+        if (!self.isImportedGlobal(symbol_id, .jest)) return null;
+        return .{
+            .canonical = "jest",
+            .source = source_name,
+            .scope = reference.scope,
+        };
+    }
+
+    fn replacementObject(self: *const Visitor, object: ObjectMatch, canonical: []const u8) ?[]const u8 {
+        if (std.mem.eql(u8, canonical, object.canonical)) return object.source;
+
+        const global: JestGlobal = if (std.mem.eql(u8, canonical, "jest")) .jest else .expect;
+        if (self.accessibleImportedName(object.scope, global)) |name| return name;
+        if (self.hasImportedGlobal(global)) return null;
+        if (self.symbol_table.resolve(self.scope_tree, object.scope, canonical) == null) return canonical;
+        return null;
+    }
+
+    fn hasImportedGlobal(self: *const Visitor, expected: JestGlobal) bool {
+        var iterator = self.imported_globals.valueIterator();
+        while (iterator.next()) |global| {
+            if (global.* == expected) return true;
+        }
+        return false;
+    }
+
+    fn accessibleImportedName(
+        self: *const Visitor,
+        scope: traverser.semantic.ScopeId,
+        expected: JestGlobal,
+    ) ?[]const u8 {
+        var best: ?[]const u8 = null;
+        var iterator = self.imported_globals.iterator();
+        while (iterator.next()) |entry| {
+            if (entry.value_ptr.* != expected) continue;
+            const symbol_id = self.symbol_table.resolve(self.scope_tree, scope, entry.key_ptr.*) orelse continue;
+            if (!self.isImportedGlobal(symbol_id, expected)) continue;
+            if (best == null or std.mem.order(u8, entry.key_ptr.*, best.?) == .lt) best = entry.key_ptr.*;
+        }
+        return best;
+    }
+
+    fn isImportedGlobal(self: *const Visitor, symbol_id: traverser.semantic.SymbolId, expected: JestGlobal) bool {
+        const symbol = self.symbol_table.getSymbol(symbol_id);
+        if (!symbol.flags.import) return false;
+        return (self.imported_globals.get(self.symbol_table.tree.string(symbol.name)) orelse return false) == expected;
+    }
 };
+
+fn collectImportedGlobals(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    imported_globals: *ImportedGlobals,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |value| value,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |value| value,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const source = stringLiteralValue(tree, declaration.source) orelse continue;
+        if (!std.mem.eql(u8, source, "@jest/globals")) continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .import_specifier => |value| value,
+                else => continue,
+            };
+            if (specifier.import_kind == .type) continue;
+            const imported = propertyNodeName(tree, specifier.imported) orelse continue;
+            const global: JestGlobal = if (std.mem.eql(u8, imported, "jest"))
+                .jest
+            else if (std.mem.eql(u8, imported, "expect"))
+                .expect
+            else
+                continue;
+            const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+            try imported_globals.put(allocator, local, global);
+        }
+    }
+}
 
 fn deprecationFor(version: u32, object: []const u8, property: []const u8) ?Deprecation {
     if (version >= 15 and std.mem.eql(u8, object, "jest") and std.mem.eql(u8, property, "resetModuleRegistry")) {
@@ -136,6 +276,29 @@ fn deprecationFor(version: u32, object: []const u8, property: []const u8) ?Depre
 fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
     return switch (tree.data(unwrapTransparent(tree, index))) {
         .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyNodeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
         else => null,
     };
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -79,6 +79,7 @@ pub const import_no_named_as_default_member = @import("import_no_named_as_defaul
 pub const import_no_unresolved = @import("import_no_unresolved.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jest_no_conditional_expect = @import("jest_no_conditional_expect.zig");
+pub const jest_no_deprecated_functions = @import("jest_no_deprecated_functions.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -585,6 +586,9 @@ pub fn runBasicWithOptionsPtr(
     file_path: []const u8,
     options: *const core.Options,
 ) Allocator.Error!void {
+    if (options.jest_no_deprecated_functions) {
+        try jest_no_deprecated_functions.run(allocator, diagnostics, tree, options.jest_version);
+    }
     if (options.capitalized_comments) {
         try capitalized_comments.runWithOptions(allocator, diagnostics, tree, .{
             .mode = switch (options.capitalized_comments_mode) {

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -586,9 +586,6 @@ pub fn runBasicWithOptionsPtr(
     file_path: []const u8,
     options: *const core.Options,
 ) Allocator.Error!void {
-    if (options.jest_no_deprecated_functions) {
-        try jest_no_deprecated_functions.run(allocator, diagnostics, tree, options.jest_version);
-    }
     if (options.capitalized_comments) {
         try capitalized_comments.runWithOptions(allocator, diagnostics, tree, .{
             .mode = switch (options.capitalized_comments_mode) {
@@ -1001,6 +998,17 @@ fn runSemanticAfterIo(
     semantic_result: traverser.semantic.Result,
     options: core.Options,
 ) Allocator.Error!void {
+    if (options.jest_no_deprecated_functions) {
+        try jest_no_deprecated_functions.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.scope_tree,
+            semantic_result.symbol_table,
+            options.jest_version,
+        );
+    }
+
     if (options.jest_no_conditional_expect) {
         try jest_no_conditional_expect.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -304,6 +304,32 @@ fn parseConfig(
         }
     }
 
+    const settings_value = if (root) |object| object.get("settings") else null;
+    if (settings_value) |value| {
+        const settings = switch (value) {
+            .object => |object| object,
+            else => {
+                failure.* = .{ .code = "INVALID_OPTIONS", .message = "settings must be a JSON object" };
+                return error.InvalidOptions;
+            },
+        };
+        if (settings.get("jest")) |jest_value| {
+            const jest = switch (jest_value) {
+                .object => |object| object,
+                else => {
+                    failure.* = .{ .code = "INVALID_OPTIONS", .message = "settings.jest must be a JSON object" };
+                    return error.InvalidOptions;
+                },
+            };
+            if (jest.get("version")) |version| {
+                config.options.setJestVersionFromConfig(version) catch |err| {
+                    failure.* = .{ .code = "INVALID_OPTIONS", .message = @errorName(err) };
+                    return error.InvalidOptions;
+                };
+            }
+        }
+    }
+
     try appendSkippedRules(allocator, &config.skipped_rules, config.options);
     return config;
 }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -268,6 +268,7 @@ comptime {
 
 comptime {
     _ = @import("rules/jest_no_conditional_expect.zig");
+    _ = @import("rules/jest_no_deprecated_functions.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_deprecated_functions.zig
+++ b/tests/rules/jest_no_deprecated_functions.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const source_all =
+    \\jest.resetModuleRegistry();
+    \\jest.addMatchers({});
+    \\require.requireMock("module");
+    \\require.requireActual("module");
+    \\jest.runTimersToTime(1000);
+    \\jest.genMockFromModule("module");
+;
+
+test "reports deprecated Jest functions at their version thresholds" {
+    const cases = [_]struct { version: u32, count: usize }{
+        .{ .version = 14, .count = 0 },
+        .{ .version = 15, .count = 1 },
+        .{ .version = 17, .count = 2 },
+        .{ .version = 20, .count = 2 },
+        .{ .version = 21, .count = 4 },
+        .{ .version = 22, .count = 5 },
+        .{ .version = 26, .count = 6 },
+        .{ .version = 30, .count = 6 },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, source_all, "fixture.js", optionsFor(case.version));
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.count, helpers.countRule(result, lint.rules.jest_no_deprecated_functions.id));
+    }
+}
+
+test "reports useful locations and applies upstream autofixes" {
+    const source =
+        \\jest.resetModuleRegistry();
+        \\jest['addMatchers']({});
+        \\require.requireMock("module");
+        \\require["requireActual"]("module");
+        \\jest.runTimersToTime(1000);
+        \\jest.genMockFromModule("module");
+    ;
+    const expected =
+        \\jest.resetModules();
+        \\expect['extend']({});
+        \\jest.requireMock("module");
+        \\jest['requireActual']("module");
+        \\jest.advanceTimersByTime(1000);
+        \\jest.createMockFromModule("module");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsFor(30));
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, lint.rules.jest_no_deprecated_functions.id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, lint.rules.jest_no_deprecated_functions.id)) continue;
+        try std.testing.expectEqual(@as(usize, 2), diagnostic.fixes.len);
+        const reported = source[diagnostic.span.start..diagnostic.span.end];
+        try std.testing.expect(std.mem.endsWith(u8, reported, ")"));
+    }
+    try std.testing.expectEqualStrings(
+        "`jest.resetModuleRegistry` has been deprecated in favor of `jest.resetModules`",
+        result.diagnostics[0].message,
+    );
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(expected, fixed.output);
+}
+
+test "allows functions before deprecation and non-call references" {
+    const source =
+        \\jest.resetModuleRegistry;
+        \\jest.addMatchers;
+        \\const actual = require.requireActual;
+        \\other.resetModuleRegistry();
+        \\jest[method]();
+        \\jest.runTimersToTime();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsFor(21));
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jest_no_deprecated_functions.id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "jest.genMockFromModule('x');", .file_name = "fixture.js" },
+        .{ .source = "jest.genMockFromModule<Type>('x');", .file_name = "fixture.ts" },
+        .{ .source = "const node = <div />; jest.genMockFromModule('x');", .file_name = "fixture.jsx" },
+        .{ .source = "const node: JSX.Element = <div />; jest.genMockFromModule<Type>('x');", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsFor(30));
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, lint.rules.jest_no_deprecated_functions.id));
+    }
+}
+
+test "detects the closest installed Jest version and honors explicit settings" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(std.testing.io, "node_modules/jest");
+    try tmp.dir.createDirPath(std.testing.io, "project/node_modules/jest");
+    try tmp.dir.createDirPath(std.testing.io, "project/src");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "node_modules/jest/package.json",
+        .data = "{\"version\":\"30.0.0\"}\n",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "project/node_modules/jest/package.json",
+        .data = "{\"version\":\"21.4.0\"}\n",
+    });
+    const file_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "project",
+        "src",
+        "fixture.js",
+    });
+    defer std.testing.allocator.free(file_path);
+
+    var detected = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source_all, file_path, optionsFor(0));
+    defer detected.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(detected, lint.rules.jest_no_deprecated_functions.id));
+
+    var explicit = try lint.lintSourceWithIo(std.testing.allocator, std.testing.io, source_all, file_path, optionsFor(14));
+    defer explicit.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(explicit, lint.rules.jest_no_deprecated_functions.id));
+}
+
+test "parses numeric and semver Jest settings" {
+    var options = lint.Options.allDisabled();
+    try options.setJestVersionFromConfig(.{ .integer = 26 });
+    try std.testing.expectEqual(@as(u32, 26), options.jest_version);
+    try options.setJestVersionFromConfig(.{ .string = "27.0.0-next.11" });
+    try std.testing.expectEqual(@as(u32, 27), options.jest_version);
+    try std.testing.expectError(error.InvalidJestVersion, options.setJestVersionFromConfig(.{ .string = "latest" }));
+}
+
+fn optionsFor(version: u32) lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_deprecated_functions = true;
+    options.jest_version = version;
+    return options;
+}

--- a/tests/rules/jest_no_deprecated_functions.zig
+++ b/tests/rules/jest_no_deprecated_functions.zig
@@ -83,6 +83,51 @@ test "allows functions before deprecation and non-call references" {
     try std.testing.expect(!helpers.hasRule(result, lint.rules.jest_no_deprecated_functions.id));
 }
 
+test "ignores shadowed Jest and require objects" {
+    const source =
+        \\function run(jest, require) {
+        \\  jest.resetModuleRegistry();
+        \\  jest.addMatchers({});
+        \\  require.requireActual("module");
+        \\}
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsFor(30));
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, lint.rules.jest_no_deprecated_functions.id));
+}
+
+test "supports aliased @jest/globals imports without unsafe replacements" {
+    const source =
+        \\import { expect as assertion, jest as testJest } from "@jest/globals";
+        \\testJest.resetModuleRegistry();
+        \\testJest.addMatchers({});
+    ;
+    const expected =
+        \\import { expect as assertion, jest as testJest } from "@jest/globals";
+        \\testJest.resetModules();
+        \\assertion.extend({});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsFor(30));
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, lint.rules.jest_no_deprecated_functions.id));
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(expected, fixed.output);
+
+    const shadowed_replacement =
+        \\function load(jest) {
+        \\  return require.requireActual("module");
+        \\}
+    ;
+    var shadowed_result = try lint.lintSource(std.testing.allocator, shadowed_replacement, "fixture.js", optionsFor(30));
+    defer shadowed_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(shadowed_result, lint.rules.jest_no_deprecated_functions.id));
+    try std.testing.expectEqual(@as(usize, 0), shadowed_result.diagnostics[0].fixes.len);
+}
+
 test "supports JavaScript TypeScript JSX and TSX" {
     const cases = [_]struct { source: []const u8, file_name: []const u8 }{
         .{ .source = "jest.genMockFromModule('x');", .file_name = "fixture.js" },

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -111,6 +111,25 @@ test("applies no-magic-numbers Number and BigInt ignore values", () => {
   assert.equal(diagnostics[0].message, "No magic number: 9.");
 });
 
+test("applies configured Jest versions to version-aware rules", () => {
+  const source = "jest.runTimersToTime(1000);";
+  const oldJest = linter.lint(source, {
+    filePath: "input.js",
+    settings: { jest: { version: "21.4.0" } },
+    rules: { "jest/no-deprecated-functions": "error" },
+  });
+  assert.equal(oldJest.diagnostics.length, 0);
+
+  const newJest = linter.lint(source, {
+    filePath: "input.js",
+    settings: { jest: { version: 22 } },
+    rules: { "jest/no-deprecated-functions": "error" },
+  });
+  assert.equal(newJest.diagnostics.length, 1);
+  assert.equal(newJest.diagnostics[0].ruleId, "jest/no-deprecated-functions");
+  assert.equal(newJest.diagnostics[0].fixes.length, 2);
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Implement native `jest/no-deprecated-functions` diagnostics and upstream-compatible autofixes.
- Detect the closest installed Jest version, support `settings.jest.version`, and preserve settings through native, ESM, CommonJS, flat-config, and WebAssembly paths.
- Add version-threshold, location, JS/TS/JSX/TSX, fix, CLI, config, type, and WebAssembly coverage.
- Closes #1153


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test --summary all`
- `zig build test-wasm --summary all`
- `pnpm --dir npm/utoo-lint test`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`