### PR TITLE
feat: add jest/no-focused-tests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,10 +176,22 @@ versions or needs to pin the version used for linting:
 
 ```json
 {
-  "settings": { "jest": { "version": "29.7.0" } },
-  "rules": { "jest/no-deprecated-functions": "error" }
+  "settings": {
+    "jest": {
+      "version": "29.7.0",
+      "globalAliases": { "describe": ["context"] }
+    }
+  },
+  "rules": {
+    "jest/no-deprecated-functions": "error",
+    "jest/no-focused-tests": "error"
+  }
 }
 ```
+
+Use `settings.jest.globalAliases` to map canonical Jest functions to
+project-specific global names. For example, the configuration above treats
+`context` as an alias for `describe`.
 
 ESLint config files are a migration input, not the recommended long-term
 configuration format. Generate a native config with:

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -125,10 +125,20 @@ npm 封装层会执行 TypeScript 文件，将其结果转换为 JSON，再把�
 
 ```json
 {
-  "settings": { "jest": { "version": "29.7.0" } },
-  "rules": { "jest/no-deprecated-functions": "error" }
+  "settings": {
+    "jest": {
+      "version": "29.7.0",
+      "globalAliases": { "describe": ["context"] }
+    }
+  },
+  "rules": {
+    "jest/no-deprecated-functions": "error",
+    "jest/no-focused-tests": "error"
+  }
 }
 ```
+
+可通过 `settings.jest.globalAliases` 将 Jest 的标准函数名映射到项目自定义的全局别名。例如，上面的配置会将 `context` 视为 `describe` 的别名。
 
 ESLint 配置文件仅作为迁移输入，不是推荐的长期配置格式。可使用以下命令生成原生配置：
 

