### PR TITLE
perf(node-api): cache config discovery per invocation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,8 @@ on:
       - "benchmarks/**"
       - "build.zig"
       - "build.zig.zon"
+      - "npm/utoo-lint/index.*"
+      - "npm/utoo-lint/lib/config-loader.*"
       - "src/**"
       - "vendor/yuku/**"
   push:
@@ -18,6 +20,8 @@ on:
       - "benchmarks/**"
       - "build.zig"
       - "build.zig.zon"
+      - "npm/utoo-lint/index.*"
+      - "npm/utoo-lint/lib/config-loader.*"
       - "src/**"
       - "vendor/yuku/**"
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,7 +24,12 @@ including the target file count and the shared rule list used for that run.
 ```bash
 npm run generate -- --files=2000 --statements=40
 npm run bench -- --runs=10 --warmups=3
+npm run bench:config-discovery -- --time=1000 --warmup-time=500
 ```
+
+The config-discovery benchmark models 1,000 lint inputs spread across 100
+package directories. It reports both uncached upward searches and the
+per-invocation directory cache used by the npm wrapper.
 
 The default `utoo-lint` command is `../zig-out/bin/utoo-lint fixtures/src`.
 Override it with:

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate": "node scripts/generate-corpus.mjs",
     "bench": "node scripts/run-benchmark.mjs",
+    "bench:config-discovery": "node scripts/run-codspeed.mjs --config-only",
     "chart": "node scripts/render-chart.mjs",
     "codspeed": "node scripts/run-codspeed.mjs"
   },

--- a/benchmarks/scripts/run-codspeed.mjs
+++ b/benchmarks/scripts/run-codspeed.mjs
@@ -1,21 +1,24 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Bench } from "tinybench";
 import { withCodSpeed } from "@codspeed/tinybench-plugin";
+import { findConfigPath } from "../../npm/utoo-lint/lib/config-loader.js";
 import { benchmarkRuleNames, utooRuleArgs } from "./shared-rules.mjs";
 
 const args = parseArgs(process.argv.slice(2));
