### PR TITLE
feat: add jest/valid-title

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -273,6 +273,7 @@ instead of being rewritten.
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | Supports suite, test, hook, helper, imported API, and `additionalTestBlockFunctions` context detection |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | Enforces synchronous function callbacks without unexpected parameters or return values, including aliases and `describe.each` |
 | [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | Requires expectation-bearing `then`, `catch`, and `finally` chains in tests to be returned, awaited, or consumed through supported promise patterns |
+| [`jest/valid-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-title.md) | Supports static and template titles, all upstream options, `.each` specifiers, and upstream-safe autofixes |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -272,6 +272,7 @@
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | 支持测试套件、测试、钩子、辅助函数、导入 API 和 `additionalTestBlockFunctions` 上下文检查 |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | 校验同步函数回调、意外参数和返回值，并支持别名及 `describe.each` |
 | [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | 要求测试中包含断言的 `then`、`catch` 和 `finally` 链被返回、等待或通过受支持的 Promise 模式消费 |
+| [`jest/valid-title`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-title.md) | 支持静态及模板标题、全部上游选项、`.each` 格式符检查和上游安全自动修复 |
 
 ## Promise 插件规则
 

--- a/npm/@utoo/lint-wasm/test/lint.test.mjs
+++ b/npm/@utoo/lint-wasm/test/lint.test.mjs
@@ -57,6 +57,25 @@ test("provides a lazy convenience API", async () => {
   assert.ok(result.diagnostics.some((item) => item.ruleId === "no-extra-semi"));
 });
 
+test("exposes jest/valid-title diagnostics and autofixes", async () => {
+  const linter = await createUtooLint();
+  const checked = linter.lint("test(' forbidden ', () => {});", {
+    filePath: "input.jsx",
+    rules: {
+      "jest/valid-title": ["error", { disallowedWords: ["forbidden"] }],
+    },
+  });
+  assert.equal(checked.diagnostics.length, 1);
+  assert.equal(checked.diagnostics[0]?.ruleId, "jest/valid-title");
+
+  const fixed = linter.lintAndFix("test('test works ', () => {});", {
+    filePath: "input.tsx",
+    rules: { "jest/valid-title": "error" },
+  });
+  assert.equal(fixed.fixed, true);
+  assert.equal(fixed.output, "test('works', () => {});");
+});
+
 test("loads browser-friendly Response, byte, and compiled module inputs", async () => {
   const bytes = await wasmBytesPromise;
   const response = new Response(bytes, {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -322,6 +322,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
   "jest/valid-expect-in-promise",
+  "jest/valid-title",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -325,6 +325,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
   "jest/valid-expect-in-promise",
+  "jest/valid-title",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -3025,6 +3025,77 @@ test("project config and CLI --rules enable jest/valid-expect-in-promise", (t) =
   }
 });
 
+test("jest/valid-title preserves options, CLI selection, and safe fixes", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({
+      rules: {
+        "jest/valid-title": [
+          "error",
+          {
+            ignoreTypeOfDescribeName: true,
+            disallowedWords: ["forbidden"],
+            mustMatch: { test: "^that" }
+          }
+        ]
+      }
+    })
+  );
+  const source = [
+    "describe(makeName(), () => {});",
+    "test('contains forbidden', () => {});",
+    "test('wrong title', () => {});",
+    "it('it works ', () => {});",
+    ""
+  ].join("\n");
+  const expected = [
+    "describe(makeName(), () => {});",
+    "test('contains forbidden', () => {});",
+    "test('wrong title', () => {});",
+    "it('works', () => {});",
+    ""
+  ].join("\n");
+  const sourcePath = write(join(project, "title.test.js"), source);
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.equal(configuredReport.diagnostics.length, 4);
+    assert.ok(configuredReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/valid-title" && severity === "error"
+    ));
+
+    const selected = execute(["--rules=jest/valid-title", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.equal(selectedReport.diagnostics.length, 4);
+    assert.ok(selectedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/valid-title" && severity === "warning"
+    ));
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/valid-title", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 3);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/valid-title" && severity === "warning"
+    ));
+
+    const dryRun = execute(["--fix-dry-run", "--json", sourcePath], options);
+    const dryRunReport = JSON.parse(dryRun.stdout);
+    assert.equal(dryRun.status, 1, dryRun.stderr);
+    assert.equal(dryRunReport.outputs.length, 1);
+    assert.equal(dryRunReport.outputs[0].output, expected);
+    assert.equal(readFileSync(sourcePath, "utf8"), source);
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2771,6 +2771,13 @@ pub const Options = struct {
     jest_no_standalone_expect_additional_test_block_functions: JestAdditionalTestBlockFunctions = .{},
     jest_valid_describe_callback: bool = true,
     jest_valid_expect_in_promise: bool = true,
+    jest_valid_title: bool = true,
+    jest_valid_title_ignore_spaces: bool = false,
+    jest_valid_title_ignore_type_of_describe_name: bool = false,
+    jest_valid_title_ignore_type_of_test_name: bool = false,
+    jest_valid_title_disallowed_words: JestValidTitleDisallowedWords = .{},
+    jest_valid_title_must_not_match: JestValidTitleMatchers = .{},
+    jest_valid_title_must_match: JestValidTitleMatchers = .{},
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -3482,6 +3489,15 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "jest/no-standalone-expect")) {
             self.jest_no_standalone_expect_additional_test_block_functions = try jestAdditionalTestBlockFunctionsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "jest/valid-title")) {
+            const config = try jestValidTitleFromConfig(value);
+            self.jest_valid_title_ignore_spaces = config.ignore_spaces;
+            self.jest_valid_title_ignore_type_of_describe_name = config.ignore_type_of_describe_name;
+            self.jest_valid_title_ignore_type_of_test_name = config.ignore_type_of_test_name;
+            self.jest_valid_title_disallowed_words = config.disallowed_words;
+            self.jest_valid_title_must_not_match = config.must_not_match;
+            self.jest_valid_title_must_match = config.must_match;
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
@@ -5124,6 +5140,109 @@ pub const Options = struct {
             if (!result.append(function_name)) return error.UnsupportedRuleConfigValue;
         }
         return result;
+    }
+
+    const JestValidTitleConfig = struct {
+        ignore_spaces: bool = false,
+        ignore_type_of_describe_name: bool = false,
+        ignore_type_of_test_name: bool = false,
+        disallowed_words: JestValidTitleDisallowedWords = .{},
+        must_not_match: JestValidTitleMatchers = .{},
+        must_match: JestValidTitleMatchers = .{},
+    };
+
+    fn jestValidTitleFromConfig(value: std.json.Value) RuleConfigError!JestValidTitleConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const object = switch (items[1]) {
+            .object => |config| config,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+
+        var result = JestValidTitleConfig{};
+        result.ignore_spaces = try optionalBoolObjectValue(object, "ignoreSpaces", false);
+        result.ignore_type_of_describe_name = try optionalBoolObjectValue(object, "ignoreTypeOfDescribeName", false);
+        result.ignore_type_of_test_name = try optionalBoolObjectValue(object, "ignoreTypeOfTestName", false);
+
+        if (object.get("disallowedWords")) |configured| {
+            const words = switch (configured) {
+                .array => |array| array.items,
+                .null => &.{},
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            for (words) |word_value| {
+                const word = switch (word_value) {
+                    .string => |text| text,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!result.disallowed_words.append(word)) return error.UnsupportedRuleConfigValue;
+            }
+        }
+
+        if (object.get("mustNotMatch")) |configured| {
+            result.must_not_match = try jestValidTitleMatchersFromValue(configured);
+        }
+        if (object.get("mustMatch")) |configured| {
+            result.must_match = try jestValidTitleMatchersFromValue(configured);
+        }
+        return result;
+    }
+
+    fn optionalBoolObjectValue(object: std.json.ObjectMap, key: []const u8, default: bool) RuleConfigError!bool {
+        return switch (object.get(key) orelse return default) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
+    fn jestValidTitleMatchersFromValue(value: std.json.Value) RuleConfigError!JestValidTitleMatchers {
+        var result = JestValidTitleMatchers{};
+        switch (value) {
+            .string, .array => {
+                const matcher = try jestValidTitleMatcherFromValue(value);
+                result.applyToAll(matcher);
+            },
+            .object => |object| {
+                if (object.get("describe")) |configured| {
+                    result.describe = try jestValidTitleMatcherFromValue(configured);
+                }
+                if (object.get("test")) |configured| {
+                    result.test_case = try jestValidTitleMatcherFromValue(configured);
+                }
+                if (object.get("it")) |configured| {
+                    result.it = try jestValidTitleMatcherFromValue(configured);
+                }
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+        return result;
+    }
+
+    fn jestValidTitleMatcherFromValue(value: std.json.Value) RuleConfigError!JestValidTitleMatcher {
+        var matcher = JestValidTitleMatcher{};
+        switch (value) {
+            .string => |pattern| {
+                if (!matcher.set(pattern, null)) return error.UnsupportedRuleConfigValue;
+            },
+            .array => |array| {
+                if (array.items.len < 1 or array.items.len > 2) return error.UnsupportedRuleConfigValue;
+                const pattern = switch (array.items[0]) {
+                    .string => |text| text,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                const message = if (array.items.len == 2) switch (array.items[1]) {
+                    .string => |text| text,
+                    else => return error.UnsupportedRuleConfigValue,
+                } else null;
+                if (!matcher.set(pattern, message)) return error.UnsupportedRuleConfigValue;
+            },
+            else => return error.UnsupportedRuleConfigValue,
+        }
+        return matcher;
     }
 
     const IdLengthConfig = struct {
@@ -10018,6 +10137,75 @@ pub const JestAdditionalTestBlockFunctions = struct {
     }
 };
 
+pub const max_jest_valid_title_disallowed_words = 64;
+pub const max_jest_valid_title_disallowed_word_len = 128;
+
+pub const JestValidTitleDisallowedWords = struct {
+    count: usize = 0,
+    lengths: [max_jest_valid_title_disallowed_words]usize = undefined,
+    storage: [max_jest_valid_title_disallowed_words][max_jest_valid_title_disallowed_word_len]u8 = undefined,
+
+    pub fn at(self: *const JestValidTitleDisallowedWords, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *JestValidTitleDisallowedWords, word: []const u8) bool {
+        if (word.len > max_jest_valid_title_disallowed_word_len) return false;
+        if (self.count >= max_jest_valid_title_disallowed_words) return false;
+
+        @memcpy(self.storage[self.count][0..word.len], word);
+        self.lengths[self.count] = word.len;
+        self.count += 1;
+        return true;
+    }
+};
+
+pub const max_jest_valid_title_pattern_len = 512;
+pub const max_jest_valid_title_matcher_message_len = 512;
+
+pub const JestValidTitleMatcher = struct {
+    active: bool = false,
+    pattern_length: usize = 0,
+    message_length: usize = 0,
+    pattern_storage: [max_jest_valid_title_pattern_len]u8 = undefined,
+    message_storage: [max_jest_valid_title_matcher_message_len]u8 = undefined,
+
+    pub fn pattern(self: *const JestValidTitleMatcher) ?[]const u8 {
+        if (!self.active) return null;
+        return self.pattern_storage[0..self.pattern_length];
+    }
+
+    pub fn message(self: *const JestValidTitleMatcher) ?[]const u8 {
+        if (self.message_length == 0) return null;
+        return self.message_storage[0..self.message_length];
+    }
+
+    pub fn set(self: *JestValidTitleMatcher, pattern_value: []const u8, message_value: ?[]const u8) bool {
+        if (pattern_value.len > max_jest_valid_title_pattern_len) return false;
+        const custom_message = message_value orelse "";
+        if (custom_message.len > max_jest_valid_title_matcher_message_len) return false;
+
+        @memcpy(self.pattern_storage[0..pattern_value.len], pattern_value);
+        @memcpy(self.message_storage[0..custom_message.len], custom_message);
+        self.active = true;
+        self.pattern_length = pattern_value.len;
+        self.message_length = custom_message.len;
+        return true;
+    }
+};
+
+pub const JestValidTitleMatchers = struct {
+    describe: JestValidTitleMatcher = .{},
+    test_case: JestValidTitleMatcher = .{},
+    it: JestValidTitleMatcher = .{},
+
+    pub fn applyToAll(self: *JestValidTitleMatchers, matcher: JestValidTitleMatcher) void {
+        self.describe = matcher;
+        self.test_case = matcher;
+        self.it = matcher;
+    }
+};
+
 pub const max_jest_global_aliases = 32;
 pub const max_jest_global_alias_len = 128;
 
@@ -10695,6 +10883,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_valid_expect_in_promise);
     try std.testing.expect(options.setByCliName("jest/valid-expect-in-promise", true));
     try std.testing.expect(options.jest_valid_expect_in_promise);
+
+    try std.testing.expect(!options.jest_valid_title);
+    try std.testing.expect(options.setByCliName("jest/valid-title", true));
+    try std.testing.expect(options.jest_valid_title);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -302,6 +302,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_standalone_expect or
         options.jest_valid_describe_callback or
         options.jest_valid_expect_in_promise or
+        options.jest_valid_title or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_valid_title.zig
+++ b/src/rules/jest_valid_title.zig
@@ -1,0 +1,711 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/valid-title";
+
+const title_must_be_string = "Title must be a string";
+const duplicate_prefix = "should not have duplicate prefix";
+const accidental_space = "should not have leading or trailing spaces";
+
+pub const Options = struct {
+    ignore_spaces: bool = false,
+    ignore_type_of_describe_name: bool = false,
+    ignore_type_of_test_name: bool = false,
+    disallowed_words: core.JestValidTitleDisallowedWords = .{},
+    must_not_match: core.JestValidTitleMatchers = .{},
+    must_match: core.JestValidTitleMatchers = .{},
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+    options: Options,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+        .options = options,
+    };
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+    options: Options,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        expression: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        const call = self.resolver.parseCall(expression, index, ctx.path.parent()) orelse return .proceed;
+        const kind = call.function.kind();
+        if (kind == .expect) return .proceed;
+
+        const arguments = ctx.tree.extra(expression.arguments);
+        if (arguments.len == 0) return .proceed;
+        const argument = arguments[0];
+        const static_title = staticTitle(ctx.tree, argument);
+        if (static_title == null) {
+            if (containsStringInBinaryExpression(ctx.tree, argument)) return .proceed;
+            if (treeIsTemplateLiteral(ctx.tree, argument)) return .proceed;
+            if ((kind == .describe and self.options.ignore_type_of_describe_name) or
+                (kind == .test_case and self.options.ignore_type_of_test_name)) return .proceed;
+
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                title_must_be_string,
+                ctx.tree.span(argument),
+            );
+            return .proceed;
+        }
+
+        const title = static_title.?;
+        if (title.value.len == 0) {
+            try core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                ctx.tree.span(index),
+                "{s} should not have an empty title",
+                .{if (kind == .describe) "describe" else "test"},
+            );
+            return .proceed;
+        }
+
+        if (call.memberNamed("each") != null and call.nested_calls != 0) {
+            if (invalidEachSpecifier(title.value)) |specifier| {
+                try core.addDiagnosticFmt(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    title.span,
+                    "\"%{c}\" is not a valid format specifier",
+                    .{specifier},
+                );
+            }
+        }
+
+        if (self.disallowedWord(title.value)) |word| {
+            try core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                title.span,
+                "\"{s}\" is not allowed in test titles",
+                .{word},
+            );
+            return .proceed;
+        }
+
+        if (!self.options.ignore_spaces and hasAccidentalSpace(title.value)) {
+            const fixes = accidentalSpaceFixes(ctx.tree, title.span);
+            try core.addDiagnosticWithFixes(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                accidental_space,
+                title.span,
+                fixes.slice(),
+            );
+        }
+
+        const function_group = functionGroup(call.function);
+        if (hasDuplicatePrefix(title.value, function_group.name)) {
+            if (duplicatePrefixFix(ctx.tree, title.span)) |fix| {
+                try core.addDiagnosticWithFix(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    duplicate_prefix,
+                    title.span,
+                    fix,
+                );
+            } else {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    duplicate_prefix,
+                    title.span,
+                );
+            }
+        }
+
+        const must_not_match = matcherFor(&self.options.must_not_match, function_group.matcher_kind);
+        if (must_not_match.pattern()) |pattern| {
+            if (regexMatches(pattern, title.value)) {
+                try self.addMatcherDiagnostic(title.span, function_group.name, pattern, must_not_match.message(), false);
+                return .proceed;
+            }
+        }
+
+        const must_match = matcherFor(&self.options.must_match, function_group.matcher_kind);
+        if (must_match.pattern()) |pattern| {
+            if (!regexMatches(pattern, title.value)) {
+                try self.addMatcherDiagnostic(title.span, function_group.name, pattern, must_match.message(), true);
+                return .proceed;
+            }
+        }
+
+        return .proceed;
+    }
+
+    fn disallowedWord(self: *const Visitor, title: []const u8) ?[]const u8 {
+        for (0..title.len + 1) |offset| {
+            for (0..self.options.disallowed_words.count) |word_index| {
+                const word = self.options.disallowed_words.at(word_index);
+                if (word.len == 0) {
+                    const left_word = offset != 0 and isAsciiWord(title[offset - 1]);
+                    const right_word = offset < title.len and isAsciiWord(title[offset]);
+                    if (left_word != right_word) return title[offset..offset];
+                    continue;
+                }
+                if (offset + word.len > title.len) continue;
+                const candidate = title[offset .. offset + word.len];
+                if (!std.ascii.eqlIgnoreCase(candidate, word)) continue;
+                if (offset != 0 and isAsciiWord(title[offset - 1])) continue;
+                if (offset + word.len != title.len and isAsciiWord(title[offset + word.len])) continue;
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    fn addMatcherDiagnostic(
+        self: *Visitor,
+        span: ast.Span,
+        function_name: []const u8,
+        pattern: []const u8,
+        custom_message: ?[]const u8,
+        should_match: bool,
+    ) Allocator.Error!void {
+        if (custom_message) |message| {
+            return core.addDiagnostic(self.allocator, self.diagnostics, .warning, id, message, span);
+        }
+        if (should_match) {
+            return core.addDiagnosticFmt(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                span,
+                "{s} should match /{s}/u",
+                .{ function_name, pattern },
+            );
+        }
+        return core.addDiagnosticFmt(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            span,
+            "{s} should not match /{s}/u",
+            .{ function_name, pattern },
+        );
+    }
+};
+
+const MatcherKind = enum { describe, test_case, it };
+
+const FunctionGroup = struct {
+    name: []const u8,
+    matcher_kind: MatcherKind,
+};
+
+fn functionGroup(function: jest_fn_call.Function) FunctionGroup {
+    return switch (function) {
+        .describe, .fdescribe, .xdescribe => .{ .name = "describe", .matcher_kind = .describe },
+        .test_case, .xtest => .{ .name = "test", .matcher_kind = .test_case },
+        .it, .fit, .xit => .{ .name = "it", .matcher_kind = .it },
+        .expect => unreachable,
+    };
+}
+
+fn matcherFor(matchers: *const core.JestValidTitleMatchers, kind: MatcherKind) *const core.JestValidTitleMatcher {
+    return switch (kind) {
+        .describe => &matchers.describe,
+        .test_case => &matchers.test_case,
+        .it => &matchers.it,
+    };
+}
+
+const StaticTitle = struct {
+    value: []const u8,
+    span: ast.Span,
+};
+
+fn staticTitle(tree: *const ast.Tree, index: ast.NodeIndex) ?StaticTitle {
+    return switch (tree.data(index)) {
+        .string_literal => |literal| .{ .value = tree.string(literal.value), .span = tree.span(index) },
+        .template_literal => |literal| blk: {
+            if (literal.expressions.len != 0) break :blk null;
+            const quasis = tree.extra(literal.quasis);
+            if (quasis.len != 1) break :blk null;
+            switch (tree.data(quasis[0])) {
+                .template_element => {},
+                else => break :blk null,
+            }
+            const span = tree.span(index);
+            if (span.end <= span.start + 1) break :blk null;
+            break :blk .{ .value = tree.source[span.start + 1 .. span.end - 1], .span = span };
+        },
+        else => null,
+    };
+}
+
+fn treeIsTemplateLiteral(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    return switch (tree.data(index)) {
+        .template_literal => true,
+        else => false,
+    };
+}
+
+fn containsStringInBinaryExpression(tree: *const ast.Tree, index: ast.NodeIndex) bool {
+    const expression = switch (tree.data(index)) {
+        .binary_expression => |value| value,
+        else => return false,
+    };
+    if (staticTitle(tree, expression.right) != null) return true;
+    if (tree.data(expression.left) == .binary_expression) {
+        return containsStringInBinaryExpression(tree, expression.left);
+    }
+    return staticTitle(tree, expression.left) != null;
+}
+
+fn invalidEachSpecifier(title: []const u8) ?u8 {
+    var index: usize = 0;
+    while (index + 1 < title.len) {
+        if (title[index] != '%') {
+            index += 1;
+            continue;
+        }
+        if (title[index + 1] == '%') {
+            index += 2;
+            continue;
+        }
+        const specifier = title[index + 1];
+        if (std.mem.indexOfScalar(u8, "psdifjo#$%", specifier) == null) return specifier;
+        index += 1;
+    }
+    return null;
+}
+
+fn hasAccidentalSpace(title: []const u8) bool {
+    if (title.len == 0) return false;
+    return startsWithJsWhitespace(title) or endsWithJsWhitespace(title);
+}
+
+fn startsWithJsWhitespace(value: []const u8) bool {
+    if (std.ascii.isWhitespace(value[0])) return true;
+    const whitespace = [_][]const u8{
+        "\xC2\xA0", // no-break space
+        "\xE1\x9A\x80", // ogham space mark
+        "\xE2\x80\x80",
+        "\xE2\x80\x81",
+        "\xE2\x80\x82",
+        "\xE2\x80\x83",
+        "\xE2\x80\x84",
+        "\xE2\x80\x85",
+        "\xE2\x80\x86",
+        "\xE2\x80\x87",
+        "\xE2\x80\x88", "\xE2\x80\x89", "\xE2\x80\x8A", // U+2000..U+200A
+        "\xE2\x80\xA8", "\xE2\x80\xA9", "\xE2\x80\xAF",
+        "\xE2\x81\x9F", "\xE3\x80\x80", "\xEF\xBB\xBF",
+    };
+    for (whitespace) |sequence| {
+        if (std.mem.startsWith(u8, value, sequence)) return true;
+    }
+    return false;
+}
+
+fn endsWithJsWhitespace(value: []const u8) bool {
+    if (std.ascii.isWhitespace(value[value.len - 1])) return true;
+    const whitespace = [_][]const u8{
+        "\xC2\xA0",
+        "\xE1\x9A\x80",
+        "\xE2\x80\x80",
+        "\xE2\x80\x81",
+        "\xE2\x80\x82",
+        "\xE2\x80\x83",
+        "\xE2\x80\x84",
+        "\xE2\x80\x85",
+        "\xE2\x80\x86",
+        "\xE2\x80\x87",
+        "\xE2\x80\x88",
+        "\xE2\x80\x89",
+        "\xE2\x80\x8A",
+        "\xE2\x80\xA8",
+        "\xE2\x80\xA9",
+        "\xE2\x80\xAF",
+        "\xE2\x81\x9F",
+        "\xE3\x80\x80",
+        "\xEF\xBB\xBF",
+    };
+    for (whitespace) |sequence| {
+        if (std.mem.endsWith(u8, value, sequence)) return true;
+    }
+    return false;
+}
+
+const FixBuffer = struct {
+    items: [2]core.Fix = undefined,
+    len: usize = 0,
+
+    fn append(self: *FixBuffer, fix: core.Fix) void {
+        self.items[self.len] = fix;
+        self.len += 1;
+    }
+
+    fn slice(self: *const FixBuffer) []const core.Fix {
+        return self.items[0..self.len];
+    }
+};
+
+fn accidentalSpaceFixes(tree: *const ast.Tree, span: ast.Span) FixBuffer {
+    var result = FixBuffer{};
+    if (span.end <= span.start + 1) return result;
+    const content_start: usize = span.start + 1;
+    const content_end: usize = span.end - 1;
+    var trimmed_start = content_start;
+    while (trimmed_start < content_end and tree.source[trimmed_start] == ' ') trimmed_start += 1;
+    var trimmed_end = content_end;
+    while (trimmed_end > trimmed_start and tree.source[trimmed_end - 1] == ' ') trimmed_end -= 1;
+    if (trimmed_start > content_start) result.append(.{
+        .span = .{ .start = @intCast(content_start), .end = @intCast(trimmed_start) },
+        .replacement = "",
+    });
+    if (trimmed_end < content_end) result.append(.{
+        .span = .{ .start = @intCast(trimmed_end), .end = @intCast(content_end) },
+        .replacement = "",
+    });
+    return result;
+}
+
+fn hasDuplicatePrefix(title: []const u8, function_name: []const u8) bool {
+    const separator = std.mem.indexOfScalar(u8, title, ' ') orelse return false;
+    return std.ascii.eqlIgnoreCase(title[0..separator], function_name);
+}
+
+fn duplicatePrefixFix(tree: *const ast.Tree, span: ast.Span) ?core.Fix {
+    if (span.end <= span.start + 1) return null;
+    const content_start: usize = span.start + 1;
+    const content_end: usize = span.end - 1;
+    const separator = std.mem.indexOfScalar(u8, tree.source[content_start..content_end], ' ') orelse return null;
+    return .{
+        .span = .{ .start = @intCast(content_start), .end = @intCast(content_start + separator + 1) },
+        .replacement = "",
+    };
+}
+
+fn isAsciiWord(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_';
+}
+
+// A small allocation-free ECMAScript-pattern matcher for rule configuration.
+// It supports anchors, groups, lookaheads, alternation, character classes,
+// common escape classes, and the ?, *, +, and {n,m} quantifiers used by the
+// upstream option examples.
+fn regexMatches(pattern: []const u8, text: []const u8) bool {
+    for (0..text.len + 1) |start| {
+        if (matchAlternatives(pattern, 0, pattern.len, text, start, null)) return true;
+    }
+    return false;
+}
+
+fn matchAlternatives(
+    pattern: []const u8,
+    start: usize,
+    end: usize,
+    text: []const u8,
+    text_start: usize,
+    required_end: ?usize,
+) bool {
+    var branch_start = start;
+    var cursor = start;
+    var depth: usize = 0;
+    var in_class = false;
+    while (cursor < end) : (cursor += 1) {
+        const byte = pattern[cursor];
+        if (byte == '\\') {
+            cursor += @intFromBool(cursor + 1 < end);
+            continue;
+        }
+        if (in_class) {
+            if (byte == ']') in_class = false;
+            continue;
+        }
+        if (byte == '[') {
+            in_class = true;
+        } else if (byte == '(') {
+            depth += 1;
+        } else if (byte == ')' and depth != 0) {
+            depth -= 1;
+        } else if (byte == '|' and depth == 0) {
+            if (matchSequence(pattern, branch_start, cursor, text, text_start, required_end)) return true;
+            branch_start = cursor + 1;
+        }
+    }
+    return matchSequence(pattern, branch_start, end, text, text_start, required_end);
+}
+
+const Atom = struct {
+    start: usize,
+    end: usize,
+    next: usize,
+    min: usize = 1,
+    max: usize = 1,
+};
+
+fn matchSequence(
+    pattern: []const u8,
+    start: usize,
+    end: usize,
+    text: []const u8,
+    text_start: usize,
+    required_end: ?usize,
+) bool {
+    if (start >= end) return required_end == null or text_start == required_end.?;
+    const atom = parseAtom(pattern, start, end) orelse return false;
+    return matchQuantified(pattern, atom, end, text, text_start, 0, required_end);
+}
+
+fn matchQuantified(
+    pattern: []const u8,
+    atom: Atom,
+    sequence_end: usize,
+    text: []const u8,
+    text_start: usize,
+    count: usize,
+    required_end: ?usize,
+) bool {
+    if (count >= atom.min and matchSequence(pattern, atom.next, sequence_end, text, text_start, required_end)) return true;
+    if (count >= atom.max) return false;
+
+    var candidate_end = text_start;
+    while (candidate_end <= text.len) : (candidate_end += 1) {
+        if (!atomMatches(pattern, atom.start, atom.end, text, text_start, candidate_end)) continue;
+        if (candidate_end == text_start and atom.max != 1) return false;
+        if (matchQuantified(pattern, atom, sequence_end, text, candidate_end, count + 1, required_end)) return true;
+    }
+    return false;
+}
+
+fn parseAtom(pattern: []const u8, start: usize, end: usize) ?Atom {
+    var atom_end = start + 1;
+    if (pattern[start] == '\\') {
+        atom_end = @min(start + 2, end);
+    } else if (pattern[start] == '[') {
+        atom_end = findClassEnd(pattern, start, end) orelse return null;
+    } else if (pattern[start] == '(') {
+        atom_end = findGroupEnd(pattern, start, end) orelse return null;
+    } else if (pattern[start] >= 0x80) {
+        const sequence_length: usize = std.unicode.utf8ByteSequenceLength(pattern[start]) catch 1;
+        atom_end = @min(start + sequence_length, end);
+    }
+
+    var atom = Atom{ .start = start, .end = atom_end, .next = atom_end };
+    if (atom.next >= end) return atom;
+    switch (pattern[atom.next]) {
+        '?' => {
+            atom.min = 0;
+            atom.max = 1;
+            atom.next += 1;
+        },
+        '*' => {
+            atom.min = 0;
+            atom.max = std.math.maxInt(usize);
+            atom.next += 1;
+        },
+        '+' => {
+            atom.min = 1;
+            atom.max = std.math.maxInt(usize);
+            atom.next += 1;
+        },
+        '{' => parseBraceQuantifier(pattern, &atom, end),
+        else => {},
+    }
+    return atom;
+}
+
+fn parseBraceQuantifier(pattern: []const u8, atom: *Atom, end: usize) void {
+    const close = std.mem.indexOfScalarPos(u8, pattern[0..end], atom.next + 1, '}') orelse return;
+    const body = pattern[atom.next + 1 .. close];
+    const comma = std.mem.indexOfScalar(u8, body, ',');
+    const minimum_text = if (comma) |index| body[0..index] else body;
+    const minimum = std.fmt.parseUnsigned(usize, minimum_text, 10) catch return;
+    var maximum = minimum;
+    if (comma) |index| {
+        maximum = if (index + 1 == body.len)
+            std.math.maxInt(usize)
+        else
+            std.fmt.parseUnsigned(usize, body[index + 1 ..], 10) catch return;
+    }
+    if (maximum < minimum) return;
+    atom.min = minimum;
+    atom.max = maximum;
+    atom.next = close + 1;
+}
+
+fn findClassEnd(pattern: []const u8, start: usize, end: usize) ?usize {
+    var cursor = start + 1;
+    while (cursor < end) : (cursor += 1) {
+        if (pattern[cursor] == '\\') {
+            cursor += @intFromBool(cursor + 1 < end);
+        } else if (pattern[cursor] == ']') {
+            return cursor + 1;
+        }
+    }
+    return null;
+}
+
+fn findGroupEnd(pattern: []const u8, start: usize, end: usize) ?usize {
+    var cursor = start + 1;
+    var depth: usize = 1;
+    var in_class = false;
+    while (cursor < end) : (cursor += 1) {
+        const byte = pattern[cursor];
+        if (byte == '\\') {
+            cursor += @intFromBool(cursor + 1 < end);
+            continue;
+        }
+        if (in_class) {
+            if (byte == ']') in_class = false;
+            continue;
+        }
+        if (byte == '[') in_class = true else if (byte == '(') depth += 1 else if (byte == ')') {
+            depth -= 1;
+            if (depth == 0) return cursor + 1;
+        }
+    }
+    return null;
+}
+
+fn atomMatches(
+    pattern: []const u8,
+    start: usize,
+    end: usize,
+    text: []const u8,
+    text_start: usize,
+    text_end: usize,
+) bool {
+    const atom = pattern[start..end];
+    if (atom.len == 1) {
+        if (atom[0] == '^') return text_start == 0 and text_end == text_start;
+        if (atom[0] == '$') return text_start == text.len and text_end == text_start;
+        if (text_start >= text.len) return false;
+        if (atom[0] == '.') return text_end == nextCodepoint(text, text_start);
+        return text_end == text_start + 1 and text[text_start] == atom[0];
+    }
+    if (atom[0] == '\\') return escapedAtomMatches(atom, text, text_start, text_end);
+    if (atom[0] == '[') return classMatches(atom, text, text_start, text_end);
+    if (atom[0] == '(') return groupMatches(atom, text, text_start, text_end);
+    return text_end == text_start + atom.len and std.mem.eql(u8, text[text_start..text_end], atom);
+}
+
+fn escapedAtomMatches(atom: []const u8, text: []const u8, start: usize, end: usize) bool {
+    if (atom.len != 2) return false;
+    const escape = atom[1];
+    if (escape == 'b' or escape == 'B') {
+        if (end != start) return false;
+        const left_word = start != 0 and isAsciiWord(text[start - 1]);
+        const right_word = start < text.len and isAsciiWord(text[start]);
+        return (left_word != right_word) == (escape == 'b');
+    }
+    if (start >= text.len or end != nextCodepoint(text, start)) return false;
+    const byte = text[start];
+    return switch (escape) {
+        'd' => std.ascii.isDigit(byte),
+        'D' => !std.ascii.isDigit(byte),
+        'w' => isAsciiWord(byte),
+        'W' => !isAsciiWord(byte),
+        's' => std.ascii.isWhitespace(byte),
+        'S' => !std.ascii.isWhitespace(byte),
+        'n' => byte == '\n',
+        'r' => byte == '\r',
+        't' => byte == '\t',
+        else => end == start + 1 and byte == escape,
+    };
+}
+
+fn classMatches(atom: []const u8, text: []const u8, start: usize, end: usize) bool {
+    if (start >= text.len or end != nextCodepoint(text, start)) return false;
+    const byte = text[start];
+    var cursor: usize = 1;
+    const negated = cursor < atom.len - 1 and atom[cursor] == '^';
+    if (negated) cursor += 1;
+    var found = false;
+    while (cursor < atom.len - 1) {
+        if (atom[cursor] == '\\' and cursor + 1 < atom.len - 1) {
+            const escaped = atom[cursor + 1];
+            found = found or switch (escaped) {
+                'd' => std.ascii.isDigit(byte),
+                'w' => isAsciiWord(byte),
+                's' => std.ascii.isWhitespace(byte),
+                else => byte == escaped,
+            };
+            cursor += 2;
+            continue;
+        }
+        if (cursor + 2 < atom.len - 1 and atom[cursor + 1] == '-') {
+            found = found or (byte >= atom[cursor] and byte <= atom[cursor + 2]);
+            cursor += 3;
+        } else {
+            found = found or byte == atom[cursor];
+            cursor += 1;
+        }
+    }
+    return if (negated) !found else found;
+}
+
+fn groupMatches(atom: []const u8, text: []const u8, start: usize, end: usize) bool {
+    var content_start: usize = 1;
+    if (std.mem.startsWith(u8, atom, "(?:")) content_start = 3;
+    if (std.mem.startsWith(u8, atom, "(?=")) {
+        return end == start and matchAlternatives(atom, 3, atom.len - 1, text, start, null);
+    }
+    if (std.mem.startsWith(u8, atom, "(?!")) {
+        return end == start and !matchAlternatives(atom, 3, atom.len - 1, text, start, null);
+    }
+    return matchAlternatives(atom, content_start, atom.len - 1, text, start, end);
+}
+
+fn nextCodepoint(text: []const u8, start: usize) usize {
+    if (start >= text.len) return start;
+    const length: usize = std.unicode.utf8ByteSequenceLength(text[start]) catch 1;
+    return @min(start + length, text.len);
+}
+
+test "configured regular-expression matching" {
+    try std.testing.expect(regexMatches("^that", "that works"));
+    try std.testing.expect(!regexMatches("^that", "not that"));
+    try std.testing.expect(regexMatches("^[^#]+$|(?:#(?:unit|e2e))", "works #unit"));
+    try std.testing.expect(regexMatches("(?:#(?!unit|e2e))\\w+", "works #jest4life"));
+    try std.testing.expect(!regexMatches("(?:#(?!unit|e2e))\\w+", "works #unit"));
+    try std.testing.expect(regexMatches("\\.$", "ends."));
+}

--- a/src/rules/jest_valid_title.zig
+++ b/src/rules/jest_valid_title.zig
@@ -122,15 +122,26 @@ const Visitor = struct {
 
         if (!self.options.ignore_spaces and hasAccidentalSpace(title.value)) {
             const fixes = accidentalSpaceFixes(ctx.tree, title.span);
-            try core.addDiagnosticWithFixes(
-                self.allocator,
-                self.diagnostics,
-                .warning,
-                id,
-                accidental_space,
-                title.span,
-                fixes.slice(),
-            );
+            if (fixes.len == 0) {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    accidental_space,
+                    title.span,
+                );
+            } else {
+                try core.addDiagnosticWithFixes(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    accidental_space,
+                    title.span,
+                    fixes.slice(),
+                );
+            }
         }
 
         const function_group = functionGroup(call.function);
@@ -267,13 +278,11 @@ fn staticTitle(tree: *const ast.Tree, index: ast.NodeIndex) ?StaticTitle {
             if (literal.expressions.len != 0) break :blk null;
             const quasis = tree.extra(literal.quasis);
             if (quasis.len != 1) break :blk null;
-            switch (tree.data(quasis[0])) {
-                .template_element => {},
+            const value = switch (tree.data(quasis[0])) {
+                .template_element => |element| tree.string(element.cooked),
                 else => break :blk null,
-            }
-            const span = tree.span(index);
-            if (span.end <= span.start + 1) break :blk null;
-            break :blk .{ .value = tree.source[span.start + 1 .. span.end - 1], .span = span };
+            };
+            break :blk .{ .value = value, .span = tree.span(index) };
         },
         else => null,
     };
@@ -321,56 +330,57 @@ fn hasAccidentalSpace(title: []const u8) bool {
     return startsWithJsWhitespace(title) or endsWithJsWhitespace(title);
 }
 
+const js_unicode_whitespace = [_][]const u8{
+    "\xC2\xA0", // no-break space
+    "\xE1\x9A\x80", // ogham space mark
+    "\xE2\x80\x80",
+    "\xE2\x80\x81",
+    "\xE2\x80\x82",
+    "\xE2\x80\x83",
+    "\xE2\x80\x84",
+    "\xE2\x80\x85",
+    "\xE2\x80\x86",
+    "\xE2\x80\x87",
+    "\xE2\x80\x88",
+    "\xE2\x80\x89",
+    "\xE2\x80\x8A", // U+2000..U+200A
+    "\xE2\x80\xA8",
+    "\xE2\x80\xA9",
+    "\xE2\x80\xAF",
+    "\xE2\x81\x9F",
+    "\xE3\x80\x80",
+    "\xEF\xBB\xBF",
+};
+
 fn startsWithJsWhitespace(value: []const u8) bool {
-    if (std.ascii.isWhitespace(value[0])) return true;
-    const whitespace = [_][]const u8{
-        "\xC2\xA0", // no-break space
-        "\xE1\x9A\x80", // ogham space mark
-        "\xE2\x80\x80",
-        "\xE2\x80\x81",
-        "\xE2\x80\x82",
-        "\xE2\x80\x83",
-        "\xE2\x80\x84",
-        "\xE2\x80\x85",
-        "\xE2\x80\x86",
-        "\xE2\x80\x87",
-        "\xE2\x80\x88", "\xE2\x80\x89", "\xE2\x80\x8A", // U+2000..U+200A
-        "\xE2\x80\xA8", "\xE2\x80\xA9", "\xE2\x80\xAF",
-        "\xE2\x81\x9F", "\xE3\x80\x80", "\xEF\xBB\xBF",
-    };
-    for (whitespace) |sequence| {
-        if (std.mem.startsWith(u8, value, sequence)) return true;
-    }
-    return false;
+    return jsWhitespacePrefixLen(value) != 0;
 }
 
 fn endsWithJsWhitespace(value: []const u8) bool {
-    if (std.ascii.isWhitespace(value[value.len - 1])) return true;
-    const whitespace = [_][]const u8{
-        "\xC2\xA0",
-        "\xE1\x9A\x80",
-        "\xE2\x80\x80",
-        "\xE2\x80\x81",
-        "\xE2\x80\x82",
-        "\xE2\x80\x83",
-        "\xE2\x80\x84",
-        "\xE2\x80\x85",
-        "\xE2\x80\x86",
-        "\xE2\x80\x87",
-        "\xE2\x80\x88",
-        "\xE2\x80\x89",
-        "\xE2\x80\x8A",
-        "\xE2\x80\xA8",
-        "\xE2\x80\xA9",
-        "\xE2\x80\xAF",
-        "\xE2\x81\x9F",
-        "\xE3\x80\x80",
-        "\xEF\xBB\xBF",
-    };
-    for (whitespace) |sequence| {
-        if (std.mem.endsWith(u8, value, sequence)) return true;
+    return jsWhitespaceSuffixLen(value) != 0;
+}
+
+fn jsWhitespacePrefixLen(value: []const u8) usize {
+    if (value.len == 0) return 0;
+    if (std.ascii.isWhitespace(value[0])) return 1;
+    for (js_unicode_whitespace) |sequence| {
+        if (std.mem.startsWith(u8, value, sequence)) return sequence.len;
     }
-    return false;
+    return 0;
+}
+
+fn jsWhitespaceSuffixLen(value: []const u8) usize {
+    if (value.len == 0) return 0;
+    if (std.ascii.isWhitespace(value[value.len - 1])) return 1;
+    for (js_unicode_whitespace) |sequence| {
+        if (std.mem.endsWith(u8, value, sequence)) return sequence.len;
+    }
+    return 0;
+}
+
+fn isJsWhitespaceCodepoint(value: []const u8, start: usize, end: usize) bool {
+    if (start >= end or end > value.len) return false;
+    return jsWhitespacePrefixLen(value[start..end]) == end - start;
 }
 
 const FixBuffer = struct {
@@ -393,9 +403,17 @@ fn accidentalSpaceFixes(tree: *const ast.Tree, span: ast.Span) FixBuffer {
     const content_start: usize = span.start + 1;
     const content_end: usize = span.end - 1;
     var trimmed_start = content_start;
-    while (trimmed_start < content_end and tree.source[trimmed_start] == ' ') trimmed_start += 1;
+    while (trimmed_start < content_end) {
+        const whitespace_len = jsWhitespacePrefixLen(tree.source[trimmed_start..content_end]);
+        if (whitespace_len == 0) break;
+        trimmed_start += whitespace_len;
+    }
     var trimmed_end = content_end;
-    while (trimmed_end > trimmed_start and tree.source[trimmed_end - 1] == ' ') trimmed_end -= 1;
+    while (trimmed_end > trimmed_start) {
+        const whitespace_len = jsWhitespaceSuffixLen(tree.source[trimmed_start..trimmed_end]);
+        if (whitespace_len == 0) break;
+        trimmed_end -= whitespace_len;
+    }
     if (trimmed_start > content_start) result.append(.{
         .span = .{ .start = @intCast(content_start), .end = @intCast(trimmed_start) },
         .replacement = "",
@@ -644,8 +662,8 @@ fn escapedAtomMatches(atom: []const u8, text: []const u8, start: usize, end: usi
         'D' => !std.ascii.isDigit(byte),
         'w' => isAsciiWord(byte),
         'W' => !isAsciiWord(byte),
-        's' => std.ascii.isWhitespace(byte),
-        'S' => !std.ascii.isWhitespace(byte),
+        's' => isJsWhitespaceCodepoint(text, start, end),
+        'S' => !isJsWhitespaceCodepoint(text, start, end),
         'n' => byte == '\n',
         'r' => byte == '\r',
         't' => byte == '\t',
@@ -665,8 +683,14 @@ fn classMatches(atom: []const u8, text: []const u8, start: usize, end: usize) bo
             const escaped = atom[cursor + 1];
             found = found or switch (escaped) {
                 'd' => std.ascii.isDigit(byte),
+                'D' => !std.ascii.isDigit(byte),
                 'w' => isAsciiWord(byte),
-                's' => std.ascii.isWhitespace(byte),
+                'W' => !isAsciiWord(byte),
+                's' => isJsWhitespaceCodepoint(text, start, end),
+                'S' => !isJsWhitespaceCodepoint(text, start, end),
+                'n' => byte == '\n',
+                'r' => byte == '\r',
+                't' => byte == '\t',
                 else => byte == escaped,
             };
             cursor += 2;
@@ -708,4 +732,7 @@ test "configured regular-expression matching" {
     try std.testing.expect(regexMatches("(?:#(?!unit|e2e))\\w+", "works #jest4life"));
     try std.testing.expect(!regexMatches("(?:#(?!unit|e2e))\\w+", "works #unit"));
     try std.testing.expect(regexMatches("\\.$", "ends."));
+    try std.testing.expect(regexMatches("^foo\\sbar$", "foo\xC2\xA0bar"));
+    try std.testing.expect(!regexMatches("^foo\\Sbar$", "foo\xC2\xA0bar"));
+    try std.testing.expect(regexMatches("^foo[\\s]bar$", "foo\xC2\xA0bar"));
 }

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -89,6 +89,7 @@ pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
 pub const jest_no_standalone_expect = @import("jest_no_standalone_expect.zig");
 pub const jest_valid_describe_callback = @import("jest_valid_describe_callback.zig");
 pub const jest_valid_expect_in_promise = @import("jest_valid_expect_in_promise.zig");
+pub const jest_valid_title = @import("jest_valid_title.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1088,6 +1089,24 @@ fn runSemanticAfterIo(
             tree,
             semantic_result.symbol_table,
             options.jest_global_aliases,
+        );
+    }
+
+    if (options.jest_valid_title) {
+        try jest_valid_title.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+            .{
+                .ignore_spaces = options.jest_valid_title_ignore_spaces,
+                .ignore_type_of_describe_name = options.jest_valid_title_ignore_type_of_describe_name,
+                .ignore_type_of_test_name = options.jest_valid_title_ignore_type_of_test_name,
+                .disallowed_words = options.jest_valid_title_disallowed_words,
+                .must_not_match = options.jest_valid_title_must_not_match,
+                .must_match = options.jest_valid_title_must_match,
+            },
         );
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -278,6 +278,7 @@ comptime {
     _ = @import("rules/jest_no_standalone_expect.zig");
     _ = @import("rules/jest_valid_describe_callback.zig");
     _ = @import("rules/jest_valid_expect_in_promise.zig");
+    _ = @import("rules/jest_valid_title.zig");
 }
 
 comptime {

--- a/tests/rules/jest_valid_title.zig
+++ b/tests/rules/jest_valid_title.zig
@@ -1,0 +1,232 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_valid_title.id;
+
+test "reports invalid titles with upstream messages and useful locations" {
+    const cases = [_]struct { source: []const u8, message: []const u8, reported: []const u8 }{
+        .{ .source = "describe('', () => {});", .message = "describe should not have an empty title", .reported = "describe('', () => {})" },
+        .{ .source = "it(123, () => {});", .message = "Title must be a string", .reported = "123" },
+        .{ .source = "test(' test title', () => {});", .message = "should not have leading or trailing spaces", .reported = "' test title'" },
+        .{ .source = "xit('it works', () => {});", .message = "should not have duplicate prefix", .reported = "'it works'" },
+        .{ .source = "test.each([])('%Q', () => {});", .message = "\"%Q\" is not a valid format specifier", .reported = "'%Q'" },
+    };
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, "fixture.js", optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+        const diagnostic = findDiagnostic(result).?;
+        try std.testing.expectEqualStrings(case.message, diagnostic.message);
+        try std.testing.expectEqualStrings(case.reported, case.source[diagnostic.span.start..diagnostic.span.end]);
+    }
+}
+
+test "allows valid aliases templates binary titles and dynamic templates" {
+    const source =
+        \\describe('suite', () => {});
+        \\fdescribe(`focused suite`, () => {});
+        \\xdescribe('skipped suite', () => {});
+        \\test('works', () => {});
+        \\xtest(`skips`, () => {});
+        \\it('runs', () => {});
+        \\fit('focuses', () => {});
+        \\xit('skips', () => {});
+        \\it('is' + ' a string', () => {});
+        \\it(1 + ' + ' + 1, () => {});
+        \\test(`${dynamic} title`, () => {});
+        \\someFn('', () => {});
+        \\function local(test) { test('', () => {}); }
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "supports disallowedWords and type-ignore options" {
+    const source =
+        \\describe(makeName(), () => {});
+        \\it(testName, () => {});
+        \\test('the correct way', () => {});
+        \\it('correctly works', () => {});
+        \\xdescribe('has ALL things', () => {});
+    ;
+    const options = try optionsFromConfig(
+        \\["error",{"ignoreTypeOfDescribeName":true,"ignoreTypeOfTestName":true,"disallowedWords":["correct","all"]}]
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("\"correct\" is not allowed in test titles", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("\"ALL\" is not allowed in test titles", result.diagnostics[1].message);
+}
+
+test "preserves grouped mustMatch and mustNotMatch options and custom messages" {
+    const source =
+        \\describe('suite #unit', () => {});
+        \\test('that works #unit', () => {});
+        \\it('does not start correctly #jest4life', () => {});
+        \\it('does not start correctly', () => {});
+    ;
+    const options = try optionsFromConfig(
+        \\["error",{
+        \\  "mustMatch":{"test":["^that","Test titles must start with that"],"it":"^that"},
+        \\  "mustNotMatch":"(?:#(?!unit|e2e))\\w+"
+        \\}]
+    );
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("it should not match /(?:#(?!unit|e2e))\\w+/u", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("it should match /^that/u", result.diagnostics[1].message);
+
+    const custom = try optionsFromConfig(
+        \\["error",{"mustMatch":{"describe":["^when","Describe title needs context"]}}]
+    );
+    var custom_result = try lint.lintSource(std.testing.allocator, "describe('suite', () => {});", "fixture.js", custom);
+    defer custom_result.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("Describe title needs context", findDiagnostic(custom_result).?.message);
+}
+
+test "checks only array each printf specifiers" {
+    const valid =
+        \\it.each([])('%p %s %d %i %f %j %o %# %$ %%', () => {});
+        \\test.only.each(entries)('%%%i', () => {});
+        \\describe.each([])('$value', () => {});
+        \\it.each`value | expected`('%Q is literal for tagged each', () => {});
+    ;
+    var valid_result = try lint.lintSource(std.testing.allocator, valid, "fixture.js", optionsOnly());
+    defer valid_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(valid_result, rule_id));
+
+    const invalid =
+        \\it.each([])('%Y', () => {});
+        \\test.each(entries)('%i + %x', () => {});
+        \\describe.skip.each([])('%%y + %z', () => {});
+    ;
+    var invalid_result = try lint.lintSource(std.testing.allocator, invalid, "fixture.js", optionsOnly());
+    defer invalid_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(invalid_result, rule_id));
+}
+
+test "applies upstream-safe whitespace and duplicate-prefix autofixes" {
+    const source =
+        \\describe(' describe suite ', () => {
+        \\  test(` test works  `, () => {});
+        \\  it('it behaves', () => {});
+        \\});
+    ;
+    const expected =
+        \\describe('suite', () => {
+        \\  test(`works`, () => {});
+        \\  it('behaves', () => {});
+        \\});
+    ;
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, rule_id));
+}
+
+test "ignoreSpaces disables whitespace diagnostics and fixes" {
+    const options = try optionsFromConfig(
+        \\["error",{"ignoreSpaces":true}]
+    );
+    var result = try lint.lintSource(std.testing.allocator, "test(' title ', () => {});", "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "supports imported required and configured aliases" {
+    const imported =
+        \\import { describe as context, test as testThat, it as spec } from '@jest/globals';
+        \\context('describe duplicate', () => {});
+        \\testThat('test duplicate', () => {});
+        \\spec('it duplicate', () => {});
+    ;
+    var imported_result = try lint.lintSource(std.testing.allocator, imported, "fixture.js", optionsOnly());
+    defer imported_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), helpers.countRule(imported_result, rule_id));
+
+    const required =
+        \\const { describe: context, test: testThat } = require('@jest/globals');
+        \\context('', () => {});
+        \\testThat(123, () => {});
+    ;
+    var required_result = try lint.lintSource(std.testing.allocator, required, "fixture.js", optionsOnly());
+    defer required_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(required_result, rule_id));
+
+    var alias_options = optionsOnly();
+    try std.testing.expect(alias_options.jest_global_aliases.append("describe", "suite"));
+    try std.testing.expect(alias_options.jest_global_aliases.append("test", "spec"));
+    var alias_result = try lint.lintSource(std.testing.allocator, "suite('', () => {}); spec(1, () => {});", "fixture.js", alias_options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(alias_result, rule_id));
+}
+
+test "supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "test('test js ', () => {});", .file_name = "fixture.js" },
+        .{ .source = "test('test ts ', (): void => {});", .file_name = "fixture.ts" },
+        .{ .source = "test('test jsx ', () => <div />);", .file_name = "fixture.jsx" },
+        .{ .source = "test('test tsx ', (): JSX.Element => <div />);", .file_name = "fixture.tsx" },
+    };
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+        try std.testing.expect(result.diagnostics[0].fixes.len != 0);
+        try std.testing.expect(result.diagnostics[1].fixes.len != 0);
+    }
+}
+
+test "uses recommended defaults accepts CLI name and parses every option shape" {
+    try std.testing.expect((lint.Options{}).jest_valid_title);
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_valid_title);
+
+    options = try optionsFromConfig(
+        \\["error",{
+        \\  "ignoreSpaces":true,
+        \\  "ignoreTypeOfDescribeName":true,
+        \\  "ignoreTypeOfTestName":true,
+        \\  "disallowedWords":["all","every"],
+        \\  "mustNotMatch":["\\.$","No full stops"],
+        \\  "mustMatch":{"describe":"^when","test":["^that"],"it":["^it","Start with it"]}
+        \\}]
+    );
+    try std.testing.expect(options.jest_valid_title_ignore_spaces);
+    try std.testing.expect(options.jest_valid_title_ignore_type_of_describe_name);
+    try std.testing.expect(options.jest_valid_title_ignore_type_of_test_name);
+    try std.testing.expectEqual(@as(usize, 2), options.jest_valid_title_disallowed_words.count);
+    try std.testing.expectEqualStrings("all", options.jest_valid_title_disallowed_words.at(0));
+    try std.testing.expectEqualStrings("\\.$", options.jest_valid_title_must_not_match.describe.pattern().?);
+    try std.testing.expectEqualStrings("No full stops", options.jest_valid_title_must_not_match.it.message().?);
+    try std.testing.expectEqualStrings("^when", options.jest_valid_title_must_match.describe.pattern().?);
+    try std.testing.expectEqualStrings("^that", options.jest_valid_title_must_match.test_case.pattern().?);
+    try std.testing.expectEqualStrings("Start with it", options.jest_valid_title_must_match.it.message().?);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_valid_title = true;
+    return options;
+}
+
+fn optionsFromConfig(config: []const u8) !lint.Options {
+    var options = optionsOnly();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue(rule_id, parsed.value);
+    return options;
+}
+
+fn findDiagnostic(result: lint.Result) ?lint.Diagnostic {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id)) return diagnostic;
+    }
+    return null;
+}

--- a/tests/rules/jest_valid_title.zig
+++ b/tests/rules/jest_valid_title.zig
@@ -129,6 +129,43 @@ test "applies upstream-safe whitespace and duplicate-prefix autofixes" {
     try std.testing.expect(!helpers.hasRule(result.result, rule_id));
 }
 
+test "uses cooked static template values without unsafe escaped fixes" {
+    const source = "test(`\\u0020name`, () => {});";
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    const diagnostic = findDiagnostic(result).?;
+    try std.testing.expectEqualStrings("should not have leading or trailing spaces", diagnostic.message);
+    try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+}
+
+test "autofixes literal ECMAScript whitespace" {
+    const source = "test('\tworks\xC2\xA0', () => {});";
+    const expected = "test('works', () => {});";
+    var result = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.fixed);
+    try std.testing.expectEqualStrings(expected, result.output);
+    try std.testing.expect(!helpers.hasRule(result.result, rule_id));
+}
+
+test "uses ECMAScript whitespace semantics in configured regexes" {
+    const source = "test('foo\xC2\xA0bar', () => {});";
+    const matches_space = try optionsFromConfig(
+        \\["error",{"mustMatch":"^foo\\sbar$"}]
+    );
+    var matching_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", matches_space);
+    defer matching_result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(matching_result, rule_id));
+
+    const requires_non_space = try optionsFromConfig(
+        \\["error",{"mustMatch":"^foo\\Sbar$"}]
+    );
+    var non_matching_result = try lint.lintSource(std.testing.allocator, source, "fixture.js", requires_non_space);
+    defer non_matching_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(non_matching_result, rule_id));
+}
+
 test "ignoreSpaces disables whitespace diagnostics and fixes" {
     const options = try optionsFromConfig(
         \\["error",{"ignoreSpaces":true}]

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -298,6 +298,37 @@ test("reports floating expectation-bearing promise chains", () => {
   );
 });
 
+test("validates and fixes Jest titles with configured options", () => {
+  const source = [
+    "describe(makeName(), () => {});",
+    "test('test forbidden ', () => {});",
+  ].join("\n");
+  const options = {
+    filePath: "input.ts",
+    rules: {
+      "jest/valid-title": [
+        "error",
+        {
+          ignoreTypeOfDescribeName: true,
+          disallowedWords: ["forbidden"],
+        },
+      ],
+    },
+  };
+  const checked = linter.lint(source, options);
+  assert.equal(checked.diagnostics.length, 1);
+  assert.equal(checked.diagnostics[0].ruleId, "jest/valid-title");
+  assert.equal(checked.diagnostics[0].message, '"forbidden" is not allowed in test titles');
+
+  const fixed = linter.lintAndFix("it('it works ', () => {});", {
+    filePath: "input.tsx",
+    rules: { "jest/valid-title": "error" },
+  });
+  assert.equal(fixed.fixed, true);
+  assert.equal(fixed.output, "it('works', () => {});");
+  assert.equal(fixed.diagnostics.length, 0);
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Closes #1164.

Implements jest/valid-title across native, CLI/config, npm ESM/CJS, and WebAssembly entry points. The rule covers Jest globals and imports, aliases and modifiers, each variants, all upstream options, regex constraints, and safe autofixes, with English and Chinese status documentation.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
- zig build test
- zig build -Doptimize=ReleaseFast -j1
- pnpm --dir npm/utoo-lint test
- pnpm --dir npm/utoo-lint test:types
- pnpm package:wasm
- pnpm test:wasm
- pnpm --dir npm/@utoo/lint-wasm test
- pnpm --dir npm/@utoo/lint-wasm test:types
- zig build test -Doptimize=ReleaseFast -j1