### PR TITLE
feat: add jest/no-identical-title

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -266,6 +266,7 @@ instead of being rewritten.
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | Implemented with installed or configured Jest version detection and upstream autofixes |
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | Implemented for ESM, CommonJS, and TypeScript exports in files containing Jest tests |
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | Implemented for focused global, imported, aliased, and chained tests with upstream editor suggestions |
+| [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | Implemented for duplicate static test and suite titles at the same suite level |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -265,6 +265,7 @@
 | [`jest/no-deprecated-functions`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md) | 已实现已安装或显式配置的 Jest 版本检测，并支持上游自动修复 |
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | 已实现对包含 Jest 测试的文件中的 ESM、CommonJS 和 TypeScript 导出检查 |
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | 已实现对全局、导入、别名及链式聚焦测试的检查，并提供上游编辑器建议 |
+| [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | 已实现对同一测试套件层级中重复静态测试和套件标题的检查 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -315,6 +315,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-deprecated-functions",
   "jest/no-export",
   "jest/no-focused-tests",
+  "jest/no-identical-title",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -318,6 +318,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-deprecated-functions",
   "jest/no-export",
   "jest/no-focused-tests",
+  "jest/no-identical-title",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2738,6 +2738,38 @@ test("jest/no-focused-tests preserves project settings and editor suggestions", 
   }
 });
 
+test("project config and CLI --rules enable jest/no-identical-title", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-identical-title": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "titles.test.js"),
+    "it('same', () => {}); test('same', () => {});\n"
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-identical-title", severity: "error" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-identical-title", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.deepEqual(isolatedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-identical-title", severity: "warning" }
+    ]);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2763,6 +2763,7 @@ pub const Options = struct {
     jest_no_deprecated_functions: bool = true,
     jest_no_export: bool = true,
     jest_no_focused_tests: bool = true,
+    jest_no_identical_title: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10602,6 +10603,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_focused_tests);
     try std.testing.expect(options.setByCliName("jest/no-focused-tests", true));
     try std.testing.expect(options.jest_no_focused_tests);
+
+    try std.testing.expect(!options.jest_no_identical_title);
+    try std.testing.expect(options.setByCliName("jest/no-identical-title", true));
+    try std.testing.expect(options.jest_no_identical_title);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -296,6 +296,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_deprecated_functions or
         options.jest_no_export or
         options.jest_no_focused_tests or
