### PR TITLE
feat: add jest/valid-expect-in-promise

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -272,6 +272,7 @@ instead of being rewritten.
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | Implemented for static imports, dynamic imports, and CommonJS requires from nested `__mocks__` directories |
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | Supports suite, test, hook, helper, imported API, and `additionalTestBlockFunctions` context detection |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | Enforces synchronous function callbacks without unexpected parameters or return values, including aliases and `describe.each` |
+| [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | Requires expectation-bearing `then`, `catch`, and `finally` chains in tests to be returned, awaited, or consumed through supported promise patterns |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -271,6 +271,7 @@
 | [`jest/no-mocks-import`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md) | 已实现对嵌套 `__mocks__` 目录中静态导入、动态导入和 CommonJS `require` 的检查 |
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | 支持测试套件、测试、钩子、辅助函数、导入 API 和 `additionalTestBlockFunctions` 上下文检查 |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | 校验同步函数回调、意外参数和返回值，并支持别名及 `describe.each` |
+| [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | 要求测试中包含断言的 `then`、`catch` 和 `finally` 链被返回、等待或通过受支持的 Promise 模式消费 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -321,6 +321,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-mocks-import",
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
+  "jest/valid-expect-in-promise",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -324,6 +324,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-mocks-import",
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
+  "jest/valid-expect-in-promise",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -2982,6 +2982,49 @@ test("project config and CLI --rules enable jest/valid-describe-callback", (t) =
   }
 });
 
