### PR TITLE
fix(ci): make npm releases OIDC-safe and retryable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test release publishing
+        run: pnpm test:release-publish
+
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,9 +310,4 @@ jobs:
       - name: Publish npm packages
         env:
           NPM_TAG: ${{ steps.release_version.outputs.npm_tag }}
-        run: |
-          for package_dir in npm/@utoo/lint-*; do
-            pnpm publish "${package_dir}/" --access public --provenance --tag "${NPM_TAG}" --no-git-checks
-          done
-
-          pnpm publish npm/utoo-lint/ --access public --provenance --tag "${NPM_TAG}" --no-git-checks
+        run: node scripts/publish-npm-packages.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,14 +193,25 @@ The release workflow builds all native and WebAssembly assets, stages the npm
 packages from the same artifacts, uploads the release assets to GitHub, and
 publishes the scoped packages before the CLI wrapper.
 
-Required GitHub repository secret:
+Every npm package must already exist and authorize this repository through npm
+Trusted Publishing with these GitHub Actions settings:
 
 ```text
-NPM_TOKEN
+Organization: utooland
+Repository: utoo-lint
+Workflow: release.yml
+Allowed action: npm publish
 ```
 
-Create it from npm as an automation token, then add it in GitHub under
-`Settings -> Secrets and variables -> Actions`.
+The release job uses OIDC exclusively and does not receive an npm publishing
+token. Before adding a new package to the release workflow, initialize it on
+npm and configure the Trusted Publisher above.
+
+Publishing is idempotent. The workflow checks every exact package version
+before publishing, skips versions already present on npm, rejects uninitialized
+packages before publishing anything, publishes `@utoo/lint-wasm` first to catch
+Trusted Publisher configuration errors early, and publishes the root
+`@utoo/lint` package last.
 
 Publish from GitHub:
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -325,16 +325,17 @@ pnpm add -g ./npm/utoo-lint
 utoo-lint test/fixtures/bad.ts
 ```
 
-Publishing order:
+Publishing is orchestrated by `scripts/publish-npm-packages.mjs`:
 
 ```bash