+        options.jest_no_identical_title or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_no_identical_title.zig
+++ b/src/rules/jest_no_identical_title.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-identical-title";
+
+const test_message = "Test title is used multiple times in the same describe block";
+const describe_message = "Describe block title is used multiple times in the same describe block";
+
+const TitleSet = std.StringHashMapUnmanaged(void);
+
+const DescribeContext = struct {
+    describe_titles: TitleSet = .empty,
+    test_titles: TitleSet = .empty,
+
+    fn deinit(self: *DescribeContext, allocator: Allocator) void {
+        self.describe_titles.deinit(allocator);
+        self.test_titles.deinit(allocator);
+    }
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var contexts: std.ArrayList(DescribeContext) = .empty;
+    defer {
+        for (contexts.items) |*context| context.deinit(allocator);
+        contexts.deinit(allocator);
+    }
+    try contexts.append(allocator, .{});
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+        .contexts = &contexts,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+    contexts: *std.ArrayList(DescribeContext),
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+        const kind = call.function.kind();
+        const parent_context_index = self.contexts.items.len - 1;
+
+        if (kind == .describe) try self.contexts.append(self.allocator, .{});
+        if (call.memberNamed("each") != null) return .proceed;
+
+        const arguments = ctx.tree.extra(call_expression.arguments);
+        if (arguments.len == 0) return .proceed;
+        const title = staticTitle(ctx.tree, arguments[0]) orelse return .proceed;
+
+        const parent_context = &self.contexts.items[parent_context_index];
+        const titles = if (kind == .describe) &parent_context.describe_titles else &parent_context.test_titles;
+        const entry = try titles.getOrPut(self.allocator, title);
+        if (!entry.found_existing) return .proceed;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            if (kind == .describe) describe_message else test_message,
+            ctx.tree.span(arguments[0]),
+        );
+        return .proceed;
+    }
+
+    pub fn exit_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return;
+        if (call.function.kind() != .describe) return;
+        if (self.contexts.pop()) |context_value| {
+            var context = context_value;
+            context.deinit(self.allocator);
+        }
+    }
+};
+
+fn staticTitle(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateTitle(tree, literal),
+        else => null,
+    };
+}
+
+fn templateTitle(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -82,6 +82,7 @@ pub const jest_no_conditional_expect = @import("jest_no_conditional_expect.zig")
 pub const jest_no_deprecated_functions = @import("jest_no_deprecated_functions.zig");
 pub const jest_no_export = @import("jest_no_export.zig");
 pub const jest_no_focused_tests = @import("jest_no_focused_tests.zig");
+pub const jest_no_identical_title = @import("jest_no_identical_title.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1021,6 +1022,16 @@ fn runSemanticAfterIo(
 
     if (options.jest_no_focused_tests) {
         try jest_no_focused_tests.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+        );
+    }
+
+    if (options.jest_no_identical_title) {
+        try jest_no_identical_title.run(
             allocator,
             diagnostics,
             tree,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -271,6 +271,7 @@ comptime {
     _ = @import("rules/jest_no_deprecated_functions.zig");
     _ = @import("rules/jest_no_export.zig");
     _ = @import("rules/jest_no_focused_tests.zig");
+    _ = @import("rules/jest_no_identical_title.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_identical_title.zig
+++ b/tests/rules/jest_no_identical_title.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_identical_title.id;
+
+test "reports duplicate test and describe titles with useful locations" {
+    const source =
+        \\describe("root", () => {
+        \\  it("same", () => {});
+        \\  test.only("same", () => {});
+        \\  describe("child", () => {});
+        \\  fdescribe("child", () => {});
+        \\});
+        \\test.concurrent("top", () => {});
+        \\xtest("top", () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+
+    const diagnostics = ruleDiagnostics(result);
+    try std.testing.expectEqualStrings("Test title is used multiple times in the same describe block", diagnostics[0].message);
+    try std.testing.expectEqualStrings("\"same\"", source[diagnostics[0].span.start..diagnostics[0].span.end]);
+    try std.testing.expectEqualStrings("Describe block title is used multiple times in the same describe block", diagnostics[1].message);
+    try std.testing.expectEqualStrings("\"child\"", source[diagnostics[1].span.start..diagnostics[1].span.end]);
+    try std.testing.expectEqualStrings("Test title is used multiple times in the same describe block", diagnostics[2].message);
+    try std.testing.expectEqualStrings("\"top\"", source[diagnostics[2].span.start..diagnostics[2].span.end]);
+}
+
+test "keeps nested suites and test and describe namespaces separate" {
+    const cases = [_][]const u8{
+        "describe('same', () => {}); it('same', () => {});",
+        \\describe("foo", () => {
+        \\  it("works", () => {});
+        \\  describe("child", () => {
+        \\    it("works", () => {});
+        \\  });
+        \\});
+        ,
+        \\describe("foo", () => {
+        \\  describe("child", () => {});
+        \\});
+        \\describe("child", () => {});
+        ,
+        "it(); it(); describe(); describe();",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, rule_id));
+    }
+}
+
+test "compares static templates and ignores dynamic and each titles" {
+    const source =
+        \\it(`static title`, () => {});
+        \\it("static title", () => {});
+        \\it(`${value}`, () => {});
+        \\it(`${value}`, () => {});
+        \\test("number " + value, () => {});
+        \\test("number " + value, () => {});
+        \\describe.each([])("generated", () => {});
+        \\describe.each([])("generated", () => {});
+        \\test.each``("generated test", () => {});
+        \\test.each``("generated test", () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    const diagnostic = ruleDiagnostics(result)[0];
+    try std.testing.expectEqualStrings("\"static title\"", source[diagnostic.span.start..diagnostic.span.end]);
+}
+
+test "supports imported Jest functions and configured global aliases" {
+    const imported_source =
+        \\import { describe as suite, test as check } from "@jest/globals";
+        \\suite("group", () => {});
+        \\suite("group", () => {});
+        \\check("case", () => {});
+        \\check("case", () => {});
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported_source, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(imported_result, rule_id));
+
+    var options = optionsOnly();
+    try std.testing.expect(options.jest_global_aliases.append("describe", "context"));
+    const alias_source =
+        \\context("group", () => {});
+        \\describe("group", () => {});
+    ;
+    var alias_result = try lint.lintSource(std.testing.allocator, alias_source, "fixture.js", options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "it('same', () => {}); it('same', () => {});", .file_name = "fixture.js" },
+        .{ .source = "it('same', (): void => {}); it('same', (): void => {});", .file_name = "fixture.ts" },
+        .{ .source = "it('same', () => <div />); it('same', () => <span />);", .file_name = "fixture.jsx" },
+        .{ .source = "it('same', (): JSX.Element => <div />); it('same', (): JSX.Element => <span />);", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_identical_title);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_identical_title);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer config.deinit();
+    options.jest_no_identical_title = false;
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_no_identical_title);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_identical_title = true;
+    return options;
+}
+
+fn ruleDiagnostics(result: lint.Result) []const lint.Diagnostic {
+    var start: usize = 0;
+    while (start < result.diagnostics.len and !std.mem.eql(u8, result.diagnostics[start].rule_id, rule_id)) : (start += 1) {}
+    var end = start;
+    while (end < result.diagnostics.len and std.mem.eql(u8, result.diagnostics[end].rule_id, rule_id)) : (end += 1) {}
+    return result.diagnostics[start..end];
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -166,6 +166,22 @@ test("reports focused Jest tests with non-automatic suggestions", () => {
   assert.equal(fixed.output, source);
 });
 
+test("reports identical Jest titles at the same suite level", () => {
+  const result = linter.lint(
+    "describe('group', () => { it('same', () => {}); test('same', () => {}); });",
+    {
+      filePath: "input.js",
+      rules: { "jest/no-identical-title": "error" },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/no-identical-title");
+  assert.equal(
+    result.diagnostics[0].message,
+    "Test title is used multiple times in the same describe block",
+  );
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Implement native `jest/no-identical-title` diagnostics for duplicate static test and suite titles at the same suite level.
- Keep nested suite contexts and test/describe namespaces separate while matching upstream handling for static templates, dynamic titles, and `.each`.
- Register the rule across native, ESM, CommonJS, and WebAssembly paths with config, CLI, alias, language-mode, and documentation coverage.
- Closes #1156


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `zig build test-wasm --summary all`