### PR TITLE
feat: add jest/no-jasmine-globals

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -268,6 +268,7 @@ instead of being rewritten.
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | Implemented for focused global, imported, aliased, and chained tests with upstream editor suggestions |
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | Implemented for duplicate static test and suite titles at the same suite level |
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | Implemented for interpolated inline snapshot templates, including property matcher overloads |
+| [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | Implemented for Jasmine globals, member calls, assignments, shadowed bindings, and upstream autofixes |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -267,6 +267,7 @@
 | [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) | 已实现对全局、导入、别名及链式聚焦测试的检查，并提供上游编辑器建议 |
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | 已实现对同一测试套件层级中重复静态测试和套件标题的检查 |
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | 已实现对内联快照模板插值的检查，包括属性匹配器重载形式 |
+| [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | 已实现 Jasmine 全局函数、成员调用、赋值、局部遮蔽和上游自动修复 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -317,6 +317,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-focused-tests",
   "jest/no-identical-title",
   "jest/no-interpolation-in-snapshots",
+  "jest/no-jasmine-globals",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -465,6 +466,7 @@ const NATIVE_ONLY_RULE_IDS = [
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "jest/no-deprecated-functions",
+  "jest/no-jasmine-globals",
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -320,6 +320,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-focused-tests",
   "jest/no-identical-title",
   "jest/no-interpolation-in-snapshots",
+  "jest/no-jasmine-globals",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",
@@ -468,6 +469,7 @@ const NATIVE_ONLY_RULE_IDS = [
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "jest/no-deprecated-functions",
+  "jest/no-jasmine-globals",
   "no-extra-semi",
   "@typescript-eslint/no-extra-semi",
   "unused-imports/no-unused-imports"

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2802,6 +2802,59 @@ test("project config and CLI --rules enable jest/no-interpolation-in-snapshots",
   }
 });
 
+test("jest/no-jasmine-globals supports config, --rules, and safe fixes", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-jasmine-globals": "error" } })
+  );
+  const source = [
+    "jasmine.any(String);",
+    "jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;",
+    ""
+  ].join("\n");
+  const expected = [
+    "expect.any(String);",
+    "jest.setTimeout(5000);",
+    ""
+  ].join("\n");
+  const sourcePath = write(join(project, "jasmine.test.js"), source);
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.equal(configuredReport.diagnostics.length, 2);
+    assert.ok(configuredReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-jasmine-globals" && severity === "error"
+    ));
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-jasmine-globals", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 2);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-jasmine-globals" && severity === "warning"
+    ));
+
+    const dryRun = execute(["--fix-dry-run", "--json", sourcePath], options);
+    const dryRunReport = JSON.parse(dryRun.stdout);
+    assert.equal(dryRun.status, 0, dryRun.stderr);
+    assert.equal(dryRunReport.outputs.length, 1);
+    assert.equal(dryRunReport.outputs[0].output, expected);
+    assert.equal(readFileSync(sourcePath, "utf8"), source);
+
+    const fixed = execute(["--fix", "--json", sourcePath], options);
+    assert.equal(fixed.status, 0, fixed.stderr);
+    assert.equal(readFileSync(sourcePath, "utf8"), expected);
+    writeFileSync(sourcePath, source);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2765,6 +2765,7 @@ pub const Options = struct {
     jest_no_focused_tests: bool = true,
     jest_no_identical_title: bool = true,
     jest_no_interpolation_in_snapshots: bool = true,
+    jest_no_jasmine_globals: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10612,6 +10613,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_interpolation_in_snapshots);
     try std.testing.expect(options.setByCliName("jest/no-interpolation-in-snapshots", true));
     try std.testing.expect(options.jest_no_interpolation_in_snapshots);
+
+    try std.testing.expect(!options.jest_no_jasmine_globals);
+    try std.testing.expect(options.setByCliName("jest/no-jasmine-globals", true));
+    try std.testing.expect(options.jest_no_jasmine_globals);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -298,6 +298,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_focused_tests or
         options.jest_no_identical_title or
         options.jest_no_interpolation_in_snapshots or
+        options.jest_no_jasmine_globals or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_no_jasmine_globals.zig
+++ b/src/rules/jest_no_jasmine_globals.zig
@@ -110,7 +110,8 @@ const Visitor = struct {
         };
 
         const property = staticPropertyName(ctx.tree, member.property, member.computed);
