### PR TITLE
feat: add jest/no-mocks-import

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -269,6 +269,7 @@ instead of being rewritten.
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | Implemented for duplicate static test and suite titles at the same suite level |
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | Implemented for interpolated inline snapshot templates, including property matcher overloads |
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | Implemented for Jasmine globals, member calls, assignments, shadowed bindings, and upstream autofixes |
+| [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | Implemented for static imports, dynamic imports, and CommonJS requires from nested `__mocks__` directories |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -268,6 +268,7 @@
 | [`jest/no-identical-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) | 已实现对同一测试套件层级中重复静态测试和套件标题的检查 |
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | 已实现对内联快照模板插值的检查，包括属性匹配器重载形式 |
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | 已实现 Jasmine 全局函数、成员调用、赋值、局部遮蔽和上游自动修复 |
+| [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | 已实现对嵌套 `__mocks__` 目录中静态导入、动态导入和 CommonJS `require` 的检查 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -318,6 +318,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-identical-title",
   "jest/no-interpolation-in-snapshots",
   "jest/no-jasmine-globals",
+  "jest/no-mocks-import",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -321,6 +321,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-identical-title",
   "jest/no-interpolation-in-snapshots",
   "jest/no-jasmine-globals",
+  "jest/no-mocks-import",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2855,6 +2855,45 @@ test("jest/no-jasmine-globals supports config, --rules, and safe fixes", (t) => 
   }
 });
 
+test("project config and CLI --rules enable jest/no-mocks-import", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/no-mocks-import": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "mocks.test.js"),
+    [
+      "import mock from './__mocks__/mock.js';",
+      "import('./nested/__mocks__/dynamic.js');",
+      "require('./__mocks__/commonjs.js');",
+      ""
+    ].join("\n")
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.equal(configuredReport.diagnostics.length, 3);
+    assert.ok(configuredReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-mocks-import" && severity === "error"
+    ));
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-mocks-import", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 3);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-mocks-import" && severity === "warning"
+    ));
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2766,6 +2766,7 @@ pub const Options = struct {
     jest_no_identical_title: bool = true,
     jest_no_interpolation_in_snapshots: bool = true,
     jest_no_jasmine_globals: bool = true,
+    jest_no_mocks_import: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10617,6 +10618,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_jasmine_globals);
     try std.testing.expect(options.setByCliName("jest/no-jasmine-globals", true));
     try std.testing.expect(options.jest_no_jasmine_globals);
+
+    try std.testing.expect(!options.jest_no_mocks_import);
+    try std.testing.expect(options.setByCliName("jest/no-mocks-import", true));
+    try std.testing.expect(options.jest_no_mocks_import);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/rules/jest_no_mocks_import.zig
+++ b/src/rules/jest_no_mocks_import.zig
@@ -53,11 +53,13 @@ fn checkSource(
 }
 
 fn isMockPath(path: []const u8) bool {
-    var segments = std.mem.splitScalar(u8, path, '/');
-    while (segments.next()) |segment| {
-        if (std.mem.eql(u8, segment, "__mocks__")) return true;
+    var segment_start: usize = 0;
+    for (path, 0..) |character, index| {
+        if (character != '/' and character != '\\') continue;
+        if (std.mem.eql(u8, path[segment_start..index], "__mocks__")) return true;
+        segment_start = index + 1;
     }
-    return false;
+    return std.mem.eql(u8, path[segment_start..], "__mocks__");
 }
 
 fn isRequireIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {

--- a/src/rules/jest_no_mocks_import.zig
+++ b/src/rules/jest_no_mocks_import.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-mocks-import";
+
+const message = "Mocks should not be manually imported from a __mocks__ directory. Instead use `jest.mock` and import from the original module path";
+
+pub fn checkImportDeclaration(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    declaration: ast.ImportDeclaration,
+    index: ast.NodeIndex,
+) Allocator.Error!void {
+    try checkSource(allocator, diagnostics, tree, declaration.source, tree.span(index));
+}
+
+pub fn checkImportExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    expression: ast.ImportExpression,
+) Allocator.Error!void {
+    try checkSource(allocator, diagnostics, tree, expression.source, tree.span(expression.source));
+}
+
+pub fn checkCallExpression(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    call: ast.CallExpression,
+) Allocator.Error!void {
+    if (!isRequireIdentifier(tree, call.callee)) return;
+    const arguments = tree.extra(call.arguments);
+    if (arguments.len == 0) return;
+    try checkSource(allocator, diagnostics, tree, arguments[0], tree.span(arguments[0]));
+}
+
+fn checkSource(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    source_index: ast.NodeIndex,
+    diagnostic_span: ast.Span,
+) Allocator.Error!void {
+    const source = staticStringValue(tree, source_index) orelse return;
+    if (!isMockPath(source)) return;
+    try core.addDiagnostic(allocator, diagnostics, .warning, id, message, diagnostic_span);
+}
+
+fn isMockPath(path: []const u8) bool {
+    var segments = std.mem.splitScalar(u8, path, '/');
+    while (segments.next()) |segment| {
+        if (std.mem.eql(u8, segment, "__mocks__")) return true;
+    }
+    return false;
+}
+
+fn isRequireIdentifier(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), "require"),
+        else => false,
+    };
+}
+
+fn staticStringValue(tree: *const ast.Tree, index: ast.NodeIndex) ?[]const u8 {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -85,6 +85,7 @@ pub const jest_no_focused_tests = @import("jest_no_focused_tests.zig");
 pub const jest_no_identical_title = @import("jest_no_identical_title.zig");
 pub const jest_no_interpolation_in_snapshots = @import("jest_no_interpolation_in_snapshots.zig");
 pub const jest_no_jasmine_globals = @import("jest_no_jasmine_globals.zig");
+pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -2037,6 +2038,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.jest_no_mocks_import) {
+            try jest_no_mocks_import.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index);
+        }
         if (self.options.alipay_ant_prefer_import_as_required) {
             try alipay_ant_prefer_import_as_required.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index);
         }
@@ -2045,6 +2049,18 @@ const BasicVisitor = struct {
         }
         if (self.options.alipay_ant_no_import_files_from_pages_in_common) {
             try alipay_ant_no_import_files_from_pages_in_common.checkImportDeclaration(self.allocator, self.diagnostics, ctx.tree, declaration, index, self.file_path);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_import_expression(
+        self: *BasicVisitor,
+        expression: ast.ImportExpression,
+        _: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.jest_no_mocks_import) {
+            try jest_no_mocks_import.checkImportExpression(self.allocator, self.diagnostics, ctx.tree, expression);
         }
         return .proceed;
     }
@@ -3616,6 +3632,9 @@ const BasicVisitor = struct {
         index: ast.NodeIndex,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!traverser.Action {
+        if (self.options.jest_no_mocks_import) {
+            try jest_no_mocks_import.checkCallExpression(self.allocator, self.diagnostics, ctx.tree, call);
+        }
         if (self.options.react_no_direct_mutation_state) {
             react_no_direct_mutation_state.enterCallExpression(ctx.tree, ctx, &self.react_no_direct_mutation_state_state);
         }

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -274,6 +274,7 @@ comptime {
     _ = @import("rules/jest_no_identical_title.zig");
     _ = @import("rules/jest_no_interpolation_in_snapshots.zig");
     _ = @import("rules/jest_no_jasmine_globals.zig");
+    _ = @import("rules/jest_no_mocks_import.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_mocks_import.zig
+++ b/tests/rules/jest_no_mocks_import.zig
@@ -1,0 +1,116 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_mocks_import.id;
+const expected_message = "Mocks should not be manually imported from a __mocks__ directory. Instead use `jest.mock` and import from the original module path";
+
+test "reports ES imports from mock directories with useful locations" {
+    const cases = [_][]const u8{
+        "import thing from './__mocks__/index';",
+        "import './nested/__mocks__/setup';",
+        "import type { Mock } from '@scope/pkg/__mocks__/types';",
+    };
+
+    for (cases) |source| {
+        var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings(expected_message, diagnostic.message);
+        const reported = source[diagnostic.span.start..diagnostic.span.end];
+        try std.testing.expect(std.mem.startsWith(u8, reported, "import"));
+        try std.testing.expect(std.mem.indexOf(u8, reported, "__mocks__") != null);
+    }
+}
+
+test "reports CommonJS requires and dynamic imports" {
+    const source =
+        \\require("./__mocks__");
+        \\require("./nested/__mocks__/");
+        \\require("__mocks__/index", extra);
+        \\import("./__mocks__/dynamic");
+        \\import(`./nested/__mocks__/template`);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, rule_id));
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, rule_id)) continue;
+        try std.testing.expectEqualStrings(expected_message, diagnostic.message);
+        const reported = source[diagnostic.span.start..diagnostic.span.end];
+        try std.testing.expect(reported[0] == '"' or reported[0] == '`');
+        try std.testing.expect(std.mem.indexOf(u8, reported, "__mocks__") != null);
+    }
+}
+
+test "allows similarly named paths and non-static module references" {
+    const source =
+        \\import something from "something";
+        \\require("./__mocks__.js");
+        \\require("./__mocks__x");
+        \\require("./__mocks__x/x");
+        \\require("./x__mocks__");
+        \\require("./x__mocks__/x");
+        \\require();
+        \\const path = "./__mocks__/index";
+        \\require(path);
+        \\import(path);
+        \\import(`./${directory}/__mocks__/index`);
+        \\entirelyDifferent("./__mocks__/index");
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "matches upstream handling of shadowed require calls" {
+    const source = "function load(require) { return require('./__mocks__/index'); }";
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "require('./__mocks__/js');", .file_name = "fixture.js" },
+        .{ .source = "import type { Mock } from './__mocks__/ts';", .file_name = "fixture.ts" },
+        .{ .source = "const node = <div />; import('./__mocks__/jsx');", .file_name = "fixture.jsx" },
+        .{ .source = "const node: JSX.Element = <div />; import('./__mocks__/tsx');", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_mocks_import);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_mocks_import);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"error\"", .{});
+    defer config.deinit();
+    options.jest_no_mocks_import = false;
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_no_mocks_import);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_mocks_import = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/jest_no_mocks_import.zig
+++ b/tests/rules/jest_no_mocks_import.zig
@@ -45,6 +45,18 @@ test "reports CommonJS requires and dynamic imports" {
     }
 }
 