+const configOnly = Boolean(args["config-only"]);
 const target = args.target ?? "fixtures/codspeed";
 const time = nonNegativeNumber(args.time, 1000, "time");
 const warmupTime = nonNegativeNumber(args["warmup-time"], 500, "warmup-time");
 const utooBin = process.env.UTOO_LINT_BIN ?? join("..", "zig-out", "bin", process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint");
 
-if (!existsSync(utooBin)) {
+if (!configOnly && !existsSync(utooBin)) {
   throw new Error(`utoo-lint binary was not found at ${utooBin}. Build utoo-lint first.`);
 }
 
-if (!existsSync(target)) {
+if (!configOnly && !existsSync(target)) {
   throw new Error(`benchmark target was not found at ${target}. Run npm run generate first.`);
 }
 
@@ -27,14 +30,27 @@ const bench = withCodSpeed(
   })
 );
 
-bench.add(`utoo-lint/${target}`, () => {
-  runUtooLint(target);
+if (!configOnly) {
+  bench.add(`utoo-lint/${target}`, () => {
+    runUtooLint(target);
+  });
+  console.log(`Rules: ${benchmarkRuleNames().join(", ")}`);
+}
+
+const configFixture = createConfigDiscoveryFixture();
+bench.add("npm-wrapper/config-discovery/uncached-1000-inputs", () => {
+  discoverConfigs(configFixture, false);
+});
+bench.add("npm-wrapper/config-discovery/cached-1000-inputs", () => {
+  discoverConfigs(configFixture, true);
 });
 
-console.log(`Rules: ${benchmarkRuleNames().join(", ")}`);
-
-await bench.run();
-console.table(bench.table());
+try {
+  await bench.run();
+  console.table(bench.table());
+} finally {
+  rmSync(configFixture.root, { recursive: true, force: true });
+}
 
 function runUtooLint(targetPath) {
   const result = spawnSync(utooBin, [...utooRuleArgs(), targetPath], {
@@ -57,6 +73,32 @@ function runUtooLint(targetPath) {
       .filter(Boolean)
       .join("\n");
     throw new Error(`utoo-lint failed with status ${result.status ?? "unknown"}:\n${detail}`);
+  }
+}
+
+function createConfigDiscoveryFixture() {
+  const root = mkdtempSync(join(tmpdir(), "utoo-lint-config-benchmark-"));
+  const configPath = join(root, "utlint.config.json");
+  writeFileSync(configPath, "{}\n");
+  const directories = [];
+
+  for (let packageIndex = 0; packageIndex < 100; packageIndex += 1) {
+    const directory = join(root, "packages", `package-${packageIndex}`, "src", "features");
+    mkdirSync(directory, { recursive: true });
+    for (let fileIndex = 0; fileIndex < 10; fileIndex += 1) {
+      directories.push(directory);
+    }
+  }
+
+  return { configPath, directories, root };
+}
+
+function discoverConfigs(fixture, cached) {
+  const cache = cached ? new Map() : undefined;
+  for (const directory of fixture.directories) {
+    if (findConfigPath(directory, cache) !== fixture.configPath) {
+      throw new Error(`config discovery failed for ${directory}`);
+    }
   }
 }
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -14,6 +14,7 @@ const version = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const MAX_AUTOFIX_PASSES = 10;
+const CONFIG_DISCOVERY_CACHE = Symbol("configDiscoveryCache");
 const JS_KEYWORDS = new Set([
   "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
   "do", "else", "export", "extends", "finally", "for", "function", "if", "import", "in",
@@ -569,7 +570,7 @@ class UtooLint {
   }
 
   async isPathIgnored(filePath) {
-    return isPathIgnored(filePath, mergeLintOptions(this.options, {}));
+    return isPathIgnored(filePath, withConfigCache(mergeLintOptions(this.options, {})));
   }
 
   async calculateConfigForFile(filePath) {
@@ -577,7 +578,7 @@ class UtooLint {
   }
 
   async findConfigFile(filePath) {
-    const options = eslintConstructorOptions(this.options);
+    const options = withConfigCache(eslintConstructorOptions(this.options));
     if (options.noConfig) {
       return undefined;
     }
@@ -711,7 +712,7 @@ class CLIEngine {
   }
 
   isPathIgnored(filePath) {
-    return isPathIgnored(filePath, eslintConstructorOptions(this.options));
+    return isPathIgnored(filePath, withConfigCache(eslintConstructorOptions(this.options)));
   }
 
   getConfigForFile(filePath) {
@@ -1509,9 +1510,17 @@ function mergeLintOptions(base, override) {
 }
 
 function withConfigCache(options) {
-  // Executable configs are otherwise re-evaluated at every per-file lookup.
-  // Keep the cache on the options object so one public invocation shares it.
-  return options.configCache ? options : { ...options, configCache: new Map() };
+  if (options.configCache && options[CONFIG_DISCOVERY_CACHE]) {
+    return options;
+  }
+
+  return {
+    ...options,
+    // Executable configs are otherwise re-evaluated at every per-file lookup.
+    configCache: options.configCache ?? new Map(),
+    // Discovery results must not survive into a later public invocation.
+    [CONFIG_DISCOVERY_CACHE]: new Map()
+  };
 }
 
 function eslintConstructorOptions(options) {
@@ -1852,7 +1861,7 @@ function configPathForOptions(options) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  return configPathFromDirectory(cwd);
+  return configPathFromDirectory(cwd, options);
 }
 
 function configPathForFile(options, filePath) {
@@ -1862,7 +1871,7 @@ function configPathForFile(options, filePath) {
   if (options.config) {
     return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
-  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd));
+  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd), options);
 }
 
 function configSearchDirectoryForFile(filePath, cwd) {
@@ -1877,8 +1886,8 @@ function configSearchDirectoryForFile(filePath, cwd) {
   return dirname(absolute);
 }
 
-function configPathFromDirectory(directory) {
-  return findConfigPathFromDirectory(directory);
+function configPathFromDirectory(directory, options) {
+  return findConfigPathFromDirectory(directory, options[CONFIG_DISCOVERY_CACHE]);
 }
 
 function withTemporaryConfig(options, callback) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -17,6 +17,7 @@ export const version = JSON.parse(readFileSync(new URL("./package.json", import.
 
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const MAX_AUTOFIX_PASSES = 10;
+const CONFIG_DISCOVERY_CACHE = Symbol("configDiscoveryCache");
 const JS_KEYWORDS = new Set([
   "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
   "do", "else", "export", "extends", "finally", "for", "function", "if", "import", "in",
@@ -572,7 +573,7 @@ export class UtooLint {
   }
 
   async isPathIgnored(filePath) {
-    return isPathIgnored(filePath, mergeLintOptions(this.options, {}));
+    return isPathIgnored(filePath, withConfigCache(mergeLintOptions(this.options, {})));
   }
 
   async calculateConfigForFile(filePath) {
@@ -580,7 +581,7 @@ export class UtooLint {
   }
 
   async findConfigFile(filePath) {
-    const options = eslintConstructorOptions(this.options);
+    const options = withConfigCache(eslintConstructorOptions(this.options));
     if (options.noConfig) {
       return undefined;
     }
@@ -2600,7 +2601,7 @@ export class CLIEngine {
   }
 
   isPathIgnored(filePath) {
-    return isPathIgnored(filePath, eslintConstructorOptions(this.options));
+    return isPathIgnored(filePath, withConfigCache(eslintConstructorOptions(this.options)));
   }
 
   getConfigForFile(filePath) {
@@ -3398,9 +3399,17 @@ function mergeLintOptions(base, override) {
 }
 
 function withConfigCache(options) {
-  // Executable configs are otherwise re-evaluated at every per-file lookup.
-  // Keep the cache on the options object so one public invocation shares it.
-  return options.configCache ? options : { ...options, configCache: new Map() };
+  if (options.configCache && options[CONFIG_DISCOVERY_CACHE]) {
+    return options;
+  }
+
+  return {
+    ...options,
+    // Executable configs are otherwise re-evaluated at every per-file lookup.
+    configCache: options.configCache ?? new Map(),
+    // Discovery results must not survive into a later public invocation.
+    [CONFIG_DISCOVERY_CACHE]: new Map()
+  };
 }
 
 function eslintConstructorOptions(options) {
@@ -3741,7 +3750,7 @@ function configPathForOptions(options) {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  return configPathFromDirectory(cwd);
+  return configPathFromDirectory(cwd, options);
 }
 
 function configPathForFile(options, filePath) {
@@ -3751,7 +3760,7 @@ function configPathForFile(options, filePath) {
   if (options.config) {
     return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
-  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd));
+  return configPathFromDirectory(configSearchDirectoryForFile(filePath, options.cwd), options);
 }
 
 function configSearchDirectoryForFile(filePath, cwd) {
@@ -3766,8 +3775,8 @@ function configSearchDirectoryForFile(filePath, cwd) {
   return dirname(absolute);
 }
 
-function configPathFromDirectory(directory) {
-  return findConfigPathFromDirectory(directory);
+function configPathFromDirectory(directory, options) {
+  return findConfigPathFromDirectory(directory, options[CONFIG_DISCOVERY_CACHE]);
 }
 
 function withTemporaryConfig(options, callback) {

--- a/npm/utoo-lint/lib/config-loader.cjs
+++ b/npm/utoo-lint/lib/config-loader.cjs
@@ -13,21 +13,34 @@ const TYPESCRIPT_CONFIG_EXTENSIONS = new Set([".ts", ".mts", ".cts"]);
 const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const loaderPath = join(__dirname, "load-config.js");
 
-function findConfigPath(directory) {
+function findConfigPath(directory, cache) {
   let current = resolvePath(directory);
+  const visited = [];
   while (true) {
+    if (cache?.has(current)) {
+      return cacheConfigPath(cache, visited, cache.get(current));
+    }
+
+    visited.push(current);
     for (const filename of CONFIG_FILENAMES) {
       const candidate = resolvePath(current, filename);
       if (isFile(candidate)) {
-        return candidate;
+        return cacheConfigPath(cache, visited, candidate);
       }
     }
     const parent = dirname(current);
     if (parent === current) {
-      return undefined;
+      return cacheConfigPath(cache, visited, undefined);
     }
     current = parent;
   }
+}
+
+function cacheConfigPath(cache, directories, configPath) {
+  for (const directory of directories) {
+    cache?.set(directory, configPath);
+  }
+  return configPath;
 }
 
 function isFile(path) {

--- a/npm/utoo-lint/lib/config-loader.js
+++ b/npm/utoo-lint/lib/config-loader.js
@@ -14,21 +14,34 @@ const TYPESCRIPT_CONFIG_EXTENSIONS = new Set([".ts", ".mts", ".cts"]);
 const JAVASCRIPT_CONFIG_EXTENSIONS = new Set([".js", ".mjs", ".cjs"]);
 const loaderPath = fileURLToPath(new URL("./load-config.js", import.meta.url));
 
-export function findConfigPath(directory) {
+export function findConfigPath(directory, cache) {
   let current = resolvePath(directory);
+  const visited = [];
   while (true) {
+    if (cache?.has(current)) {
+      return cacheConfigPath(cache, visited, cache.get(current));
+    }
+
+    visited.push(current);
     for (const filename of CONFIG_FILENAMES) {
       const candidate = resolvePath(current, filename);
       if (isFile(candidate)) {
-        return candidate;
+        return cacheConfigPath(cache, visited, candidate);
       }
     }
     const parent = dirname(current);
     if (parent === current) {
-      return undefined;
+      return cacheConfigPath(cache, visited, undefined);
     }
     current = parent;
   }
+}
+
+function cacheConfigPath(cache, directories, configPath) {
+  for (const directory of directories) {
+    cache?.set(directory, configPath);
+  }
+  return configPath;
 }
 
 function isFile(path) {

--- a/npm/utoo-lint/test/config-discovery.test.mjs
+++ b/npm/utoo-lint/test/config-discovery.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import fs, { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { ESLint, lintFiles, resolveBinary } from "../index.js";
+import { CONFIG_FILENAMES, findConfigPath } from "../lib/config-loader.js";
+
+const require = createRequire(import.meta.url);
+const { findConfigPath: findCommonJSConfigPath } = require("../lib/config-loader.cjs");
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const builtBinary = resolve(
+  packageDirectory,
+  "..",
+  "..",
+  "zig-out",
+  "bin",
+  process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint"
+);
+
+function testBinary() {
+  return fs.existsSync(builtBinary) ? builtBinary : resolveBinary();
+}
+
+function createProject(t) {
+  const project = mkdtempSync(join(tmpdir(), "utoo-lint-config-discovery-"));
+  t.after(() => rmSync(project, { recursive: true, force: true }));
+  return project;
+}
+
+function write(path, source = "{}\n") {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, source);
+  return path;
+}
+
+function countConfigStatCalls(callback) {
+  const originalStatSync = fs.statSync;
+  let count = 0;
+  fs.statSync = (path, ...args) => {
+    if (CONFIG_FILENAMES.includes(basename(path))) {
+      count += 1;
+    }
+    return originalStatSync(path, ...args);
+  };
+  syncBuiltinESMExports();
+
+  try {
+    const value = callback();
+    return { count, value };
+  } finally {
+    fs.statSync = originalStatSync;
+    syncBuiltinESMExports();
+  }
+}
+
+for (const [format, findConfig] of [
+  ["ESM", findConfigPath],
+  ["CommonJS", findCommonJSConfigPath]
+]) {
+  test(`${format} config discovery memoizes hits for visited and sibling directories`, (t) => {
+    const project = createProject(t);
+    const firstDirectory = join(project, "packages", "first", "src");
+    const siblingDirectory = join(project, "packages", "second", "src");
+    mkdirSync(firstDirectory, { recursive: true });
+    mkdirSync(siblingDirectory, { recursive: true });
+    const configPath = write(join(project, "utlint.config.json"));
+    const cache = new Map();
+
+    assert.equal(findConfig(firstDirectory, cache), configPath);
+    for (const directory of [
+      firstDirectory,
+      dirname(firstDirectory),
+      join(project, "packages"),
+      project
+    ]) {
+      assert.equal(cache.get(directory), configPath, directory);
+    }
+
+    rmSync(configPath);
+    assert.equal(findConfig(siblingDirectory, cache), configPath);
+    assert.equal(cache.get(siblingDirectory), configPath);
+    assert.equal(findConfig(siblingDirectory, new Map()), undefined);
+  });
+
+  test(`${format} config discovery memoizes negative ancestor results`, (t) => {
+    const project = createProject(t);
+    const firstDirectory = join(project, "packages", "first", "src");
+    const siblingDirectory = join(project, "packages", "second", "src");
+    mkdirSync(firstDirectory, { recursive: true });
+    mkdirSync(siblingDirectory, { recursive: true });
+    const cache = new Map();
+
+    assert.equal(findConfig(firstDirectory, cache), undefined);
+    assert.equal(cache.has(firstDirectory), true);
+    assert.equal(cache.has(join(project, "packages")), true);
+    const configPath = write(join(project, "utlint.config.ts"), "export default {};\n");
+
+    assert.equal(findConfig(siblingDirectory, cache), undefined);
+    assert.equal(cache.has(siblingDirectory), true);
+    assert.equal(findConfig(siblingDirectory, new Map()), configPath);
+  });
+}
+
+test("cached config discovery preserves nearest-directory and filename precedence", (t) => {
+  const project = createProject(t);
+  const rootJson = write(join(project, "utlint.config.json"));
+  const rootTypeScript = write(join(project, "utlint.config.ts"), "export default {};\n");
+  const nestedDirectory = join(project, "packages", "app", "src");
+  const nestedConfig = write(join(project, "packages", "app", "utoo-lint.json"));
+  mkdirSync(nestedDirectory, { recursive: true });
+
+  assert.equal(findConfigPath(project, new Map()), rootTypeScript);
+  assert.notEqual(rootJson, rootTypeScript);
+  assert.equal(findConfigPath(nestedDirectory, new Map()), nestedConfig);
+});
+
+test("one lint invocation discovers a shared config only once", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.ts"),
+    'export default { rules: { "no-debugger": "off" } };\n'
+  );
+  const firstSource = write(join(project, "src", "first.js"), "debugger;\n");
+  const secondSource = write(join(project, "src", "second.js"), "debugger;\n");
+  const options = { binary: testBinary(), cwd: project };
+
+  const first = countConfigStatCalls(() => lintFiles([firstSource, secondSource], options));
+  const second = countConfigStatCalls(() => lintFiles([firstSource, secondSource], options));
+
+  assert.equal(first.value.files, 2);
+  assert.equal(second.value.files, 2);
+  assert.equal(first.count, CONFIG_FILENAMES.length + 1);
+  assert.equal(second.count, CONFIG_FILENAMES.length + 1);
+});
+
+test("separate public config lookups observe config changes", async (t) => {
+  const project = createProject(t);
+  const editorDirectory = join(project, "packages", "editor", "src");
+  mkdirSync(editorDirectory, { recursive: true });
+  const nonexistentEditorFile = join(editorDirectory, "unsaved.ts");
+  const eslint = new ESLint({ cwd: project });
+
+  assert.equal(await eslint.findConfigFile(nonexistentEditorFile), undefined);
+  const configPath = write(join(project, "utlint.config.json"));
+  assert.equal(await eslint.findConfigFile(nonexistentEditorFile), configPath);
+  rmSync(configPath);
+  assert.equal(await eslint.findConfigFile(nonexistentEditorFile), undefined);
+});
+
+test("explicit and disabled config options bypass automatic discovery", async (t) => {
+  const project = createProject(t);
+  write(join(project, "utlint.config.ts"), "export default {};\n");
+  const explicitConfig = write(join(project, "configs", "explicit.json"));
+  const sourcePath = join(project, "src", "unsaved.ts");
+
+  const explicit = new ESLint({ cwd: project, overrideConfigFile: explicitConfig });
+  assert.equal(await explicit.findConfigFile(sourcePath), explicitConfig);
+
+  const disabled = new ESLint({ cwd: project, overrideConfigFile: true });
+  assert.equal(await disabled.findConfigFile(sourcePath), undefined);
+});


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- cache nearest config discovery by normalized absolute directory within one public lint invocation
- memoize both hits and misses across every visited ancestor while preserving nearest-config and filename precedence
- keep discovery caches private and fresh across independent ESLint, CLIEngine, CLI, lintFiles, and lintText calls
- add deterministic filesystem-probe tests plus a 1,000-input CodSpeed regression benchmark

## Verification

- zig build
- pnpm --filter @utoo/lint test
- pnpm --dir benchmarks bench:config-discovery -- --time=100 --warmup-time=20
- pnpm --dir benchmarks codspeed -- --target=fixtures/codspeed-smoke --time=50 --warmup-time=10

Local config-discovery benchmark: cached ~8-9 ms vs uncached ~94-102 ms for 1,000 inputs.

Fixes #1186