-        if (property != null and
+        if (assignment.operator == .assign and
+            property != null and
             std.mem.eql(u8, property.?, "DEFAULT_TIMEOUT_INTERVAL") and
             isLiteral(ctx.tree, assignment.right))
         {

--- a/src/rules/jest_no_jasmine_globals.zig
+++ b/src/rules/jest_no_jasmine_globals.zig
@@ -1,0 +1,265 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-jasmine-globals";
+
+const illegal_fail = "Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback";
+const illegal_pending = "Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`";
+const illegal_jasmine = "Illegal usage of jasmine global";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+) Allocator.Error!void {
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .symbol_table = symbol_table,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    symbol_table: traverser.semantic.SymbolTable,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const callee = unwrapTransparent(ctx.tree, call_expression.callee);
+        if (unresolvedIdentifierName(ctx.tree, self.symbol_table, callee)) |name| {
+            if (std.mem.eql(u8, name, "spyOn") or std.mem.eql(u8, name, "spyOnProperty")) {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    ctx.tree.span(index),
+                    "Illegal usage of global `{s}`, prefer `jest.spyOn`",
+                    .{name},
+                );
+            } else if (std.mem.eql(u8, name, "fail")) {
+                try core.addDiagnostic(self.allocator, self.diagnostics, .warning, id, illegal_fail, ctx.tree.span(index));
+            } else if (std.mem.eql(u8, name, "pending")) {
+                try core.addDiagnostic(self.allocator, self.diagnostics, .warning, id, illegal_pending, ctx.tree.span(index));
+            }
+            return .proceed;
+        }
+
+        const jasmine_call = jasmineCall(ctx.tree, callee) orelse return .proceed;
+        if (jasmine_call.direct_method) |method| {
+            if (expectReplacement(method)) |replacement| {
+                const diagnostic_message = try std.fmt.allocPrint(
+                    self.allocator,
+                    "Illegal usage of `jasmine.{s}`, prefer `expect.{s}`",
+                    .{ method, replacement },
+                );
+                defer self.allocator.free(diagnostic_message);
+                try core.addDiagnosticWithFix(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    diagnostic_message,
+                    ctx.tree.span(index),
+                    .{ .span = jasmine_call.object_span, .replacement = "expect" },
+                );
+                return .proceed;
+            }
+
+            if (methodReplacement(method)) |replacement| {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    ctx.tree.span(index),
+                    "Illegal usage of `jasmine.{s}`, prefer `{s}`",
+                    .{ method, replacement },
+                );
+                return .proceed;
+            }
+        }
+
+        try core.addDiagnostic(self.allocator, self.diagnostics, .warning, id, illegal_jasmine, ctx.tree.span(index));
+        return .proceed;
+    }
+
+    pub fn enter_member_expression(
+        self: *Visitor,
+        member: ast.MemberExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (!isJasmineIdentifier(ctx.tree, member.object)) return .proceed;
+        const parent_index = ctx.path.parent() orelse return .proceed;
+        const assignment = switch (ctx.tree.data(parent_index)) {
+            .assignment_expression => |value| value,
+            else => return .proceed,
+        };
+
+        const property = staticPropertyName(ctx.tree, member.property, member.computed);
+        if (property != null and
+            std.mem.eql(u8, property.?, "DEFAULT_TIMEOUT_INTERVAL") and
+            isLiteral(ctx.tree, assignment.right))
+        {
+            const replacement = try std.fmt.allocPrint(
+                self.allocator,
+                "jest.setTimeout({s})",
+                .{ctx.tree.source[ctx.tree.span(assignment.right).start..ctx.tree.span(assignment.right).end]},
+            );
+            defer self.allocator.free(replacement);
+            try core.addDiagnosticWithFix(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                illegal_jasmine,
+                ctx.tree.span(index),
+                .{ .span = ctx.tree.span(parent_index), .replacement = replacement },
+            );
+            return .proceed;
+        }
+
+        try core.addDiagnostic(self.allocator, self.diagnostics, .warning, id, illegal_jasmine, ctx.tree.span(index));
+        return .proceed;
+    }
+};
+
+const JasmineCall = struct {
+    direct_method: ?[]const u8,
+    object_span: ast.Span,
+};
+
+fn jasmineCall(tree: *const ast.Tree, callee: ast.NodeIndex) ?JasmineCall {
+    const outer_member = switch (tree.data(callee)) {
+        .member_expression => |value| value,
+        else => return null,
+    };
+    const direct_method = staticPropertyName(tree, outer_member.property, outer_member.computed) orelse return null;
+    const object_span = tree.span(outer_member.object);
+
+    var object = unwrapTransparent(tree, outer_member.object);
+    var depth: usize = 1;
+    while (true) {
+        switch (tree.data(object)) {
+            .identifier_reference => |identifier| {
+                if (!std.mem.eql(u8, tree.string(identifier.name), "jasmine")) return null;
+                return .{
+                    .direct_method = if (depth == 1) direct_method else null,
+                    .object_span = object_span,
+                };
+            },
+            .member_expression => |member| {
+                _ = staticPropertyName(tree, member.property, member.computed) orelse return null;
+                object = unwrapTransparent(tree, member.object);
+                depth += 1;
+            },
+            else => return null,
+        }
+    }
+}
+
+fn expectReplacement(method: []const u8) ?[]const u8 {
+    const methods = [_][]const u8{
+        "any",
+        "anything",
+        "arrayContaining",
+        "objectContaining",
+        "stringMatching",
+    };
+    for (methods) |candidate| {
+        if (std.mem.eql(u8, method, candidate)) return candidate;
+    }
+    return null;
+}
+
+fn methodReplacement(method: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, method, "addMatchers")) return "expect.extend";
+    if (std.mem.eql(u8, method, "createSpy")) return "jest.fn";
+    return null;
+}
+
+fn unresolvedIdentifierName(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+) ?[]const u8 {
+    const identifier = switch (tree.data(index)) {
+        .identifier_reference => |value| value,
+        else => return null,
+    };
+    if (!symbol_table.isUnresolvedReference(index)) return null;
+    return tree.string(identifier.name);
+}
+
+fn isJasmineIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "jasmine"),
+        else => false,
+    };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (!computed) {
+        return switch (tree.data(index)) {
+            .identifier_name => |identifier| tree.string(identifier.name),
+            else => null,
+        };
+    }
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn isLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .regexp_literal,
+        => true,
+        else => false,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -84,6 +84,7 @@ pub const jest_no_export = @import("jest_no_export.zig");
 pub const jest_no_focused_tests = @import("jest_no_focused_tests.zig");
 pub const jest_no_identical_title = @import("jest_no_identical_title.zig");
 pub const jest_no_interpolation_in_snapshots = @import("jest_no_interpolation_in_snapshots.zig");