+test "reports Windows-style CommonJS mock paths" {
+    const invalid = "require('.\\\\nested\\\\__mocks__\\\\user');";
+    var invalid_result = try lint.lintSource(std.testing.allocator, invalid, "fixture.js", optionsOnly());
+    defer invalid_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(invalid_result, rule_id));
+
+    const valid = "require('.\\\\nested\\\\__mocks__.js');";
+    var valid_result = try lint.lintSource(std.testing.allocator, valid, "fixture.js", optionsOnly());
+    defer valid_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(valid_result, rule_id));
+}
+
 test "allows similarly named paths and non-static module references" {
     const source =
         \\import something from "something";

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -215,6 +215,22 @@ test("reports and fixes Jasmine globals", () => {
   ].join("\n"));
 });
 
+test("reports imports from mock directories", () => {
+  const result = linter.lint(
+    [
+      "import mock from './__mocks__/mock.js';",
+      "import('./nested/__mocks__/dynamic.js');",
+      "require('./__mocks__/commonjs.js');",
+    ].join("\n"),
+    {
+      filePath: "input.js",
+      rules: { "jest/no-mocks-import": "error" },
+    },
+  );
+  assert.equal(result.diagnostics.length, 3);
+  assert.ok(result.diagnostics.every(({ ruleId }) => ruleId === "jest/no-mocks-import"));
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements native `jest/no-mocks-import` support and closes #1159.

- reports ES imports, dynamic imports, and CommonJS requires from `__mocks__` path segments
- handles nested mock directories while allowing similarly named paths and non-static module references
- exposes the rule through native, npm ESM/CommonJS, CLI, and WASM entry points


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseFast -j1`
- `zig build -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
