### PR TITLE
feat: add jest/no-standalone-expect

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -270,6 +270,7 @@ instead of being rewritten.
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | Implemented for interpolated inline snapshot templates, including property matcher overloads |
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | Implemented for Jasmine globals, member calls, assignments, shadowed bindings, and upstream autofixes |
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | Implemented for static imports, dynamic imports, and CommonJS requires from nested `__mocks__` directories |
+| [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | Supports suite, test, hook, helper, imported API, and `additionalTestBlockFunctions` context detection |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -269,6 +269,7 @@
 | [`jest/no-interpolation-in-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) | 已实现对内联快照模板插值的检查，包括属性匹配器重载形式 |
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | 已实现 Jasmine 全局函数、成员调用、赋值、局部遮蔽和上游自动修复 |
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | 已实现对嵌套 `__mocks__` 目录中静态导入、动态导入和 CommonJS `require` 的检查 |
+| [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | 支持测试套件、测试、钩子、辅助函数、导入 API 和 `additionalTestBlockFunctions` 上下文检查 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -319,6 +319,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-interpolation-in-snapshots",
   "jest/no-jasmine-globals",
   "jest/no-mocks-import",
+  "jest/no-standalone-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -322,6 +322,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-interpolation-in-snapshots",
   "jest/no-jasmine-globals",
   "jest/no-mocks-import",
+  "jest/no-standalone-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2894,6 +2894,57 @@ test("project config and CLI --rules enable jest/no-mocks-import", (t) => {
   }
 });
 
+test("jest/no-standalone-expect preserves custom test-block options", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({
+      rules: {
+        "jest/no-standalone-expect": [
+          "error",
+          { additionalTestBlockFunctions: ["customTest"] }
+        ]
+      }
+    })
+  );
+  const sourcePath = write(
+    join(project, "standalone.test.js"),
+    [
+      "customTest('works', () => expect(true).toBe(true));",
+      "describe('suite', () => expect(true).toBe(true));",
+      ""
+    ].join("\n")
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-standalone-expect", severity: "error" }
+    ]);
+
+    const selected = execute(["--rules=jest/no-standalone-expect", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/no-standalone-expect", severity: "warning" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/no-standalone-expect", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 2);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/no-standalone-expect" && severity === "warning"
+    ));
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2767,6 +2767,8 @@ pub const Options = struct {
     jest_no_interpolation_in_snapshots: bool = true,
     jest_no_jasmine_globals: bool = true,
     jest_no_mocks_import: bool = true,
+    jest_no_standalone_expect: bool = true,
+    jest_no_standalone_expect_additional_test_block_functions: JestAdditionalTestBlockFunctions = .{},
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -3475,6 +3477,9 @@ pub const Options = struct {
             self.import_no_unresolved_amd = try importNoUnresolvedBoolOptionFromConfig(value, "amd", false);
             self.import_no_unresolved_commonjs = try importNoUnresolvedBoolOptionFromConfig(value, "commonjs", false);
             self.import_no_unresolved_ignore = try importNoUnresolvedIgnorePatternsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "jest/no-standalone-expect")) {
+            self.jest_no_standalone_expect_additional_test_block_functions = try jestAdditionalTestBlockFunctionsFromConfig(value);
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
@@ -5089,6 +5094,34 @@ pub const Options = struct {
             names.append(name) catch return error.UnsupportedRuleConfigValue;
         }
         return names;
+    }
+
+    fn jestAdditionalTestBlockFunctionsFromConfig(value: std.json.Value) RuleConfigError!JestAdditionalTestBlockFunctions {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        const configured = config.get("additionalTestBlockFunctions") orelse return .{};
+        const functions = switch (configured) {
+            .array => |array| array.items,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = JestAdditionalTestBlockFunctions{};
+        for (functions) |function_value| {
+            const function_name = switch (function_value) {
+                .string => |name| name,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            if (!result.append(function_name)) return error.UnsupportedRuleConfigValue;
+        }
+        return result;
     }
 
     const IdLengthConfig = struct {
@@ -9957,6 +9990,32 @@ pub const DeprecatedDependenceProfile = enum {
     profile_b,
 };
 
+pub const max_jest_additional_test_block_functions = 64;
+pub const max_jest_additional_test_block_function_len = 128;
+
+pub const JestAdditionalTestBlockFunctions = struct {
+    count: usize = 0,
+    lengths: [max_jest_additional_test_block_functions]usize = undefined,
+    storage: [max_jest_additional_test_block_functions][max_jest_additional_test_block_function_len]u8 = undefined,
+
+    pub fn at(self: *const JestAdditionalTestBlockFunctions, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *JestAdditionalTestBlockFunctions, name: []const u8) bool {
+        if (name.len > max_jest_additional_test_block_function_len) return false;
+        if (self.count >= max_jest_additional_test_block_functions) return false;
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
+    }
+};
+
 pub const max_jest_global_aliases = 32;
 pub const max_jest_global_alias_len = 128;
 
@@ -10622,6 +10681,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_mocks_import);
     try std.testing.expect(options.setByCliName("jest/no-mocks-import", true));
     try std.testing.expect(options.jest_no_mocks_import);
+
+    try std.testing.expect(!options.jest_no_standalone_expect);
+    try std.testing.expect(options.setByCliName("jest/no-standalone-expect", true));
+    try std.testing.expect(options.jest_no_standalone_expect);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -299,6 +299,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_identical_title or
         options.jest_no_interpolation_in_snapshots or
         options.jest_no_jasmine_globals or
+        options.jest_no_standalone_expect or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_fn_call.zig
+++ b/src/rules/jest_fn_call.zig
@@ -70,6 +70,7 @@ pub const Call = struct {
     local_name: []const u8,
     members: [4]Member = undefined,
     member_count: usize = 0,
+    nested_calls: usize = 0,
 
     pub fn memberSlice(self: *const Call) []const Member {
         return self.members[0..self.member_count];
@@ -159,6 +160,7 @@ pub const Resolver = struct {
             .head = chain.root,
             .local_name = binding.local_name,
             .member_count = chain.member_count,
+            .nested_calls = chain.nested_calls,
         };
         @memcpy(result.members[0..chain.member_count], chain.members[0..chain.member_count]);
         return result;

--- a/src/rules/jest_no_standalone_expect.zig
+++ b/src/rules/jest_no_standalone_expect.zig
@@ -72,31 +72,11 @@ const Visitor = struct {
                     }
                     return .proceed;
                 },
-                .test_case => {
-                    try self.markers.append(self.allocator, .{ .node = index, .kind = .test_case });
-                    return .proceed;
-                },
+                .test_case => return .proceed,
                 .describe => {},
             }
         }
-
-        if (matchesAdditionalTestBlockFunction(
-            ctx.tree,
-            index,
-            self.additional_test_block_functions,
-        )) {
-            try self.markers.append(self.allocator, .{ .node = index, .kind = .test_case });
-        }
         return .proceed;
-    }
-
-    pub fn exit_call_expression(
-        self: *Visitor,
-        _: ast.CallExpression,
-        index: ast.NodeIndex,
-        _: *traverser.basic.Ctx,
-    ) void {
-        self.popMarker(index);
     }
 
     pub fn enter_function(
@@ -158,16 +138,21 @@ const Visitor = struct {
             .call_expression => |call| call,
             else => return null,
         };
-        if (!isCallArgument(tree, parent_call, function_index)) return null;
+        if (!isTestCallback(tree, parent_call, function_index)) return null;
 
         const parsed = self.resolver.parseCall(parent_call, parent_index, grandparent_index);
         if (parsed) |call| {
             return switch (call.function.kind()) {
                 .describe => .describe,
-                .test_case => null,
+                .test_case => .test_case,
                 .expect => null,
             };
         }
+        if (matchesAdditionalTestBlockFunction(
+            tree,
+            parent_index,
+            self.additional_test_block_functions,
+        )) return .test_case;
         return null;
     }
 
@@ -202,11 +187,9 @@ fn isCallExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
     return tree.data(index) == .call_expression;
 }
 
-fn isCallArgument(tree: *const ast.Tree, call: ast.CallExpression, index: ast.NodeIndex) bool {
-    for (tree.extra(call.arguments)) |argument| {
-        if (argument == index) return true;
-    }
-    return false;
+fn isTestCallback(tree: *const ast.Tree, call: ast.CallExpression, index: ast.NodeIndex) bool {
+    const arguments = tree.extra(call.arguments);
+    return arguments.len > 1 and arguments[1] == index;
 }
 
 fn matchesAdditionalTestBlockFunction(

--- a/src/rules/jest_no_standalone_expect.zig
+++ b/src/rules/jest_no_standalone_expect.zig
@@ -1,0 +1,299 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/no-standalone-expect";
+
+const message = "Expect must be inside of a test block";
+
+const MarkerKind = enum {
+    test_case,
+    function,
+    describe,
+};
+
+const Marker = struct {
+    node: ast.NodeIndex,
+    kind: MarkerKind,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+    additional_test_block_functions: core.JestAdditionalTestBlockFunctions,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+        .additional_test_block_functions = additional_test_block_functions,
+    };
+    defer visitor.markers.deinit(allocator);
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+    additional_test_block_functions: core.JestAdditionalTestBlockFunctions,
+    markers: std.ArrayList(Marker) = .empty,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.resolver.parseCall(call_expression, index, ctx.path.parent())) |call| {
+            switch (call.function.kind()) {
+                .expect => {
+                    if (isAllowedStandaloneMethod(call)) return .proceed;
+                    if (!self.expectIsAllowed()) {
+                        try core.addDiagnostic(
+                            self.allocator,
+                            self.diagnostics,
+                            .warning,
+                            id,
+                            message,
+                            ctx.tree.span(index),
+                        );
+                    }
+                    return .proceed;
+                },
+                .test_case => {
+                    try self.markers.append(self.allocator, .{ .node = index, .kind = .test_case });
+                    return .proceed;
+                },
+                .describe => {},
+            }
+        }
+
+        if (matchesAdditionalTestBlockFunction(
+            ctx.tree,
+            index,
+            self.additional_test_block_functions,
+        )) {
+            try self.markers.append(self.allocator, .{ .node = index, .kind = .test_case });
+        }
+        return .proceed;
+    }
+
+    pub fn exit_call_expression(
+        self: *Visitor,
+        _: ast.CallExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.popMarker(index);
+    }
+
+    pub fn enter_function(
+        self: *Visitor,
+        function: ast.Function,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        if (self.callbackMarker(ctx.tree, index, parent, ctx.path.ancestor(2))) |kind| {
+            try self.markers.append(self.allocator, .{ .node = index, .kind = kind });
+        } else if (function.type == .function_declaration or isVariableInitializer(ctx.tree, index, parent)) {
+            try self.markers.append(self.allocator, .{ .node = index, .kind = .function });
+        }
+        return .proceed;
+    }
+
+    pub fn exit_function(
+        self: *Visitor,
+        _: ast.Function,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.popMarker(index);
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const parent = ctx.path.ancestor(1) orelse .null;
+        if (self.callbackMarker(ctx.tree, index, parent, ctx.path.ancestor(2))) |kind| {
+            try self.markers.append(self.allocator, .{ .node = index, .kind = kind });
+        } else if (!isCallExpression(ctx.tree, parent)) {
+            try self.markers.append(self.allocator, .{ .node = index, .kind = .function });
+        }
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        self.popMarker(index);
+    }
+
+    fn callbackMarker(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        function_index: ast.NodeIndex,
+        parent_index: ast.NodeIndex,
+        grandparent_index: ?ast.NodeIndex,
+    ) ?MarkerKind {
+        const parent_call = switch (tree.data(parent_index)) {
+            .call_expression => |call| call,
+            else => return null,
+        };
+        if (!isCallArgument(tree, parent_call, function_index)) return null;
+
+        const parsed = self.resolver.parseCall(parent_call, parent_index, grandparent_index);
+        if (parsed) |call| {
+            return switch (call.function.kind()) {
+                .describe => .describe,
+                .test_case => null,
+                .expect => null,
+            };
+        }
+        return null;
+    }
+
+    fn expectIsAllowed(self: *const Visitor) bool {
+        if (self.markers.items.len == 0) return false;
+        return self.markers.items[self.markers.items.len - 1].kind != .describe;
+    }
+
+    fn popMarker(self: *Visitor, index: ast.NodeIndex) void {
+        if (self.markers.items.len == 0) return;
+        if (self.markers.items[self.markers.items.len - 1].node == index) {
+            _ = self.markers.pop();
+        }
+    }
+};
+
+fn isAllowedStandaloneMethod(call: jest_fn_call.Call) bool {
+    if (call.nested_calls != 0 or call.member_count != 1) return false;
+    const member = call.members[0].name;
+    return !std.mem.eql(u8, member, "assertions") and
+        !std.mem.eql(u8, member, "hasAssertions");
+}
+
+fn isVariableInitializer(tree: *const ast.Tree, index: ast.NodeIndex, parent_index: ast.NodeIndex) bool {
+    return switch (tree.data(parent_index)) {
+        .variable_declarator => |declarator| declarator.init == index,
+        else => false,
+    };
+}
+
+fn isCallExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return tree.data(index) == .call_expression;
+}
+
+fn isCallArgument(tree: *const ast.Tree, call: ast.CallExpression, index: ast.NodeIndex) bool {
+    for (tree.extra(call.arguments)) |argument| {
+        if (argument == index) return true;
+    }
+    return false;
+}
+
+fn matchesAdditionalTestBlockFunction(
+    tree: *const ast.Tree,
+    call_index: ast.NodeIndex,
+    configured: core.JestAdditionalTestBlockFunctions,
+) bool {
+    if (configured.count == 0) return false;
+
+    var buffer: [core.max_jest_additional_test_block_function_len]u8 = undefined;
+    var length: usize = 0;
+    if (!writeNodeName(tree, call_index, &buffer, &length)) return false;
+    const name = buffer[0..length];
+    for (0..configured.count) |index| {
+        if (std.mem.eql(u8, configured.at(index), name)) return true;
+    }
+    return false;
+}
+
+fn writeNodeName(
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    buffer: *[core.max_jest_additional_test_block_function_len]u8,
+    length: *usize,
+) bool {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .identifier_reference => |identifier| appendName(buffer, length, tree.string(identifier.name)),
+        .call_expression => |call| writeNodeName(tree, call.callee, buffer, length),
+        .tagged_template_expression => |tagged| writeNodeName(tree, tagged.tag, buffer, length),
+        .member_expression => |member| blk: {
+            if (!writeNodeName(tree, member.object, buffer, length)) break :blk false;
+            const property = staticPropertyName(tree, member.property, member.computed) orelse break :blk false;
+            if (!appendName(buffer, length, ".")) break :blk false;
+            break :blk appendName(buffer, length, property);
+        },
+        else => false,
+    };
+}
+
+fn appendName(
+    buffer: *[core.max_jest_additional_test_block_function_len]u8,
+    length: *usize,
+    value: []const u8,
+) bool {
+    if (value.len > buffer.len - length.*) return false;
+    @memcpy(buffer[length.* .. length.* + value.len], value);
+    length.* += value.len;
+    return true;
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (!computed) {
+        return switch (tree.data(index)) {
+            .identifier_name => |identifier| tree.string(identifier.name),
+            else => null,
+        };
+    }
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -86,6 +86,7 @@ pub const jest_no_identical_title = @import("jest_no_identical_title.zig");
 pub const jest_no_interpolation_in_snapshots = @import("jest_no_interpolation_in_snapshots.zig");
 pub const jest_no_jasmine_globals = @import("jest_no_jasmine_globals.zig");
 pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
+pub const jest_no_standalone_expect = @import("jest_no_standalone_expect.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1055,6 +1056,17 @@ fn runSemanticAfterIo(
 
     if (options.jest_no_jasmine_globals) {
         try jest_no_jasmine_globals.run(allocator, diagnostics, tree, semantic_result.symbol_table);
+    }
+
+    if (options.jest_no_standalone_expect) {
+        try jest_no_standalone_expect.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+            options.jest_no_standalone_expect_additional_test_block_functions,
+        );
     }
 
     if (options.block_scoped_var) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -275,6 +275,7 @@ comptime {
     _ = @import("rules/jest_no_interpolation_in_snapshots.zig");
     _ = @import("rules/jest_no_jasmine_globals.zig");
     _ = @import("rules/jest_no_mocks_import.zig");
+    _ = @import("rules/jest_no_standalone_expect.zig");
 }
 
 comptime {

--- a/tests/rules/jest_no_standalone_expect.zig
+++ b/tests/rules/jest_no_standalone_expect.zig
@@ -1,0 +1,212 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_no_standalone_expect.id;
+const expected_message = "Expect must be inside of a test block";
+
+test "reports standalone expects and suite-body expects with useful locations" {
+    const cases = [_]struct {
+        source: []const u8,
+        reported: []const u8,
+    }{
+        .{ .source = "expect(1).toBe(1);", .reported = "expect(1).toBe(1)" },
+        .{ .source = "{ expect(1).toBe(1); }", .reported = "expect(1).toBe(1)" },
+        .{ .source = "describe('suite', () => { expect(1).toBe(1); });", .reported = "expect(1).toBe(1)" },
+        .{ .source = "describe('suite', () => expect(1).toBe(1));", .reported = "expect(1).toBe(1)" },
+        .{ .source = "beforeEach(() => expect.hasAssertions());", .reported = "expect.hasAssertions()" },
+        .{ .source = "run(() => expect(true).toBe(false));", .reported = "expect(true).toBe(false)" },
+        .{ .source = "expect().hasAssertions();", .reported = "expect().hasAssertions()" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings(expected_message, diagnostic.message);
+        try std.testing.expectEqualStrings(case.reported, case.source[diagnostic.span.start..diagnostic.span.end]);
+    }
+}
+
+test "allows expect calls in tests and helper functions" {
+    const source =
+        \\describe('suite', () => {
+        \\  it('works', () => { expect(1).toBe(1); });
+        \\  test.only('only', () => expect(true).toBe(true));
+        \\  test.concurrent('concurrent', () => expect(true).toBe(true));
+        \\  it.each([1, 2])('each', value => expect(value).toBeTruthy());
+        \\  function declaredHelper() { expect(1).toBe(1); }
+        \\  const arrowHelper = () => { expect(1).toBe(1); };
+        \\  const functionHelper = function () { expect(1).toBe(1); };
+        \\});
+        \\const topLevelArrow = () => expect(1).toBe(1);
+        \\const topLevelFunction = function () { expect(1).toBe(1); };
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "allows standalone asymmetric helpers but checks assertion-count methods" {
+    const source =
+        \\expect.any(String);
+        \\expect.extend({});
+        \\expect.arrayContaining([]);
+        \\expect.assertions(1);
+        \\expect.hasAssertions();
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("expect.assertions(1)", source[result.diagnostics[0].span.start..result.diagnostics[0].span.end]);
+    try std.testing.expectEqualStrings("expect.hasAssertions()", source[result.diagnostics[1].span.start..result.diagnostics[1].span.end]);
+}
+
+test "does not leak test context after modified and parameterized tests" {
+    const source =
+        \\it.only('only', () => expect(true).toBe(true));
+        \\expect('after only').toBe(true);
+        \\it.each([1])('each', value => expect(value).toBe(1));
+        \\expect('after each').toBe(true);
+        \\it.each`value\n${1}`('tagged', value => expect(value).toBe(1));
+        \\expect('after tagged').toBe(true);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+}
+
+test "reports hooks but allows nested callbacks executing in a test" {
+    const source =
+        \\beforeAll(() => expect(true).toBe(true));
+        \\beforeEach(() => expect(true).toBe(true));
+        \\afterEach(() => expect(true).toBe(true));
+        \\afterAll(() => expect(true).toBe(true));
+        \\it('async work', () => promise.then(() => expect(true).toBe(true)));
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+}
+
+test "supports additionalTestBlockFunctions including chained names" {
+    const source =
+        \\const t = Math.random() ? it.only : it;
+        \\t('custom', () => expect(true).toBe(true));
+        \\each([[1, 2]]).test('chained', (value, expected) => {
+        \\  expect(value).toBe(expected);
+        \\});
+    ;
+
+    var without_options = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer without_options.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(without_options, rule_id));
+
+    var options = try optionsFromConfig(
+        \\["error", {"additionalTestBlockFunctions":["t", "each.test"]}]
+    );
+    var configured = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer configured.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(configured, rule_id));
+
+    options = try optionsFromConfig(
+        \\["error", {"additionalTestBlockFunctions":["each"]}]
+    );
+    var partial = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer partial.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(partial, rule_id));
+}
+
+test "supports imported required and configured Jest APIs" {
+    const imported =
+        \\import { describe as suite, expect as pleaseExpect, it as spec } from '@jest/globals';
+        \\suite('group', () => pleaseExpect(true).toBe(true));
+        \\spec('works', () => pleaseExpect(true).toBe(true));
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(imported_result, rule_id));
+
+    const required =
+        \\const { expect: check, test: verify } = require('@jest/globals');
+        \\verify('works', () => check(true).toBe(true));
+        \\check(true).toBe(true);
+    ;
+    var required_result = try lint.lintSource(std.testing.allocator, required, "fixture.js", optionsOnly());
+    defer required_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(required_result, rule_id));
+
+    var alias_options = optionsOnly();
+    try std.testing.expect(alias_options.jest_global_aliases.append("describe", "suite"));
+    try std.testing.expect(alias_options.jest_global_aliases.append("test", "spec"));
+    try std.testing.expect(alias_options.jest_global_aliases.append("expect", "check"));
+    const aliases =
+        \\suite('group', () => check(true).toBe(true));
+        \\spec('works', () => check(true).toBe(true));
+    ;
+    var alias_result = try lint.lintSource(std.testing.allocator, aliases, "fixture.js", alias_options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+}
+
+test "ignores a shadowed expect binding" {
+    const source = "function run(expect) { expect(true).toBe(true); }";
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "expect(value).toBe(true);", .file_name = "fixture.js" },
+        .{ .source = "expect(value as boolean).toBe(true);", .file_name = "fixture.ts" },
+        .{ .source = "expect(<div />).toBeTruthy();", .file_name = "fixture.jsx" },
+        .{ .source = "expect(<div /> as JSX.Element).toBeTruthy();", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_no_standalone_expect);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_no_standalone_expect);
+
+    options = try optionsFromConfig(
+        \\["error", {"additionalTestBlockFunctions":["customTest"]}]
+    );
+    try std.testing.expect(options.jest_no_standalone_expect);
+    try std.testing.expectEqual(@as(usize, 1), options.jest_no_standalone_expect_additional_test_block_functions.count);
+    try std.testing.expectEqualStrings("customTest", options.jest_no_standalone_expect_additional_test_block_functions.at(0));
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_no_standalone_expect = true;
+    return options;
+}
+
+fn optionsFromConfig(config: []const u8) !lint.Options {
+    var options = optionsOnly();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue(rule_id, parsed.value);
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/jest_no_standalone_expect.zig
+++ b/tests/rules/jest_no_standalone_expect.zig
@@ -79,6 +79,24 @@ test "does not leak test context after modified and parameterized tests" {
     try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
 }
 
+test "restricts test context to the callback argument" {
+    const source =
+        \\test(expect(value).toBe(true), () => {});
+        \\test('name', setup(expect(value).toBe(true)), () => {});
+        \\test(() => expect(value).toBe(true), () => {});
+        \\test('works', () => expect(value).toBe(true));
+        \\customTest(expect(value).toBe(true), () => {});
+        \\customTest('works', () => expect(value).toBe(true));
+    ;
+
+    const options = try optionsFromConfig(
+        \\["error", {"additionalTestBlockFunctions":["customTest"]}]
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+}
+
 test "reports hooks but allows nested callbacks executing in a test" {
     const source =
         \\beforeAll(() => expect(true).toBe(true));

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -231,6 +231,27 @@ test("reports imports from mock directories", () => {
   assert.ok(result.diagnostics.every(({ ruleId }) => ruleId === "jest/no-mocks-import"));
 });
 
+test("reports standalone expects and honors custom test blocks", () => {
+  const result = linter.lint(
+    [
+      "customTest('works', () => expect(true).toBe(true));",
+      "describe('suite', () => expect(true).toBe(true));",
+    ].join("\n"),
+    {
+      filePath: "input.js",
+      rules: {
+        "jest/no-standalone-expect": [
+          "error",
+          { additionalTestBlockFunctions: ["customTest"] },
+        ],
+      },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/no-standalone-expect");
+  assert.equal(result.diagnostics[0].message, "Expect must be inside of a test block");
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements `jest/no-standalone-expect`, including Jest API resolution, suite/test/hook/helper context tracking, imported and configured aliases, and `additionalTestBlockFunctions`.

Closes #1160.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