--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -265,6 +265,7 @@ instead of being rewritten.
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | Implemented for conditionals, catch clauses, Promise catch callbacks, inline test callbacks, and named test callbacks |
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | Implemented with installed or configured Jest version detection and upstream autofixes |
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | Implemented for ESM, CommonJS, and TypeScript exports in files containing Jest tests |
+| [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | Implemented for focused global, imported, aliased, and chained tests with upstream editor suggestions |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -264,6 +264,7 @@
 | [`jest/no-conditional-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md) | 已实现条件表达式、`catch` 子句、Promise `catch` 回调、内联测试回调及命名测试回调检查 |
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | 已实现已安装或显式配置的 Jest 版本检测，并支持上游自动修复 |
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | 已实现对包含 Jest 测试的文件中的 ESM、CommonJS 和 TypeScript 导出检查 |
+| [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | 已实现对全局、导入、别名及链式聚焦测试的检查，并提供上游编辑器建议 |
 
 ## Promise 插件规则
 

--- a/npm/@utoo/lint-wasm/index.d.ts
+++ b/npm/@utoo/lint-wasm/index.d.ts
@@ -3,6 +3,7 @@ export type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]];
 
 export interface JestPluginSettings {
   version?: string | number;
+  globalAliases?: Record<string, string[]>;
   [key: string]: unknown;
 }
 
@@ -14,6 +15,11 @@ export interface SharedSettings {
 export interface LintFix {
   range: [number, number];
   text: string;
+}
+
+export interface LintSuggestion {
+  desc: string;
+  fix: LintFix[];
 }
 
 export interface LintSuppression {
@@ -32,6 +38,7 @@ export interface LintDiagnostic {
   endLine: number;
   endColumn: number;
   fixes: LintFix[];
+  suggestions: LintSuggestion[];
   suppression?: LintSuppression;
 }
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -314,6 +314,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-conditional-expect",
   "jest/no-deprecated-functions",
   "jest/no-export",
+  "jest/no-focused-tests",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -465,6 +466,9 @@ const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"
+]);
+const SUGGESTION_BUILTIN_RULE_IDS = new Set([
+  "jest/no-focused-tests"
 ]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));
 
@@ -4581,6 +4585,9 @@ function ruleMetaForRuleId(ruleId) {
   if (FIXABLE_BUILTIN_RULE_IDS.has(ruleId)) {
     meta.fixable = "code";
   }
+  if (SUGGESTION_BUILTIN_RULE_IDS.has(ruleId)) {
+    meta.hasSuggestions = true;
+  }
   return meta;
 }
 
@@ -4670,6 +4677,21 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
   }));
   if (fixes.length > 0) {
     message.fix = fixes.length === 1 ? fixes[0] : fixes;
+  }
+  const suggestions = (diagnostic.suggestions ?? []).map((suggestion) => {
+    const suggestionFixes = (suggestion.fix ?? []).map((fix) => ({
+      range: fix.range,
+      text: fix.text
+    }));
+    return {
+      desc: suggestion.desc,
+      ...(suggestionFixes.length === 0 ? {} : {
+        fix: suggestionFixes.length === 1 ? suggestionFixes[0] : suggestionFixes
+      })
+    };
+  });
+  if (suggestions.length > 0) {
+    message.suggestions = suggestions;
   }
   return message;
 }

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -69,6 +69,7 @@ export interface PluginObject {
 
 export interface JestPluginSettings {
   version?: string | number;
+  globalAliases?: Record<string, string[]>;
   [key: string]: unknown;
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -317,6 +317,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-conditional-expect",
   "jest/no-deprecated-functions",
   "jest/no-export",
+  "jest/no-focused-tests",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -468,6 +469,9 @@ const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"
+]);
+const SUGGESTION_BUILTIN_RULE_IDS = new Set([
+  "jest/no-focused-tests"
 ]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));
 
@@ -4584,6 +4588,9 @@ function ruleMetaForRuleId(ruleId) {
   if (FIXABLE_BUILTIN_RULE_IDS.has(ruleId)) {
     meta.fixable = "code";
   }
+  if (SUGGESTION_BUILTIN_RULE_IDS.has(ruleId)) {
+    meta.hasSuggestions = true;
+  }
   return meta;
 }
 
@@ -4673,6 +4680,21 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
   }));
   if (fixes.length > 0) {
     message.fix = fixes.length === 1 ? fixes[0] : fixes;
+  }
+  const suggestions = (diagnostic.suggestions ?? []).map((suggestion) => {
+    const suggestionFixes = (suggestion.fix ?? []).map((fix) => ({
+      range: fix.range,
+      text: fix.text
+    }));
+    return {
+      desc: suggestion.desc,
+      ...(suggestionFixes.length === 0 ? {} : {
+        fix: suggestionFixes.length === 1 ? suggestionFixes[0] : suggestionFixes
+      })
+    };
+  });
+  if (suggestions.length > 0) {
+    message.suggestions = suggestions;
   }
   return message;
 }

--- a/npm/utoo-lint/schema.json
+++ b/npm/utoo-lint/schema.json
@@ -43,6 +43,15 @@
                     { "type": "integer", "minimum": 1 },
                     { "type": "string", "pattern": "^[0-9]+(?:\\..*)?$" }
                   ]
+                },
+                "globalAliases": {
+                  "description": "Additional global aliases for canonical Jest functions.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "uniqueItems": true
+                  }
                 }
               }
             }

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2673,6 +2673,71 @@ test("project config and CLI --rules enable jest/no-export", (t) => {
   }
 });
 
+test("jest/no-focused-tests preserves project settings and editor suggestions", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({
+      settings: { jest: { globalAliases: { describe: ["context"] } } },
+      rules: { "jest/no-focused-tests": "error" }
+    })
+  );
+  const source = "context.only('suite', () => {});\n";
+  const sourcePath = write(join(project, "focused.test.js"), source);
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-focused-tests", severity: "error" }
+    ]);
+    assert.equal(configuredReport.diagnostics[0].fixes.length, 0);
+    assert.equal(configuredReport.diagnostics[0].suggestions[0].desc, "Remove focus from test");
+    assert.deepEqual(configuredReport.diagnostics[0].suggestions[0].fix, [
+      { range: [7, 12], text: "" }
+    ]);
+
+    const selected = execute(["--rules=jest/no-focused-tests", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-focused-tests", severity: "warning" }
+    ]);
+
+    const fixed = execute(["--fix", "--json", sourcePath], options);
+    assert.equal(fixed.status, 1, fixed.stderr);
+    assert.equal(readFileSync(sourcePath, "utf8"), source);
+  }
+
+  const previousBinary = process.env.UTOO_LINT_BIN;
+  process.env.UTOO_LINT_BIN = testBinary();
+  t.after(() => {
+    if (previousBinary === undefined) delete process.env.UTOO_LINT_BIN;
+    else process.env.UTOO_LINT_BIN = previousBinary;
+  });
+
+  const importedSource = [
+    'import { describe as suite } from "@jest/globals";',
+    "suite.only('suite', () => {});",
+    ""
+  ].join("\n");
+  for (const LinterImplementation of [Linter, CommonJSLinter]) {
+    const linter = new LinterImplementation();
+    const messages = linter.verify(
+      importedSource,
+      { rules: { "jest/no-focused-tests": "error" } },
+      { filename: "focused.test.js" }
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].fix, undefined);
+    assert.equal(messages[0].suggestions[0].desc, "Remove focus from test");
+    assert.deepEqual(messages[0].suggestions[0].fix, { range: [56, 61], text: "" });
+    assert.equal(linter.getRules().get("jest/no-focused-tests").meta.hasSuggestions, true);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2762,6 +2762,8 @@ pub const Options = struct {
     jest_no_conditional_expect: bool = true,
     jest_no_deprecated_functions: bool = true,
     jest_no_export: bool = true,
+    jest_no_focused_tests: bool = true,
+    jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
     jsx_a11y_alt_text_img: bool = true,
@@ -4213,6 +4215,31 @@ pub const Options = struct {
             },
             else => return error.InvalidJestVersion,
         };
+    }
+
+    pub fn setJestGlobalAliasesFromConfig(self: *Options, value: std.json.Value) RuleConfigError!void {
+        const aliases = switch (value) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        self.jest_global_aliases = .{};
+        var iterator = aliases.iterator();
+        while (iterator.next()) |entry| {
+            const values = switch (entry.value_ptr.*) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (values) |item| {
+                const alias = switch (item) {
+                    .string => |string| string,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!self.jest_global_aliases.append(entry.key_ptr.*, alias)) {
+                    return error.UnsupportedRuleConfigValue;
+                }
+            }
+        }
     }
 
     pub fn severityFromRuleConfigValue(value: std.json.Value) RuleConfigError!?Severity {
@@ -9926,12 +9953,53 @@ pub const DeprecatedDependenceProfile = enum {
     profile_b,
 };
 
+pub const max_jest_global_aliases = 32;
+pub const max_jest_global_alias_len = 128;
+
+pub const JestGlobalAliases = struct {
+    count: usize = 0,
+    canonical_lengths: [max_jest_global_aliases]usize = undefined,
+    alias_lengths: [max_jest_global_aliases]usize = undefined,
+    canonical_storage: [max_jest_global_aliases][max_jest_global_alias_len]u8 = undefined,
+    alias_storage: [max_jest_global_aliases][max_jest_global_alias_len]u8 = undefined,
+
+    pub fn canonicalAt(self: *const JestGlobalAliases, index: usize) []const u8 {
+        return self.canonical_storage[index][0..self.canonical_lengths[index]];
+    }
+
+    pub fn aliasAt(self: *const JestGlobalAliases, index: usize) []const u8 {
+        return self.alias_storage[index][0..self.alias_lengths[index]];
+    }
+
+    pub fn canonicalFor(self: *const JestGlobalAliases, alias: []const u8) ?[]const u8 {
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.aliasAt(index), alias)) return self.canonicalAt(index);
+        }
+        return null;
+    }
+
+    pub fn append(self: *JestGlobalAliases, canonical: []const u8, alias: []const u8) bool {
+        if (canonical.len == 0 or alias.len == 0) return false;
+        if (canonical.len > max_jest_global_alias_len or alias.len > max_jest_global_alias_len) return false;
+        if (self.count >= max_jest_global_aliases) return false;
+        if (self.canonicalFor(alias) != null) return true;
+
+        @memcpy(self.canonical_storage[self.count][0..canonical.len], canonical);
+        @memcpy(self.alias_storage[self.count][0..alias.len], alias);
+        self.canonical_lengths[self.count] = canonical.len;
+        self.alias_lengths[self.count] = alias.len;
+        self.count += 1;
+        return true;
+    }
+};
+
 pub const Diagnostic = struct {
     rule_id: []const u8,
     message: []const u8,
     span: ast.Span,
     severity: Severity,
     fixes: []Fix,
+    suggestions: []Suggestion = &.{},
     suppression: ?Suppression = null,
 };
 
@@ -9942,6 +10010,11 @@ pub const Suppression = struct {
 pub const Fix = struct {
     span: ast.Span,
     replacement: []const u8,
+};
+
+pub const Suggestion = struct {
+    message: []const u8,
+    fixes: []const Fix,
 };
 
 pub const Result = struct {
@@ -10020,11 +10093,57 @@ pub fn addDiagnosticWithFixes(
     span: ast.Span,
     fixes: []const Fix,
 ) Allocator.Error!void {
+    return addDiagnosticWithFixesAndSuggestions(
+        allocator,
+        diagnostics,
+        severity,
+        rule_id,
+        message,
+        span,
+        fixes,
+        &.{},
+    );
+}
+
+pub fn addDiagnosticWithSuggestions(
+    allocator: Allocator,
+    diagnostics: *DiagnosticList,
+    severity: Severity,
+    rule_id: []const u8,
+    message: []const u8,
+    span: ast.Span,
+    suggestions: []const Suggestion,
+) Allocator.Error!void {
+    return addDiagnosticWithFixesAndSuggestions(
+        allocator,
+        diagnostics,
+        severity,
+        rule_id,
+        message,
+        span,
+        &.{},
+        suggestions,
+    );
+}
+
+fn addDiagnosticWithFixesAndSuggestions(
+    allocator: Allocator,
+    diagnostics: *DiagnosticList,
+    severity: Severity,
+    rule_id: []const u8,
+    message: []const u8,
+    span: ast.Span,
+    fixes: []const Fix,
+    suggestions: []const Suggestion,
+) Allocator.Error!void {
     const owned_message = try allocator.dupe(u8, message);
     errdefer allocator.free(owned_message);
 
     const owned_fixes = try dupeFixes(allocator, fixes);
     errdefer freeFixes(allocator, owned_fixes);
+
+    const owned_suggestions = try dupeSuggestions(allocator, suggestions);
+    errdefer freeSuggestions(allocator, owned_suggestions);
 
     try diagnostics.append(allocator, .{
         .rule_id = rule_id,
@@ -10032,6 +10151,7 @@ pub fn addDiagnosticWithFixes(
         .span = span,
         .severity = severity,
         .fixes = owned_fixes,
+        .suggestions = owned_suggestions,
     });
 }
 
@@ -10083,9 +10203,43 @@ fn dupeFixes(allocator: Allocator, fixes: []const Fix) Allocator.Error![]Fix {
     return owned;
 }
 
+fn dupeSuggestions(allocator: Allocator, suggestions: []const Suggestion) Allocator.Error![]Suggestion {
+    if (suggestions.len == 0) return &.{};
+
+    const owned = try allocator.alloc(Suggestion, suggestions.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (owned[0..initialized]) |suggestion| {
+            allocator.free(suggestion.message);
+            freeFixes(allocator, suggestion.fixes);
+        }
+        allocator.free(owned);
+    }
+
+    for (suggestions, 0..) |suggestion, index| {
+        const owned_message = try allocator.dupe(u8, suggestion.message);
+        errdefer allocator.free(owned_message);
+        owned[index] = .{
+            .message = owned_message,
+            .fixes = try dupeFixes(allocator, suggestion.fixes),
+        };
+        initialized += 1;
+    }
+    return owned;
+}
+
+fn freeSuggestions(allocator: Allocator, suggestions: []Suggestion) void {
+    for (suggestions) |suggestion| {
+        allocator.free(suggestion.message);
+        freeFixes(allocator, suggestion.fixes);
+    }
+    if (suggestions.len > 0) allocator.free(suggestions);
+}
+
 pub fn freeDiagnostic(allocator: Allocator, diagnostic: Diagnostic) void {
     allocator.free(diagnostic.message);
     freeFixes(allocator, diagnostic.fixes);
+    freeSuggestions(allocator, diagnostic.suggestions);
     if (diagnostic.suppression) |suppression| allocator.free(suppression.justification);
 }
 
@@ -10094,7 +10248,7 @@ pub fn freeDiagnosticSlice(allocator: Allocator, diagnostics: []Diagnostic) void
     if (diagnostics.len > 0) allocator.free(diagnostics);
 }
 
-fn freeFixes(allocator: Allocator, fixes: []Fix) void {
+fn freeFixes(allocator: Allocator, fixes: []const Fix) void {
     for (fixes) |fix| allocator.free(fix.replacement);
     if (fixes.len > 0) allocator.free(fixes);
 }
@@ -10444,6 +10598,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_export);
     try std.testing.expect(options.setByCliName("jest/no-export", true));
     try std.testing.expect(options.jest_no_export);
+
+    try std.testing.expect(!options.jest_no_focused_tests);
+    try std.testing.expect(options.setByCliName("jest/no-focused-tests", true));
+    try std.testing.expect(options.jest_no_focused_tests);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,11 @@ const JsonFix = struct {
     text: []const u8,
 };
 
+const JsonSuggestion = struct {
+    desc: []const u8,
+    fix: []const JsonFix,
+};
+
 const JsonSuppression = struct {
     kind: []const u8,
     justification: []const u8,
@@ -49,6 +54,7 @@ const JsonDiagnostic = struct {
     message: []const u8,
     ruleId: []const u8,
     fixes: []const JsonFix,
+    suggestions: []const JsonSuggestion,
     suppression: ?JsonSuppression = null,
 };
 
@@ -163,8 +169,10 @@ pub fn main(init: std.process.Init) !void {
                 std.process.exit(2);
             };
         } else if (std.mem.startsWith(u8, arg, "--rules=")) {
+            const jest_global_aliases = options.jest_global_aliases;
             const jest_version = options.jest_version;
             options = lint.Options.allDisabled();
+            options.jest_global_aliases = jest_global_aliases;
             options.jest_version = jest_version;
             clearRuleSeverities(allocator, &rule_severities);
             try parseEnabledRules(allocator, arg["--rules=".len..], &options, &rule_severities);
@@ -1499,6 +1507,15 @@ fn loadConfigFile(
                     std.process.exit(2);
                 };
             }
+            if (jest.get("globalAliases")) |aliases| {
+                options.setJestGlobalAliasesFromConfig(aliases) catch |err| {
+                    std.debug.print(
+                        "utoo-lint: invalid config {s} setting settings.jest.globalAliases: {s}\n",
+                        .{ path, @errorName(err) },
+                    );
+                    std.process.exit(2);
+                };
+            }
         }
     }
     const rules_value = root.get("rules") orelse return;
@@ -1547,7 +1564,7 @@ fn collectLintablePaths(
         if (json_diagnostics) |diagnostics| {
             const message = try std.fmt.allocPrint(allocator, "unable to stat path: {s}", .{@errorName(err)});
             defer allocator.free(message);
-            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{}, null);
+            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null);
         } else {
             std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
         }
@@ -2095,7 +2112,7 @@ fn lintFileJson(
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
         defer allocator.free(message);
-        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{}, null);
+        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null);
         stats.errors += 1;
         stats.diagnostics += 1;
         return;
@@ -2232,6 +2249,7 @@ fn appendJsonDiagnostic(
     rule_id: []const u8,
     source: []const u8,
     fixes: []const lint.Fix,
+    suggestions: []const lint.Suggestion,
     suppression: ?JsonSuppression,
 ) !void {
     const owned_path = try allocator.dupe(u8, path);
@@ -2245,6 +2263,9 @@ fn appendJsonDiagnostic(
 
     const owned_fixes = try dupeJsonFixes(allocator, source, fixes);
     errdefer freeOwnedJsonFixes(allocator, owned_fixes);
+
+    const owned_suggestions = try dupeJsonSuggestions(allocator, source, suggestions);
+    errdefer freeOwnedJsonSuggestions(allocator, owned_suggestions);
 
     const owned_suppression: ?JsonSuppression = if (suppression) |item| suppression: {
         const kind = try allocator.dupe(u8, item.kind);
@@ -2265,6 +2286,7 @@ fn appendJsonDiagnostic(
         .message = owned_message,
         .ruleId = owned_rule_id,
         .fixes = owned_fixes,
+        .suggestions = owned_suggestions,
         .suppression = owned_suppression,
     });
 }
@@ -2292,6 +2314,7 @@ fn appendJsonResultDiagnostics(
             diagnostic.rule_id,
             source,
             diagnostic.fixes,
+            diagnostic.suggestions,
             null,
         );
 
@@ -2322,6 +2345,7 @@ fn appendJsonResultSuppressedDiagnostics(
             diagnostic.rule_id,
             source,
             diagnostic.fixes,
+            diagnostic.suggestions,
             if (diagnostic.suppression) |suppression| .{
                 .kind = "directive",
                 .justification = suppression.justification,
@@ -2366,6 +2390,44 @@ fn freeOwnedJsonFixes(allocator: std.mem.Allocator, fixes: []const JsonFix) void
     if (fixes.len > 0) allocator.free(fixes);
 }
 
+fn dupeJsonSuggestions(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    suggestions: []const lint.Suggestion,
+) ![]JsonSuggestion {
+    if (suggestions.len == 0) return &.{};
+
+    const owned = try allocator.alloc(JsonSuggestion, suggestions.len);
+    var initialized: usize = 0;
+    errdefer {
+        freeJsonSuggestions(allocator, owned[0..initialized]);
+        allocator.free(owned);
+    }
+
+    for (suggestions, 0..) |suggestion, index| {
+        const desc = try allocator.dupe(u8, suggestion.message);
+        errdefer allocator.free(desc);
+        owned[index] = .{
+            .desc = desc,
+            .fix = try dupeJsonFixes(allocator, source, suggestion.fixes),
+        };
+        initialized += 1;
+    }
+    return owned;
+}
+
+fn freeJsonSuggestions(allocator: std.mem.Allocator, suggestions: []const JsonSuggestion) void {
+    for (suggestions) |suggestion| {
+        allocator.free(suggestion.desc);
+        freeOwnedJsonFixes(allocator, suggestion.fix);
+    }
+}
+
+fn freeOwnedJsonSuggestions(allocator: std.mem.Allocator, suggestions: []const JsonSuggestion) void {
+    freeJsonSuggestions(allocator, suggestions);
+    if (suggestions.len > 0) allocator.free(suggestions);
+}
+
 fn appendJsonOutput(allocator: std.mem.Allocator, outputs: *JsonOutputList, path: []const u8, output: []const u8) !void {
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
@@ -2381,6 +2443,7 @@ fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosti
         allocator.free(diagnostic.message);
         allocator.free(diagnostic.ruleId);
         freeOwnedJsonFixes(allocator, diagnostic.fixes);
+        freeOwnedJsonSuggestions(allocator, diagnostic.suggestions);
         if (diagnostic.suppression) |suppression| {
             allocator.free(suppression.kind);
             allocator.free(suppression.justification);

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,6 +13,7 @@ pub const Options = core.Options;
 pub const Diagnostic = core.Diagnostic;
 pub const Suppression = core.Suppression;
 pub const Fix = core.Fix;
+pub const Suggestion = core.Suggestion;
 pub const Result = core.Result;
 pub const ApplyFixesResult = fixer.ApplyResult;
 pub const max_autofix_passes = 10;
@@ -294,6 +295,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_conditional_expect or
         options.jest_no_deprecated_functions or
         options.jest_no_export or
+        options.jest_no_focused_tests or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_fn_call.zig
+++ b/src/rules/jest_fn_call.zig
@@ -1,0 +1,437 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const Function = enum {
+    describe,
+    fdescribe,
+    xdescribe,
+    test_case,
+    xtest,
+    it,
+    fit,
+    xit,
+
+    pub fn canonicalName(self: Function) []const u8 {
+        return switch (self) {
+            .describe => "describe",
+            .fdescribe => "fdescribe",
+            .xdescribe => "xdescribe",
+            .test_case => "test",
+            .xtest => "xtest",
+            .it => "it",
+            .fit => "fit",
+            .xit => "xit",
+        };
+    }
+
+    pub fn kind(self: Function) Kind {
+        return switch (self) {
+            .describe, .fdescribe, .xdescribe => .describe,
+            .test_case, .xtest, .it, .fit, .xit => .test_case,
+        };
+    }
+
+    pub fn isFocused(self: Function) bool {
+        return self == .fdescribe or self == .fit;
+    }
+};
+
+pub const Kind = enum {
+    describe,
+    test_case,
+};
+
+pub const Origin = enum {
+    global,
+    import,
+    require,
+};
+
+pub const Member = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+    computed: bool,
+};
+
+pub const Call = struct {
+    function: Function,
+    origin: Origin,
+    head: ast.NodeIndex,
+    local_name: []const u8,
+    members: [4]Member = undefined,
+    member_count: usize = 0,
+
+    pub fn memberSlice(self: *const Call) []const Member {
+        return self.members[0..self.member_count];
+    }
+
+    pub fn memberNamed(self: *const Call, name: []const u8) ?Member {
+        for (self.memberSlice()) |member| {
+            if (std.mem.eql(u8, member.name, name)) return member;
+        }
+        return null;
+    }
+
+    pub fn isAliasedImport(self: *const Call) bool {
+        return self.origin != .global and !std.mem.eql(u8, self.function.canonicalName(), self.local_name);
+    }
+};
+
+const Binding = struct {
+    function: Function,
+    origin: Origin,
+    local_name: []const u8,
+};
+
+const BindingMap = std.AutoHashMapUnmanaged(traverser.semantic.SymbolId, Binding);
+
+pub const Resolver = struct {
+    allocator: Allocator,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+    bindings: BindingMap = .empty,
+
+    pub fn init(
+        allocator: Allocator,
+        tree: *const ast.Tree,
+        symbol_table: traverser.semantic.SymbolTable,
+        global_aliases: core.JestGlobalAliases,
+    ) Allocator.Error!Resolver {
+        var resolver = Resolver{
+            .allocator = allocator,
+            .tree = tree,
+            .symbol_table = symbol_table,
+            .global_aliases = global_aliases,
+        };
+        errdefer resolver.deinit();
+        try resolver.collectBindings();
+        return resolver;
+    }
+
+    pub fn deinit(self: *Resolver) void {
+        self.bindings.deinit(self.allocator);
+    }
+
+    pub fn parseCall(
+        self: *const Resolver,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        parent: ?ast.NodeIndex,
+    ) ?Call {
+        if (!isTopmostCall(self.tree, index, parent)) return null;
+
+        var chain: CalleeChain = .{};
+        if (!collectCalleeChain(self.tree, call.callee, &chain)) return null;
+        const local_name = identifierName(self.tree, chain.root) orelse return null;
+        const reference_id = self.symbol_table.model.referenceOf(chain.root) orelse return null;
+        const symbol_id = self.symbol_table.referenceSymbol(reference_id);
+
+        const binding: Binding = if (symbol_id == .none) blk: {
+            const canonical_name = self.global_aliases.canonicalFor(local_name) orelse local_name;
+            break :blk .{
+                .function = functionForName(canonical_name) orelse return null,
+                .origin = .global,
+                .local_name = local_name,
+            };
+        } else self.bindings.get(symbol_id) orelse return null;
+
+        if (!isValidCall(binding.function, chain)) return null;
+
+        var result = Call{
+            .function = binding.function,
+            .origin = binding.origin,
+            .head = chain.root,
+            .local_name = binding.local_name,
+            .member_count = chain.member_count,
+        };
+        @memcpy(result.members[0..chain.member_count], chain.members[0..chain.member_count]);
+        return result;
+    }
+
+    fn collectBindings(self: *Resolver) Allocator.Error!void {
+        const program = switch (self.tree.data(self.tree.root)) {
+            .program => |value| value,
+            else => return,
+        };
+
+        for (self.tree.extra(program.body)) |statement_index| {
+            switch (self.tree.data(statement_index)) {
+                .import_declaration => |declaration| try self.collectImportDeclaration(declaration),
+                else => {},
+            }
+        }
+
+        var visitor = BindingCollector{ .resolver = self };
+        try traverser.basic.traverse(BindingCollector, self.tree, &visitor);
+    }
+
+    fn collectImportDeclaration(self: *Resolver, declaration: ast.ImportDeclaration) Allocator.Error!void {
+        if (declaration.import_kind == .type) return;
+        const source = stringLiteralValue(self.tree, declaration.source) orelse return;
+        if (!std.mem.eql(u8, source, "@jest/globals")) return;
+
+        for (self.tree.extra(declaration.specifiers)) |specifier_index| {
+            const specifier = switch (self.tree.data(specifier_index)) {
+                .import_specifier => |value| value,
+                else => continue,
+            };
+            if (specifier.import_kind == .type) continue;
+            const imported = propertyNodeName(self.tree, specifier.imported) orelse continue;
+            const function = functionForName(imported) orelse continue;
+            const local_name = bindingIdentifierName(self.tree, specifier.local) orelse continue;
+            const symbol_id = self.symbol_table.symbolOf(specifier.local) orelse continue;
+            try self.bindings.put(self.allocator, symbol_id, .{
+                .function = function,
+                .origin = .import,
+                .local_name = local_name,
+            });
+        }
+    }
+
+    fn collectRequireDeclarator(self: *Resolver, declarator: ast.VariableDeclarator) Allocator.Error!void {
+        const pattern = switch (self.tree.data(declarator.id)) {
+            .object_pattern => |value| value,
+            else => return,
+        };
+        const call_index = unwrapTransparent(self.tree, declarator.init);
+        const call = switch (self.tree.data(call_index)) {
+            .call_expression => |value| value,
+            else => return,
+        };
+        const callee = unwrapTransparent(self.tree, call.callee);
+        const callee_name = identifierName(self.tree, callee) orelse return;
+        if (!std.mem.eql(u8, callee_name, "require")) return;
+        if (!self.symbol_table.isUnresolvedReference(callee)) return;
+        const arguments = self.tree.extra(call.arguments);
+        if (arguments.len != 1) return;
+        const source = stringLiteralValue(self.tree, arguments[0]) orelse return;
+        if (!std.mem.eql(u8, source, "@jest/globals")) return;
+
+        for (self.tree.extra(pattern.properties)) |property_index| {
+            const property = switch (self.tree.data(property_index)) {
+                .binding_property => |value| value,
+                else => continue,
+            };
+            if (property.computed) continue;
+            const imported = propertyNodeName(self.tree, property.key) orelse continue;
+            const function = functionForName(imported) orelse continue;
+            const local_name = bindingIdentifierName(self.tree, property.value) orelse continue;
+            const symbol_id = self.symbol_table.symbolOf(property.value) orelse continue;
+            try self.bindings.put(self.allocator, symbol_id, .{
+                .function = function,
+                .origin = .require,
+                .local_name = local_name,
+            });
+        }
+    }
+};
+
+const BindingCollector = struct {
+    resolver: *Resolver,
+
+    pub fn enter_variable_declarator(
+        self: *BindingCollector,
+        declarator: ast.VariableDeclarator,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.resolver.collectRequireDeclarator(declarator);
+        return .proceed;
+    }
+};
+
+const CalleeChain = struct {
+    root: ast.NodeIndex = .null,
+    members: [4]Member = undefined,
+    member_count: usize = 0,
+    nested_calls: usize = 0,
+    tagged_templates: usize = 0,
+
+    fn append(self: *CalleeChain, member: Member) bool {
+        if (self.member_count == self.members.len) return false;
+        self.members[self.member_count] = member;
+        self.member_count += 1;
+        return true;
+    }
+
+    fn memberSlice(self: *const CalleeChain) []const Member {
+        return self.members[0..self.member_count];
+    }
+};
+
+fn collectCalleeChain(tree: *const ast.Tree, index: ast.NodeIndex, chain: *CalleeChain) bool {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .identifier_reference => blk: {
+            if (chain.root != .null) break :blk false;
+            chain.root = current;
+            break :blk true;
+        },
+        .member_expression => |member| blk: {
+            if (!collectCalleeChain(tree, member.object, chain)) break :blk false;
+            const property = staticPropertyName(tree, member.property) orelse break :blk false;
+            break :blk chain.append(.{
+                .name = property,
+                .node = member.property,
+                .computed = member.computed,
+            });
+        },
+        .call_expression => |call| {
+            chain.nested_calls += 1;
+            return collectCalleeChain(tree, call.callee, chain);
+        },
+        .tagged_template_expression => |tagged| {
+            chain.tagged_templates += 1;
+            return collectCalleeChain(tree, tagged.tag, chain);
+        },
+        else => false,
+    };
+}
+
+fn isTopmostCall(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeIndex) bool {
+    const parent_index = parent orelse return true;
+    return switch (tree.data(parent_index)) {
+        .call_expression => |call| unwrapTransparent(tree, call.callee) != index,
+        .member_expression => |member| unwrapTransparent(tree, member.object) != index,
+        .tagged_template_expression => |tagged| unwrapTransparent(tree, tagged.tag) != index,
+        else => true,
+    };
+}
+
+fn isValidCall(function: Function, chain: CalleeChain) bool {
+    const members = chain.memberSlice();
+    const ends_in_each = members.len != 0 and std.mem.eql(u8, members[members.len - 1].name, "each");
+
+    if (ends_in_each) {
+        if (chain.nested_calls + chain.tagged_templates != 1) return false;
+    } else if (chain.nested_calls != 0 or chain.tagged_templates != 0) {
+        return false;
+    }
+
+    return switch (function) {
+        .describe => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"only"}) or
+            matchesMembers(members, &.{ "only", "each" }) or
+            matchesMembers(members, &.{"skip"}) or
+            matchesMembers(members, &.{ "skip", "each" }),
+        .fdescribe, .xdescribe => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}),
+        .test_case, .it => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"todo"}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"failing"}) or
+            matchesMembers(members, &.{ "failing", "each" }) or
+            matchesMembers(members, &.{"only"}) or
+            matchesMembers(members, &.{ "only", "each" }) or
+            matchesMembers(members, &.{ "only", "failing" }) or
+            matchesMembers(members, &.{ "only", "failing", "each" }) or
+            matchesMembers(members, &.{"skip"}) or
+            matchesMembers(members, &.{ "skip", "each" }) or
+            matchesMembers(members, &.{ "skip", "failing" }) or
+            matchesMembers(members, &.{ "skip", "failing", "each" }) or
+            matchesMembers(members, &.{"concurrent"}) or
+            matchesMembers(members, &.{ "concurrent", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "only", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "skip", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "only", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "skip", "each" }),
+        .xtest, .fit, .xit => matchesMembers(members, &.{}) or
+            matchesMembers(members, &.{"each"}) or
+            matchesMembers(members, &.{"failing"}) or
+            matchesMembers(members, &.{ "failing", "each" }),
+    };
+}
+
+fn matchesMembers(actual: []const Member, expected: []const []const u8) bool {
+    if (actual.len != expected.len) return false;
+    for (actual, expected) |actual_member, expected_member| {
+        if (!std.mem.eql(u8, actual_member.name, expected_member)) return false;
+    }
+    return true;
+}
+
+fn functionForName(name: []const u8) ?Function {
+    if (std.mem.eql(u8, name, "describe")) return .describe;
+    if (std.mem.eql(u8, name, "fdescribe")) return .fdescribe;
+    if (std.mem.eql(u8, name, "xdescribe")) return .xdescribe;
+    if (std.mem.eql(u8, name, "test")) return .test_case;
+    if (std.mem.eql(u8, name, "xtest")) return .xtest;
+    if (std.mem.eql(u8, name, "it")) return .it;
+    if (std.mem.eql(u8, name, "fit")) return .fit;
+    if (std.mem.eql(u8, name, "xit")) return .xit;
+    return null;
+}
+
+fn identifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn bindingIdentifierName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .binding_identifier => |identifier| tree.string(identifier.name),
+        else => null,
+    };
+}
+
+fn propertyNodeName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn stringLiteralValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/jest_fn_call.zig
+++ b/src/rules/jest_fn_call.zig
@@ -56,6 +56,7 @@ pub const Member = struct {
     name: []const u8,
     node: ast.NodeIndex,
     computed: bool,
+    accessor_span: ast.Span,
 };
 
 pub const Call = struct {
@@ -77,8 +78,8 @@ pub const Call = struct {
         return null;
     }
 
-    pub fn isAliasedImport(self: *const Call) bool {
-        return self.origin != .global and !std.mem.eql(u8, self.function.canonicalName(), self.local_name);
+    pub fn usesCanonicalName(self: *const Call) bool {
+        return std.mem.eql(u8, self.function.canonicalName(), self.local_name);
     }
 };
 
@@ -276,10 +277,12 @@ fn collectCalleeChain(tree: *const ast.Tree, index: ast.NodeIndex, chain: *Calle
         .member_expression => |member| blk: {
             if (!collectCalleeChain(tree, member.object, chain)) break :blk false;
             const property = staticPropertyName(tree, member.property) orelse break :blk false;
+            const accessor_start = memberAccessorStart(tree, member) orelse break :blk false;
             break :blk chain.append(.{
                 .name = property,
                 .node = member.property,
                 .computed = member.computed,
+                .accessor_span = .{ .start = @intCast(accessor_start), .end = tree.span(current).end },
             });
         },
         .call_expression => |call| {
@@ -340,8 +343,10 @@ fn isValidCall(function: Function, chain: CalleeChain) bool {
             matchesMembers(members, &.{ "concurrent", "each" }) or
             matchesMembers(members, &.{ "concurrent", "failing" }) or
             matchesMembers(members, &.{ "concurrent", "failing", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "failing", "only" }) or
             matchesMembers(members, &.{ "concurrent", "failing", "only", "each" }) or
             matchesMembers(members, &.{ "concurrent", "failing", "skip", "each" }) or
+            matchesMembers(members, &.{ "concurrent", "only" }) or
             matchesMembers(members, &.{ "concurrent", "only", "each" }) or
             matchesMembers(members, &.{ "concurrent", "skip", "each" }),
         .xtest, .fit, .xit => matchesMembers(members, &.{}) or
@@ -418,6 +423,39 @@ fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]c
         .template_element => |element| tree.string(element.cooked),
         else => null,
     };
+}
+
+fn memberAccessorStart(tree: *const ast.Tree, member: ast.MemberExpression) ?usize {
+    const source = tree.source;
+    const object_end = tree.span(member.object).end;
+    const property_start = tree.span(member.property).start;
+    if (object_end > property_start or property_start > source.len) return null;
+
+    var cursor = object_end;
+    while (cursor < property_start) {
+        if (std.ascii.isWhitespace(source[cursor])) {
+            cursor += 1;
+            continue;
+        }
+        if (cursor + 1 < property_start and source[cursor] == '/' and source[cursor + 1] == '/') {
+            cursor += 2;
+            while (cursor < property_start and source[cursor] != '\n' and source[cursor] != '\r') cursor += 1;
+            continue;
+        }
+        if (cursor + 1 < property_start and source[cursor] == '/' and source[cursor + 1] == '*') {
+            cursor += 2;
+            while (cursor + 1 < property_start and !(source[cursor] == '*' and source[cursor + 1] == '/')) {
+                cursor += 1;
+            }
+            if (cursor + 1 < property_start) cursor += 2;
+            continue;
+        }
+        if (member.optional and source[cursor] == '?') return cursor;
+        if (member.computed and source[cursor] == '[') return cursor;
+        if (!member.computed and source[cursor] == '.') return cursor;
+        cursor += 1;
+    }
+    return null;
 }
 
 fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {

--- a/src/rules/jest_no_focused_tests.zig
+++ b/src/rules/jest_no_focused_tests.zig
@@ -44,7 +44,7 @@ const Visitor = struct {
         const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
 
         if (call.function.isFocused()) {
-            if (call.isAliasedImport()) {
+            if (!call.usesCanonicalName()) {
                 try core.addDiagnostic(
                     self.allocator,
                     self.diagnostics,
@@ -77,9 +77,6 @@ const Visitor = struct {
 
         const only = call.memberNamed("only") orelse return .proceed;
         const property_span = ctx.tree.span(only.node);
-        if (property_span.start == 0) return .proceed;
-        const end = property_span.end + @intFromBool(only.computed);
-        if (end > ctx.tree.source.len) return .proceed;
 
         try core.addDiagnosticWithSuggestions(
             self.allocator,
@@ -91,7 +88,7 @@ const Visitor = struct {
             &.{.{
                 .message = suggestion_message,
                 .fixes = &.{.{
-                    .span = .{ .start = property_span.start - 1, .end = end },
+                    .span = only.accessor_span,
                     .replacement = "",
                 }},
             }},

--- a/src/rules/jest_no_focused_tests.zig
+++ b/src/rules/jest_no_focused_tests.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-focused-tests";
+
+const message = "Unexpected focused test";
+const suggestion_message = "Remove focus from test";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+
+        if (call.function.isFocused()) {
+            if (call.isAliasedImport()) {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    message,
+                    ctx.tree.span(call.head),
+                );
+                return .proceed;
+            }
+
+            const head_span = ctx.tree.span(call.head);
+            try core.addDiagnosticWithSuggestions(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                message,
+                head_span,
+                &.{.{
+                    .message = suggestion_message,
+                    .fixes = &.{.{
+                        .span = .{ .start = head_span.start, .end = head_span.start + 1 },
+                        .replacement = "",
+                    }},
+                }},
+            );
+            return .proceed;
+        }
+
+        const only = call.memberNamed("only") orelse return .proceed;
+        const property_span = ctx.tree.span(only.node);
+        if (property_span.start == 0) return .proceed;
+        const end = property_span.end + @intFromBool(only.computed);
+        if (end > ctx.tree.source.len) return .proceed;
+
+        try core.addDiagnosticWithSuggestions(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            message,
+            property_span,
+            &.{.{
+                .message = suggestion_message,
+                .fixes = &.{.{
+                    .span = .{ .start = property_span.start - 1, .end = end },
+                    .replacement = "",
+                }},
+            }},
+        );
+        return .proceed;
+    }
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -81,6 +81,7 @@ pub const import_no_self_import = @import("import_no_self_import.zig");
 pub const jest_no_conditional_expect = @import("jest_no_conditional_expect.zig");
 pub const jest_no_deprecated_functions = @import("jest_no_deprecated_functions.zig");
 pub const jest_no_export = @import("jest_no_export.zig");
+pub const jest_no_focused_tests = @import("jest_no_focused_tests.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1016,6 +1017,16 @@ fn runSemanticAfterIo(
 
     if (options.jest_no_export) {
         try jest_no_export.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.jest_no_focused_tests) {
+        try jest_no_focused_tests.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+        );
     }
 
     if (options.block_scoped_var) {

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -327,6 +327,12 @@ fn parseConfig(
                     return error.InvalidOptions;
                 };
             }
+            if (jest.get("globalAliases")) |aliases| {
+                config.options.setJestGlobalAliasesFromConfig(aliases) catch |err| {
+                    failure.* = .{ .code = "INVALID_OPTIONS", .message = @errorName(err) };
+                    return error.InvalidOptions;
+                };
+            }
         }
     }
 
@@ -458,12 +464,31 @@ fn writeDiagnostic(
         end.column,
     });
     try writeFixes(writer, source, diagnostic.fixes);
+    try writer.writeAll(",\"suggestions\":");
+    try writeSuggestions(writer, source, diagnostic.suggestions);
     if (diagnostic.suppression) |suppression| {
         try writer.writeAll(",\"suppression\":{\"kind\":\"directive\",\"justification\":");
         try writeJsonValue(writer, suppression.justification);
         try writer.writeByte('}');
     }
     try writer.writeByte('}');
+}
+
+fn writeSuggestions(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    suggestions: []const lint_engine.Suggestion,
+) !void {
+    try writer.writeByte('[');
+    for (suggestions, 0..) |suggestion, index| {
+        if (index != 0) try writer.writeByte(',');
+        try writer.writeAll("{\"desc\":");
+        try writeJsonValue(writer, suggestion.message);
+        try writer.writeAll(",\"fix\":");
+        try writeFixes(writer, source, suggestion.fixes);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
 }
 
 fn writeFixes(

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -270,6 +270,7 @@ comptime {
     _ = @import("rules/jest_no_conditional_expect.zig");
     _ = @import("rules/jest_no_deprecated_functions.zig");
     _ = @import("rules/jest_no_export.zig");
+    _ = @import("rules/jest_no_focused_tests.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_focused_tests.zig
+++ b/tests/rules/jest_no_focused_tests.zig
@@ -1,0 +1,203 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_focused_tests.id;
+
+test "reports focused global calls with useful locations and suggestions" {
+    const cases = [_]struct {
+        source: []const u8,
+        reported: []const u8,
+        expected: []const u8,
+    }{
+        .{ .source = "describe.only()", .reported = "only", .expected = "describe()" },
+        .{ .source = "describe.only.each()()", .reported = "only", .expected = "describe.each()()" },
+        .{ .source = "describe.only.each`table`()", .reported = "only", .expected = "describe.each`table`()" },
+        .{ .source = "describe[\"only\"]()", .reported = "\"only\"", .expected = "describe()" },
+        .{ .source = "it.concurrent.only.each``()", .reported = "only", .expected = "it.concurrent.each``()" },
+        .{ .source = "test.only.each()()", .reported = "only", .expected = "test.each()()" },
+        .{ .source = "fdescribe()", .reported = "fdescribe", .expected = "describe()" },
+        .{ .source = "fit()", .reported = "fit", .expected = "it()" },
+        .{ .source = "fit.each`table`()", .reported = "fit", .expected = "it.each`table`()" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings("Unexpected focused test", diagnostic.message);
+        try std.testing.expectEqualStrings(case.reported, case.source[diagnostic.span.start..diagnostic.span.end]);
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        try std.testing.expectEqual(@as(usize, 1), diagnostic.suggestions.len);
+        try std.testing.expectEqualStrings("Remove focus from test", diagnostic.suggestions[0].message);
+        try std.testing.expectEqual(@as(usize, 1), diagnostic.suggestions[0].fixes.len);
+
+        const suggested = try applySuggestion(std.testing.allocator, case.source, diagnostic.suggestions[0]);
+        defer std.testing.allocator.free(suggested);
+        try std.testing.expectEqualStrings(case.expected, suggested);
+    }
+}
+
+test "allows unfocused and indirect Jest calls" {
+    const cases = [_][]const u8{
+        "describe()",
+        "it()",
+        "describe.skip()",
+        "it.skip()",
+        "test()",
+        "test.skip()",
+        "const appliedOnly = describe.only; appliedOnly.apply(describe);",
+        "const calledOnly = it.only; calledOnly.call(it);",
+        "it.each()()",
+        "it.each`table`()",
+        "test.each()()",
+        "test.each`table`()",
+        "test.concurrent()",
+        "function fit() {} fit();",
+        "function describe() {} describe.only();",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, rule_id));
+    }
+}
+
+test "supports configured global aliases" {
+    const source = "context.only('suite', () => {});";
+    var options = optionsOnly();
+    try std.testing.expect(options.jest_global_aliases.append("describe", "context"));
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+
+    const diagnostic = findDiagnostic(result).?;
+    const suggested = try applySuggestion(std.testing.allocator, source, diagnostic.suggestions[0]);
+    defer std.testing.allocator.free(suggested);
+    try std.testing.expectEqualStrings("context('suite', () => {});", suggested);
+}
+
+test "supports ESM aliases and withholds unsafe focused-name suggestions" {
+    const source =
+        \\import { describe as describeThis, fdescribe as describeJustThis } from "@jest/globals";
+        \\describeThis.only();
+        \\describeJustThis();
+        \\describeJustThis.each()();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics[0].suggestions.len);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[1].suggestions.len);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[2].suggestions.len);
+
+    const valid_alias =
+        \\import { describe as fdescribe } from "@jest/globals";
+        \\fdescribe();
+    ;
+    var valid_result = try lint.lintSource(std.testing.allocator, valid_alias, "fixture.js", optionsOnly());
+    defer valid_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(valid_result, rule_id));
+}
+
+test "supports destructured CommonJS Jest globals" {
+    const source =
+        \\const { describe: suite, fdescribe } = require("@jest/globals");
+        \\suite.only();
+        \\fdescribe();
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics[0].suggestions.len);
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics[1].suggestions.len);
+
+    const nested =
+        \\function register() {
+        \\  const { fdescribe } = require("@jest/globals");
+        \\  fdescribe();
+        \\}
+    ;
+    var nested_result = try lint.lintSource(std.testing.allocator, nested, "fixture.js", optionsOnly());
+    defer nested_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(nested_result, rule_id));
+
+    const shadowed =
+        \\function load(require) {
+        \\  const { fdescribe } = require("@jest/globals");
+        \\  fdescribe();
+        \\}
+    ;
+    var shadowed_result = try lint.lintSource(std.testing.allocator, shadowed, "fixture.js", optionsOnly());
+    defer shadowed_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(shadowed_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "test.only('js', () => {});", .file_name = "fixture.js" },
+        .{ .source = "test.only('ts', (): void => {});", .file_name = "fixture.ts" },
+        .{ .source = "test.only('jsx', () => <div />);", .file_name = "fixture.jsx" },
+        .{ .source = "test.only('tsx', (): JSX.Element => <div />);", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and parses rule and alias configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_focused_tests);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_focused_tests);
+
+    var rule_config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer rule_config.deinit();
+    options.jest_no_focused_tests = false;
+    try options.setByRuleConfigValue(rule_id, rule_config.value);
+    try std.testing.expect(options.jest_no_focused_tests);
+
+    var aliases = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "{\"describe\":[\"context\"],\"test\":[\"specify\"]}",
+        .{},
+    );
+    defer aliases.deinit();
+    try options.setJestGlobalAliasesFromConfig(aliases.value);
+    try std.testing.expectEqualStrings("describe", options.jest_global_aliases.canonicalFor("context").?);
+    try std.testing.expectEqualStrings("test", options.jest_global_aliases.canonicalFor("specify").?);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_focused_tests = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}
+
+fn applySuggestion(allocator: std.mem.Allocator, source: []const u8, suggestion: lint.Suggestion) ![]u8 {
+    const fix = suggestion.fixes[0];
+    return std.mem.concat(allocator, u8, &.{
+        source[0..fix.span.start],
+        fix.replacement,
+        source[fix.span.end..],
+    });
+}

--- a/tests/rules/jest_no_focused_tests.zig
+++ b/tests/rules/jest_no_focused_tests.zig
@@ -14,7 +14,11 @@ test "reports focused global calls with useful locations and suggestions" {
         .{ .source = "describe.only.each()()", .reported = "only", .expected = "describe.each()()" },
         .{ .source = "describe.only.each`table`()", .reported = "only", .expected = "describe.each`table`()" },
         .{ .source = "describe[\"only\"]()", .reported = "\"only\"", .expected = "describe()" },
+        .{ .source = "describe . only()", .reported = "only", .expected = "describe ()" },
+        .{ .source = "describe [ \"only\" /* focus */ ]()", .reported = "\"only\"", .expected = "describe ()" },
         .{ .source = "it.concurrent.only.each``()", .reported = "only", .expected = "it.concurrent.each``()" },
+        .{ .source = "test.concurrent.only()", .reported = "only", .expected = "test.concurrent()" },
+        .{ .source = "test.concurrent.failing.only()", .reported = "only", .expected = "test.concurrent.failing()" },
         .{ .source = "test.only.each()()", .reported = "only", .expected = "test.each()()" },
         .{ .source = "fdescribe()", .reported = "fdescribe", .expected = "describe()" },
         .{ .source = "fit()", .reported = "fit", .expected = "it()" },
@@ -79,6 +83,13 @@ test "supports configured global aliases" {
     const suggested = try applySuggestion(std.testing.allocator, source, diagnostic.suggestions[0]);
     defer std.testing.allocator.free(suggested);
     try std.testing.expectEqualStrings("context('suite', () => {});", suggested);
+
+    var focused_options = optionsOnly();
+    try std.testing.expect(focused_options.jest_global_aliases.append("fdescribe", "focusSuite"));
+    var focused_result = try lint.lintSource(std.testing.allocator, "focusSuite();", "fixture.js", focused_options);
+    defer focused_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(focused_result, rule_id));
+    try std.testing.expectEqual(@as(usize, 0), focused_result.diagnostics[0].suggestions.len);
 }
 
 test "supports ESM aliases and withholds unsafe focused-name suggestions" {

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -143,6 +143,29 @@ test("reports exports from files containing Jest tests", () => {
   assert.equal(result.diagnostics[0].message, "Do not export from a test file");
 });
 
+test("reports focused Jest tests with non-automatic suggestions", () => {
+  const source = "context.only('suite', () => {});";
+  const result = linter.lint(source, {
+    filePath: "input.js",
+    settings: { jest: { globalAliases: { describe: ["context"] } } },
+    rules: { "jest/no-focused-tests": "error" },
+  });
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/no-focused-tests");
+  assert.equal(result.diagnostics[0].fixes.length, 0);
+  assert.deepEqual(result.diagnostics[0].suggestions, [
+    { desc: "Remove focus from test", fix: [{ range: [7, 12], text: "" }] },
+  ]);
+
+  const fixed = linter.lintAndFix(source, {
+    filePath: "input.js",
+    settings: { jest: { globalAliases: { describe: ["context"] } } },
+    rules: { "jest/no-focused-tests": "error" },
+  });
+  assert.equal(fixed.fixed, false);
+  assert.equal(fixed.output, source);
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Implement native `jest/no-focused-tests` diagnostics for global, imported, aliased, CommonJS, and chained Jest calls.
- Add upstream-compatible editor suggestions without turning them into automatic fixes, including CLI, ESM/CommonJS, and WebAssembly output.
- Preserve `settings.jest.globalAliases` across project config and `--rules`, with schema, types, docs, and JS/TS/JSX/TSX coverage.
- Closes #1155


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
- `zig build test-wasm --summary all`