### PR TITLE
feat: add jest/no-interpolation-in-snapshots

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -267,6 +267,7 @@ instead of being rewritten.
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | Implemented for ESM, CommonJS, and TypeScript exports in files containing Jest tests |
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | Implemented for focused global, imported, aliased, and chained tests with upstream editor suggestions |
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | Implemented for duplicate static test and suite titles at the same suite level |
+| [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | Implemented for interpolated inline snapshot templates, including property matcher overloads |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -266,6 +266,7 @@
 | [`jest/no-export`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) | 已实现对包含 Jest 测试的文件中的 ESM、CommonJS 和 TypeScript 导出检查 |
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | 已实现对全局、导入、别名及链式聚焦测试的检查，并提供上游编辑器建议 |
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | 已实现对同一测试套件层级中重复静态测试和套件标题的检查 |
+| [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | 已实现对内联快照模板插值的检查，包括属性匹配器重载形式 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -316,6 +316,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-export",
   "jest/no-focused-tests",
   "jest/no-identical-title",
+  "jest/no-interpolation-in-snapshots",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -319,6 +319,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-export",
   "jest/no-focused-tests",
   "jest/no-identical-title",
+  "jest/no-interpolation-in-snapshots",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2770,6 +2770,38 @@ test("project config and CLI --rules enable jest/no-identical-title", (t) => {
   }
 });
 
+test("project config and CLI --rules enable jest/no-interpolation-in-snapshots", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-interpolation-in-snapshots": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "inline-snapshot.test.js"),
+    "expect(value).toMatchInlineSnapshot(`${value}`);\n"
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-interpolation-in-snapshots", severity: "error" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-interpolation-in-snapshots", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.deepEqual(isolatedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-interpolation-in-snapshots", severity: "warning" }
+    ]);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2764,6 +2764,7 @@ pub const Options = struct {
     jest_no_export: bool = true,
     jest_no_focused_tests: bool = true,
     jest_no_identical_title: bool = true,
+    jest_no_interpolation_in_snapshots: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10607,6 +10608,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_identical_title);
     try std.testing.expect(options.setByCliName("jest/no-identical-title", true));
     try std.testing.expect(options.jest_no_identical_title);
+
+    try std.testing.expect(!options.jest_no_interpolation_in_snapshots);
+    try std.testing.expect(options.setByCliName("jest/no-interpolation-in-snapshots", true));
+    try std.testing.expect(options.jest_no_interpolation_in_snapshots);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -297,6 +297,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_export or
         options.jest_no_focused_tests or
         options.jest_no_identical_title or
+        options.jest_no_interpolation_in_snapshots or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_fn_call.zig
+++ b/src/rules/jest_fn_call.zig
@@ -15,6 +15,7 @@ pub const Function = enum {
     it,
     fit,
     xit,
+    expect,
 
     pub fn canonicalName(self: Function) []const u8 {
         return switch (self) {
@@ -26,6 +27,7 @@ pub const Function = enum {
             .it => "it",
             .fit => "fit",
             .xit => "xit",
+            .expect => "expect",
         };
     }
 
@@ -33,6 +35,7 @@ pub const Function = enum {
         return switch (self) {
             .describe, .fdescribe, .xdescribe => .describe,
             .test_case, .xtest, .it, .fit, .xit => .test_case,
+            .expect => .expect,
         };
     }
 
@@ -44,6 +47,7 @@ pub const Function = enum {
 pub const Kind = enum {
     describe,
     test_case,
+    expect,
 };
 
 pub const Origin = enum {
@@ -76,6 +80,11 @@ pub const Call = struct {
             if (std.mem.eql(u8, member.name, name)) return member;
         }
         return null;
+    }
+
+    pub fn lastMember(self: *const Call) ?Member {
+        if (self.member_count == 0) return null;
+        return self.members[self.member_count - 1];
     }
 
     pub fn usesCanonicalName(self: *const Call) bool {
@@ -308,6 +317,8 @@ fn isTopmostCall(tree: *const ast.Tree, index: ast.NodeIndex, parent: ?ast.NodeI
 }
 
 fn isValidCall(function: Function, chain: CalleeChain) bool {
+    if (function == .expect) return isValidExpectCall(chain);
+
     const members = chain.memberSlice();
     const ends_in_each = members.len != 0 and std.mem.eql(u8, members[members.len - 1].name, "each");
 
@@ -353,6 +364,25 @@ fn isValidCall(function: Function, chain: CalleeChain) bool {
             matchesMembers(members, &.{"each"}) or
             matchesMembers(members, &.{"failing"}) or
             matchesMembers(members, &.{ "failing", "each" }),
+        .expect => unreachable,
+    };
+}
+
+fn isValidExpectCall(chain: CalleeChain) bool {
+    if (chain.tagged_templates != 0 or chain.nested_calls > 1) return false;
+    const members = chain.memberSlice();
+    if (members.len == 0) return chain.nested_calls == 0;
+
+    const modifiers = members[0 .. members.len - 1];
+    return switch (modifiers.len) {
+        0 => true,
+        1 => std.mem.eql(u8, modifiers[0].name, "not") or
+            std.mem.eql(u8, modifiers[0].name, "resolves") or
+            std.mem.eql(u8, modifiers[0].name, "rejects"),
+        2 => (std.mem.eql(u8, modifiers[0].name, "resolves") or
+            std.mem.eql(u8, modifiers[0].name, "rejects")) and
+            std.mem.eql(u8, modifiers[1].name, "not"),
+        else => false,
     };
 }
 
@@ -373,6 +403,7 @@ fn functionForName(name: []const u8) ?Function {
     if (std.mem.eql(u8, name, "it")) return .it;
     if (std.mem.eql(u8, name, "fit")) return .fit;
     if (std.mem.eql(u8, name, "xit")) return .xit;
+    if (std.mem.eql(u8, name, "expect")) return .expect;
     return null;
 }
 

--- a/src/rules/jest_no_focused_tests.zig
+++ b/src/rules/jest_no_focused_tests.zig
@@ -42,6 +42,7 @@ const Visitor = struct {
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
         const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+        if (call.function.kind() == .expect) return .proceed;
 
         if (call.function.isFocused()) {
             if (!call.usesCanonicalName()) {

--- a/src/rules/jest_no_identical_title.zig
+++ b/src/rules/jest_no_identical_title.zig
@@ -64,6 +64,7 @@ const Visitor = struct {
     ) Allocator.Error!traverser.Action {
         const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
         const kind = call.function.kind();
+        if (kind == .expect) return .proceed;
         const parent_context_index = self.contexts.items.len - 1;
 
         if (kind == .describe) try self.contexts.append(self.allocator, .{});

--- a/src/rules/jest_no_interpolation_in_snapshots.zig
+++ b/src/rules/jest_no_interpolation_in_snapshots.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-interpolation-in-snapshots";
+
+const message = "Do not use string interpolation inside of snapshots";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+        if (call.function.kind() != .expect) return .proceed;
+
+        const matcher = call.lastMember() orelse return .proceed;
+        if (!isInlineSnapshotMatcher(matcher.name)) return .proceed;
+
+        for (ctx.tree.extra(call_expression.arguments)) |argument| {
+            const template = switch (ctx.tree.data(argument)) {
+                .template_literal => |value| value,
+                else => continue,
+            };
+            if (template.expressions.len == 0) continue;
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                message,
+                ctx.tree.span(argument),
+            );
+        }
+        return .proceed;
+    }
+};
+
+fn isInlineSnapshotMatcher(name: []const u8) bool {
+    return std.mem.eql(u8, name, "toMatchInlineSnapshot") or
+        std.mem.eql(u8, name, "toThrowErrorMatchingInlineSnapshot");
+}

--- a/src/rules/jest_no_interpolation_in_snapshots.zig
+++ b/src/rules/jest_no_interpolation_in_snapshots.zig
@@ -47,7 +47,8 @@ const Visitor = struct {
         if (!isInlineSnapshotMatcher(matcher.name)) return .proceed;
 
         for (ctx.tree.extra(call_expression.arguments)) |argument| {
-            const template = switch (ctx.tree.data(argument)) {
+            const template_index = unwrapTransparent(ctx.tree, argument);
+            const template = switch (ctx.tree.data(template_index)) {
                 .template_literal => |value| value,
                 else => continue,
             };
@@ -58,7 +59,7 @@ const Visitor = struct {
                 .warning,
                 id,
                 message,
-                ctx.tree.span(argument),
+                ctx.tree.span(template_index),
             );
         }
         return .proceed;
@@ -68,4 +69,20 @@ const Visitor = struct {
 fn isInlineSnapshotMatcher(name: []const u8) bool {
     return std.mem.eql(u8, name, "toMatchInlineSnapshot") or
         std.mem.eql(u8, name, "toThrowErrorMatchingInlineSnapshot");
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -83,6 +83,7 @@ pub const jest_no_deprecated_functions = @import("jest_no_deprecated_functions.z
 pub const jest_no_export = @import("jest_no_export.zig");
 pub const jest_no_focused_tests = @import("jest_no_focused_tests.zig");
 pub const jest_no_identical_title = @import("jest_no_identical_title.zig");
+pub const jest_no_interpolation_in_snapshots = @import("jest_no_interpolation_in_snapshots.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1032,6 +1033,16 @@ fn runSemanticAfterIo(
 
     if (options.jest_no_identical_title) {
         try jest_no_identical_title.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+        );
+    }
+
+    if (options.jest_no_interpolation_in_snapshots) {
+        try jest_no_interpolation_in_snapshots.run(
             allocator,
             diagnostics,
             tree,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -272,6 +272,7 @@ comptime {
     _ = @import("rules/jest_no_export.zig");
     _ = @import("rules/jest_no_focused_tests.zig");
     _ = @import("rules/jest_no_identical_title.zig");
+    _ = @import("rules/jest_no_interpolation_in_snapshots.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_focused_tests.zig
+++ b/tests/rules/jest_no_focused_tests.zig
@@ -59,6 +59,7 @@ test "allows unfocused and indirect Jest calls" {
         "test.each()()",
         "test.each`table`()",
         "test.concurrent()",
+        "expect(value).only();",
         "function fit() {} fit();",
         "function describe() {} describe.only();",
     };

--- a/tests/rules/jest_no_identical_title.zig
+++ b/tests/rules/jest_no_identical_title.zig
@@ -45,6 +45,7 @@ test "keeps nested suites and test and describe namespaces separate" {
         \\describe("child", () => {});
         ,
         "it(); it(); describe(); describe();",
+        "expect('same'); expect('same');",
     };
 
     for (cases) |source| {

--- a/tests/rules/jest_no_interpolation_in_snapshots.zig
+++ b/tests/rules/jest_no_interpolation_in_snapshots.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_interpolation_in_snapshots.id;
+
+test "reports interpolated inline snapshots with useful locations" {
+    const cases = [_][]const u8{
+        "expect(value).toMatchInlineSnapshot(`${interpolated}`);",
+        "expect(value).not.toMatchInlineSnapshot(`${interpolated}`);",
+        "expect(value).toMatchInlineSnapshot({}, `${interpolated}`);",
+        "expect(value).not.toMatchInlineSnapshot({}, `${interpolated}`);",
+        "expect(value).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+        "expect(value).rejects.not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings("Do not use string interpolation inside of snapshots", diagnostic.message);
+        try std.testing.expectEqualStrings("`${interpolated}`", source[diagnostic.span.start..diagnostic.span.end]);
+    }
+}
+
+test "checks every snapshot argument and allows static and escaped templates" {
+    const invalid = "expect(value).toMatchInlineSnapshot(`${first}`, `${second}`);";
+    var invalid_result = try lint.lintSource(std.testing.allocator, invalid, "fixture.js", optionsOnly());
+    defer invalid_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(invalid_result, rule_id));
+
+    const valid_cases = [_][]const u8{
+        "expect(value).toMatchInlineSnapshot();",
+        "expect(value).toMatchInlineSnapshot(`No interpolation`);",
+        "expect(value).toMatchInlineSnapshot({}, `No interpolation`);",
+        "expect(value).toMatchInlineSnapshot(`\\${escaped}`);",
+        "expect(value).toThrowErrorMatchingInlineSnapshot(`No interpolation`);",
+    };
+    for (valid_cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, rule_id));
+    }
+}
+
+test "ignores non-snapshot templates and shadowed APIs" {
+    const cases = [_][]const u8{
+        "expect(value).toEqual(`${interpolated}`);",
+        "myObjectWants.toMatchInlineSnapshot({}, `${interpolated}`);",
+        "toMatchInlineSnapshot({}, `${interpolated}`);",
+        "function expect() {} expect(value).toMatchInlineSnapshot(`${interpolated}`);",
+        "const expect = makeExpect(); expect(value).toMatchInlineSnapshot(`${interpolated}`);",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(!helpers.hasRule(result, rule_id));
+    }
+}
+
+test "supports imported and configured expect aliases" {
+    const imported_source =
+        \\import { expect as check } from "@jest/globals";
+        \\check(value).toMatchInlineSnapshot(`${interpolated}`);
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported_source, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(imported_result, rule_id));
+
+    var options = optionsOnly();
+    try std.testing.expect(options.jest_global_aliases.append("expect", "check"));
+    var alias_result = try lint.lintSource(
+        std.testing.allocator,
+        "check(value).toMatchInlineSnapshot(`${interpolated}`);",
+        "fixture.js",
+        options,
+    );
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "expect(value).toMatchInlineSnapshot(`${js}`);", .file_name = "fixture.js" },
+        .{ .source = "expect(value as string).toMatchInlineSnapshot(`${ts}`);", .file_name = "fixture.ts" },
+        .{ .source = "expect(<div />).toMatchInlineSnapshot(`${jsx}`);", .file_name = "fixture.jsx" },
+        .{ .source = "expect(<div /> as JSX.Element).toMatchInlineSnapshot(`${tsx}`);", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_interpolation_in_snapshots);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_interpolation_in_snapshots);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer config.deinit();
+    options.jest_no_interpolation_in_snapshots = false;
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_no_interpolation_in_snapshots);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_interpolation_in_snapshots = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/jest_no_interpolation_in_snapshots.zig
+++ b/tests/rules/jest_no_interpolation_in_snapshots.zig
@@ -12,6 +12,7 @@ test "reports interpolated inline snapshots with useful locations" {
         "expect(value).not.toMatchInlineSnapshot({}, `${interpolated}`);",
         "expect(value).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
         "expect(value).rejects.not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+        "expect(value).toMatchInlineSnapshot(((`${interpolated}`)));",
     };
 
     for (cases) |source| {

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -182,6 +182,22 @@ test("reports identical Jest titles at the same suite level", () => {
   );
 });
 
+test("reports interpolation in inline Jest snapshots", () => {
+  const result = linter.lint(
+    "expect(value).toMatchInlineSnapshot({}, `${value}`);",
+    {
+      filePath: "input.js",
+      rules: { "jest/no-interpolation-in-snapshots": "error" },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/no-interpolation-in-snapshots");
+  assert.equal(
+    result.diagnostics[0].message,
+    "Do not use string interpolation inside of snapshots",
+  );
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Implement native `jest/no-interpolation-in-snapshots` diagnostics for interpolated inline snapshot template arguments.
- Support property matcher overloads, `not` and Promise modifiers, imported/configured expect aliases, and upstream escaped-interpolation behavior.
- Extend the shared Jest call resolver for semantic expect chains while keeping existing focused-test and identical-title rules isolated.
- Register the rule across native, ESM, CommonJS, and WebAssembly paths with config, CLI, language-mode, and documentation coverage.
- Closes #1157


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig fmt --check build.zig src tests`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `zig build test-wasm --summary all`