-for package_dir in npm/@utoo/lint-*; do
-  pnpm publish "${package_dir}/" --access public
-done
-
-pnpm publish npm/utoo-lint/ --access public
+NPM_TAG=latest node scripts/publish-npm-packages.mjs
 ```
 
 GitHub Actions stages the native package directories from the release matrix,
 copies their binaries into the workspace packages, updates package versions from
 the release tag, and publishes with pnpm in `.github/workflows/release.yml`.
+Exact versions that already exist are skipped so interrupted releases can be
+retried. All packages publish through npm Trusted Publishing/OIDC; new packages
+must be initialized and authorize `release.yml` before they are added to a
+release. The WebAssembly package is attempted first and the root `@utoo/lint`
+package last.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "package:wasm": "bash scripts/package-wasm.sh",
     "stage:playground-wasm": "node scripts/stage-playground-wasm.mjs",
     "test:wasm": "zig build test-wasm",
+    "test:release-publish": "node --test scripts/publish-npm-packages.test.mjs",
     "playground:dev": "pnpm stage:playground-wasm && pnpm --filter @utoo/lint-playground dev",
     "playground:build": "pnpm stage:playground-wasm && pnpm --filter @utoo/lint-playground build",
     "playground:typecheck": "pnpm --filter @utoo/lint-playground typecheck",

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -1,0 +1,177 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const workspaceRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: options.stdio === 'pipe' ? 'utf8' : undefined,
+    env: options.env,
+    stdio: options.stdio ?? 'inherit',
+  });
+
+  return {
+    code: result.status ?? 1,
+    error: result.error,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+  };
+}
+
+function isNotFound(result) {
+  const output = `${result.stdout}\n${result.stderr}`;
+  return /\bE404\b|404 Not Found|is not in this registry/i.test(output);
+}
+
+function describeFailure(command, args, result) {
+  const details = [result.stderr, result.stdout, result.error?.message]
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+  const suffix = details ? `\n${details}` : '';
+  return `${command} ${args.join(' ')} failed with exit code ${result.code}${suffix}`;
+}
+
+function runChecked(run, command, args, options) {
+  const result = run(command, args, options);
+  if (result.code !== 0) {
+    throw new Error(describeFailure(command, args, result));
+  }
+  return result;
+}
+
+function readPackage(directory, root) {
+  const manifestPath = path.resolve(root, directory, 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (!manifest.name || !manifest.version) {
+    throw new Error(`Package manifest is missing name or version: ${manifestPath}`);
+  }
+
+  return {
+    directory,
+    name: manifest.name,
+    version: manifest.version,
+  };
+}
+
+export function discoverPackages(root = workspaceRoot) {
+  const scopedRoot = path.resolve(root, 'npm', '@utoo');
+  const scopedDirectories = readdirSync(scopedRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('lint-'))
+    .map((entry) => path.posix.join('npm', '@utoo', entry.name));
+
+  return [...scopedDirectories, path.posix.join('npm', 'utoo-lint')].map(
+    (directory) => readPackage(directory, root),
+  );
+}
+
+function publishPriority(pkg) {
+  if (pkg.name === '@utoo/lint-wasm') return 0;
+  if (pkg.name === '@utoo/lint') return 2;
+  return 1;
+}
+
+function orderedPackages(packages) {
+  return [...packages].sort(
+    (left, right) =>
+      publishPriority(left) - publishPriority(right) ||
+      left.name.localeCompare(right.name),
+  );
+}
+
+function inspectPackage(pkg, { cwd, env, run }) {
+  const exactSpecifier = `${pkg.name}@${pkg.version}`;
+  const exactArgs = ['view', exactSpecifier, 'version', '--json'];
+  const exactResult = run('npm', exactArgs, { cwd, env, stdio: 'pipe' });
+  if (exactResult.code === 0) {
+    return { pkg, state: 'published' };
+  }
+  if (!isNotFound(exactResult)) {
+    throw new Error(describeFailure('npm', exactArgs, exactResult));
+  }
+
+  const packageArgs = ['view', pkg.name, 'name', '--json'];
+  const packageResult = run('npm', packageArgs, {
+    cwd,
+    env,
+    stdio: 'pipe',
+  });
+  if (packageResult.code === 0) {
+    return { pkg, state: 'unpublished-version' };
+  }
+  if (isNotFound(packageResult)) {
+    return { pkg, state: 'missing-package' };
+  }
+
+  throw new Error(describeFailure('npm', packageArgs, packageResult));
+}
+
+export function publishPackages({
+  cwd = workspaceRoot,
+  env = process.env,
+  logger = console,
+  npmTag,
+  packages = discoverPackages(cwd),
+  run = runCommand,
+}) {
+  if (!npmTag) {
+    throw new Error('NPM_TAG is required');
+  }
+
+  const inspections = packages.map((pkg) =>
+    inspectPackage(pkg, { cwd, env, run }),
+  );
+  const missingPackages = inspections
+    .filter(({ state }) => state === 'missing-package')
+    .map(({ pkg }) => pkg);
+
+  if (missingPackages.length > 0) {
+    const names = missingPackages.map(({ name }) => name).join(', ');
+    throw new Error(
+      `Initialize these npm packages and configure Trusted Publishing for utooland/utoo-lint and release.yml before releasing: ${names}`,
+    );
+  }
+
+  const inspectionByName = new Map(
+    inspections.map(({ pkg, state }) => [pkg.name, state]),
+  );
+
+  for (const pkg of orderedPackages(packages)) {
+    if (inspectionByName.get(pkg.name) === 'published') {
+      logger.log(`Skipping ${pkg.name}@${pkg.version}; already published`);
+      continue;
+    }
+
+    logger.log(`Publishing ${pkg.name}@${pkg.version} through npm OIDC`);
+    runChecked(
+      run,
+      'pnpm',
+      [
+        'publish',
+        `${pkg.directory}/`,
+        '--access',
+        'public',
+        '--provenance',
+        '--tag',
+        npmTag,
+        '--no-git-checks',
+      ],
+      { cwd, env, stdio: 'inherit' },
+    );
+  }
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : '';
+if (import.meta.url === invokedPath) {
+  publishPackages({
+    npmTag: process.env.NPM_TAG,
+  });
+}

--- a/scripts/publish-npm-packages.test.mjs
+++ b/scripts/publish-npm-packages.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { publishPackages } from './publish-npm-packages.mjs';
+
+const packages = [
+  {
+    directory: 'npm/utoo-lint',
+    name: '@utoo/lint',
+    version: '0.3.4',
+  },
+  {
+    directory: 'npm/@utoo/lint-linux-x64',
+    name: '@utoo/lint-linux-x64',
+    version: '0.3.4',
+  },
+  {
+    directory: 'npm/@utoo/lint-wasm',
+    name: '@utoo/lint-wasm',
+    version: '0.3.4',
+  },
+];
+
+function result(code, { stdout = '', stderr = '' } = {}) {
+  return { code, stderr, stdout };
+}
+
+function npmRegistryStub({ exactVersions = [], missingPackages = [] } = {}) {
+  const exactVersionSet = new Set(exactVersions);
+  const missingPackageSet = new Set(missingPackages);
+  const calls = [];
+
+  return {
+    calls,
+    run(command, args, options = {}) {
+      calls.push({ args, command, options });
+
+      if (command !== 'npm' || args[0] !== 'view') {
+        return result(0);
+      }
+
+      const specifier = args[1];
+      if (args[2] === 'version' && exactVersionSet.has(specifier)) {
+        return result(0, { stdout: '"0.3.4"\n' });
+      }
+
+      if (args[2] === 'name' && !missingPackageSet.has(specifier)) {
+        return result(0, { stdout: `${JSON.stringify(specifier)}\n` });
+      }
+
+      return result(1, {
+        stderr: `npm error code E404\nnpm error 404 ${specifier} is not in this registry\n`,
+      });
+    },
+  };
+}
+
+function publishCalls(calls) {
+  return calls.filter(({ args }) => args[0] === 'publish');
+}
+
+test('fails before publishing when a package is not initialized for OIDC', () => {
+  const registry = npmRegistryStub({
+    missingPackages: ['@utoo/lint-wasm'],
+  });
+
+  assert.throws(
+    () =>
+      publishPackages({
+        env: { CI: 'true' },
+        logger: { log() {} },
+        npmTag: 'latest',
+        packages,
+        run: registry.run,
+      }),
+    /initialize.*Trusted Publishing/i,
+  );
+  assert.deepEqual(publishCalls(registry.calls), []);
+});
+
+test('publishes an initialized wasm package through OIDC before native packages', () => {
+  const registry = npmRegistryStub();
+
+  publishPackages({
+    env: { CI: 'true', NODE_AUTH_TOKEN: 'oidc-placeholder' },
+    logger: { log() {} },
+    npmTag: 'latest',
+    packages,
+    run: registry.run,
+  });
+
+  const publishes = publishCalls(registry.calls);
+  assert.deepEqual(
+    publishes.map(({ args, command }) => [command, args[1]]),
+    [
+      ['pnpm', 'npm/@utoo/lint-wasm/'],
+      ['pnpm', 'npm/@utoo/lint-linux-x64/'],
+      ['pnpm', 'npm/utoo-lint/'],
+    ],
+  );
+  assert.ok(
+    publishes.every(
+      ({ options }) =>
+        options.env.NODE_AUTH_TOKEN === 'oidc-placeholder',
+    ),
+  );
+});
+
+test('skips exact versions that are already published', () => {
+  const registry = npmRegistryStub({
+    exactVersions: packages.map(({ name, version }) => `${name}@${version}`),
+  });
+
+  publishPackages({
+    env: { CI: 'true' },
+    logger: { log() {} },
+    npmTag: 'latest',
+    packages,
+    run: registry.run,
+  });
+
+  assert.deepEqual(publishCalls(registry.calls), []);
+});


### PR DESCRIPTION
## Summary

- publish every initialized npm package, including @utoo/lint-wasm, through Trusted Publishing/OIDC
- preflight package existence before publishing to prevent partial releases
- skip exact versions already present on npm so interrupted releases can be retried
- publish wasm first, native packages next, and the root @utoo/lint package last
- document the package-level Trusted Publisher requirement

## Root cause

The v0.3.x release workflow discovered the new @utoo/lint-wasm directory through a glob and attempted to publish it after four native packages. Because the package had not been initialized and authorized for release.yml on npm, the publish failed after leaving a partial release.

## Validation

- pnpm test:release-publish
- actionlint .github/workflows/ci.yml .github/workflows/release.yml
- node syntax checks for the publish helper and tests
- git diff --check