### PR TITLE
feat(playground): restore version selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Build and audit unified site
         run: pnpm site:build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install Chromium
         run: pnpm exec playwright install --with-deps --only-shell chromium

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -25,6 +25,11 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -39,7 +44,7 @@ env:
 
 jobs:
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: (github.event_name != 'workflow_run' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +71,8 @@ jobs:
 
       - name: Build and audit site
         run: pnpm site:build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 /server/
 .DS_Store
 npm/@utoo/lint-wasm/utoo-lint.wasm
+apps/playground/public/versions/

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -20,17 +20,20 @@ pnpm 10:
 pnpm install --frozen-lockfile
 ```
 
-The versioned WebAssembly artifact is downloaded from the matching GitHub
-release and intentionally is not checked into Git. The staging script verifies
-its pinned SHA-256 before starting the Playground:
+The available WebAssembly versions are discovered from stable GitHub releases
+that contain `utoo-lint.wasm` and intentionally are not checked into Git. The
+staging script downloads the latest ten versions, verifies their release
+SHA-256 digests, and generates the version manifest before starting the
+Playground. If GitHub is temporarily unavailable during local development, a
+previously verified local manifest and its cached assets are reused:
 
 ```bash
 pnpm playground:dev
 ```
 
-The root script stages the v0.3.0 artifact as
-`npm/@utoo/lint-wasm/utoo-lint.wasm` before starting EVJS. The Utoopack
-development URL is printed in the terminal.
+The newest stable version is selected by default. Selecting an older version
+adds `?version=<version>` to the Playground URL so the same engine can be
+reopened or shared. The Utoopack development URL is printed in the terminal.
 Open the `/playground` route rather than the server root.
 
 ## Verify and build

--- a/apps/playground/ev.config.ts
+++ b/apps/playground/ev.config.ts
@@ -1,9 +1,37 @@
 import { defineConfig } from '@evjs/ev';
 import { staticDeploymentAdapter } from '@evjs/ev/deployment';
+import { definePlugin } from '@evjs/ev/plugin';
+
+interface CopyCapableBundlerConfig {
+  output?: {
+    copy?: Array<string | { from: string; to?: string }>;
+  };
+}
+
+const versionAssetsPlugin = definePlugin({
+  id: 'playground-version-assets',
+  setup() {
+    return {
+      configureBundler(config, context) {
+        if (context.bundlerName !== 'utoopack') return;
+
+        const utoopackConfig = config as CopyCapableBundlerConfig;
+        utoopackConfig.output ??= {};
+        utoopackConfig.output.copy = [
+          ...(utoopackConfig.output.copy ?? []),
+          { from: 'public/versions', to: 'versions' },
+          ...(context.mode === 'development'
+            ? [{ from: 'public/versions', to: 'playground/versions' }]
+            : []),
+        ];
+      },
+    };
+  },
+});
 
 export default defineConfig({
   application: {
     routes: [{ path: '/playground', page: '.' }],
   },
-  plugins: [staticDeploymentAdapter()],
+  plugins: [versionAssetsPlugin(), staticDeploymentAdapter()],
 });

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -6,7 +6,7 @@
     "dev": "ev dev",
     "build": "ev build && node scripts/stage-static.mjs && node scripts/verify-dist.mjs",
     "inspect": "ev inspect --json",
-    "test": "pnpm --workspace-root stage:playground-wasm && node --test scripts/lint-client.test.mjs",
+    "test": "node --test scripts/lint-client.test.mjs",
     "typecheck": "ev prepare && tsc --noEmit"
   },
   "dependencies": {

--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -22,6 +22,9 @@ await run(
     fileURLToPath(
       new URL('../src/features/playground/model.ts', import.meta.url),
     ),
+    fileURLToPath(
+      new URL('../src/features/playground/versions.ts', import.meta.url),
+    ),
     '--target',
     'es2022',
     '--module',
@@ -63,6 +66,14 @@ const {
   removePlaygroundShareState,
 } = await import(
   pathToFileURL(join(outputDirectory, 'playground', 'model.js')).href
+);
+const {
+  initialLintVersion,
+  lintVersionManifestUrl,
+  lintVersionUrl,
+  parseLintVersionCatalog,
+} = await import(
+  pathToFileURL(join(outputDirectory, 'playground', 'versions.js')).href
 );
 await rm(outputDirectory, { force: true, recursive: true });
 
@@ -187,6 +198,103 @@ test('passes the selected WebAssembly version URL to the lint worker', async (t)
     result: { diagnostics: [], mode: 'lint' },
   });
   await result;
+});
+
+test('loads versioned WebAssembly URLs and defaults to the latest release', () => {
+  const manifestUrl = lintVersionManifestUrl(
+    'https://example.test/playground/',
+  );
+  const catalog = parseLintVersionCatalog(
+    {
+      latest: '0.3.4',
+      versions: [
+        {
+          id: '0.3.4',
+          label: 'v0.3.4',
+          file: 'utoo-lint-v0.3.4.wasm',
+          sha256: 'a'.repeat(64),
+        },
+        {
+          id: '0.3.3',
+          label: 'v0.3.3',
+          file: 'utoo-lint-v0.3.3.wasm',
+          sha256: 'b'.repeat(64),
+        },
+      ],
+    },
+    manifestUrl,
+  );
+
+  assert.equal(
+    manifestUrl,
+    'https://example.test/playground/versions/manifest.json',
+  );
+  assert.equal(
+    lintVersionManifestUrl('https://example.test/playground'),
+    'https://example.test/versions/manifest.json',
+  );
+  assert.equal(
+    catalog.versions[0].wasmUrl,
+    'https://example.test/playground/versions/utoo-lint-v0.3.4.wasm',
+  );
+  assert.equal(
+    initialLintVersion(catalog, 'https://example.test/playground/'),
+    '0.3.4',
+  );
+  assert.equal(
+    initialLintVersion(
+      catalog,
+      'https://example.test/playground/?version=0.3.3',
+    ),
+    '0.3.3',
+  );
+  assert.equal(
+    initialLintVersion(
+      catalog,
+      'https://example.test/playground/?version=0.2.9',
+    ),
+    '0.3.4',
+  );
+});
+
+test('keeps old version selections in the URL but leaves latest implicit', () => {
+  assert.equal(
+    lintVersionUrl(
+      'https://example.test/playground/?theme=dark#playground=state',
+      '0.3.3',
+      '0.3.4',
+    ),
+    'https://example.test/playground/?theme=dark&version=0.3.3#playground=state',
+  );
+  assert.equal(
+    lintVersionUrl(
+      'https://example.test/playground/?theme=dark&version=0.3.3#playground=state',
+      '0.3.4',
+      '0.3.4',
+    ),
+    'https://example.test/playground/?theme=dark#playground=state',
+  );
+});
+
+test('rejects unsafe or inconsistent version manifests', () => {
+  assert.throws(
+    () =>
+      parseLintVersionCatalog(
+        {
+          latest: '0.3.4',
+          versions: [
+            {
+              id: '0.3.4',
+              label: 'v0.3.4',
+              file: '../utoo-lint.wasm',
+              sha256: 'a'.repeat(64),
+            },
+          ],
+        },
+        'https://example.test/playground/versions/manifest.json',
+      ),
+    /invalid/i,
+  );
 });
 
 test('coalesces queued AST work to the newest source', async (t) => {

--- a/apps/playground/scripts/verify-dist.mjs
+++ b/apps/playground/scripts/verify-dist.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,6 +11,7 @@ const requiredFiles = [
   '_headers',
   '_redirects',
   'deployment.static.json',
+  'versions/manifest.json',
 ];
 const forbiddenText = [
   '@alipay/evjs',
@@ -39,20 +41,33 @@ for (const fileName of requiredFiles) {
 }
 
 const files = await collectFiles(clientDir);
-const wasmFiles = files.filter((file) => path.extname(file) === '.wasm');
-if (wasmFiles.length !== 2) {
-  throw new Error(`expected two WebAssembly assets, found ${wasmFiles.length}`);
+const versionManifest = JSON.parse(
+  await readFile(path.join(clientDir, 'versions', 'manifest.json'), 'utf8'),
+);
+if (
+  typeof versionManifest.latest !== 'string' ||
+  !Array.isArray(versionManifest.versions) ||
+  versionManifest.versions.length === 0 ||
+  versionManifest.versions[0]?.id !== versionManifest.latest
+) {
+  throw new Error('invalid Playground version manifest');
 }
 
-const wasmAssets = new Map();
+const wasmFiles = files.filter((file) => path.extname(file) === '.wasm');
+if (wasmFiles.length !== versionManifest.versions.length + 2) {
+  throw new Error(
+    `expected ${versionManifest.versions.length + 2} WebAssembly assets, found ${wasmFiles.length}`,
+  );
+}
+
+let parserWasm;
+let bundledLintWasm;
 for (const file of wasmFiles) {
   const name = path.basename(file);
-  const kind = name.includes('utoo-lint')
-    ? 'lint'
-    : name.includes('yuku-parser')
-      ? 'parser'
-      : undefined;
-  if (!kind || wasmAssets.has(kind)) {
+  const isParser = name.includes('yuku-parser');
+  const isLintVersion = /^utoo-lint-v\d+\.\d+\.\d+\.wasm$/.test(name);
+  const isBundledLint = /^utoo-lint\.[^.]+\.wasm$/.test(name);
+  if (!isParser && !isLintVersion && !isBundledLint) {
     throw new Error(`unexpected WebAssembly asset: ${name}`);
   }
 
@@ -63,13 +78,55 @@ for (const file of wasmFiles) {
   ) {
     throw new Error(`invalid WebAssembly asset: ${name}`);
   }
-  wasmAssets.set(kind, contents);
+  if (isParser) {
+    if (parserWasm) {
+      throw new Error(`duplicate parser WebAssembly asset: ${name}`);
+    }
+    parserWasm = contents;
+  } else if (isBundledLint) {
+    if (bundledLintWasm) {
+      throw new Error(`duplicate bundled lint WebAssembly asset: ${name}`);
+    }
+    bundledLintWasm = contents;
+  }
 }
 
-for (const kind of ['lint', 'parser']) {
-  if (!wasmAssets.has(kind)) {
-    throw new Error(`missing ${kind} WebAssembly asset`);
+if (!parserWasm) throw new Error('missing parser WebAssembly asset');
+if (!bundledLintWasm) throw new Error('missing bundled lint WebAssembly asset');
+
+const lintWasmSizes = new Map();
+for (const version of versionManifest.versions) {
+  if (
+    !/^\d+\.\d+\.\d+$/.test(version.id) ||
+    version.label !== `v${version.id}` ||
+    version.file !== `utoo-lint-v${version.id}.wasm` ||
+    !/^[a-f0-9]{64}$/.test(version.sha256)
+  ) {
+    throw new Error(
+      `invalid Playground version entry: ${JSON.stringify(version)}`,
+    );
   }
+
+  const contents = await readFile(
+    path.join(clientDir, 'versions', version.file),
+  );
+  const actualSha256 = createHash('sha256').update(contents).digest('hex');
+  if (actualSha256 !== version.sha256) {
+    throw new Error(
+      `unexpected ${version.label} WebAssembly SHA-256: ${actualSha256}`,
+    );
+  }
+  lintWasmSizes.set(version.id, contents.length);
+}
+
+const latestVersion = versionManifest.versions[0];
+const bundledLintSha256 = createHash('sha256')
+  .update(bundledLintWasm)
+  .digest('hex');
+if (bundledLintSha256 !== latestVersion.sha256) {
+  throw new Error(
+    `bundled lint WebAssembly does not match latest ${latestVersion.label}`,
+  );
 }
 
 const deployment = JSON.parse(
@@ -139,9 +196,13 @@ for (const file of files) {
   }
 }
 
-const wasmSizes = [...wasmAssets]
-  .map(([kind, contents]) => `${kind} ${(contents.length / 1024 / 1024).toFixed(1)} MiB`)
-  .join(', ');
+const wasmSizes = [
+  `parser ${(parserWasm.length / 1024 / 1024).toFixed(1)} MiB`,
+  ...versionManifest.versions.map(
+    (version) =>
+      `${version.label} ${(lintWasmSizes.get(version.id) / 1024 / 1024).toFixed(1)} MiB`,
+  ),
+].join(', ');
 console.log(
   `verified static EVJS deployment (${files.length} files, ${wasmSizes})`,
 );

--- a/apps/playground/src/features/playground/versions.ts
+++ b/apps/playground/src/features/playground/versions.ts
@@ -1,0 +1,109 @@
+export interface LintVersionDefinition {
+  id: string;
+  label: string;
+  wasmUrl: string;
+}
+
+export interface LintVersionCatalog {
+  latest: string;
+  versions: LintVersionDefinition[];
+}
+
+interface ManifestVersion {
+  id: string;
+  label: string;
+  file: string;
+  sha256: string;
+}
+
+interface VersionManifest {
+  latest: string;
+  versions: ManifestVersion[];
+}
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+function isManifestVersion(value: unknown): value is ManifestVersion {
+  if (!value || typeof value !== 'object') return false;
+  const version = value as Partial<ManifestVersion>;
+  return (
+    typeof version.id === 'string' &&
+    VERSION_PATTERN.test(version.id) &&
+    version.label === `v${version.id}` &&
+    version.file === `utoo-lint-v${version.id}.wasm` &&
+    typeof version.sha256 === 'string' &&
+    SHA256_PATTERN.test(version.sha256)
+  );
+}
+
+export function lintVersionManifestUrl(pageUrl: string): string {
+  return new URL('versions/manifest.json', pageUrl).href;
+}
+
+export function parseLintVersionCatalog(
+  value: unknown,
+  manifestUrl: string,
+): LintVersionCatalog {
+  if (!value || typeof value !== 'object') {
+    throw new Error('The Playground version manifest is invalid.');
+  }
+
+  const manifest = value as Partial<VersionManifest>;
+  if (
+    typeof manifest.latest !== 'string' ||
+    !VERSION_PATTERN.test(manifest.latest) ||
+    !Array.isArray(manifest.versions) ||
+    manifest.versions.length === 0 ||
+    !manifest.versions.every(isManifestVersion)
+  ) {
+    throw new Error('The Playground version manifest is invalid.');
+  }
+
+  const ids = new Set(manifest.versions.map(({ id }) => id));
+  if (ids.size !== manifest.versions.length || !ids.has(manifest.latest)) {
+    throw new Error('The Playground version manifest is inconsistent.');
+  }
+
+  return {
+    latest: manifest.latest,
+    versions: manifest.versions.map(({ id, label, file }) => ({
+      id,
+      label,
+      wasmUrl: new URL(file, manifestUrl).href,
+    })),
+  };
+}
+
+export async function loadLintVersionCatalog(
+  manifestUrl: string,
+): Promise<LintVersionCatalog> {
+  const response = await fetch(manifestUrl, { credentials: 'same-origin' });
+  if (!response.ok) {
+    throw new Error(
+      `Unable to load Playground versions (${response.status} ${response.statusText}).`,
+    );
+  }
+  return parseLintVersionCatalog(await response.json(), manifestUrl);
+}
+
+export function initialLintVersion(
+  catalog: LintVersionCatalog,
+  currentUrl: string,
+): string {
+  const requested = new URL(currentUrl).searchParams.get('version');
+  return catalog.versions.some(({ id }) => id === requested)
+    ? requested!
+    : catalog.latest;
+}
+
+export function lintVersionUrl(
+  currentUrl: string,
+  version: string,
+  latest: string,
+): string {
+  const url = new URL(currentUrl);
+  if (version === latest) url.searchParams.delete('version');
+  else url.searchParams.set('version', version);
+  return url.href;
+}

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -33,6 +33,13 @@ import {
 } from '../features/playground/model';
 import '../features/playground/monaco';
 import { Splitter } from '../features/playground/splitter';
+import {
+  initialLintVersion,
+  lintVersionManifestUrl,
+  lintVersionUrl,
+  loadLintVersionCatalog,
+  type LintVersionCatalog,
+} from '../features/playground/versions';
 import '../style.css';
 
 type EditorInstance = Parameters<OnMount>[0];
@@ -46,10 +53,6 @@ const EDITOR_THEME = 'utoo-dark';
 const DEFAULT_EDITOR_RATIO = 68;
 const DEFAULT_RULES_RATIO = 42;
 const INSPECTOR_MODES = ['rules', 'ast'] as const;
-const LINT_WASM_URL = new URL(
-  '../../../../npm/@utoo/lint-wasm/utoo-lint.wasm',
-  import.meta.url,
-).href;
 
 interface RunState {
   phase: RunPhase;
@@ -139,6 +142,10 @@ export default function PlaygroundPage() {
   const [rulesSource, setRulesSource] = useState(
     initialSharePayload?.rulesSource ?? INITIAL_RULES,
   );
+  const [versionCatalog, setVersionCatalog] =
+    useState<LintVersionCatalog>();
+  const [lintVersion, setLintVersion] = useState('');
+  const [versionError, setVersionError] = useState<string>();
   const [runState, setRunState] = useState<RunState>(EMPTY_RUN_STATE);
   const [astState, setASTState] = useState<ASTState>(EMPTY_AST_STATE);
   const [shareState, setShareState] = useState<ShareState>('idle');
@@ -162,6 +169,33 @@ export default function PlaygroundPage() {
   const source = sources[language];
   const fileName = fileNameForLanguage(language);
   const monacoLanguage = monacoLanguageForLanguage(language);
+  const selectedLintVersion = versionCatalog?.versions.find(
+    ({ id }) => id === lintVersion,
+  );
+
+  useEffect(() => {
+    let active = true;
+    const manifestUrl = lintVersionManifestUrl(window.location.href);
+    void loadLintVersionCatalog(manifestUrl)
+      .then((catalog) => {
+        if (!active) return;
+        setVersionCatalog(catalog);
+        setLintVersion(initialLintVersion(catalog, window.location.href));
+        setVersionError(undefined);
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unable to load Playground versions.';
+        setVersionError(message);
+        setRunState({ phase: 'error', message });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const execute = useCallback(
     async (
@@ -169,6 +203,14 @@ export default function PlaygroundPage() {
       requestId = ++latestRequestRef.current,
     ) => {
       if (requestId !== latestRequestRef.current) return;
+
+      if (!selectedLintVersion) {
+        setRunState({
+          phase: 'error',
+          message: versionError ?? 'The lint version is not ready.',
+        });
+        return;
+      }
 
       if (rulesMode === 'custom' && !parsedRules.ok) {
         setRunState({ phase: 'error', message: parsedRules.message });
@@ -190,7 +232,7 @@ export default function PlaygroundPage() {
                   ? parsedRules.rules
                   : {},
           },
-          LINT_WASM_URL,
+          selectedLintVersion.wasmUrl,
         );
 
         if (!result || requestId !== latestRequestRef.current) return;
@@ -215,10 +257,19 @@ export default function PlaygroundPage() {
         });
       }
     },
-    [fileName, language, parsedRules, rulesMode, source],
+    [
+      fileName,
+      language,
+      parsedRules,
+      rulesMode,
+      selectedLintVersion,
+      source,
+      versionError,
+    ],
   );
 
   useEffect(() => {
+    if (!selectedLintVersion) return;
     const requestId = ++latestRequestRef.current;
     clientRef.current?.cancelQueued();
     setRunState(EMPTY_RUN_STATE);
@@ -386,6 +437,26 @@ export default function PlaygroundPage() {
     invalidateShareUrl();
     setRunState(EMPTY_RUN_STATE);
     setLanguage(nextLanguage);
+  };
+
+  const selectLintVersion = (nextVersion: string) => {
+    if (!versionCatalog) return;
+    const definition = versionCatalog.versions.find(
+      ({ id }) => id === nextVersion,
+    );
+    if (!definition || definition.id === lintVersion) return;
+
+    setRunState(EMPTY_RUN_STATE);
+    setLintVersion(definition.id);
+    window.history.replaceState(
+      null,
+      '',
+      lintVersionUrl(
+        window.location.href,
+        definition.id,
+        versionCatalog.latest,
+      ),
+    );
   };
 
   const sharePlayground = async () => {
@@ -565,13 +636,40 @@ export default function PlaygroundPage() {
           <button
             aria-label={fixButtonLabel}
             className="fix-button"
-            disabled={isRetry ? !hasValidRules : !canFix}
+            disabled={
+              !selectedLintVersion || (isRetry ? !hasValidRules : !canFix)
+            }
             onClick={() => void execute(isRetry ? 'lint' : 'fix')}
             title={fixButtonLabel}
             type="button"
           >
             {fixButtonText}
           </button>
+
+          <label className="version-control">
+            <span className="version-control-label">Version</span>
+            <span className="select-wrap">
+              <select
+                aria-label="Utoo Lint version"
+                disabled={!versionCatalog}
+                onChange={(event) => selectLintVersion(event.target.value)}
+                title={versionError}
+                value={lintVersion}
+              >
+                {!versionCatalog && (
+                  <option value="">
+                    {versionError ? 'Unavailable' : 'Loading…'}
+                  </option>
+                )}
+                {versionCatalog?.versions.map((version) => (
+                  <option key={version.id} value={version.id}>
+                    {version.label}
+                    {version.id === versionCatalog.latest ? ' (latest)' : ''}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
 
           <button
             aria-label="Share this playground"

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -347,6 +347,68 @@ select:focus-visible {
   margin-left: auto;
 }
 
+.version-control {
+  display: inline-flex;
+  min-height: 30px;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+  padding: 0 7px 0 9px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: transparent;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.version-control:hover,
+.version-control:focus-within {
+  border-color: #3a4047;
+  background: var(--surface-raised);
+}
+
+.version-control-label {
+  color: var(--muted-subtle);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.version-control .select-wrap::after {
+  right: 1px;
+}
+
+.version-control select {
+  width: 102px;
+  height: 28px;
+  padding: 0 15px 0 0;
+  appearance: none;
+  border: 0;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 550;
+}
+
+.version-control select:focus-visible {
+  outline-width: 1px;
+  outline-offset: 1px;
+}
+
+.version-control select:disabled {
+  color: var(--muted-subtle);
+  cursor: wait;
+}
+
+.version-control option {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+
 .fix-button,
 .share-button {
   display: inline-flex;

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createReadStream } from 'node:fs';
-import { access, stat } from 'node:fs/promises';
+import { access, readFile, stat } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -153,6 +153,12 @@ async function waitForSettledPage(page) {
 }
 
 async function runSmoke(page, origin) {
+  const versionManifest = JSON.parse(
+    await readFile(
+      path.join(siteRoot, 'playground', 'versions', 'manifest.json'),
+      'utf8',
+    ),
+  );
   const issues = [];
   let stage = 'startup';
   const report = (kind, detail) => issues.push(`[${stage}] ${kind}: ${detail}`);
@@ -235,6 +241,21 @@ async function runSmoke(page, origin) {
       undefined,
       { timeout: 30_000 },
     );
+    const versionSelect = page.getByRole('combobox', {
+      name: 'Utoo Lint version',
+    });
+    await versionSelect.waitFor();
+    assert.equal(await versionSelect.inputValue(), versionManifest.latest);
+
+    const previousVersion = versionManifest.versions[1]?.id;
+    if (previousVersion) {
+      await versionSelect.selectOption(previousVersion);
+      await page.waitForURL(
+        (url) => url.searchParams.get('version') === previousVersion,
+      );
+      await versionSelect.selectOption(versionManifest.latest);
+      await page.waitForURL((url) => !url.searchParams.has('version'));
+    }
 
     // Let late worker/resource errors reach the event handlers before leaving
     // the standalone Playground document.

--- a/scripts/stage-playground-wasm.mjs
+++ b/scripts/stage-playground-wasm.mjs
@@ -1,9 +1,13 @@
 import { createHash } from 'node:crypto';
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gunzipSync } from 'node:zlib';
 
-const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
 const packagePath = path.join(
   rootDir,
   'npm',
@@ -11,18 +15,195 @@ const packagePath = path.join(
   'lint-wasm',
   'utoo-lint.wasm',
 );
-const releaseUrl =
-  'https://github.com/utooland/utoo-lint/releases/download/v0.3.0/utoo-lint.wasm';
-const expectedSha256 =
-  '535dcb3da3878e2a89ddbc0e8a4a86cd895d2da0e711ec37b6de08807348c1ce';
+const versionsDir = path.join(
+  rootDir,
+  'apps',
+  'playground',
+  'public',
+  'versions',
+);
+const releasesUrl =
+  'https://api.github.com/repos/utooland/utoo-lint/releases?per_page=100';
+const releaseAssetName = 'utoo-lint.wasm';
+const compressedAssetName = `${releaseAssetName}.gz`;
+const maxVersions = 10;
 
 function sha256(contents) {
   return createHash('sha256').update(contents).digest('hex');
 }
 
-async function readCachedRelease() {
+function githubHeaders() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'utoo-lint-playground-build',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function githubAssetHeaders() {
+  return {
+    ...githubHeaders(),
+    Accept: 'application/octet-stream',
+  };
+}
+
+async function fetchChecked(url, options) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(url, { redirect: 'follow', ...options });
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (response?.ok) return response;
+    if (response) {
+      lastError = new Error(
+        `failed to download ${url}: ${response.status} ${response.statusText}`,
+      );
+      if (response.status !== 429 && response.status < 500) throw lastError;
+    }
+
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1_000));
+    }
+  }
+  throw lastError;
+}
+
+async function expectedDigest(release, asset) {
+  const digest = asset.digest?.match(/^sha256:([a-f0-9]{64})$/i)?.[1];
+  if (digest) return digest.toLowerCase();
+
+  const checksumAsset = release.assets.find(
+    (candidate) => candidate.name === `${releaseAssetName}.sha256`,
+  );
+  if (!checksumAsset) {
+    throw new Error(
+      `${release.tag_name} is missing a SHA-256 digest for ${releaseAssetName}`,
+    );
+  }
+
+  const checksum = await (
+    await fetchChecked(checksumAsset.url, {
+      headers: githubAssetHeaders(),
+    })
+  ).text();
+  const match = checksum.match(/\b([a-f0-9]{64})\b/i);
+  if (!match) {
+    throw new Error(`invalid ${release.tag_name} ${releaseAssetName}.sha256`);
+  }
+  return match[1].toLowerCase();
+}
+
+function isStableVersionTag(tagName) {
+  return /^v\d+\.\d+\.\d+$/.test(tagName);
+}
+
+function compareStableVersionsDescending(left, right) {
+  const leftParts = left.tag_name.slice(1).split('.').map(Number);
+  const rightParts = right.tag_name.slice(1).split('.').map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return rightParts[index] - leftParts[index];
+    }
+  }
+  return 0;
+}
+
+async function discoverVersions() {
+  const response = await fetchChecked(releasesUrl, {
+    headers: githubHeaders(),
+  });
+  const releases = await response.json();
+  if (!Array.isArray(releases)) {
+    throw new Error('GitHub releases response was not an array');
+  }
+
+  const candidates = releases
+    .filter(
+      (release) =>
+        !release.draft &&
+        !release.prerelease &&
+        isStableVersionTag(release.tag_name) &&
+        release.assets?.some((asset) => asset.name === releaseAssetName),
+    )
+    .sort(compareStableVersionsDescending)
+    .slice(0, maxVersions);
+
+  if (candidates.length === 0) {
+    throw new Error(`no stable GitHub release contains ${releaseAssetName}`);
+  }
+
+  return Promise.all(
+    candidates.map(async (release) => {
+      const asset = release.assets.find(
+        (candidate) => candidate.name === releaseAssetName,
+      );
+      const compressedAsset = release.assets.find(
+        (candidate) => candidate.name === compressedAssetName,
+      );
+      return {
+        id: release.tag_name.slice(1),
+        label: release.tag_name,
+        publishedAt: release.published_at,
+        asset,
+        downloadAsset: compressedAsset ?? asset,
+        compressed: Boolean(compressedAsset),
+        sha256: await expectedDigest(release, asset),
+      };
+    }),
+  );
+}
+
+async function discoverCachedVersions() {
+  const manifest = JSON.parse(
+    await readFile(path.join(versionsDir, 'manifest.json'), 'utf8'),
+  );
+  if (
+    !Array.isArray(manifest.versions) ||
+    manifest.versions.length === 0 ||
+    manifest.versions[0]?.id !== manifest.latest ||
+    !manifest.versions.every(
+      (version) =>
+        typeof version.id === 'string' &&
+        isStableVersionTag(`v${version.id}`) &&
+        version.label === `v${version.id}` &&
+        version.file === `utoo-lint-v${version.id}.wasm` &&
+        /^[a-f0-9]{64}$/.test(version.sha256),
+    )
+  ) {
+    throw new Error('cached Playground version manifest is invalid');
+  }
+  return manifest.versions.map((version) => ({
+    ...version,
+    cachedOnly: true,
+  }));
+}
+
+async function discoverVersionsWithLocalFallback() {
   try {
-    const contents = await readFile(packagePath);
+    return await discoverVersions();
+  } catch (error) {
+    if (process.env.CI) throw error;
+    try {
+      const cached = await discoverCachedVersions();
+      console.warn(
+        `unable to refresh GitHub releases; using ${cached.length} cached Playground versions`,
+      );
+      return cached;
+    } catch {
+      throw error;
+    }
+  }
+}
+
+async function readCachedAsset(file, expectedSha256) {
+  try {
+    const contents = await readFile(file);
     return sha256(contents) === expectedSha256 ? contents : undefined;
   } catch (error) {
     if (error?.code === 'ENOENT') return undefined;
@@ -30,24 +211,83 @@ async function readCachedRelease() {
   }
 }
 
-let contents = await readCachedRelease();
-if (!contents) {
-  const response = await fetch(releaseUrl, { redirect: 'follow' });
-  if (!response.ok) {
-    throw new Error(
-      `failed to download utoo-lint v0.3.0 WebAssembly: ${response.status} ${response.statusText}`,
+async function stageVersion(version) {
+  const file = `utoo-lint-v${version.id}.wasm`;
+  const target = path.join(versionsDir, file);
+  let contents = await readCachedAsset(target, version.sha256);
+
+  if (!contents) {
+    if (version.cachedOnly) {
+      throw new Error(
+        `cached ${version.label} WebAssembly is missing or invalid`,
+      );
+    }
+    console.log(
+      `downloading utoo-lint ${version.label} WebAssembly${version.compressed ? ' (gzip)' : ''}`,
     );
+    const downloaded = Buffer.from(
+      await (
+        await fetchChecked(version.downloadAsset.url, {
+          headers: githubAssetHeaders(),
+        })
+      ).arrayBuffer(),
+    );
+    contents = version.compressed ? gunzipSync(downloaded) : downloaded;
+    const actualSha256 = sha256(contents);
+    if (actualSha256 !== version.sha256) {
+      throw new Error(
+        `unexpected ${version.label} WebAssembly SHA-256: ${actualSha256}`,
+      );
+    }
+    if (!contents.subarray(0, 4).equals(Buffer.from([0, 97, 115, 109]))) {
+      throw new Error(`invalid ${version.label} WebAssembly module`);
+    }
+    await writeFile(target, contents, { mode: 0o644 });
   }
 
-  contents = Buffer.from(await response.arrayBuffer());
-  const actualSha256 = sha256(contents);
-  if (actualSha256 !== expectedSha256) {
-    throw new Error(
-      `unexpected utoo-lint v0.3.0 WebAssembly SHA-256: ${actualSha256}`,
-    );
-  }
-
-  await writeFile(packagePath, contents, { mode: 0o644 });
+  return {
+    id: version.id,
+    label: version.label,
+    file,
+    sha256: version.sha256,
+    publishedAt: version.publishedAt,
+    contents,
+  };
 }
 
-console.log(`staged utoo-lint v0.3.0 WebAssembly (${expectedSha256})`);
+await mkdir(versionsDir, { recursive: true });
+const versions = await discoverVersionsWithLocalFallback();
+const expectedFiles = new Set([
+  'manifest.json',
+  ...versions.map(({ id }) => `utoo-lint-v${id}.wasm`),
+]);
+for (const entry of await readdir(versionsDir, { withFileTypes: true })) {
+  if (entry.isFile() && !expectedFiles.has(entry.name)) {
+    await rm(path.join(versionsDir, entry.name));
+  }
+}
+
+const stagedVersions = [];
+for (const version of versions) {
+  stagedVersions.push(await stageVersion(version));
+}
+
+const latest = stagedVersions[0];
+await writeFile(packagePath, latest.contents, { mode: 0o644 });
+await writeFile(
+  path.join(versionsDir, 'manifest.json'),
+  `${JSON.stringify(
+    {
+      latest: latest.id,
+      versions: stagedVersions.map(
+        ({ contents: _contents, ...version }) => version,
+      ),
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+console.log(
+  `staged ${stagedVersions.length} utoo-lint WebAssembly versions; latest is ${latest.label}`,
+);

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { access, readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -734,12 +735,95 @@ for (const match of playgroundIndex.matchAll(/\b(?:href|src)="([^"]+)"/g)) {
 await verifyLocalAssets(playgroundIndex, 'Playground index');
 
 const playgroundFiles = await collectFiles(playgroundDir);
+const versionManifest = JSON.parse(
+  await readFile(
+    await requireFile('playground/versions/manifest.json'),
+    'utf8',
+  ),
+);
+if (
+  typeof versionManifest.latest !== 'string' ||
+  !Array.isArray(versionManifest.versions) ||
+  versionManifest.versions.length === 0 ||
+  versionManifest.versions[0]?.id !== versionManifest.latest
+) {
+  throw new Error('invalid Playground version manifest');
+}
+
 const wasmFiles = playgroundFiles.filter(
   (file) => path.extname(file) === '.wasm',
 );
-if (wasmFiles.length !== 2) {
+if (wasmFiles.length !== versionManifest.versions.length + 2) {
   throw new Error(
-    `expected two Playground WebAssembly assets, found ${wasmFiles.length}`,
+    `expected ${versionManifest.versions.length + 2} Playground WebAssembly assets, found ${wasmFiles.length}`,
+  );
+}
+
+let parserWasm;
+let bundledLintWasm;
+for (const file of wasmFiles) {
+  const name = path.basename(file);
+  const isParser = name.includes('yuku-parser');
+  const isLintVersion = /^utoo-lint-v\d+\.\d+\.\d+\.wasm$/.test(name);
+  const isBundledLint = /^utoo-lint\.[^.]+\.wasm$/.test(name);
+  if (!isParser && !isLintVersion && !isBundledLint) {
+    throw new Error(`unexpected Playground WebAssembly asset: ${name}`);
+  }
+
+  const contents = await readFile(file);
+  if (
+    contents.length === 0 ||
+    !contents.subarray(0, 4).equals(Buffer.from([0, 97, 115, 109]))
+  ) {
+    throw new Error(`invalid Playground WebAssembly asset: ${name}`);
+  }
+  if (isParser) {
+    if (parserWasm) {
+      throw new Error(`duplicate parser WebAssembly asset: ${name}`);
+    }
+    parserWasm = contents;
+  } else if (isBundledLint) {
+    if (bundledLintWasm) {
+      throw new Error(`duplicate bundled lint WebAssembly asset: ${name}`);
+    }
+    bundledLintWasm = contents;
+  }
+}
+
+for (const version of versionManifest.versions) {
+  if (
+    !/^\d+\.\d+\.\d+$/.test(version.id) ||
+    version.label !== `v${version.id}` ||
+    version.file !== `utoo-lint-v${version.id}.wasm` ||
+    !/^[a-f0-9]{64}$/.test(version.sha256)
+  ) {
+    throw new Error(
+      `invalid Playground version entry: ${JSON.stringify(version)}`,
+    );
+  }
+  const contents = await readFile(
+    path.join(playgroundDir, 'versions', version.file),
+  );
+  const actualSha256 = createHash('sha256').update(contents).digest('hex');
+  if (actualSha256 !== version.sha256) {
+    throw new Error(
+      `unexpected ${version.label} WebAssembly SHA-256: ${actualSha256}`,
+    );
+  }
+}
+
+if (!parserWasm) {
+  throw new Error('missing Playground parser WebAssembly asset');
+}
+if (!bundledLintWasm) {
+  throw new Error('missing bundled Playground lint WebAssembly asset');
+}
+const bundledLintSha256 = createHash('sha256')
+  .update(bundledLintWasm)
+  .digest('hex');
+if (bundledLintSha256 !== versionManifest.versions[0].sha256) {
+  throw new Error(
+    `bundled lint WebAssembly does not match latest ${versionManifest.versions[0].label}`,
   );
 }
 for (const controlFile of ['_headers', '_redirects']) {


### PR DESCRIPTION
## Summary

- restore the Playground lint version selector and default it to the latest stable GitHub release
- stage and verify the latest ten release WASM assets, while preserving older selections in the URL
- redeploy the site automatically after successful Release workflow runs
- extend build audits and browser smoke coverage for versioned WASM assets

## Verification

- pnpm --filter @utoo/lint-playground test
- pnpm playground:typecheck
- pnpm --filter @utoo/lint-playground inspect
- pnpm site:build
- pnpm site:smoke
- manual browser checks for latest and previous version selection