### PR TITLE
feat(playground): default to latest lint version

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -31,10 +31,11 @@ previously verified local manifest and its cached assets are reused:
 pnpm playground:dev
 ```
 
-The newest stable version is selected by default. Selecting an older version
-adds `?version=<version>` to the Playground URL so the same engine can be
-reopened or shared. The Utoopack development URL is printed in the terminal.
-Open the `/playground` route rather than the server root.
+The `latest` channel is selected by default and follows the newest stable
+version. Selecting a concrete version adds `?version=<version>` to the
+Playground URL so the same engine can be reopened or shared even after a newer
+release. The Utoopack development URL is printed in the terminal. Open the
+`/playground` route rather than the server root.
 
 ## Verify and build
 

--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -69,9 +69,11 @@ const {
 );
 const {
   initialLintVersion,
+  LATEST_LINT_VERSION,
   lintVersionManifestUrl,
   lintVersionUrl,
   parseLintVersionCatalog,
+  resolveLintVersion,
 } = await import(
   pathToFileURL(join(outputDirectory, 'playground', 'versions.js')).href
 );
@@ -239,7 +241,7 @@ test('loads versioned WebAssembly URLs and defaults to the latest release', () =
   );
   assert.equal(
     initialLintVersion(catalog, 'https://example.test/playground/'),
-    '0.3.4',
+    LATEST_LINT_VERSION,
   );
   assert.equal(
     initialLintVersion(
@@ -253,16 +255,17 @@ test('loads versioned WebAssembly URLs and defaults to the latest release', () =
       catalog,
       'https://example.test/playground/?version=0.2.9',
     ),
-    '0.3.4',
+    LATEST_LINT_VERSION,
   );
+  assert.equal(resolveLintVersion(catalog, LATEST_LINT_VERSION)?.id, '0.3.4');
+  assert.equal(resolveLintVersion(catalog, '0.3.3')?.id, '0.3.3');
 });
 
-test('keeps old version selections in the URL but leaves latest implicit', () => {
+test('pins concrete version selections but leaves the latest channel implicit', () => {
   assert.equal(
     lintVersionUrl(
       'https://example.test/playground/?theme=dark#playground=state',
       '0.3.3',
-      '0.3.4',
     ),
     'https://example.test/playground/?theme=dark&version=0.3.3#playground=state',
   );
@@ -270,7 +273,13 @@ test('keeps old version selections in the URL but leaves latest implicit', () =>
     lintVersionUrl(
       'https://example.test/playground/?theme=dark&version=0.3.3#playground=state',
       '0.3.4',
-      '0.3.4',
+    ),
+    'https://example.test/playground/?theme=dark&version=0.3.4#playground=state',
+  );
+  assert.equal(
+    lintVersionUrl(
+      'https://example.test/playground/?theme=dark&version=0.3.3#playground=state',
+      LATEST_LINT_VERSION,
     ),
     'https://example.test/playground/?theme=dark#playground=state',
   );

--- a/apps/playground/src/features/playground/versions.ts
+++ b/apps/playground/src/features/playground/versions.ts
@@ -24,6 +24,8 @@ interface VersionManifest {
 const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 
+export const LATEST_LINT_VERSION = 'latest';
+
 function isManifestVersion(value: unknown): value is ManifestVersion {
   if (!value || typeof value !== 'object') return false;
   const version = value as Partial<ManifestVersion>;
@@ -94,16 +96,24 @@ export function initialLintVersion(
   const requested = new URL(currentUrl).searchParams.get('version');
   return catalog.versions.some(({ id }) => id === requested)
     ? requested!
-    : catalog.latest;
+    : LATEST_LINT_VERSION;
+}
+
+export function resolveLintVersion(
+  catalog: LintVersionCatalog,
+  selection: string,
+): LintVersionDefinition | undefined {
+  const version =
+    selection === LATEST_LINT_VERSION ? catalog.latest : selection;
+  return catalog.versions.find(({ id }) => id === version);
 }
 
 export function lintVersionUrl(
   currentUrl: string,
   version: string,
-  latest: string,
 ): string {
   const url = new URL(currentUrl);
-  if (version === latest) url.searchParams.delete('version');
+  if (version === LATEST_LINT_VERSION) url.searchParams.delete('version');
   else url.searchParams.set('version', version);
   return url.href;
 }

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -35,9 +35,11 @@ import '../features/playground/monaco';
 import { Splitter } from '../features/playground/splitter';
 import {
   initialLintVersion,
+  LATEST_LINT_VERSION,
   lintVersionManifestUrl,
   lintVersionUrl,
   loadLintVersionCatalog,
+  resolveLintVersion,
   type LintVersionCatalog,
 } from '../features/playground/versions';
 import '../style.css';
@@ -169,9 +171,9 @@ export default function PlaygroundPage() {
   const source = sources[language];
   const fileName = fileNameForLanguage(language);
   const monacoLanguage = monacoLanguageForLanguage(language);
-  const selectedLintVersion = versionCatalog?.versions.find(
-    ({ id }) => id === lintVersion,
-  );
+  const selectedLintVersion = versionCatalog
+    ? resolveLintVersion(versionCatalog, lintVersion)
+    : undefined;
 
   useEffect(() => {
     let active = true;
@@ -441,21 +443,15 @@ export default function PlaygroundPage() {
 
   const selectLintVersion = (nextVersion: string) => {
     if (!versionCatalog) return;
-    const definition = versionCatalog.versions.find(
-      ({ id }) => id === nextVersion,
-    );
-    if (!definition || definition.id === lintVersion) return;
+    const definition = resolveLintVersion(versionCatalog, nextVersion);
+    if (!definition || nextVersion === lintVersion) return;
 
     setRunState(EMPTY_RUN_STATE);
-    setLintVersion(definition.id);
+    setLintVersion(nextVersion);
     window.history.replaceState(
       null,
       '',
-      lintVersionUrl(
-        window.location.href,
-        definition.id,
-        versionCatalog.latest,
-      ),
+      lintVersionUrl(window.location.href, nextVersion),
     );
   };
 
@@ -661,10 +657,14 @@ export default function PlaygroundPage() {
                     {versionError ? 'Unavailable' : 'Loading…'}
                   </option>
                 )}
+                {versionCatalog && (
+                  <option value={LATEST_LINT_VERSION}>
+                    latest (v{versionCatalog.latest})
+                  </option>
+                )}
                 {versionCatalog?.versions.map((version) => (
                   <option key={version.id} value={version.id}>
                     {version.label}
-                    {version.id === versionCatalog.latest ? ' (latest)' : ''}
                   </option>
                 ))}
               </select>

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -245,7 +245,7 @@ async function runSmoke(page, origin) {
       name: 'Utoo Lint version',
     });
     await versionSelect.waitFor();
-    assert.equal(await versionSelect.inputValue(), versionManifest.latest);
+    assert.equal(await versionSelect.inputValue(), 'latest');
 
     const previousVersion = versionManifest.versions[1]?.id;
     if (previousVersion) {
@@ -254,6 +254,10 @@ async function runSmoke(page, origin) {
         (url) => url.searchParams.get('version') === previousVersion,
       );
       await versionSelect.selectOption(versionManifest.latest);
+      await page.waitForURL(
+        (url) => url.searchParams.get('version') === versionManifest.latest,
+      );
+      await versionSelect.selectOption('latest');
       await page.waitForURL((url) => !url.searchParams.has('version'));
     }
 


### PR DESCRIPTION
## Summary

- add an explicit latest channel to the Playground version selector
- select latest by default and resolve it through the current version manifest
- keep concrete version selections pinned in the URL for reproducible links

## Verification

- pnpm --filter @utoo/lint-playground test
- pnpm playground:typecheck
- pnpm --filter @utoo/lint-playground inspect
- pnpm --filter @utoo/lint-playground build
- node scripts/verify-site.mjs
- node scripts/smoke-site.mjs