### PR TITLE
feat: add jest/valid-describe-callback

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -271,6 +271,7 @@ instead of being rewritten.
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | Implemented for Jasmine globals, member calls, assignments, shadowed bindings, and upstream autofixes |
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | Implemented for static imports, dynamic imports, and CommonJS requires from nested `__mocks__` directories |
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | Supports suite, test, hook, helper, imported API, and `additionalTestBlockFunctions` context detection |
+| [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | Enforces synchronous function callbacks without unexpected parameters or return values, including aliases and `describe.each` |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -270,6 +270,7 @@
 | [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md) | 已实现 Jasmine 全局函数、成员调用、赋值、局部遮蔽和上游自动修复 |
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | 已实现对嵌套 `__mocks__` 目录中静态导入、动态导入和 CommonJS `require` 的检查 |
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | 支持测试套件、测试、钩子、辅助函数、导入 API 和 `additionalTestBlockFunctions` 上下文检查 |
+| [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | 校验同步函数回调、意外参数和返回值，并支持别名及 `describe.each` |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -320,6 +320,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-jasmine-globals",
   "jest/no-mocks-import",
   "jest/no-standalone-expect",
+  "jest/valid-describe-callback",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -323,6 +323,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-jasmine-globals",
   "jest/no-mocks-import",
   "jest/no-standalone-expect",
+  "jest/valid-describe-callback",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2945,6 +2945,43 @@ test("jest/no-standalone-expect preserves custom test-block options", (t) => {
   }
 });
 
+test("project config and CLI --rules enable jest/valid-describe-callback", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/valid-describe-callback": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "describe.test.js"),
+    [
+      "describe('valid', () => {});",
+      "describe('invalid', async () => {});",
+      ""
+    ].join("\n")
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity, message }) => ({ ruleId, severity, message })), [
+      {
+        ruleId: "jest/valid-describe-callback",
+        severity: "error",
+        message: "No async describe callback"
+      }
+    ]);
+
+    const selected = execute(["--rules=jest/valid-describe-callback", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-describe-callback", severity: "warning" }
+    ]);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2769,6 +2769,7 @@ pub const Options = struct {
     jest_no_mocks_import: bool = true,
     jest_no_standalone_expect: bool = true,
     jest_no_standalone_expect_additional_test_block_functions: JestAdditionalTestBlockFunctions = .{},
+    jest_valid_describe_callback: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10685,6 +10686,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_no_standalone_expect);
     try std.testing.expect(options.setByCliName("jest/no-standalone-expect", true));
     try std.testing.expect(options.jest_no_standalone_expect);
+
+    try std.testing.expect(!options.jest_valid_describe_callback);
+    try std.testing.expect(options.setByCliName("jest/valid-describe-callback", true));
+    try std.testing.expect(options.jest_valid_describe_callback);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -300,6 +300,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_interpolation_in_snapshots or
         options.jest_no_jasmine_globals or
         options.jest_no_standalone_expect or
