### PR TITLE
feat: add jest/no-export

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -264,6 +264,7 @@ instead of being rewritten.
 | --- | --- |
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | Implemented for conditionals, catch clauses, Promise catch callbacks, inline test callbacks, and named test callbacks |
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | Implemented with installed or configured Jest version detection and upstream autofixes |
+| [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | Implemented for ESM, CommonJS, and TypeScript exports in files containing Jest tests |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -263,6 +263,7 @@
 | --- | --- |
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | 已实现条件表达式、`catch` 子句、Promise `catch` 回调、内联测试回调及命名测试回调检查 |
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | 已实现已安装或显式配置的 Jest 版本检测，并支持上游自动修复 |
+| [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | 已实现对包含 Jest 测试的文件中的 ESM、CommonJS 和 TypeScript 导出检查 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -313,6 +313,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-self-import",
   "jest/no-conditional-expect",
   "jest/no-deprecated-functions",
+  "jest/no-export",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -316,6 +316,7 @@ const BUILTIN_RULE_IDS = [
   "import/no-self-import",
   "jest/no-conditional-expect",
   "jest/no-deprecated-functions",
+  "jest/no-export",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2641,6 +2641,38 @@ test("jest/no-deprecated-functions uses project settings, auto detection, and fi
   }
 });
 
+test("project config and CLI --rules enable jest/no-export", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-export": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "export.test.js"),
+    "export const helper = 1; test('export', () => expect(helper).toBe(1));\n"
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-export", severity: "error" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-export", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.deepEqual(isolatedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-export", severity: "warning" }
+    ]);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2761,6 +2761,7 @@ pub const Options = struct {
     import_no_self_import: bool = true,
     jest_no_conditional_expect: bool = true,
     jest_no_deprecated_functions: bool = true,
+    jest_no_export: bool = true,
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_alt_text_img: bool = true,
@@ -10439,6 +10440,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_deprecated_functions);
     try std.testing.expect(options.setByCliName("jest/no-deprecated-functions", true));
     try std.testing.expect(options.jest_no_deprecated_functions);
+
+    try std.testing.expect(!options.jest_no_export);
+    try std.testing.expect(options.setByCliName("jest/no-export", true));
+    try std.testing.expect(options.jest_no_export);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -293,6 +293,7 @@ fn hasSemanticRules(options: Options) bool {
         options.import_no_unresolved or
         options.jest_no_conditional_expect or
         options.jest_no_deprecated_functions or
+        options.jest_no_export or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_no_export.zig
+++ b/src/rules/jest_no_export.zig
@@ -1,0 +1,384 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-export";
+
+const message = "Do not export from a test file";
+
+const JestFunction = enum {
+    describe,
+    fdescribe,
+    xdescribe,
+    test_case,
+    xtest,
+    it,
+    fit,
+    xit,
+};
+
+const ImportedGlobals = std.StringHashMapUnmanaged(JestFunction);
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var imported_globals: ImportedGlobals = .empty;
+    defer imported_globals.deinit(allocator);
+    try collectImportedGlobals(allocator, tree, &imported_globals);
+
+    var export_nodes: std.ArrayList(ast.NodeIndex) = .empty;
+    defer export_nodes.deinit(allocator);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .symbol_table = symbol_table,
+        .imported_globals = &imported_globals,
+        .export_nodes = &export_nodes,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+
+    if (!visitor.has_test_case) return;
+    for (export_nodes.items) |index| {
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(index),
+        );
+    }
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    symbol_table: traverser.semantic.SymbolTable,
+    imported_globals: *const ImportedGlobals,
+    export_nodes: *std.ArrayList(ast.NodeIndex),
+    has_test_case: bool = false,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isTopmostCall(ctx.tree, index, ctx.path.parent())) return .proceed;
+
+        var chain: JestCalleeChain = .{};
+        if (!collectJestCalleeChain(ctx.tree, call.callee, &chain)) return .proceed;
+        const root = chain.root;
+        const name = identifierName(ctx.tree, root) orelse return .proceed;
+        const reference_id = self.symbol_table.model.referenceOf(root) orelse return .proceed;
+        const symbol_id = self.symbol_table.referenceSymbol(reference_id);
+
+        const jest_function: JestFunction = if (symbol_id == .none) blk: {
+            break :blk jestFunctionForName(name) orelse return .proceed;
+        } else blk: {
+            const symbol = self.symbol_table.getSymbol(symbol_id);
+            if (!symbol.flags.import) return .proceed;
+            break :blk self.imported_globals.get(self.symbol_table.tree.string(symbol.name)) orelse return .proceed;
+        };
+
+        if (!isValidJestCall(jest_function, chain)) return .proceed;
+
+        self.has_test_case = true;
+        return .proceed;
+    }
+
+    pub fn enter_export_named_declaration(
+        self: *Visitor,
+        _: ast.ExportNamedDeclaration,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.export_nodes.append(self.allocator, index);
+        return .proceed;
+    }
+
+    pub fn enter_export_default_declaration(
+        self: *Visitor,
+        _: ast.ExportDefaultDeclaration,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.export_nodes.append(self.allocator, index);
+        return .proceed;
+    }
+
+    pub fn enter_ts_export_assignment(
+        self: *Visitor,
+        _: ast.TSExportAssignment,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.export_nodes.append(self.allocator, index);
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *Visitor,
+        assignment: ast.AssignmentExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const left = unwrapTransparent(ctx.tree, assignment.left);
+        const outer_member = switch (ctx.tree.data(left)) {
+            .member_expression => |member| member,
+            else => return .proceed,
+        };
+
+        var object = unwrapTransparent(ctx.tree, outer_member.object);
+        var root_property = outer_member.property;
+        while (true) {
+            const member = switch (ctx.tree.data(object)) {
+                .member_expression => |value| value,
+                else => break,
+            };
+            root_property = member.property;
+            object = unwrapTransparent(ctx.tree, member.object);
+        }
+
+        const root_name = identifierName(ctx.tree, object) orelse return .proceed;
+        const reference_id = self.symbol_table.model.referenceOf(object) orelse return .proceed;
+        if (self.symbol_table.referenceSymbol(reference_id) != .none) return .proceed;
+
+        if (std.mem.eql(u8, root_name, "exports")) {
+            try self.export_nodes.append(self.allocator, left);
+            return .proceed;
+        }
+        if (!std.mem.eql(u8, root_name, "module")) return .proceed;
+
+        const property_name = staticPropertyName(ctx.tree, root_property) orelse return .proceed;
+        if (std.mem.eql(u8, property_name, "exports") or std.mem.eql(u8, property_name, "export")) {
+            try self.export_nodes.append(self.allocator, left);
+        }
+        return .proceed;
+    }
+};
+
+fn collectImportedGlobals(
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    imported_globals: *ImportedGlobals,
+) Allocator.Error!void {
+    const program = switch (tree.data(tree.root)) {
+        .program => |value| value,
+        else => return,
+    };
+
+    for (tree.extra(program.body)) |statement_index| {
+        const declaration = switch (tree.data(statement_index)) {
+            .import_declaration => |value| value,
+            else => continue,
+        };
+        if (declaration.import_kind == .type) continue;
+        const source = stringLiteralValue(tree, declaration.source) orelse continue;
+        if (!std.mem.eql(u8, source, "@jest/globals")) continue;
+
+        for (tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (tree.data(specifier_index)) {
+                .import_specifier => |value| value,
+                else => continue,
+            };
+            if (specifier.import_kind == .type) continue;
+            const imported = propertyNodeName(tree, specifier.imported) orelse continue;
+            const jest_function = jestFunctionForName(imported) orelse continue;
+            const local = bindingIdentifierName(tree, specifier.local) orelse continue;
+            try imported_globals.put(allocator, local, jest_function);
+        }
+    }
+}
+
+const JestCalleeChain = struct {
+    root: ast.NodeIndex = .null,
+    members: [4][]const u8 = undefined,
+    member_count: usize = 0,
+    nested_calls: usize = 0,
+    tagged_templates: usize = 0,
+
+    fn append(self: *JestCalleeChain, member: []const u8) bool {
+        if (self.member_count == self.members.len) return false;
+        self.members[self.member_count] = member;
+        self.member_count += 1;
+        return true;
+    }
+
+    fn memberSlice(self: *const JestCalleeChain) []const []const u8 {
+        return self.members[0..self.member_count];
+    }
+};
+
+fn collectJestCalleeChain(tree: *const ast.Tree, index: ast.NodeIndex, chain: *JestCalleeChain) bool {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .identifier_reference => blk: {
+            if (chain.root != .null) break :blk false;
+            chain.root = current;
+            break :blk true;
+        },
+        .member_expression => |member| blk: {
+            if (!collectJestCalleeChain(tree, member.object, chain)) break :blk false;
+            const property = staticPropertyName(tree, member.property) orelse break :blk false;
+            break :blk chain.append(property);
+        },
+        .call_expression => |call| {
+            chain.nested_calls += 1;
+            return collectJestCalleeChain(tree, call.callee, chain);
+        },
+        .tagged_template_expression => |tagged| {
+            chain.tagged_templates += 1;
+            return collectJestCalleeChain(tree, tagged.tag, chain);
+        },
+        else => return false,
+    };
+}
+
+fn isTopmostCall(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return true;
+    return switch (tree.data(parent_index)) {
+        .call_expression => |call| unwrapTransparent(tree, call.callee) != index,
+        .member_expression => |member| unwrapTransparent(tree, member.object) != index,
+        .tagged_template_expression => |tagged| unwrapTransparent(tree, tagged.tag) != index,
+        else => true,
+    };
+}
+
+fn isValidJestCall(jest_function: JestFunction, chain: JestCalleeChain) bool {
+    const members = chain.memberSlice();
+    const ends_in_each = members.len != 0 and std.mem.eql(u8, members[members.len - 1], "each");
+
+    if (ends_in_each) {
+        if (chain.nested_calls + chain.tagged_templates != 1) return false;
+    } else if (chain.nested_calls != 0 or chain.tagged_templates != 0) {
+        return false;
+    }
+
+    return switch (jest_function) {
+        .describe => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"only"}) or
+            matchesMembers(members, &.{ "only", "each" }) or
+            matchesMembers(members, &.{"skip"}) or
+            matchesMembers(members, &.{ "skip", "each" }),
+        .fdescribe, .xdescribe => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}),
+        .test_case, .it => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"todo"}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"failing"}) or
+            matchesMembers(members, &.{ "failing", "each" }) or
+            matchesMembers(members, &.{"only"}) or
+            matchesMembers(members, &.{ "only", "each" }) or
+            matchesMembers(members, &.{ "only", "failing" }) or
+            matchesMembers(members, &.{ "only", "failing", "each" }) or
+            matchesMembers(members, &.{"skip"}) or
+            matchesMembers(members, &.{ "skip", "each" }) or
+            matchesMembers(members, &.{ "skip", "failing" }) or
+            matchesMembers(members, &.{ "skip", "failing", "each" }) or
+            matchesMembers(members, &.{"concurrent"}) or
+            matchesMembers(members, &.{ "concurrent", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "only", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "skip", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "only", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "skip", "each" }),
+        .xtest, .fit, .xit => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"failing"}) or
+            matchesMembers(members, &.{ "failing", "each" }),
+    };
+}
+
+fn matchesMembers(actual: []const []const u8, expected: []const []const u8) bool {
+    if (actual.len != expected.len) return false;
+    for (actual, expected) |actual_member, expected_member| {
+        if (!std.mem.eql(u8, actual_member, expected_member)) return false;
+    }
+    return true;
+}
+
+fn jestFunctionForName(name: []const u8) ?JestFunction {
+    if (std.mem.eql(u8, name, "describe")) return .describe;
+    if (std.mem.eql(u8, name, "fdescribe")) return .fdescribe;
+    if (std.mem.eql(u8, name, "xdescribe")) return .xdescribe;
+    if (std.mem.eql(u8, name, "test")) return .test_case;
+    if (std.mem.eql(u8, name, "xtest")) return .xtest;
+    if (std.mem.eql(u8, name, "it")) return .it;
+    if (std.mem.eql(u8, name, "fit")) return .fit;
+    if (std.mem.eql(u8, name, "xit")) return .xit;
+    return null;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyNodeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -80,6 +80,7 @@ pub const import_no_unresolved = @import("import_no_unresolved.zig");
 pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jest_no_conditional_expect = @import("jest_no_conditional_expect.zig");
 pub const jest_no_deprecated_functions = @import("jest_no_deprecated_functions.zig");
+pub const jest_no_export = @import("jest_no_export.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1011,6 +1012,10 @@ fn runSemanticAfterIo(
 
     if (options.jest_no_conditional_expect) {
         try jest_no_conditional_expect.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.jest_no_export) {
+        try jest_no_export.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.block_scoped_var) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -269,6 +269,7 @@ comptime {
 comptime {
     _ = @import("rules/jest_no_conditional_expect.zig");
     _ = @import("rules/jest_no_deprecated_functions.zig");
+    _ = @import("rules/jest_no_export.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_export.zig
+++ b/tests/rules/jest_no_export.zig
@@ -1,0 +1,167 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_export.id;
+
+test "reports ESM and type-only exports with useful locations" {
+    const source =
+        \\const local = 1;
+        \\type Shape = { value: number };
+        \\export const helper = local;
+        \\export default function factory() { return helper; }
+        \\export type PublicShape = Shape;
+        \\export { type Shape };
+        \\test("works", () => expect(helper).toBe(1));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, rule_id)) continue;
+        try std.testing.expectEqualStrings("Do not export from a test file", diagnostic.message);
+        try std.testing.expect(std.mem.startsWith(u8, source[diagnostic.span.start..diagnostic.span.end], "export"));
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+    }
+}
+
+test "reports supported CommonJS export forms" {
+    const source =
+        \\module.exports = value;
+        \\module.exports.named = value;
+        \\module.exports.exports.named = value;
+        \\module.export.named = value;
+        \\module["exports"] = value;
+        \\module["exports"].named = value;
+        \\module["export"] = value;
+        \\module[`exports`] = value;
+        \\exports.named = value;
+        \\exports.export["named"] = value;
+        \\it("works", () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 10), helpers.countRule(result, rule_id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, rule_id)) continue;
+        const reported = source[diagnostic.span.start..diagnostic.span.end];
+        try std.testing.expect(std.mem.startsWith(u8, reported, "module") or std.mem.startsWith(u8, reported, "exports"));
+        try std.testing.expect(!std.mem.endsWith(u8, reported, ";"));
+    }
+}
+
+test "reports TypeScript export assignments" {
+    const source =
+        \\const value = {};
+        \\export = value;
+        \\describe("suite", () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    const diagnostic = findDiagnostic(result).?;
+    try std.testing.expectEqualStrings("export = value;", source[diagnostic.span.start..diagnostic.span.end]);
+}
+
+test "allows exports in files without tests and unrelated assignments" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "export const helper = 1; module.exports = helper;", .file_name = "fixture.js" },
+        .{ .source = "module.other = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "module[name] = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "module[`${variable}`] = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "module[`${\"exports\"}`] = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "const module = localModule; module.exports = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "const exports = {}; exports.named = value; test('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "function test() {} export const helper = 1; test();", .file_name = "fixture.js" },
+        .{ .source = "import type { test } from '@jest/globals'; export const helper = 1;", .file_name = "fixture.ts" },
+        .{ .source = "window.module.exports = value; it('works', () => {});", .file_name = "fixture.js" },
+        .{ .source = "export const helper = 1; test.each();", .file_name = "fixture.js" },
+        .{ .source = "export const helper = 1; describe.concurrent('not Jest', () => {});", .file_name = "fixture.js" },
+        .{ .source = "export const helper = 1; test().only('not Jest', () => {});", .file_name = "fixture.js" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, rule_id));
+    }
+}
+
+test "supports aliased @jest/globals imports and Jest call chains" {
+    const source =
+        \\import { describe as suite, test as check } from "@jest/globals";
+        \\export const helper = 1;
+        \\check.concurrent.each([[1]])("case", () => {});
+        \\suite.skip("suite", () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+
+    const tagged_source =
+        \\export const helper = 1;
+        \\it.each`value`("case", () => {});
+    ;
+    var tagged_result = try lint.lintSource(std.testing.allocator, tagged_source, "fixture.js", optionsOnly());
+    defer tagged_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(tagged_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "export const helper = 1; test('js', () => {});", .file_name = "fixture.js" },
+        .{ .source = "export const helper: number = 1; test('ts', () => {});", .file_name = "fixture.ts" },
+        .{ .source = "export const helper = <div />; test('jsx', () => {});", .file_name = "fixture.jsx" },
+        .{ .source = "export const helper: JSX.Element = <div />; test('tsx', () => {});", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and parses rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_export);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_export);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"warn\"]", .{});
+    defer config.deinit();
+    options.jest_no_export = false;
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_no_export);
+
+    options.jest_no_export = false;
+    var result = try lint.lintSource(
+        std.testing.allocator,
+        "export const helper = 1; test('disabled', () => {});",
+        "fixture.js",
+        options,
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_export = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -130,6 +130,19 @@ test("applies configured Jest versions to version-aware rules", () => {
   assert.equal(newJest.diagnostics[0].fixes.length, 2);
 });
 
+test("reports exports from files containing Jest tests", () => {
+  const result = linter.lint(
+    "export const helper = 1; test('export', () => expect(helper).toBe(1));",
+    {
+      filePath: "input.js",
+      rules: { "jest/no-export": "error" },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/no-export");
+  assert.equal(result.diagnostics[0].message, "Do not export from a test file");
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Implement native `jest/no-export` diagnostics for ESM, CommonJS, and TypeScript exports in files containing Jest tests.
- Resolve real Jest globals and aliased `@jest/globals` imports while ignoring shadowed bindings and invalid call chains.
- Register the rule across native, ESM, CommonJS, and WebAssembly paths with config, CLI, language-mode, and documentation coverage.
- Closes #1154


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `zig build test-wasm --summary all`