+pub const jest_no_jasmine_globals = @import("jest_no_jasmine_globals.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1049,6 +1050,10 @@ fn runSemanticAfterIo(
             semantic_result.symbol_table,
             options.jest_global_aliases,
         );
+    }
+
+    if (options.jest_no_jasmine_globals) {
+        try jest_no_jasmine_globals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.block_scoped_var) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -273,6 +273,7 @@ comptime {
     _ = @import("rules/jest_no_focused_tests.zig");
     _ = @import("rules/jest_no_identical_title.zig");
     _ = @import("rules/jest_no_interpolation_in_snapshots.zig");
+    _ = @import("rules/jest_no_jasmine_globals.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_jasmine_globals.zig
+++ b/tests/rules/jest_no_jasmine_globals.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_jasmine_globals.id;
+
+test "reports Jasmine global calls with useful locations" {
+    const cases = [_]struct {
+        source: []const u8,
+        message: []const u8,
+    }{
+        .{ .source = "spyOn(object, 'method');", .message = "Illegal usage of global `spyOn`, prefer `jest.spyOn`" },
+        .{ .source = "spyOnProperty(object, 'property');", .message = "Illegal usage of global `spyOnProperty`, prefer `jest.spyOn`" },
+        .{ .source = "fail('reason');", .message = "Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback" },
+        .{ .source = "pending('reason');", .message = "Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings(case.message, diagnostic.message);
+        try std.testing.expectEqualStrings(case.source[0 .. case.source.len - 1], case.source[diagnostic.span.start..diagnostic.span.end]);
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+    }
+}
+
+test "allows Jest APIs and shadowed Jasmine globals" {
+    const source =
+        \\jest.spyOn(object, 'method');
+        \\jest.fn();
+        \\expect.extend({});
+        \\expect.any(String);
+        \\function run(spyOn, spyOnProperty, fail, pending) {
+        \\  spyOn(); spyOnProperty(); fail(); pending();
+        \\}
+        \\const fail = () => {};
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "reports Jasmine methods and applies upstream matcher autofixes" {
+    const source =
+        \\jasmine.any(String);
+        \\jasmine['anything']();
+        \\jasmine.arrayContaining([]);
+        \\jasmine.objectContaining({});
+        \\jasmine.stringMatching('value');
+        \\jasmine.addMatchers({});
+        \\jasmine.createSpy('name');
+    ;
+    const expected =
+        \\expect.any(String);
+        \\expect['anything']();
+        \\expect.arrayContaining([]);
+        \\expect.objectContaining({});
+        \\expect.stringMatching('value');
+        \\jasmine.addMatchers({});
+        \\jasmine.createSpy('name');
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("Illegal usage of `jasmine.any`, prefer `expect.any`", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Illegal usage of `jasmine.addMatchers`, prefer `expect.extend`", result.diagnostics[5].message);
+    try std.testing.expectEqualStrings("Illegal usage of `jasmine.createSpy`, prefer `jest.fn`", result.diagnostics[6].message);
+    for (result.diagnostics[0..5]) |diagnostic| {
+        try std.testing.expectEqual(@as(usize, 1), diagnostic.fixes.len);
+    }
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[5].fixes.len);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[6].fixes.len);
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(expected, fixed.output);
+}
+
+test "reports unsupported Jasmine members and assignments" {
+    const source =
+        \\jasmine.getEnv();
+        \\jasmine.empty();
+        \\jasmine.clock();
+        \\jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 42;
+        \\matcher = jasmine.truthy;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, rule_id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, rule_id)) continue;
+        try std.testing.expectEqualStrings("Illegal usage of jasmine global", diagnostic.message);
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+    }
+}
+
+test "fixes literal Jasmine timeout assignments but not dynamic values" {
+    const source =
+        \\jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+        \\jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
+    ;
+    const expected =
+        \\jest.setTimeout(5000);
+        \\jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics[0].fixes.len);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[1].fixes.len);
+    try std.testing.expectEqualStrings(
+        "jasmine.DEFAULT_TIMEOUT_INTERVAL",
+        source[result.diagnostics[0].span.start..result.diagnostics[0].span.end],
+    );
+
+    var fixed = try lint.applyFixes(std.testing.allocator, source, result.diagnostics);
+    defer fixed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(expected, fixed.output);
+}
+
+test "matches upstream handling of a shadowed jasmine object" {
+    const source =
+        \\function run(jasmine) {
+        \\  jasmine.any(String);
+        \\  jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+        \\}
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "jasmine.any(String);", .file_name = "fixture.js" },
+        .{ .source = "jasmine.any(String as StringConstructor);", .file_name = "fixture.ts" },
+        .{ .source = "const node = <div />; jasmine.any(String);", .file_name = "fixture.jsx" },
+        .{ .source = "const node: JSX.Element = <div />; jasmine.any(String);", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_jasmine_globals);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_jasmine_globals);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer config.deinit();
+    options.jest_no_jasmine_globals = false;
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_no_jasmine_globals);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_jasmine_globals = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/jest_no_jasmine_globals.zig
+++ b/tests/rules/jest_no_jasmine_globals.zig
@@ -103,17 +103,20 @@ test "fixes literal Jasmine timeout assignments but not dynamic values" {
     const source =
         \\jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
         \\jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
+        \\jasmine.DEFAULT_TIMEOUT_INTERVAL += 5000;
     ;
     const expected =
         \\jest.setTimeout(5000);
         \\jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
+        \\jasmine.DEFAULT_TIMEOUT_INTERVAL += 5000;
     ;
 
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
     defer result.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
     try std.testing.expectEqual(@as(usize, 1), result.diagnostics[0].fixes.len);
     try std.testing.expectEqual(@as(usize, 0), result.diagnostics[1].fixes.len);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics[2].fixes.len);
     try std.testing.expectEqualStrings(
         "jasmine.DEFAULT_TIMEOUT_INTERVAL",
         source[result.diagnostics[0].span.start..result.diagnostics[0].span.end],

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -198,6 +198,23 @@ test("reports interpolation in inline Jest snapshots", () => {
   );
 });
 
+test("reports and fixes Jasmine globals", () => {
+  const source = [
+    "jasmine.any(String);",
+    "jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;",
+  ].join("\n");
+  const result = linter.lintAndFix(source, {
+    filePath: "input.js",
+    rules: { "jest/no-jasmine-globals": "error" },
+  });
+  assert.equal(result.fixed, true);
+  assert.equal(result.diagnostics.length, 0);
+  assert.equal(result.output, [
+    "expect.any(String);",
+    "jest.setTimeout(5000);",
+  ].join("\n"));
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements native `jest/no-jasmine-globals` support and closes #1158.

- reports unsupported Jasmine globals, member calls, and assignments while respecting shadowed direct globals
- applies upstream-safe matcher and timeout autofixes
- exposes the rule through native, npm ESM/CommonJS, CLI, and WASM entry points


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