+        options.jest_valid_describe_callback or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_valid_describe_callback.zig
+++ b/src/rules/jest_valid_describe_callback.zig
@@ -1,0 +1,205 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+const NodeSet = std.AutoHashMapUnmanaged(ast.NodeIndex, void);
+
+pub const id = "jest/valid-describe-callback";
+
+const name_and_callback_message = "Describe requires name and callback arguments";
+const function_message = "Second argument must be function";
+const async_message = "No async describe callback";
+const argument_message = "Unexpected argument(s) in describe callback";
+const return_message = "Unexpected return statement in describe callback";
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var describe_callbacks: NodeSet = .empty;
+    defer describe_callbacks.deinit(allocator);
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+        .describe_callbacks = &describe_callbacks,
+    };
+    defer visitor.function_stack.deinit(allocator);
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+    describe_callbacks: *NodeSet,
+    function_stack: std.ArrayList(bool) = .empty,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+        if (call.function.kind() != .describe) return .proceed;
+
+        const arguments = ctx.tree.extra(call_expression.arguments);
+        if (arguments.len == 0) {
+            try self.report(name_and_callback_message, ctx.tree.span(index));
+            return .proceed;
+        }
+        if (arguments.len == 1) {
+            try self.report(name_and_callback_message, argumentsSpan(ctx.tree, arguments));
+            return .proceed;
+        }
+
+        const callback_index = unwrapTransparent(ctx.tree, arguments[1]);
+        const callback = callbackInfo(ctx.tree, callback_index) orelse {
+            try self.report(function_message, argumentsSpan(ctx.tree, arguments));
+            return .proceed;
+        };
+        try self.describe_callbacks.put(self.allocator, callback_index, {});
+
+        if (callback.async) {
+            try self.report(async_message, ctx.tree.span(callback_index));
+        }
+        if (call.memberNamed("each") == null) {
+            if (parametersSpan(ctx.tree, callback.params)) |span| {
+                try self.report(argument_message, span);
+            }
+        }
+        if (callback.returned_expression) {
+            try self.report(return_message, ctx.tree.span(callback_index));
+        }
+
+        return .proceed;
+    }
+
+    pub fn enter_function(
+        self: *Visitor,
+        _: ast.Function,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.function_stack.append(self.allocator, self.describe_callbacks.contains(index));
+        return .proceed;
+    }
+
+    pub fn exit_function(self: *Visitor, _: ast.Function, _: ast.NodeIndex, _: *traverser.basic.Ctx) void {
+        _ = self.function_stack.pop();
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        try self.function_stack.append(self.allocator, self.describe_callbacks.contains(index));
+        return .proceed;
+    }
+
+    pub fn exit_arrow_function_expression(
+        self: *Visitor,
+        _: ast.ArrowFunctionExpression,
+        _: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) void {
+        _ = self.function_stack.pop();
+    }
+
+    pub fn enter_return_statement(
+        self: *Visitor,
+        _: ast.ReturnStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.function_stack.items.len == 0) return .proceed;
+        if (self.function_stack.items[self.function_stack.items.len - 1]) {
+            try self.report(return_message, ctx.tree.span(index));
+        }
+        return .proceed;
+    }
+
+    fn report(self: *Visitor, diagnostic_message: []const u8, span: ast.Span) Allocator.Error!void {
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            diagnostic_message,
+            span,
+        );
+    }
+};
+
+const CallbackInfo = struct {
+    params: ast.NodeIndex,
+    async: bool,
+    returned_expression: bool,
+};
+
+fn callbackInfo(tree: *const ast.Tree, index: ast.NodeIndex) ?CallbackInfo {
+    return switch (tree.data(index)) {
+        .function => |function| if (function.type == .function_expression) .{
+            .params = function.params,
+            .async = function.async,
+            .returned_expression = false,
+        } else null,
+        .arrow_function_expression => |arrow| .{
+            .params = arrow.params,
+            .async = arrow.async,
+            .returned_expression = arrow.expression,
+        },
+        else => null,
+    };
+}
+
+fn argumentsSpan(tree: *const ast.Tree, arguments: []const ast.NodeIndex) ast.Span {
+    const first = tree.span(arguments[0]);
+    const last = tree.span(arguments[arguments.len - 1]);
+    return .{ .start = first.start, .end = last.end };
+}
+
+fn parametersSpan(tree: *const ast.Tree, params_index: ast.NodeIndex) ?ast.Span {
+    const params = switch (tree.data(params_index)) {
+        .formal_parameters => |value| value,
+        else => return null,
+    };
+    const items = tree.extra(params.items);
+    if (items.len == 0 and params.rest == .null) return null;
+
+    const first_index = if (items.len > 0) items[0] else params.rest;
+    const last_index = if (params.rest != .null) params.rest else items[items.len - 1];
+    const first = tree.span(first_index);
+    const last = tree.span(last_index);
+    return .{ .start = first.start, .end = last.end };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -87,6 +87,7 @@ pub const jest_no_interpolation_in_snapshots = @import("jest_no_interpolation_in
 pub const jest_no_jasmine_globals = @import("jest_no_jasmine_globals.zig");
 pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
 pub const jest_no_standalone_expect = @import("jest_no_standalone_expect.zig");
+pub const jest_valid_describe_callback = @import("jest_valid_describe_callback.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1066,6 +1067,16 @@ fn runSemanticAfterIo(
             semantic_result.symbol_table,
             options.jest_global_aliases,
             options.jest_no_standalone_expect_additional_test_block_functions,
+        );
+    }
+
+    if (options.jest_valid_describe_callback) {
+        try jest_valid_describe_callback.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
         );
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -276,6 +276,7 @@ comptime {
     _ = @import("rules/jest_no_jasmine_globals.zig");
     _ = @import("rules/jest_no_mocks_import.zig");
     _ = @import("rules/jest_no_standalone_expect.zig");
+    _ = @import("rules/jest_valid_describe_callback.zig");
 }
 
 comptime {

--- a/tests/rules/jest_valid_describe_callback.zig
+++ b/tests/rules/jest_valid_describe_callback.zig
@@ -1,0 +1,195 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_valid_describe_callback.id;
+
+test "reports missing and non-function callbacks with useful locations" {
+    const cases = [_]struct {
+        source: []const u8,
+        message: []const u8,
+        reported: []const u8,
+    }{
+        .{ .source = "describe()", .message = "Describe requires name and callback arguments", .reported = "describe()" },
+        .{ .source = "describe.each()()", .message = "Describe requires name and callback arguments", .reported = "describe.each()()" },
+        .{ .source = "describe('name')", .message = "Describe requires name and callback arguments", .reported = "'name'" },
+        .{ .source = "describe(() => {})", .message = "Describe requires name and callback arguments", .reported = "() => {}" },
+        .{ .source = "describe('name', value)", .message = "Second argument must be function", .reported = "'name', value" },
+        .{ .source = "describe('name', call())", .message = "Second argument must be function", .reported = "'name', call()" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings(case.message, diagnostic.message);
+        try std.testing.expectEqualStrings(case.reported, case.source[diagnostic.span.start..diagnostic.span.end]);
+    }
+}
+
+test "reports async callbacks for describe aliases" {
+    const source =
+        \\describe('one', async () => {});
+        \\fdescribe('two', async function () {});
+        \\xdescribe('three', async function () {});
+        \\describe.only('four', async () => {});
+        \\describe.skip('five', async () => {});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 5), helpers.countRule(result, rule_id));
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) {
+            try std.testing.expectEqualStrings("No async describe callback", diagnostic.message);
+        }
+    }
+}
+
+test "rejects parameters except for describe each callbacks" {
+    const invalid =
+        \\describe('arrow', done => {});
+        \\describe('function', function (one, two, three) {});
+        \\describe('rest', (...values) => {});
+    ;
+    var invalid_result = try lint.lintSource(std.testing.allocator, invalid, "fixture.js", optionsOnly());
+    defer invalid_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(invalid_result, rule_id));
+    try std.testing.expectEqualStrings("done", diagnosticSource(invalid, invalid_result.diagnostics[0]));
+    try std.testing.expectEqualStrings("one, two, three", diagnosticSource(invalid, invalid_result.diagnostics[1]));
+    try std.testing.expectEqualStrings("...values", diagnosticSource(invalid, invalid_result.diagnostics[2]));
+
+    const valid =
+        \\describe.each([1, 2])('%s', (one, two) => {});
+        \\describe['each']([1, 2])('%s', value => {});
+        \\describe.each`value\n${1}`('%s', ({ value }) => {});
+    ;
+    var valid_result = try lint.lintSource(std.testing.allocator, valid, "fixture.js", optionsOnly());
+    defer valid_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(valid_result, rule_id));
+}
+
+test "reports returned values without entering nested functions" {
+    const source =
+        \\describe('direct', () => { return Promise.resolve(); });
+        \\describe('conditional', () => { if (ready) return value; });
+        \\describe('concise call', () => test('works', () => {}));
+        \\describe('concise value', () => 42);
+        \\describe('nested helpers', () => {
+        \\  function helper() { return 1; }
+        \\  const arrow = () => { return 2; };
+        \\  test('works', () => { return Promise.resolve(); });
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("return Promise.resolve();", diagnosticSource(source, result.diagnostics[0]));
+    try std.testing.expectEqualStrings("return value;", diagnosticSource(source, result.diagnostics[1]));
+    try std.testing.expectEqualStrings("() => test('works', () => {})", diagnosticSource(source, result.diagnostics[2]));
+    try std.testing.expectEqualStrings("() => 42", diagnosticSource(source, result.diagnostics[3]));
+}
+
+test "reports every independent callback problem" {
+    const source = "describe('name', async function (done) { return value; });";
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("No async describe callback", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Unexpected argument(s) in describe callback", result.diagnostics[1].message);
+    try std.testing.expectEqualStrings("Unexpected return statement in describe callback", result.diagnostics[2].message);
+}
+
+test "supports imported required and configured aliases while ignoring shadows" {
+    const imported =
+        \\import { describe as suite, fdescribe, xdescribe } from '@jest/globals';
+        \\suite('one', async () => {});
+        \\fdescribe('two', done => {});
+        \\xdescribe('three', () => value);
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(imported_result, rule_id));
+
+    const required =
+        \\const { describe: suite } = require('@jest/globals');
+        \\suite('name', async () => {});
+    ;
+    var required_result = try lint.lintSource(std.testing.allocator, required, "fixture.js", optionsOnly());
+    defer required_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(required_result, rule_id));
+
+    var alias_options = optionsOnly();
+    try std.testing.expect(alias_options.jest_global_aliases.append("describe", "suite"));
+    const aliases = "suite('name', async () => {});";
+    var alias_result = try lint.lintSource(std.testing.allocator, aliases, "fixture.js", alias_options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+
+    const shadowed = "function run(describe) { describe('name', async () => {}); }";
+    var shadowed_result = try lint.lintSource(std.testing.allocator, shadowed, "fixture.js", optionsOnly());
+    defer shadowed_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(shadowed_result, rule_id));
+}
+
+test "accepts valid synchronous zero-argument callbacks" {
+    const source =
+        \\describe('arrow', () => {});
+        \\describe('function', function () {});
+        \\fdescribe('focused', () => { test('works', async () => {}); });
+        \\xdescribe('skipped', function* () { yield value; });
+        \\describe('nested return', () => { test('works', () => { return value; }); });
+        \\describe('extra argument', () => {}, timeout);
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "describe('js', async () => {});", .file_name = "fixture.js" },
+        .{ .source = "describe('ts', async (): Promise<void> => {});", .file_name = "fixture.ts" },
+        .{ .source = "describe('jsx', async () => { <div />; });", .file_name = "fixture.jsx" },
+        .{ .source = "describe('tsx', async (): Promise<void> => { <div />; });", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_valid_describe_callback);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_valid_describe_callback);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"error\"]", .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue(rule_id, parsed.value);
+    try std.testing.expect(options.jest_valid_describe_callback);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_valid_describe_callback = true;
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}
+
+fn diagnosticSource(source: []const u8, diagnostic: lint.Diagnostic) []const u8 {
+    return source[diagnostic.span.start..diagnostic.span.end];
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -252,6 +252,33 @@ test("reports standalone expects and honors custom test blocks", () => {
   assert.equal(result.diagnostics[0].message, "Expect must be inside of a test block");
 });
 
+test("validates describe callbacks", () => {
+  const result = linter.lint(
+    [
+      "describe('invalid', async done => { return value; });",
+      "describe.each([1])('%s', value => {});",
+    ].join("\n"),
+    {
+      filePath: "input.js",
+      rules: { "jest/valid-describe-callback": "error" },
+    },
+  );
+  assert.deepEqual(
+    result.diagnostics.map(({ ruleId, message }) => ({ ruleId, message })),
+    [
+      { ruleId: "jest/valid-describe-callback", message: "No async describe callback" },
+      {
+        ruleId: "jest/valid-describe-callback",
+        message: "Unexpected argument(s) in describe callback",
+      },
+      {
+        ruleId: "jest/valid-describe-callback",
+        message: "Unexpected return statement in describe callback",
+      },
+    ],
+  );
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements `jest/valid-describe-callback` for global, aliased, imported, and required Jest APIs, including missing callbacks, async callbacks, unexpected parameters, returned values, and `describe.each` behavior.

Closes #1161.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