+test("project config and CLI --rules enable jest/valid-expect-in-promise", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({ rules: { "jest/valid-expect-in-promise": "error" } })
+  );
+  const sourcePath = write(
+    join(project, "promise.test.js"),
+    [
+      "it('floating', () => { load().then(value => expect(value).toBeDefined()); });",
+      "it('returned', () => load().then(value => expect(value).toBeDefined()));",
+      ""
+    ].join("\n")
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-expect-in-promise", severity: "error" }
+    ]);
+
+    const selected = execute(["--rules=jest/valid-expect-in-promise", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-expect-in-promise", severity: "warning" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/valid-expect-in-promise", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.deepEqual(isolatedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-expect-in-promise", severity: "warning" }
+    ]);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2770,6 +2770,7 @@ pub const Options = struct {
     jest_no_standalone_expect: bool = true,
     jest_no_standalone_expect_additional_test_block_functions: JestAdditionalTestBlockFunctions = .{},
     jest_valid_describe_callback: bool = true,
+    jest_valid_expect_in_promise: bool = true,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -10690,6 +10691,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_valid_describe_callback);
     try std.testing.expect(options.setByCliName("jest/valid-describe-callback", true));
     try std.testing.expect(options.jest_valid_describe_callback);
+
+    try std.testing.expect(!options.jest_valid_expect_in_promise);
+    try std.testing.expect(options.setByCliName("jest/valid-expect-in-promise", true));
+    try std.testing.expect(options.jest_valid_expect_in_promise);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -301,6 +301,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_jasmine_globals or
         options.jest_no_standalone_expect or
         options.jest_valid_describe_callback or
+        options.jest_valid_expect_in_promise or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_valid_expect_in_promise.zig
+++ b/src/rules/jest_valid_expect_in_promise.zig
@@ -1,0 +1,545 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+const SymbolId = traverser.semantic.SymbolId;
+
+pub const id = "jest/valid-expect-in-promise";
+
+const message = "This promise should either be returned or awaited to ensure the expects in its chain are called";
+
+const PromiseChain = struct {
+    node: ast.NodeIndex,
+    has_expect: bool = false,
+    directly_in_test: bool,
+};
+
+const Candidate = struct {
+    report_node: ast.NodeIndex,
+    scope_function: ast.NodeIndex,
+    symbol: ?SymbolId,
+    start: u32,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .resolver = &resolver,
+        .symbol_table = symbol_table,
+    };
+    defer visitor.chains.deinit(allocator);
+    defer visitor.candidates.deinit(allocator);
+    try visitor.candidates.ensureTotalCapacity(allocator, tree.nodes.len);
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+
+    for (visitor.candidates.items) |candidate| {
+        if (candidate.symbol) |symbol| {
+            var scanner = UsageScanner{
+                .resolver = &resolver,
+                .symbol_table = symbol_table,
+                .symbol = symbol,
+                .scope_function = candidate.scope_function,
+                .start = candidate.start,
+            };
+            var subtree = tree.*;
+            subtree.root = candidate.scope_function;
+            try traverser.basic.traverse(UsageScanner, &subtree, &scanner);
+            if (scanner.consumed) continue;
+        }
+
+        try core.addDiagnostic(
+            allocator,
+            diagnostics,
+            .warning,
+            id,
+            message,
+            tree.span(candidate.report_node),
+        );
+    }
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    resolver: *const jest_fn_call.Resolver,
+    symbol_table: traverser.semantic.SymbolTable,
+    chains: std.ArrayList(PromiseChain) = .empty,
+    candidates: std.ArrayList(Candidate) = .empty,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (isPromiseChainCall(ctx.tree, call_expression)) {
+            const directly_in_test = directTestScope(ctx.tree, self.resolver, index, &ctx.path) != null;
+            if (directly_in_test or self.chains.items.len != 0) {
+                try self.chains.append(self.allocator, .{
+                    .node = index,
+                    .directly_in_test = directly_in_test,
+                });
+            }
+            return .proceed;
+        }
+
+        if (self.chains.items.len != 0) {
+            const parsed = self.resolver.parseCall(call_expression, index, ctx.path.parent());
+            if (parsed) |call| {
+                if (call.function.kind() == .expect) {
+                    self.chains.items[self.chains.items.len - 1].has_expect = true;
+                }
+            }
+        }
+        return .proceed;
+    }
+
+    pub fn exit_call_expression(
+        self: *Visitor,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) void {
+        if (!isPromiseChainCall(ctx.tree, call_expression)) return;
+        if (self.chains.items.len == 0) return;
+        const chain = self.chains.items[self.chains.items.len - 1];
+        if (chain.node != index) return;
+        _ = self.chains.pop();
+
+        if (!chain.has_expect or !chain.directly_in_test) return;
+        const scope_function = directTestScope(ctx.tree, self.resolver, index, &ctx.path) orelse return;
+        const top = topMostCall(ctx.tree, index, &ctx.path);
+        const parent = top.parent orelse return;
+
+        switch (ctx.tree.data(parent)) {
+            .return_statement, .await_expression => return,
+            .variable_declarator => |declarator| {
+                if (declarator.init != top.value) return;
+                const id_node = unwrapTransparent(ctx.tree, declarator.id);
+                const symbol = switch (ctx.tree.data(id_node)) {
+                    .binding_identifier => self.symbol_table.symbolOf(id_node),
+                    else => return,
+                };
+                self.addCandidate(parent, scope_function, symbol, ctx.tree.span(parent).end);
+            },
+            .assignment_expression => |assignment| {
+                if (assignment.right != top.value) return;
+                const left = unwrapTransparent(ctx.tree, assignment.left);
+                const symbol = referenceSymbol(self.symbol_table, left);
+                self.addCandidate(parent, scope_function, symbol, ctx.tree.span(parent).end);
+            },
+            .expression_statement => |statement| {
+                if (statement.expression != top.value) return;
+                self.addCandidate(top.call, scope_function, null, ctx.tree.span(top.value).end);
+            },
+            else => return,
+        }
+    }
+
+    fn addCandidate(
+        self: *Visitor,
+        report_node: ast.NodeIndex,
+        scope_function: ast.NodeIndex,
+        symbol: ?SymbolId,
+        start: u32,
+    ) void {
+        for (self.candidates.items) |candidate| {
+            if (candidate.report_node == report_node) return;
+        }
+        self.candidates.appendAssumeCapacity(.{
+            .report_node = report_node,
+            .scope_function = scope_function,
+            .symbol = symbol,
+            .start = start,
+        });
+    }
+};
+
+const UsageScanner = struct {
+    resolver: *const jest_fn_call.Resolver,
+    symbol_table: traverser.semantic.SymbolTable,
+    symbol: SymbolId,
+    scope_function: ast.NodeIndex,
+    start: u32,
+    consumed: bool = false,
+    stopped: bool = false,
+
+    pub fn enter_function(
+        self: *UsageScanner,
+        _: ast.Function,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return if (index == self.scope_function) .proceed else .skip;
+    }
+
+    pub fn enter_arrow_function_expression(
+        self: *UsageScanner,
+        _: ast.ArrowFunctionExpression,
+        index: ast.NodeIndex,
+        _: *traverser.basic.Ctx,
+    ) traverser.Action {
+        return if (index == self.scope_function) .proceed else .skip;
+    }
+
+    pub fn enter_return_statement(
+        self: *UsageScanner,
+        statement: ast.ReturnStatement,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (!self.shouldCheck(ctx.tree, index)) return .proceed;
+        if (promiseMethodUsesValue(ctx.tree, self.symbol_table, statement.argument, self.symbol)) {
+            self.consumed = true;
+        } else {
+            self.stopped = true;
+        }
+        return .proceed;
+    }
+
+    pub fn enter_await_expression(
+        self: *UsageScanner,
+        expression: ast.AwaitExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (!self.shouldCheck(ctx.tree, index)) return .proceed;
+        if (promiseMethodUsesValue(ctx.tree, self.symbol_table, expression.argument, self.symbol)) {
+            self.consumed = true;
+        }
+        return .proceed;
+    }
+
+    pub fn enter_assignment_expression(
+        self: *UsageScanner,
+        expression: ast.AssignmentExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (!self.shouldCheck(ctx.tree, index)) return .proceed;
+        if (!nodeReferencesSymbol(ctx.tree, self.symbol_table, expression.left, self.symbol)) return .proceed;
+        if (!isChainedAssignment(ctx.tree, self.symbol_table, expression.right, self.symbol)) {
+            self.stopped = true;
+        }
+        return .proceed;
+    }
+
+    pub fn enter_call_expression(
+        self: *UsageScanner,
+        call_expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) traverser.Action {
+        if (!self.shouldCheck(ctx.tree, index)) return .proceed;
+        const call = self.resolver.parseCall(call_expression, index, ctx.path.parent()) orelse return .proceed;
+        if (call.function.kind() != .expect) return .proceed;
+        if (call.memberNamed("resolves") == null and call.memberNamed("rejects") == null) return .proceed;
+
+        const expect_call = leftMostCall(ctx.tree, index) orelse return .proceed;
+        const arguments = ctx.tree.extra(expect_call.arguments);
+        if (arguments.len != 0 and nodeReferencesSymbol(ctx.tree, self.symbol_table, arguments[0], self.symbol)) {
+            self.consumed = true;
+        }
+        return .proceed;
+    }
+
+    fn shouldCheck(self: *const UsageScanner, tree: *const ast.Tree, index: ast.NodeIndex) bool {
+        return !self.consumed and !self.stopped and tree.span(index).start >= self.start;
+    }
+};
+
+const TopMostCall = struct {
+    call: ast.NodeIndex,
+    value: ast.NodeIndex,
+    parent: ?ast.NodeIndex,
+};
+
+fn topMostCall(tree: *const ast.Tree, index: ast.NodeIndex, path: *const parser.traverser.NodePath) TopMostCall {
+    var call_index = index;
+    var value = index;
+    var depth: usize = 1;
+
+    while (path.ancestor(depth)) |parent| {
+        switch (tree.data(parent)) {
+            .member_expression => |member| {
+                if (member.object != value) break;
+                value = parent;
+            },
+            .call_expression => |call| {
+                if (call.callee != value) break;
+                call_index = parent;
+                value = parent;
+            },
+            .chain_expression => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            .parenthesized_expression => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            .ts_as_expression => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            .ts_satisfies_expression => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            .ts_non_null_expression => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            .ts_type_assertion => |expression| {
+                if (expression.expression != value) break;
+                value = parent;
+            },
+            else => break,
+        }
+        depth += 1;
+    }
+
+    return .{ .call = call_index, .value = value, .parent = path.ancestor(depth) };
+}
+
+fn directTestScope(
+    tree: *const ast.Tree,
+    resolver: *const jest_fn_call.Resolver,
+    _: ast.NodeIndex,
+    path: *const parser.traverser.NodePath,
+) ?ast.NodeIndex {
+    var depth: usize = 1;
+    while (path.ancestor(depth)) |ancestor| : (depth += 1) {
+        const params = switch (tree.data(ancestor)) {
+            .function => |function| function.params,
+            .arrow_function_expression => |arrow| arrow.params,
+            else => continue,
+        };
+
+        var callback_value = ancestor;
+        var parent_depth = depth + 1;
+        while (path.ancestor(parent_depth)) |wrapper| : (parent_depth += 1) {
+            if (!transparentContains(tree, wrapper, callback_value)) break;
+            callback_value = wrapper;
+        }
+        const call_index = path.ancestor(parent_depth) orelse return null;
+        const call_expression = switch (tree.data(call_index)) {
+            .call_expression => |call| call,
+            else => return null,
+        };
+        const arguments = tree.extra(call_expression.arguments);
+        if (arguments.len < 2 or arguments[1] != callback_value) return null;
+        const parsed = resolver.parseCall(call_expression, call_index, path.ancestor(parent_depth + 1)) orelse return null;
+        if (parsed.function.kind() != .test_case) return null;
+
+        const parameter_count = formalParameterCount(tree, params);
+        if (parsed.memberNamed("each") != null) {
+            if (!containsTaggedTemplate(tree, call_expression.callee)) return null;
+            if (parameter_count == 2) return null;
+        } else if (parameter_count == 1) {
+            return null;
+        }
+        return ancestor;
+    }
+    return null;
+}
+
+fn formalParameterCount(tree: *const ast.Tree, params_index: ast.NodeIndex) usize {
+    return switch (tree.data(params_index)) {
+        .formal_parameters => |params| tree.extra(params.items).len,
+        else => 0,
+    };
+}
+
+fn containsTaggedTemplate(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .tagged_template_expression => true,
+        .call_expression => |call| containsTaggedTemplate(tree, call.callee),
+        .member_expression => |member| containsTaggedTemplate(tree, member.object),
+        else => false,
+    };
+}
+
+fn isPromiseChainCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return false,
+    };
+    const name = staticPropertyName(tree, member.property, member.computed) orelse return false;
+    const argument_count = tree.extra(call.arguments).len;
+    if (argument_count == 0) return false;
+    if (std.mem.eql(u8, name, "then")) return argument_count < 3;
+    if (std.mem.eql(u8, name, "catch") or std.mem.eql(u8, name, "finally")) return argument_count < 2;
+    return false;
+}
+
+fn promiseMethodUsesValue(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    symbol: SymbolId,
+) bool {
+    if (index == .null) return false;
+    const current = unwrapTransparent(tree, index);
+    if (nodeReferencesSymbol(tree, symbol_table, current, symbol)) return true;
+
+    const call = switch (tree.data(current)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    const method = promiseStaticMethod(tree, call) orelse return false;
+    const arguments = tree.extra(call.arguments);
+    if ((std.mem.eql(u8, method, "resolve") or std.mem.eql(u8, method, "reject")) and arguments.len == 1) {
+        return nodeReferencesSymbol(tree, symbol_table, arguments[0], symbol);
+    }
+    if ((!std.mem.eql(u8, method, "all") and !std.mem.eql(u8, method, "allSettled")) or arguments.len == 0) {
+        return false;
+    }
+    const array = switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+        .array_expression => |array| array,
+        else => return false,
+    };
+    for (tree.extra(array.elements)) |element| {
+        if (nodeReferencesSymbol(tree, symbol_table, element, symbol)) return true;
+    }
+    return false;
+}
+
+fn promiseStaticMethod(tree: *const ast.Tree, call: ast.CallExpression) ?[]const u8 {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member,
+        else => return null,
+    };
+    const object = unwrapTransparent(tree, member.object);
+    const object_name = switch (tree.data(object)) {
+        .identifier_reference => |identifier| tree.string(identifier.name),
+        else => return null,
+    };
+    if (!std.mem.eql(u8, object_name, "Promise")) return null;
+    return staticPropertyName(tree, member.property, member.computed);
+}
+
+fn isChainedAssignment(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    symbol: SymbolId,
+) bool {
+    const current = unwrapTransparent(tree, index);
+    const call = switch (tree.data(current)) {
+        .call_expression => |call| call,
+        else => return false,
+    };
+    if (!isPromiseChainCall(tree, call)) return false;
+    var object = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |member| member.object,
+        else => return false,
+    };
+    while (true) {
+        object = unwrapTransparent(tree, object);
+        switch (tree.data(object)) {
+            .call_expression => |inner| object = inner.callee,
+            .member_expression => |member| object = member.object,
+            else => break,
+        }
+    }
+    return nodeReferencesSymbol(tree, symbol_table, object, symbol);
+}
+
+fn leftMostCall(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.CallExpression {
+    var current = unwrapTransparent(tree, index);
+    var result: ?ast.CallExpression = null;
+    while (true) {
+        switch (tree.data(current)) {
+            .call_expression => |call| {
+                result = call;
+                current = unwrapTransparent(tree, call.callee);
+            },
+            .member_expression => |member| current = unwrapTransparent(tree, member.object),
+            .tagged_template_expression => |tagged| current = unwrapTransparent(tree, tagged.tag),
+            else => return result,
+        }
+    }
+}
+
+fn referenceSymbol(symbol_table: traverser.semantic.SymbolTable, index: ast.NodeIndex) ?SymbolId {
+    const reference_id = symbol_table.model.referenceOf(index) orelse return null;
+    const symbol = symbol_table.referenceSymbol(reference_id);
+    return if (symbol == .none) null else symbol;
+}
+
+fn nodeReferencesSymbol(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    symbol: SymbolId,
+) bool {
+    if (index == .null) return false;
+    const current = unwrapTransparent(tree, index);
+    return referenceSymbol(symbol_table, current) == symbol;
+}
+
+fn transparentContains(tree: *const ast.Tree, wrapper: ast.NodeIndex, child: ast.NodeIndex) bool {
+    return switch (tree.data(wrapper)) {
+        .chain_expression => |expression| expression.expression == child,
+        .parenthesized_expression => |expression| expression.expression == child,
+        .ts_as_expression => |expression| expression.expression == child,
+        .ts_satisfies_expression => |expression| expression.expression == child,
+        .ts_non_null_expression => |expression| expression.expression == child,
+        .ts_type_assertion => |expression| expression.expression == child,
+        else => false,
+    };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, index: ast.NodeIndex, computed: bool) ?[]const u8 {
+    if (!computed) {
+        return switch (tree.data(index)) {
+            .identifier_name => |identifier| tree.string(identifier.name),
+            else => null,
+        };
+    }
+    return switch (tree.data(index)) {
+        .string_literal => |literal| tree.string(literal.value),
+        .template_literal => |literal| templateStringValue(tree, literal),
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len != 1) return null;
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/jest_valid_expect_in_promise.zig
+++ b/src/rules/jest_valid_expect_in_promise.zig
@@ -273,40 +273,19 @@ fn topMostCall(tree: *const ast.Tree, index: ast.NodeIndex, path: *const parser.
 
     while (path.ancestor(depth)) |parent| {
         switch (tree.data(parent)) {
-            .member_expression => |member| {
-                if (member.object != value) break;
-                value = parent;
-            },
-            .call_expression => |call| {
-                if (call.callee != value) break;
+            .return_statement,
+            .await_expression,
+            .variable_declarator,
+            .assignment_expression,
+            .expression_statement,
+            .function,
+            .arrow_function_expression,
+            => break,
+            .call_expression => {
                 call_index = parent;
                 value = parent;
             },
-            .chain_expression => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            .parenthesized_expression => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            .ts_as_expression => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            .ts_satisfies_expression => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            .ts_non_null_expression => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            .ts_type_assertion => |expression| {
-                if (expression.expression != value) break;
-                value = parent;
-            },
-            else => break,
+            else => value = parent,
         }
         depth += 1;
     }
@@ -346,8 +325,12 @@ fn directTestScope(
 
         const parameter_count = formalParameterCount(tree, params);
         if (parsed.memberNamed("each") != null) {
-            if (!containsTaggedTemplate(tree, call_expression.callee)) return null;
-            if (parameter_count == 2) return null;
+            if (containsTaggedTemplate(tree, call_expression.callee)) {
+                if (parameter_count == 2) return null;
+            } else {
+                const data_arity = arrayEachDataArity(tree, call_expression.callee) orelse return null;
+                if (parameter_count == data_arity + 1) return null;
+            }
         } else if (parameter_count == 1) {
             return null;
         }
@@ -370,6 +353,44 @@ fn containsTaggedTemplate(tree: *const ast.Tree, index: ast.NodeIndex) bool {
         .call_expression => |call| containsTaggedTemplate(tree, call.callee),
         .member_expression => |member| containsTaggedTemplate(tree, member.object),
         else => false,
+    };
+}
+
+fn arrayEachDataArity(tree: *const ast.Tree, index: ast.NodeIndex) ?usize {
+    const each_call = findEachFactoryCall(tree, index) orelse return null;
+    const arguments = tree.extra(each_call.arguments);
+    if (arguments.len != 1) return null;
+    const table = switch (tree.data(unwrapTransparent(tree, arguments[0]))) {
+        .array_expression => |array| array,
+        else => return null,
+    };
+    const rows = tree.extra(table.elements);
+    if (rows.len == 0) return null;
+
+    var arity: usize = 1;
+    for (rows) |row_index| {
+        const row = switch (tree.data(unwrapTransparent(tree, row_index))) {
+            .array_expression => |array| array,
+            else => continue,
+        };
+        arity = @max(arity, tree.extra(row.elements).len);
+    }
+    return arity;
+}
+
+fn findEachFactoryCall(tree: *const ast.Tree, index: ast.NodeIndex) ?ast.CallExpression {
+    const current = unwrapTransparent(tree, index);
+    return switch (tree.data(current)) {
+        .call_expression => |call| blk: {
+            const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+                .member_expression => |member| member,
+                else => break :blk findEachFactoryCall(tree, call.callee),
+            };
+            const name = staticPropertyName(tree, member.property, member.computed) orelse break :blk null;
+            break :blk if (std.mem.eql(u8, name, "each")) call else findEachFactoryCall(tree, member.object);
+        },
+        .member_expression => |member| findEachFactoryCall(tree, member.object),
+        else => null,
     };
 }
 
@@ -400,6 +421,7 @@ fn promiseMethodUsesValue(
         .call_expression => |call| call,
         else => return false,
     };
+    if (isDerivedPromiseChain(tree, symbol_table, current, symbol)) return true;
     const method = promiseStaticMethod(tree, call) orelse return false;
     const arguments = tree.extra(call.arguments);
     if ((std.mem.eql(u8, method, "resolve") or std.mem.eql(u8, method, "reject")) and arguments.len == 1) {
@@ -433,6 +455,16 @@ fn promiseStaticMethod(tree: *const ast.Tree, call: ast.CallExpression) ?[]const
 }
 
 fn isChainedAssignment(
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    index: ast.NodeIndex,
+    symbol: SymbolId,
+) bool {
+    const current = unwrapTransparent(tree, index);
+    return isDerivedPromiseChain(tree, symbol_table, current, symbol);
+}
+
+fn isDerivedPromiseChain(
     tree: *const ast.Tree,
     symbol_table: traverser.semantic.SymbolTable,
     index: ast.NodeIndex,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -88,6 +88,7 @@ pub const jest_no_jasmine_globals = @import("jest_no_jasmine_globals.zig");
 pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
 pub const jest_no_standalone_expect = @import("jest_no_standalone_expect.zig");
 pub const jest_valid_describe_callback = @import("jest_valid_describe_callback.zig");
+pub const jest_valid_expect_in_promise = @import("jest_valid_expect_in_promise.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1072,6 +1073,16 @@ fn runSemanticAfterIo(
 
     if (options.jest_valid_describe_callback) {
         try jest_valid_describe_callback.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+        );
+    }
+
+    if (options.jest_valid_expect_in_promise) {
+        try jest_valid_expect_in_promise.run(
             allocator,
             diagnostics,
             tree,

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -277,6 +277,7 @@ comptime {
     _ = @import("rules/jest_no_mocks_import.zig");
     _ = @import("rules/jest_no_standalone_expect.zig");
     _ = @import("rules/jest_valid_describe_callback.zig");
+    _ = @import("rules/jest_valid_expect_in_promise.zig");
 }
 
 comptime {

--- a/tests/rules/jest_valid_expect_in_promise.zig
+++ b/tests/rules/jest_valid_expect_in_promise.zig
@@ -55,6 +55,20 @@ test "allows directly returned awaited and implicitly returned promise chains" {
     try std.testing.expect(!helpers.hasRule(result, rule_id));
 }
 
+test "reports floating chains wrapped in arrays arguments and logical expressions" {
+    const source =
+        \\it('wrapped', () => {
+        \\  Promise.all([load().then(value => expect(value).toBeDefined())]);
+        \\  consume(load().catch(error => expect(error).toBeDefined()));
+        \\  enabled && load().finally(() => expect(cleaned).toBe(true));
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+}
+
 test "tracks assigned promises consumed later by supported patterns" {
     const source =
         \\it('consumes promises', async () => {
@@ -121,6 +135,44 @@ test "allows promise-preserving reassignment before consumption" {
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "allows returned and awaited chains derived from tracked promises" {
+    const source =
+        \\it('returned derivative', () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  return promise.catch(handle);
+        \\});
+        \\it('awaited derivative', async () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  await promise.finally(cleanup);
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "analyzes static array each callbacks and preserves done callback bailouts" {
+    const source =
+        \\test.each([[1]])('one %s', value => {
+        \\  load(value).then(result => expect(result).toBeDefined());
+        \\});
+        \\test.each([[1, 2]])('two %s %s', (value, expected) => {
+        \\  load(value).then(result => expect(result).toBe(expected));
+        \\});
+        \\test.each([[1]])('done %s', (value, done) => {
+        \\  load(value).then(result => { expect(result).toBeDefined(); done(); });
+        \\});
+        \\test.each([])('empty', done => {
+        \\  load().then(result => { expect(result).toBeDefined(); done(); });
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
 }
 
 test "limits checks to direct test callbacks and bails out for done callbacks" {

--- a/tests/rules/jest_valid_expect_in_promise.zig
+++ b/tests/rules/jest_valid_expect_in_promise.zig
@@ -1,0 +1,203 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_valid_expect_in_promise.id;
+const expected_message = "This promise should either be returned or awaited to ensure the expects in its chain are called";
+
+test "reports floating then catch and finally chains with useful locations" {
+    const source =
+        \\it('then', () => {
+        \\  load().then(value => expect(value).toBeDefined());
+        \\});
+        \\test('catch', () => {
+        \\  load().catch(error => expect(error).toBeDefined());
+        \\});
+        \\fit('finally', () => {
+        \\  load().finally(() => expect(cleaned).toBe(true));
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(result, rule_id));
+
+    const expected = [_][]const u8{
+        "load().then(value => expect(value).toBeDefined())",
+        "load().catch(error => expect(error).toBeDefined())",
+        "load().finally(() => expect(cleaned).toBe(true))",
+    };
+    var offset: usize = 0;
+    for (result.diagnostics) |diagnostic| {
+        if (!std.mem.eql(u8, diagnostic.rule_id, rule_id)) continue;
+        try std.testing.expectEqualStrings(expected_message, diagnostic.message);
+        try std.testing.expectEqualStrings(expected[offset], source[diagnostic.span.start..diagnostic.span.end]);
+        offset += 1;
+    }
+}
+
+test "allows directly returned awaited and implicitly returned promise chains" {
+    const source =
+        \\it('returned', () => {
+        \\  return load().then(value => expect(value).toBeDefined());
+        \\});
+        \\it('awaited', async () => {
+        \\  await load().catch(error => expect(error).toBeDefined());
+        \\});
+        \\it('implicit', () => load().finally(() => expect(cleaned).toBe(true)));
+        \\it('wrapped', async () => {
+        \\  expect(await load().then(value => expect(value).toBeDefined())).toBeTruthy();
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "tracks assigned promises consumed later by supported patterns" {
+    const source =
+        \\it('consumes promises', async () => {
+        \\  const awaited = load().then(value => expect(value).toBeDefined());
+        \\  await awaited;
+        \\  const returned = load().catch(error => expect(error).toBeDefined());
+        \\  return Promise.all([returned]);
+        \\});
+        \\it('all settled', () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  return Promise.allSettled([promise]);
+        \\});
+        \\it('resolved', () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  return Promise.resolve(promise);
+        \\});
+        \\it('rejected', async () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  await Promise.reject(promise);
+        \\});
+        \\it('matcher', () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  expect(promise).resolves.toBeDefined();
+        \\});
+        \\it('nested await', async () => {
+        \\  const promise = load().then(value => expect(value).toBeDefined());
+        \\  log([[await promise]]);
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "reports unused mismatched and invalidated assigned promises" {
+    const source =
+        \\it('unused', async () => {
+        \\  const unused = load().then(value => expect(value).toBeDefined());
+        \\  const wrongMatcher = load().then(value => expect(value).toBeDefined());
+        \\  expect(other).resolves.toBeDefined();
+        \\  let reassigned = load().then(value => expect(value).toBeDefined());
+        \\  reassigned = null;
+        \\  await reassigned;
+        \\  const unsupported = load().then(value => expect(value).toBeDefined());
+        \\  return Promise.any([unsupported]);
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), helpers.countRule(result, rule_id));
+}
+
+test "allows promise-preserving reassignment before consumption" {
+    const source =
+        \\it('chains', async () => {
+        \\  let promise = load().then(value => expect(value).toBeDefined());
+        \\  promise = promise.then(value => expect(value).toBeDefined());
+        \\  await promise;
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "limits checks to direct test callbacks and bails out for done callbacks" {
+    const source =
+        \\Promise.resolve().then(() => expect(true).toBe(true));
+        \\const helper = () => Promise.resolve().then(() => expect(true).toBe(true));
+        \\it('nested helper', () => {
+        \\  run(() => Promise.resolve().then(() => expect(true).toBe(true)));
+        \\});
+        \\it('done', done => {
+        \\  Promise.resolve().then(() => { expect(true).toBe(true); done(); });
+        \\});
+        \\it('without expect', () => {
+        \\  Promise.resolve().then(() => work());
+        \\});
+    ;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "supports imported required and configured Jest APIs while ignoring shadowed expect" {
+    const imported =
+        \\import { expect as check, it as spec } from '@jest/globals';
+        \\const { test: verify } = require('@jest/globals');
+        \\spec('imported', () => { Promise.resolve().then(() => check(true).toBe(true)); });
+        \\verify('required', () => { Promise.resolve().then(() => check(true).toBe(true)); });
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(imported_result, rule_id));
+
+    var alias_options = optionsOnly();
+    try std.testing.expect(alias_options.jest_global_aliases.append("test", "spec"));
+    try std.testing.expect(alias_options.jest_global_aliases.append("expect", "check"));
+    const alias_source = "spec('alias', () => { Promise.resolve().then(() => check(true).toBe(true)); });";
+    var alias_result = try lint.lintSource(std.testing.allocator, alias_source, "fixture.js", alias_options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+
+    const shadowed = "it('shadowed', () => { const expect = verify; Promise.resolve().then(() => expect(true)); });";
+    var shadowed_result = try lint.lintSource(std.testing.allocator, shadowed, "fixture.js", optionsOnly());
+    defer shadowed_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(shadowed_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX test files" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "it('js', () => { load().then(value => expect(value).toBe(true)); });", .file_name = "fixture.js" },
+        .{ .source = "it('ts', () => { load().then((value: boolean) => expect(value).toBe(true)); });", .file_name = "fixture.ts" },
+        .{ .source = "it('jsx', () => { load().then(() => expect(<div />).toBeTruthy()); });", .file_name = "fixture.jsx" },
+        .{ .source = "it('tsx', () => { load().then(() => expect(<div /> as JSX.Element).toBeTruthy()); });", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "uses the recommended default and accepts ESLint and CLI rule configuration" {
+    try std.testing.expect((lint.Options{}).jest_valid_expect_in_promise);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_valid_expect_in_promise);
+
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"error\"]", .{});
+    defer config.deinit();
+    try options.setByRuleConfigValue(rule_id, config.value);
+    try std.testing.expect(options.jest_valid_expect_in_promise);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_valid_expect_in_promise = true;
+    return options;
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -279,6 +279,25 @@ test("validates describe callbacks", () => {
   );
 });
 
+test("reports floating expectation-bearing promise chains", () => {
+  const result = linter.lint(
+    [
+      "it('floating', () => { load().then(value => expect(value).toBeDefined()); });",
+      "it('awaited', async () => { await load().catch(error => expect(error).toBeDefined()); });",
+    ].join("\n"),
+    {
+      filePath: "input.js",
+      rules: { "jest/valid-expect-in-promise": "error" },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/valid-expect-in-promise");
+  assert.equal(
+    result.diagnostics[0].message,
+    "This promise should either be returned or awaited to ensure the expects in its chain are called",
+  );
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implement native `jest/valid-expect-in-promise` support so expectation-bearing `then`, `catch`, and `finally` chains inside Jest tests must be returned, awaited, or consumed through the promise patterns supported by the upstream rule.

The implementation covers assigned promises, later returns and awaits, `Promise.all`/`allSettled`/`resolve`/`reject`, `expect(...).resolves`/`rejects`, done-callback bailouts, imported and aliased Jest APIs, ESM/CommonJS registration, WebAssembly integration, and rule-status documentation.

Closes #1162.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug --summary all` (2109 tests)
- `zig build -Doptimize=ReleaseFast -j1 --summary all`
- `zig build test -Doptimize=ReleaseFast -j1 --summary all` (2109 tests)
- `pnpm --dir npm/utoo-lint test` (114 tests plus type checks)
- `pnpm package:wasm`
- `pnpm test:wasm` (22 tests)
- `pnpm --dir npm/@utoo/lint-wasm test` (10 tests)
- `pnpm --dir npm/@utoo/lint-wasm test:types`
