### PR TITLE
feat: add jest/valid-expect

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -273,6 +273,7 @@ instead of being rewritten.
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | Supports suite, test, hook, helper, imported API, and `additionalTestBlockFunctions` context detection |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | Enforces synchronous function callbacks without unexpected parameters or return values, including aliases and `describe.each` |
 | [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | Requires expectation-bearing `then`, `catch`, and `finally` chains in tests to be returned, awaited, or consumed through supported promise patterns |
+| [`jest/valid-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect.md) | Implements argument bounds, matcher and modifier validation, and awaited or returned async assertion checks with all upstream options |
 
 ## Promise plugin rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -272,6 +272,7 @@
 | [`jest/no-standalone-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) | 支持测试套件、测试、钩子、辅助函数、导入 API 和 `additionalTestBlockFunctions` 上下文检查 |
 | [`jest/valid-describe-callback`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md) | 校验同步函数回调、意外参数和返回值，并支持别名及 `describe.each` |
 | [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect-in-promise.md) | 要求测试中包含断言的 `then`、`catch` 和 `finally` 链被返回、等待或通过受支持的 Promise 模式消费 |
+| [`jest/valid-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect.md) | 已实现参数数量、匹配器与修饰符校验、异步断言等待或返回检查，并支持全部上游选项 |
 
 ## Promise 插件规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -322,6 +322,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
   "jest/valid-expect-in-promise",
+  "jest/valid-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -325,6 +325,7 @@ const BUILTIN_RULE_IDS = [
   "jest/no-standalone-expect",
   "jest/valid-describe-callback",
   "jest/valid-expect-in-promise",
+  "jest/valid-expect",
   "promise/no-promise-in-callback",
   "promise/no-return-in-finally",
   "promise/no-return-wrap",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -3025,6 +3025,59 @@ test("project config and CLI --rules enable jest/valid-expect-in-promise", (t) =
   }
 });
 
+test("jest/valid-expect preserves argument and async matcher options", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.json"),
+    JSON.stringify({
+      rules: {
+        "jest/valid-expect": [
+          "error",
+          { minArgs: 0, maxArgs: 2, asyncMatchers: ["toSettle"] }
+        ]
+      }
+    })
+  );
+  const sourcePath = write(
+    join(project, "valid-expect.test.js"),
+    [
+      "expect().pass();",
+      "expect(1, 'message').toBe(1);",
+      "expect(Promise.resolve(1)).toSettle();",
+      "expect(Promise.resolve(1)).toResolve();",
+      ""
+    ].join("\n")
+  );
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+
+  for (const execute of [runCli, commonJSRunCli]) {
+    const configured = execute(["--json", sourcePath], options);
+    const configuredReport = JSON.parse(configured.stdout);
+    assert.equal(configured.status, 1, configured.stderr);
+    assert.deepEqual(configuredReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-expect", severity: "error" }
+    ]);
+
+    const selected = execute(["--rules=jest/valid-expect", "--json", sourcePath], options);
+    const selectedReport = JSON.parse(selected.stdout);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.deepEqual(selectedReport.diagnostics.map(({ ruleId, severity }) => ({ ruleId, severity })), [
+      { ruleId: "jest/valid-expect", severity: "warning" }
+    ]);
+
+    const isolated = execute(
+      ["--no-config", "--rules=jest/valid-expect", "--json", sourcePath],
+      options
+    );
+    const isolatedReport = JSON.parse(isolated.stdout);
+    assert.equal(isolated.status, 0, isolated.stderr);
+    assert.equal(isolatedReport.diagnostics.length, 3);
+    assert.ok(isolatedReport.diagnostics.every(({ ruleId, severity }) =>
+      ruleId === "jest/valid-expect" && severity === "warning"
+    ));
+  }
+});
+
 test("flat config keeps Jest version settings scoped per file", (t) => {
   const project = createProject(t);
   write(

--- a/src/core.zig
+++ b/src/core.zig
@@ -2771,6 +2771,11 @@ pub const Options = struct {
     jest_no_standalone_expect_additional_test_block_functions: JestAdditionalTestBlockFunctions = .{},
     jest_valid_describe_callback: bool = true,
     jest_valid_expect_in_promise: bool = true,
+    jest_valid_expect: bool = true,
+    jest_valid_expect_always_await: bool = false,
+    jest_valid_expect_async_matchers: JestValidExpectAsyncMatchers = .{},
+    jest_valid_expect_min_args: f64 = 1,
+    jest_valid_expect_max_args: f64 = 1,
     jest_global_aliases: JestGlobalAliases = .{},
     jest_version: u32 = 0,
     jsx_a11y_alt_text: bool = true,
@@ -3482,6 +3487,13 @@ pub const Options = struct {
         }
         if (std.mem.eql(u8, cli_name, "jest/no-standalone-expect")) {
             self.jest_no_standalone_expect_additional_test_block_functions = try jestAdditionalTestBlockFunctionsFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "jest/valid-expect")) {
+            const config = try jestValidExpectFromConfig(value);
+            self.jest_valid_expect_always_await = config.always_await;
+            self.jest_valid_expect_async_matchers = config.async_matchers;
+            self.jest_valid_expect_min_args = config.min_args;
+            self.jest_valid_expect_max_args = config.max_args;
         }
         if (std.mem.eql(u8, cli_name, "func-name-matching")) {
             self.func_name_matching_style = try funcNameMatchingStyleFromConfig(value);
@@ -5124,6 +5136,65 @@ pub const Options = struct {
             if (!result.append(function_name)) return error.UnsupportedRuleConfigValue;
         }
         return result;
+    }
+
+    const JestValidExpectConfig = struct {
+        always_await: bool = false,
+        async_matchers: JestValidExpectAsyncMatchers = .{},
+        min_args: f64 = 1,
+        max_args: f64 = 1,
+    };
+
+    fn jestValidExpectFromConfig(value: std.json.Value) RuleConfigError!JestValidExpectConfig {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return .{},
+        };
+        if (items.len < 2) return .{};
+
+        const object = switch (items[1]) {
+            .object => |config| config,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        var result = JestValidExpectConfig{};
+
+        if (object.get("alwaysAwait")) |configured| {
+            result.always_await = switch (configured) {
+                .bool => |enabled| enabled,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+        }
+        if (object.get("asyncMatchers")) |configured| {
+            const matchers = switch (configured) {
+                .array => |array| array.items,
+                else => return error.UnsupportedRuleConfigValue,
+            };
+            result.async_matchers.custom = true;
+            for (matchers) |matcher_value| {
+                const matcher = switch (matcher_value) {
+                    .string => |name| name,
+                    else => return error.UnsupportedRuleConfigValue,
+                };
+                if (!result.async_matchers.append(matcher)) return error.UnsupportedRuleConfigValue;
+            }
+        }
+        if (object.get("minArgs")) |configured| {
+            result.min_args = try jestValidExpectNumberOption(configured, 0);
+        }
+        if (object.get("maxArgs")) |configured| {
+            result.max_args = try jestValidExpectNumberOption(configured, 1);
+        }
+        return result;
+    }
+
+    fn jestValidExpectNumberOption(value: std.json.Value, minimum: f64) RuleConfigError!f64 {
+        const number: f64 = switch (value) {
+            .integer => |integer| @floatFromInt(integer),
+            .float => |float| float,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        if (!std.math.isFinite(number) or number < minimum) return error.UnsupportedRuleConfigValue;
+        return number;
     }
 
     const IdLengthConfig = struct {
@@ -9992,6 +10063,43 @@ pub const DeprecatedDependenceProfile = enum {
     profile_b,
 };
 
+pub const max_jest_valid_expect_async_matchers = 64;
+pub const max_jest_valid_expect_async_matcher_len = 128;
+
+pub const JestValidExpectAsyncMatchers = struct {
+    custom: bool = false,
+    count: usize = 0,
+    lengths: [max_jest_valid_expect_async_matchers]usize = undefined,
+    storage: [max_jest_valid_expect_async_matchers][max_jest_valid_expect_async_matcher_len]u8 = undefined,
+
+    pub fn contains(self: *const JestValidExpectAsyncMatchers, name: []const u8) bool {
+        if (!self.custom) {
+            return std.mem.eql(u8, name, "toResolve") or std.mem.eql(u8, name, "toReject");
+        }
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+        return false;
+    }
+
+    pub fn at(self: *const JestValidExpectAsyncMatchers, index: usize) []const u8 {
+        return self.storage[index][0..self.lengths[index]];
+    }
+
+    pub fn append(self: *JestValidExpectAsyncMatchers, name: []const u8) bool {
+        if (name.len > max_jest_valid_expect_async_matcher_len) return false;
+        if (self.count >= max_jest_valid_expect_async_matchers) return false;
+        for (0..self.count) |index| {
+            if (std.mem.eql(u8, self.at(index), name)) return true;
+        }
+
+        @memcpy(self.storage[self.count][0..name.len], name);
+        self.lengths[self.count] = name.len;
+        self.count += 1;
+        return true;
+    }
+};
+
 pub const max_jest_additional_test_block_functions = 64;
 pub const max_jest_additional_test_block_function_len = 128;
 
@@ -10695,6 +10803,10 @@ test "Options can enable rules by CLI name" {
     try std.testing.expect(!options.jest_valid_expect_in_promise);
     try std.testing.expect(options.setByCliName("jest/valid-expect-in-promise", true));
     try std.testing.expect(options.jest_valid_expect_in_promise);
+
+    try std.testing.expect(!options.jest_valid_expect);
+    try std.testing.expect(options.setByCliName("jest/valid-expect", true));
+    try std.testing.expect(options.jest_valid_expect);
 
     try std.testing.expect(!options.unused_imports_no_unused_imports);
     try std.testing.expect(options.setByCliName("unused-imports/no-unused-imports", true));

--- a/src/root.zig
+++ b/src/root.zig
@@ -302,6 +302,7 @@ fn hasSemanticRules(options: Options) bool {
         options.jest_no_standalone_expect or
         options.jest_valid_describe_callback or
         options.jest_valid_expect_in_promise or
+        options.jest_valid_expect or
         options.no_invalid_regexp or
         options.no_label_var or
         options.no_loop_func or

--- a/src/rules/jest_fn_call.zig
+++ b/src/rules/jest_fn_call.zig
@@ -166,6 +166,23 @@ pub const Resolver = struct {
         return result;
     }
 
+    /// Resolves a bare Jest function reference while preserving normal lexical
+    /// shadowing and imports from `@jest/globals`. Rules which validate an
+    /// incomplete call chain (and therefore cannot use `parseCall`) can use
+    /// this to identify the head call before inspecting its parents.
+    pub fn resolveFunctionReference(self: *const Resolver, index: ast.NodeIndex) ?Function {
+        const reference = unwrapTransparent(self.tree, index);
+        const local_name = identifierName(self.tree, reference) orelse return null;
+        const reference_id = self.symbol_table.model.referenceOf(reference) orelse return null;
+        const symbol_id = self.symbol_table.referenceSymbol(reference_id);
+
+        if (symbol_id == .none) {
+            const canonical_name = self.global_aliases.canonicalFor(local_name) orelse local_name;
+            return functionForName(canonical_name);
+        }
+        return (self.bindings.get(symbol_id) orelse return null).function;
+    }
+
     fn collectBindings(self: *Resolver) Allocator.Error!void {
         const program = switch (self.tree.data(self.tree.root)) {
             .program => |value| value,

--- a/src/rules/jest_valid_expect.zig
+++ b/src/rules/jest_valid_expect.zig
@@ -169,10 +169,10 @@ const Visitor = struct {
         matcher_call: PathNode,
         ctx: *traverser.basic.Ctx,
     ) Allocator.Error!void {
-        var target = thenifiedTarget(tree, matcher_call, ctx);
-        const promise = promiseWrapperTarget(tree, target, ctx);
-        const wrapped = promise.index != target.index;
-        target = promise;
+        const assertion_target = thenifiedTarget(tree, matcher_call, ctx);
+        const promise_target = promiseWrapperTarget(tree, assertion_target, ctx);
+        const wrapped = promise_target.index != assertion_target.index;
+        const target = thenifiedTarget(tree, promise_target, ctx);
 
         if (acceptableParent(tree, target, ctx, !self.options.always_await)) return;
         const entry = try self.reported_async_nodes.getOrPut(self.allocator, target.index);

--- a/src/rules/jest_valid_expect.zig
+++ b/src/rules/jest_valid_expect.zig
@@ -1,0 +1,419 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const jest_fn_call = @import("jest_fn_call.zig");
+
+const ast = parser.ast;
+const traverser = @import("../semantic_compat.zig").traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "jest/valid-expect";
+
+pub const Options = struct {
+    always_await: bool = false,
+    async_matchers: core.JestValidExpectAsyncMatchers = .{},
+    min_args: f64 = 1,
+    max_args: f64 = 1,
+};
+
+pub fn run(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    symbol_table: traverser.semantic.SymbolTable,
+    global_aliases: core.JestGlobalAliases,
+    options: Options,
+) Allocator.Error!void {
+    var resolver = try jest_fn_call.Resolver.init(allocator, tree, symbol_table, global_aliases);
+    defer resolver.deinit();
+
+    var visitor = Visitor{
+        .allocator = allocator,
+        .diagnostics = diagnostics,
+        .resolver = &resolver,
+        .options = options,
+    };
+    defer visitor.reported_async_nodes.deinit(allocator);
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    resolver: *const jest_fn_call.Resolver,
+    options: Options,
+    reported_async_nodes: std.AutoHashMapUnmanaged(ast.NodeIndex, void) = .empty,
+
+    pub fn enter_call_expression(
+        self: *Visitor,
+        call: ast.CallExpression,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.resolver.resolveFunctionReference(call.callee) != .expect) return .proceed;
+
+        const chain = collectExpectChain(ctx.tree, index, ctx);
+        const matcher_call = chain.matcher_call orelse {
+            if (chain.member_count == 0) {
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    "Expect must have a corresponding matcher call",
+                    ctx.tree.span(index),
+                );
+            } else {
+                const last = chain.members[chain.member_count - 1];
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    if (isModifier(last.name))
+                        "Expect must have a corresponding matcher call"
+                    else
+                        "Matchers must be called to assert",
+                    ctx.tree.span(last.node),
+                );
+            }
+            return .proceed;
+        };
+
+        if (chain.member_count == 0) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Expect must have a corresponding matcher call",
+                ctx.tree.span(matcher_call.index),
+            );
+            return .proceed;
+        }
+
+        const modifiers = chain.members[0 .. chain.member_count - 1];
+        if (!validModifiers(modifiers)) {
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                "Expect has an unknown modifier",
+                ctx.tree.span(matcher_call.index),
+            );
+            return .proceed;
+        }
+
+        try self.checkArguments(ctx.tree, call);
+
+        const matcher = chain.members[chain.member_count - 1].name;
+        var async_assertion = self.options.async_matchers.contains(matcher);
+        for (modifiers) |modifier| {
+            if (!std.mem.eql(u8, modifier.name, "not")) async_assertion = true;
+        }
+        if (async_assertion) try self.checkAsyncAssertion(ctx.tree, matcher_call, ctx);
+        return .proceed;
+    }
+
+    fn checkArguments(self: *Visitor, tree: *const ast.Tree, call: ast.CallExpression) Allocator.Error!void {
+        const arguments = tree.extra(call.arguments);
+        const count: f64 = @floatFromInt(arguments.len);
+        if (count < self.options.min_args) {
+            const amount = self.options.min_args;
+            const message = try std.fmt.allocPrint(
+                self.allocator,
+                "Expect requires at least {d} argument{s}",
+                .{ amount, if (amount == 1) "" else "s" },
+            );
+            defer self.allocator.free(message);
+            const callee_span = tree.span(call.callee);
+            const end = @min(callee_span.end + 1, tree.source.len);
+            try core.addDiagnostic(
+                self.allocator,
+                self.diagnostics,
+                .warning,
+                id,
+                message,
+                .{ .start = callee_span.end, .end = end },
+            );
+        }
+        if (count > self.options.max_args) {
+            const first_extra_float = @floor(self.options.max_args);
+            const first_extra: usize = @intFromFloat(first_extra_float);
+            if (first_extra < arguments.len) {
+                const amount = self.options.max_args;
+                const message = try std.fmt.allocPrint(
+                    self.allocator,
+                    "Expect takes at most {d} argument{s}",
+                    .{ amount, if (amount == 1) "" else "s" },
+                );
+                defer self.allocator.free(message);
+                const first_span = tree.span(arguments[first_extra]);
+                const last_span = tree.span(arguments[arguments.len - 1]);
+                try core.addDiagnostic(
+                    self.allocator,
+                    self.diagnostics,
+                    .warning,
+                    id,
+                    message,
+                    .{ .start = first_span.start, .end = last_span.end },
+                );
+            }
+        }
+    }
+
+    fn checkAsyncAssertion(
+        self: *Visitor,
+        tree: *const ast.Tree,
+        matcher_call: PathNode,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!void {
+        var target = thenifiedTarget(tree, matcher_call, ctx);
+        const promise = promiseWrapperTarget(tree, target, ctx);
+        const wrapped = promise.index != target.index;
+        target = promise;
+
+        if (acceptableParent(tree, target, ctx, !self.options.always_await)) return;
+        const entry = try self.reported_async_nodes.getOrPut(self.allocator, target.index);
+        if (entry.found_existing) return;
+
+        try core.addDiagnostic(
+            self.allocator,
+            self.diagnostics,
+            .warning,
+            id,
+            if (wrapped)
+                if (self.options.always_await)
+                    "Promises which return async assertions must be awaited"
+                else
+                    "Promises which return async assertions must be awaited or returned"
+            else if (self.options.always_await)
+                "Async assertions must be awaited"
+            else
+                "Async assertions must be awaited or returned",
+            tree.span(target.index),
+        );
+    }
+};
+
+const ChainMember = struct {
+    name: []const u8,
+    node: ast.NodeIndex,
+};
+
+const ExpectChain = struct {
+    members: [16]ChainMember = undefined,
+    member_count: usize = 0,
+    matcher_call: ?PathNode = null,
+
+    fn append(self: *ExpectChain, member: ChainMember) bool {
+        if (self.member_count == self.members.len) return false;
+        self.members[self.member_count] = member;
+        self.member_count += 1;
+        return true;
+    }
+};
+
+const PathNode = struct {
+    index: ast.NodeIndex,
+    depth: usize,
+};
+
+fn collectExpectChain(tree: *const ast.Tree, expect_call: ast.NodeIndex, ctx: *traverser.basic.Ctx) ExpectChain {
+    var result = ExpectChain{};
+    var target = expect_call;
+    var depth: usize = 1;
+
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .chain_expression,
+            .parenthesized_expression,
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_non_null_expression,
+            .ts_type_assertion,
+            => {
+                target = ancestor;
+                continue;
+            },
+            .member_expression => |member| {
+                if (unwrapTransparent(tree, member.object) != unwrapTransparent(tree, target)) return result;
+                const name = staticPropertyName(tree, member) orelse return result;
+                if (!result.append(.{ .name = name, .node = member.property })) return result;
+                target = ancestor;
+            },
+            .call_expression => |call| {
+                if (unwrapTransparent(tree, call.callee) != unwrapTransparent(tree, target)) return result;
+                result.matcher_call = .{ .index = ancestor, .depth = depth };
+                return result;
+            },
+            else => return result,
+        }
+    }
+    return result;
+}
+
+fn validModifiers(modifiers: []const ChainMember) bool {
+    return switch (modifiers.len) {
+        0 => true,
+        1 => isModifier(modifiers[0].name),
+        2 => (std.mem.eql(u8, modifiers[0].name, "resolves") or
+            std.mem.eql(u8, modifiers[0].name, "rejects")) and
+            std.mem.eql(u8, modifiers[1].name, "not"),
+        else => false,
+    };
+}
+
+fn isModifier(name: []const u8) bool {
+    return std.mem.eql(u8, name, "not") or
+        std.mem.eql(u8, name, "resolves") or
+        std.mem.eql(u8, name, "rejects");
+}
+
+fn thenifiedTarget(tree: *const ast.Tree, initial: PathNode, ctx: *traverser.basic.Ctx) PathNode {
+    var target = initial;
+    while (true) {
+        const member_node = nextNonTransparentAncestor(tree, ctx, target.depth + 1) orelse return target;
+        const member = switch (tree.data(member_node.index)) {
+            .member_expression => |value| value,
+            else => return target,
+        };
+        if (unwrapTransparent(tree, member.object) != unwrapTransparent(tree, target.index)) return target;
+        const property = staticPropertyName(tree, member) orelse return target;
+        if (!std.mem.eql(u8, property, "then") and !std.mem.eql(u8, property, "catch")) return target;
+
+        const call_node = nextNonTransparentAncestor(tree, ctx, member_node.depth + 1) orelse return target;
+        const call = switch (tree.data(call_node.index)) {
+            .call_expression => |value| value,
+            else => return target,
+        };
+        if (unwrapTransparent(tree, call.callee) != member_node.index) return target;
+        target = call_node;
+    }
+}
+
+fn promiseWrapperTarget(tree: *const ast.Tree, target: PathNode, ctx: *traverser.basic.Ctx) PathNode {
+    const parent = nextNonTransparentAncestor(tree, ctx, target.depth + 1) orelse return target;
+    switch (tree.data(parent.index)) {
+        .call_expression => |call| {
+            if (isPromiseCall(tree, call) and argumentsContain(tree, call, target.index)) return parent;
+        },
+        .array_expression => |array| {
+            if (!nodesContain(tree, tree.extra(array.elements), target.index)) return target;
+            const call_node = nextNonTransparentAncestor(tree, ctx, parent.depth + 1) orelse return target;
+            const call = switch (tree.data(call_node.index)) {
+                .call_expression => |value| value,
+                else => return target,
+            };
+            if (isPromiseCall(tree, call) and argumentsContain(tree, call, parent.index)) return call_node;
+        },
+        else => {},
+    }
+    return target;
+}
+
+fn acceptableParent(
+    tree: *const ast.Tree,
+    initial: PathNode,
+    ctx: *traverser.basic.Ctx,
+    allow_return: bool,
+) bool {
+    var target = initial;
+    while (nextNonTransparentAncestor(tree, ctx, target.depth + 1)) |parent| {
+        switch (tree.data(parent.index)) {
+            .conditional_expression => {
+                target = parent;
+                continue;
+            },
+            .await_expression => |expression| return unwrapTransparent(tree, expression.argument) == unwrapTransparent(tree, target.index),
+            .return_statement => |statement| return allow_return and unwrapTransparent(tree, statement.argument) == unwrapTransparent(tree, target.index),
+            .arrow_function_expression => |arrow| return arrow.expression and unwrapTransparent(tree, arrow.body) == unwrapTransparent(tree, target.index),
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn isPromiseCall(tree: *const ast.Tree, call: ast.CallExpression) bool {
+    const member = switch (tree.data(unwrapTransparent(tree, call.callee))) {
+        .member_expression => |value| value,
+        else => return false,
+    };
+    return identifierReferenceNamed(tree, member.object, "Promise") and staticPropertyName(tree, member) != null;
+}
+
+fn argumentsContain(tree: *const ast.Tree, call: ast.CallExpression, expected: ast.NodeIndex) bool {
+    return nodesContain(tree, tree.extra(call.arguments), expected);
+}
+
+fn nodesContain(tree: *const ast.Tree, nodes: []const ast.NodeIndex, expected: ast.NodeIndex) bool {
+    for (nodes) |node| {
+        if (unwrapTransparent(tree, node) == unwrapTransparent(tree, expected)) return true;
+    }
+    return false;
+}
+
+fn identifierReferenceNamed(tree: *const ast.Tree, index: ast.NodeIndex, expected: []const u8) bool {
+    return switch (tree.data(unwrapTransparent(tree, index))) {
+        .identifier_reference => |identifier| std.mem.eql(u8, tree.string(identifier.name), expected),
+        else => false,
+    };
+}
+
+fn staticPropertyName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    return switch (tree.data(member.property)) {
+        .identifier_name => |identifier| tree.string(identifier.name),
+        .identifier_reference => |identifier| if (member.computed) null else tree.string(identifier.name),
+        .string_literal => |literal| if (member.computed) tree.string(literal.value) else null,
+        .template_literal => |literal| if (member.computed) templateStringValue(tree, literal) else null,
+        else => null,
+    };
+}
+
+fn templateStringValue(tree: *const ast.Tree, literal: ast.TemplateLiteral) ?[]const u8 {
+    if (literal.expressions.len != 0) return null;
+    const quasis = tree.extra(literal.quasis);
+    if (quasis.len == 0) return "";
+    return switch (tree.data(quasis[0])) {
+        .template_element => |element| tree.string(element.cooked),
+        else => null,
+    };
+}
+
+fn nextNonTransparentAncestor(
+    tree: *const ast.Tree,
+    ctx: *traverser.basic.Ctx,
+    start_depth: usize,
+) ?PathNode {
+    var depth = start_depth;
+    while (ctx.path.ancestor(depth)) |ancestor| : (depth += 1) {
+        switch (tree.data(ancestor)) {
+            .chain_expression,
+            .parenthesized_expression,
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_non_null_expression,
+            .ts_type_assertion,
+            => continue,
+            else => return .{ .index = ancestor, .depth = depth },
+        }
+    }
+    return null;
+}
+
+fn unwrapTransparent(tree: *const ast.Tree, index: ast.NodeIndex) ast.NodeIndex {
+    var current = index;
+    while (current != .null) {
+        switch (tree.data(current)) {
+            .chain_expression => |expression| current = expression.expression,
+            .parenthesized_expression => |expression| current = expression.expression,
+            .ts_as_expression => |expression| current = expression.expression,
+            .ts_satisfies_expression => |expression| current = expression.expression,
+            .ts_non_null_expression => |expression| current = expression.expression,
+            .ts_type_assertion => |expression| current = expression.expression,
+            else => return current,
+        }
+    }
+    return current;
+}

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -89,6 +89,7 @@ pub const jest_no_mocks_import = @import("jest_no_mocks_import.zig");
 pub const jest_no_standalone_expect = @import("jest_no_standalone_expect.zig");
 pub const jest_valid_describe_callback = @import("jest_valid_describe_callback.zig");
 pub const jest_valid_expect_in_promise = @import("jest_valid_expect_in_promise.zig");
+pub const jest_valid_expect = @import("jest_valid_expect.zig");
 pub const jsx_a11y_alt_text = @import("jsx_a11y_alt_text.zig");
 pub const jsx_a11y_anchor_has_content = @import("jsx_a11y_anchor_has_content.zig");
 pub const jsx_a11y_aria_props = @import("jsx_a11y_aria_props.zig");
@@ -1088,6 +1089,22 @@ fn runSemanticAfterIo(
             tree,
             semantic_result.symbol_table,
             options.jest_global_aliases,
+        );
+    }
+
+    if (options.jest_valid_expect) {
+        try jest_valid_expect.run(
+            allocator,
+            diagnostics,
+            tree,
+            semantic_result.symbol_table,
+            options.jest_global_aliases,
+            .{
+                .always_await = options.jest_valid_expect_always_await,
+                .async_matchers = options.jest_valid_expect_async_matchers,
+                .min_args = options.jest_valid_expect_min_args,
+                .max_args = options.jest_valid_expect_max_args,
+            },
         );
     }
 

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -278,6 +278,7 @@ comptime {
     _ = @import("rules/jest_no_standalone_expect.zig");
     _ = @import("rules/jest_valid_describe_callback.zig");
     _ = @import("rules/jest_valid_expect_in_promise.zig");
+    _ = @import("rules/jest_valid_expect.zig");
 }
 
 comptime {

--- a/tests/rules/jest_valid_expect.zig
+++ b/tests/rules/jest_valid_expect.zig
@@ -69,6 +69,8 @@ test "jest valid expect requires async assertions and Promise wrappers to be awa
         \\test('wrappers', async () => {
         \\  await Promise.all([expect(Promise.resolve(1)).resolves.toBe(1)]);
         \\  await Promise.resolve(expect(Promise.resolve(2)).resolves.toBe(2));
+        \\  await Promise.all([expect(Promise.resolve(3)).resolves.toBe(3)]).then(() => {});
+        \\  return Promise.resolve(expect(Promise.resolve(4)).resolves.toBe(4)).catch(() => {});
         \\});
     ;
     var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());

--- a/tests/rules/jest_valid_expect.zig
+++ b/tests/rules/jest_valid_expect.zig
@@ -1,0 +1,199 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+const rule_id = lint.rules.jest_valid_expect.id;
+
+test "jest valid expect reports invalid argument counts matcher chains and modifiers" {
+    const source =
+        \\expect().toBe(true);
+        \\expect(1, 2).toEqual(1);
+        \\expect('value');
+        \\expect(true).toBeDefined;
+        \\expect(true).not;
+        \\expect(true).nope.toBeDefined();
+        \\expect(true).not.resolves.toBeDefined();
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 7), helpers.countRule(result, rule_id));
+    try expectMessage(result, "Expect requires at least 1 argument");
+    try expectMessage(result, "Expect takes at most 1 argument");
+    try expectMessage(result, "Expect must have a corresponding matcher call");
+    try expectMessage(result, "Matchers must be called to assert");
+    try expectMessage(result, "Expect has an unknown modifier");
+
+    try std.testing.expectEqualStrings("(", source[result.diagnostics[0].span.start..result.diagnostics[0].span.end]);
+    try std.testing.expectEqualStrings("2", source[result.diagnostics[1].span.start..result.diagnostics[1].span.end]);
+    try std.testing.expectEqualStrings("expect('value')", source[result.diagnostics[2].span.start..result.diagnostics[2].span.end]);
+    try std.testing.expectEqualStrings("toBeDefined", source[result.diagnostics[3].span.start..result.diagnostics[3].span.end]);
+}
+
+test "jest valid expect allows valid matchers modifiers and static expect helpers" {
+    const source =
+        \\expect.hasAssertions;
+        \\expect.hasAssertions();
+        \\expect.extend({});
+        \\expect(1).toBe(1);
+        \\expect(undefined).not.toBeDefined();
+        \\await expect(Promise.resolve(1)).resolves.toBe(1);
+        \\await expect(Promise.reject(1)).rejects.not.toBe(2);
+        \\expect(1)["toBe"](1);
+        \\expect(1)[`toBe`](1);
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.mjs", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!helpers.hasRule(result, rule_id));
+}
+
+test "jest valid expect requires async assertions and Promise wrappers to be awaited or returned" {
+    const source =
+        \\test('invalid', () => {
+        \\  expect(Promise.resolve(1)).resolves.toBe(1);
+        \\  expect(Promise.reject(1)).rejects.toBe(1);
+        \\  expect(Promise.resolve(1)).toResolve();
+        \\  expect(Promise.resolve(1)).resolves.toBe(1).then(() => {});
+        \\  Promise.all([
+        \\    (expect(Promise.resolve(1)).resolves.toBe(1)),
+        \\    expect(Promise.resolve(2)).resolves.toBe(2),
+        \\  ]);
+        \\  Promise.resolve(expect(Promise.resolve(3)).resolves.toBe(3));
+        \\});
+        \\test('valid', async () => {
+        \\  await expect(Promise.resolve(1)).resolves.toBe(1);
+        \\  return expect(Promise.reject(1)).rejects.toBe(1);
+        \\});
+        \\test('arrow', () => expect(Promise.resolve(1)).resolves.toBe(1));
+        \\test('then', () => { return expect(Promise.resolve(1)).resolves.toBe(1).then(() => {}); });
+        \\test('wrappers', async () => {
+        \\  await Promise.all([expect(Promise.resolve(1)).resolves.toBe(1)]);
+        \\  await Promise.resolve(expect(Promise.resolve(2)).resolves.toBe(2));
+        \\});
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 6), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("Async assertions must be awaited or returned", result.diagnostics[0].message);
+    try std.testing.expectEqualStrings("Promises which return async assertions must be awaited or returned", result.diagnostics[4].message);
+    try std.testing.expectEqualStrings("Promises which return async assertions must be awaited or returned", result.diagnostics[5].message);
+}
+
+test "jest valid expect supports alwaysAwait and custom asyncMatchers" {
+    const always_options = try optionsFromConfig(
+        \\["error", {"alwaysAwait":true}]
+    );
+    const always_source =
+        \\test('returned', () => { return expect(Promise.resolve(1)).resolves.toBe(1); });
+        \\test('concise', () => expect(Promise.resolve(1)).resolves.toBe(1));
+    ;
+    var always_result = try lint.lintSource(std.testing.allocator, always_source, "fixture.js", always_options);
+    defer always_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(always_result, rule_id));
+    try std.testing.expectEqualStrings("Async assertions must be awaited", always_result.diagnostics[0].message);
+
+    const custom_options = try optionsFromConfig(
+        \\["error", {"asyncMatchers":["toSettle"]}]
+    );
+    const custom_source =
+        \\expect(Promise.resolve(1)).toResolve();
+        \\expect(Promise.resolve(1)).toSettle();
+    ;
+    var custom_result = try lint.lintSource(std.testing.allocator, custom_source, "fixture.js", custom_options);
+    defer custom_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(custom_result, rule_id));
+    try std.testing.expectEqualStrings("Async assertions must be awaited or returned", custom_result.diagnostics[0].message);
+}
+
+test "jest valid expect supports argument bounds options" {
+    const options = try optionsFromConfig(
+        \\["error", {"minArgs":0,"maxArgs":2}]
+    );
+    const source =
+        \\expect().pass();
+        \\expect(1, 'message').toBe(1);
+        \\expect(1, 'message', 'extra').toBe(1);
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    try std.testing.expectEqualStrings("Expect takes at most 2 arguments", result.diagnostics[0].message);
+}
+
+test "jest valid expect supports imported required aliased and shadowed expect APIs" {
+    const source =
+        \\import { expect as assertion } from '@jest/globals';
+        \\assertion(1);
+        \\const { expect: check } = require('@jest/globals');
+        \\check(true).toBeDefined;
+        \\function local(expect) { expect(1); }
+    ;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", optionsOnly());
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), helpers.countRule(result, rule_id));
+
+    var alias_options = optionsOnly();
+    try std.testing.expect(alias_options.jest_global_aliases.append("expect", "verify"));
+    var alias_result = try lint.lintSource(std.testing.allocator, "verify(1);", "fixture.js", alias_options);
+    defer alias_result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), helpers.countRule(alias_result, rule_id));
+}
+
+test "jest valid expect supports JavaScript TypeScript JSX and TSX" {
+    const cases = [_]struct { source: []const u8, file_name: []const u8 }{
+        .{ .source = "expect().toBe(true);", .file_name = "fixture.js" },
+        .{ .source = "expect<boolean>().toBe(true);", .file_name = "fixture.ts" },
+        .{ .source = "expect(<div />, 'message').toBeTruthy();", .file_name = "fixture.jsx" },
+        .{ .source = "expect(<div /> as JSX.Element, 'message').toBeTruthy();", .file_name = "fixture.tsx" },
+    };
+
+    for (cases) |case| {
+        var result = try lint.lintSource(std.testing.allocator, case.source, case.file_name, optionsOnly());
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), helpers.countRule(result, rule_id));
+    }
+}
+
+test "jest valid expect uses upstream defaults and accepts complete configuration" {
+    const defaults = lint.Options{};
+    try std.testing.expect(defaults.jest_valid_expect);
+    try std.testing.expect(!defaults.jest_valid_expect_always_await);
+    try std.testing.expect(defaults.jest_valid_expect_async_matchers.contains("toResolve"));
+    try std.testing.expect(defaults.jest_valid_expect_async_matchers.contains("toReject"));
+    try std.testing.expectEqual(@as(f64, 1), defaults.jest_valid_expect_min_args);
+    try std.testing.expectEqual(@as(f64, 1), defaults.jest_valid_expect_max_args);
+
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName(rule_id, true));
+    try std.testing.expect(options.jest_valid_expect);
+
+    options = try optionsFromConfig(
+        \\["error", {"alwaysAwait":true,"asyncMatchers":["toSettle"],"minArgs":2,"maxArgs":3}]
+    );
+    try std.testing.expect(options.jest_valid_expect_always_await);
+    try std.testing.expect(options.jest_valid_expect_async_matchers.contains("toSettle"));
+    try std.testing.expect(!options.jest_valid_expect_async_matchers.contains("toResolve"));
+    try std.testing.expectEqual(@as(f64, 2), options.jest_valid_expect_min_args);
+    try std.testing.expectEqual(@as(f64, 3), options.jest_valid_expect_max_args);
+}
+
+fn optionsOnly() lint.Options {
+    var options = lint.Options.allDisabled();
+    options.jest_valid_expect = true;
+    return options;
+}
+
+fn optionsFromConfig(config: []const u8) !lint.Options {
+    var options = optionsOnly();
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, config, .{});
+    defer parsed.deinit();
+    try options.setByRuleConfigValue(rule_id, parsed.value);
+    return options;
+}
+
+fn expectMessage(result: lint.Result, expected: []const u8) !void {
+    for (result.diagnostics) |diagnostic| {
+        if (std.mem.eql(u8, diagnostic.rule_id, rule_id) and std.mem.eql(u8, diagnostic.message, expected)) return;
+    }
+    return error.TestExpectedEqual;
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -298,6 +298,29 @@ test("reports floating expectation-bearing promise chains", () => {
   );
 });
 
+test("validates expect chains with configured argument and async matcher options", () => {
+  const result = linter.lint(
+    [
+      "expect().pass();",
+      "expect(1, 'message').toBe(1);",
+      "expect(Promise.resolve(1)).toSettle();",
+      "expect(Promise.resolve(1)).toResolve();",
+    ].join("\n"),
+    {
+      filePath: "input.js",
+      rules: {
+        "jest/valid-expect": [
+          "error",
+          { minArgs: 0, maxArgs: 2, asyncMatchers: ["toSettle"] },
+        ],
+      },
+    },
+  );
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].ruleId, "jest/valid-expect");
+  assert.equal(result.diagnostics[0].message, "Async assertions must be awaited or returned");
+});
+
 test("applies control-flow-aware no-useless-assignment analysis", () => {
   const result = linter.lint(
     "let value = 1; console.log(value); value = 2;",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Learn more about contributing: https://github.com/utooland/utoo-lint/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements native `jest/valid-expect` support, including argument bounds, matcher and modifier validation, async assertion handling, Jest aliases and imported APIs, and all documented rule options.

Adds rule registration for native CLI, npm ESM/CommonJS, and WebAssembly entry points, plus English and Chinese rule-status documentation.

Closes #1163.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- `zig build test -Doptimize=Debug`
- `zig build -Doptimize=ReleaseFast -j1`
- `zig build test -Doptimize=ReleaseFast -j1`
- `pnpm --dir npm/utoo-lint test`
- `pnpm package:wasm`
- `pnpm test:wasm`
- `pnpm --dir npm/@utoo/lint-wasm test`
- `pnpm --dir npm/@utoo/lint-wasm test:types`
