### PR TITLE
perf(node-api): use rules fast path for severity configs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,3 +59,13 @@ npm run bench -- --skip-eslint
   `no-unsafe-negation`.
 - The runner measures wall-clock time for fresh CLI processes. Editor daemon
   behavior, caches, and type-aware ESLint rules are intentionally out of scope.
+
+## Node API severity-config benchmark
+
+CodSpeed also runs a `CLIEngine` workload modeled after Umi: 1,000 TypeScript
+files across 100 package directories with a large flat config containing only
+rule severities. Run a smaller local sample with:
+
+```bash
+pnpm codspeed:severity-config -- --files=100 --runs=3 --warmups=1
+```

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -8,7 +8,8 @@
     "bench": "node scripts/run-benchmark.mjs",
     "bench:config-discovery": "node scripts/run-codspeed.mjs --config-only",
     "chart": "node scripts/render-chart.mjs",
-    "codspeed": "node scripts/run-codspeed.mjs"
+    "codspeed": "node scripts/run-all-codspeed.mjs",
+    "codspeed:severity-config": "node scripts/run-severity-config-codspeed.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/benchmarks/scripts/run-all-codspeed.mjs
+++ b/benchmarks/scripts/run-all-codspeed.mjs
@@ -1,0 +1,2 @@
+await import("./run-codspeed.mjs");
+await import("./run-severity-config-codspeed.mjs");

--- a/benchmarks/scripts/run-severity-config-codspeed.mjs
+++ b/benchmarks/scripts/run-severity-config-codspeed.mjs
@@ -1,0 +1,113 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Bench } from "tinybench";
+import { withCodSpeed } from "@codspeed/tinybench-plugin";
+import { CLIEngine, Linter } from "../../npm/utoo-lint/index.js";
+import { benchmarkRuleNames } from "./shared-rules.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const fileCount = positiveInt(args.files, 1000, "files");
+const runs = positiveInt(args.runs, 8, "runs");
+const warmups = nonNegativeInt(args.warmups, 2, "warmups");
+const utooBin = resolve(
+  process.env.UTOO_LINT_BIN ?? join("..", "zig-out", "bin", process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint")
+);
+
+if (!existsSync(utooBin)) {
+  throw new Error(`utoo-lint binary was not found at ${utooBin}. Build utoo-lint first.`);
+}
+
+const fixture = createFixture(fileCount);
+const severityOnly = createEngine(fixture);
+const bench = withCodSpeed(new Bench({
+  iterations: runs,
+  time: 0,
+  throws: true,
+  warmup: warmups > 0,
+  warmupIterations: warmups,
+  warmupTime: 0
+}));
+
+bench.add(`npm-wrapper/umi-severity-config/${fileCount}-files`, () => {
+  runEngine(severityOnly, fixture.files);
+});
+
+try {
+  await bench.run();
+  console.table(bench.table());
+} finally {
+  rmSync(fixture.root, { recursive: true, force: true });
+}
+
+function createFixture(count) {
+  const root = mkdtempSync(join(tmpdir(), "utoo-lint-severity-benchmark-"));
+  const files = [];
+  for (let index = 0; index < count; index += 1) {
+    const directory = join(root, "packages", `package-${index % 100}`, "src");
+    mkdirSync(directory, { recursive: true });
+    const file = join(directory, `fixture-${index}.ts`);
+    writeFileSync(file, `export const value${index} = ${index};\n`);
+    files.push(file);
+  }
+  return { files, root };
+}
+
+function createEngine(fixture) {
+  const enabled = new Set(benchmarkRuleNames());
+  const enabledSeverities = ["warn", 1, true, ["error"]];
+  const disabledSeverities = ["off", 0, false, ["off"]];
+  const availableRules = [...new Linter().getRules().keys()];
+  const configuredRules = new Set([...availableRules.slice(0, 64), ...enabled]);
+  const rules = Object.fromEntries(
+    availableRules
+      .filter((rule) => configuredRules.has(rule))
+      .map((rule, index) => [
+        rule,
+        enabled.has(rule)
+          ? enabledSeverities[index % enabledSeverities.length]
+          : disabledSeverities[index % disabledSeverities.length]
+      ])
+  );
+  return new CLIEngine({
+    binary: utooBin,
+    cwd: fixture.root,
+    overrideConfigFile: true,
+    overrideConfig: [{ files: ["packages/**/*.ts"], rules }]
+  });
+}
+
+function runEngine(engine, files) {
+  const report = engine.executeOnFiles(files);
+  if (report.errorCount !== 0 || report.warningCount !== 0 || report.results.length !== files.length) {
+    throw new Error("severity config benchmark produced an unexpected lint report");
+  }
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (const arg of argv) {
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unknown positional argument: ${arg}`);
+    }
+    const [rawKey, rawValue] = arg.slice(2).split("=", 2);
+    result[rawKey] = rawValue ?? "true";
+  }
+  return result;
+}
+
+function positiveInt(value, fallback, name) {
+  const parsed = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInt(value, fallback, name) {
+  const parsed = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return parsed;
+}

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1327,6 +1327,22 @@ function nativeConfigRunsForFiles(paths, options) {
       };
     }
 
+    const selectedRules = severityOnlyNativeRuleNames(group.rules, group.settings);
+    if (selectedRules) {
+      return {
+        paths: group.paths,
+        options: {
+          ...options,
+          config: undefined,
+          noConfig: true,
+          baseConfig: undefined,
+          overrideConfig: undefined,
+          rules: selectedRules,
+          forceMaterializedConfig: undefined
+        }
+      };
+    }
+
     return {
       paths: group.paths,
       options: {
@@ -1342,6 +1358,40 @@ function nativeConfigRunsForFiles(paths, options) {
       }
     };
   });
+}
+
+function severityOnlyNativeRuleNames(rules, settings) {
+  if (Object.keys(settings ?? {}).length > 0) {
+    return undefined;
+  }
+
+  const selected = [];
+  for (const [rule, config] of Object.entries(rules ?? {})) {
+    if (ruleConfigSeverity(config) === 0) {
+      continue;
+    }
+    if (!isPureRuleSeverity(config)) {
+      return undefined;
+    }
+    selected.push(rule);
+  }
+  return selected.length > 0 ? selected : undefined;
+}
+
+function isPureRuleSeverity(config) {
+  if (Array.isArray(config)) {
+    if (config.length !== 1) {
+      return false;
+    }
+    [config] = config;
+  }
+  if (typeof config === "boolean") {
+    return true;
+  }
+  if (typeof config === "number") {
+    return config === 0 || config === 1 || config === 2;
+  }
+  return typeof config === "string" && ["off", "warn", "warning", "error", "0", "1", "2"].includes(config.toLowerCase());
 }
 
 function allDisabledNativeRules(rules) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -3216,6 +3216,22 @@ function nativeConfigRunsForFiles(paths, options) {
       };
     }
 
+    const selectedRules = severityOnlyNativeRuleNames(group.rules, group.settings);
+    if (selectedRules) {
+      return {
+        paths: group.paths,
+        options: {
+          ...options,
+          config: undefined,
+          noConfig: true,
+          baseConfig: undefined,
+          overrideConfig: undefined,
+          rules: selectedRules,
+          forceMaterializedConfig: undefined
+        }
+      };
+    }
+
     return {
       paths: group.paths,
       options: {
@@ -3231,6 +3247,40 @@ function nativeConfigRunsForFiles(paths, options) {
       }
     };
   });
+}
+
+function severityOnlyNativeRuleNames(rules, settings) {
+  if (Object.keys(settings ?? {}).length > 0) {
+    return undefined;
+  }
+
+  const selected = [];
+  for (const [rule, config] of Object.entries(rules ?? {})) {
+    if (ruleConfigSeverity(config) === 0) {
+      continue;
+    }
+    if (!isPureRuleSeverity(config)) {
+      return undefined;
+    }
+    selected.push(rule);
+  }
+  return selected.length > 0 ? selected : undefined;
+}
+
+function isPureRuleSeverity(config) {
+  if (Array.isArray(config)) {
+    if (config.length !== 1) {
+      return false;
+    }
+    [config] = config;
+  }
+  if (typeof config === "boolean") {
+    return true;
+  }
+  if (typeof config === "number") {
+    return config === 0 || config === 1 || config === 2;
+  }
+  return typeof config === "string" && ["off", "warn", "warning", "error", "0", "1", "2"].includes(config.toLowerCase());
 }
 
 function allDisabledNativeRules(rules) {

--- a/npm/utoo-lint/test/native-config-fast-path.test.mjs
+++ b/npm/utoo-lint/test/native-config-fast-path.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { lintFiles } from "../index.js";
+
+function createProject(t) {
+  const project = mkdtempSync(join(tmpdir(), "utoo-lint-config-fast-path-"));
+  t.after(() => rmSync(project, { recursive: true, force: true }));
+  return project;
+}
+
+function write(path, source) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, source);
+  return path;
+}
+
+function writeConfig(project, config) {
+  return write(join(project, "utlint.config.json"), `${JSON.stringify(config)}\n`);
+}
+
+function captureNativeRuns(callback, diagnosticsForPath = () => []) {
+  const originalSpawnSync = childProcess.spawnSync;
+  const calls = [];
+  childProcess.spawnSync = (command, args) => {
+    const paths = args.filter((arg) => !arg.startsWith("-"));
+    const configArgument = args.find((arg) => arg.startsWith("--config="));
+    calls.push({
+      args,
+      command,
+      config: configArgument
+        ? JSON.parse(readFileSync(configArgument.slice("--config=".length), "utf8"))
+        : undefined,
+      paths
+    });
+    const diagnostics = paths.flatMap(diagnosticsForPath);
+    const stdout = JSON.stringify({
+      files: paths.length,
+      filePaths: paths,
+      diagnostics,
+      suppressedDiagnostics: [],
+      outputs: []
+    });
+    return {
+      error: undefined,
+      output: [null, stdout, ""],
+      status: diagnostics.length > 0 ? 1 : 0,
+      stderr: "",
+      stdout
+    };
+  };
+  syncBuiltinESMExports();
+
+  try {
+    return { calls, value: callback() };
+  } finally {
+    childProcess.spawnSync = originalSpawnSync;
+    syncBuiltinESMExports();
+  }
+}
+
+test("severity-only config groups use the native --rules fast path", (t) => {
+  const cases = [
+    ["string severity", { "no-debugger": "warn", "no-console": "off" }, "no-debugger"],
+    ["numeric severity", { "no-debugger": 1, "no-console": 0 }, "no-debugger"],
+    ["boolean severity", { "no-debugger": true, "no-console": false }, "no-debugger"],
+    ["one-item array severity", { "no-debugger": ["error"], "no-console": ["off"] }, "no-debugger"]
+  ];
+
+  for (const [name, rules, selectedRule] of cases) {
+    const project = join(createProject(t), name.replaceAll(" ", "-"));
+    writeConfig(project, { rules });
+    const sourcePath = write(join(project, "src", "index.js"), "debugger;\n");
+    const { calls } = captureNativeRuns(() =>
+      lintFiles([sourcePath], { binary: "mock-utoo-lint", cwd: project })
+    );
+
+    assert.equal(calls.length, 1, name);
+    assert.ok(calls[0].args.includes("--no-config"), name);
+    assert.ok(calls[0].args.includes(`--rules=${selectedRule}`), name);
+    assert.equal(calls[0].args.some((arg) => arg.startsWith("--config=")), false, name);
+  }
+});
+
+test("fast-path diagnostics keep configured severities and exit status", (t) => {
+  const project = createProject(t);
+  writeConfig(project, [
+    { files: ["warn/**"], rules: { "no-debugger": "warn" } },
+    { files: ["error/**"], rules: { "no-debugger": "error" } },
+    { files: ["off/**"], rules: { "no-debugger": "off" } }
+  ]);
+  const warningPath = write(join(project, "warn", "index.js"), "debugger;\n");
+  const errorPath = write(join(project, "error", "index.js"), "debugger;\n");
+  const offPath = write(join(project, "off", "index.js"), "debugger;\n");
+
+  const { calls, value: report } = captureNativeRuns(
+    () => lintFiles([warningPath, errorPath, offPath], { binary: "mock-utoo-lint", cwd: project }),
+    (filePath) => [{
+      column: 1,
+      endColumn: 9,
+      endLine: 1,
+      filePath,
+      fixes: [],
+      line: 1,
+      message: "Unexpected debugger statement.",
+      ruleId: "no-debugger",
+      severity: "warning",
+      suggestions: []
+    }]
+  );
+
+  assert.equal(calls.filter(({ args }) => args.includes("--rules=no-debugger")).length, 2);
+  assert.deepEqual(
+    report.diagnostics.map(({ filePath, severity }) => ({ filePath, severity })),
+    [
+      { filePath: warningPath, severity: "warning" },
+      { filePath: errorPath, severity: "error" }
+    ]
+  );
+  assert.equal(report.exitCode, 1);
+});
+
+test("rule options, settings, and all-off groups keep the materialized config path", (t) => {
+  const cases = [
+    {
+      name: "enabled rule options",
+      config: { rules: { "no-console": ["error", { allow: ["warn"] }] } }
+    },
+    {
+      name: "shared settings",
+      config: { rules: { "no-debugger": "error" }, settings: { jest: { version: 21 } } }
+    },
+    {
+      name: "all rules disabled",
+      config: { rules: { "no-debugger": "off", "no-console": false } }
+    },
+    {
+      name: "invalid nested severity array",
+      config: { rules: { "no-debugger": [["error"]] } }
+    },
+    {
+      name: "invalid numeric severity",
+      config: { rules: { "no-debugger": 3 } }
+    }
+  ];
+
+  for (const { name, config } of cases) {
+    const project = join(createProject(t), name.replaceAll(" ", "-"));
+    writeConfig(project, config);
+    const sourcePath = write(join(project, "index.js"), "debugger;\n");
+    const { calls } = captureNativeRuns(() =>
+      lintFiles([sourcePath], { binary: "mock-utoo-lint", cwd: project })
+    );
+
+    assert.equal(calls.length, 1, name);
+    assert.equal(calls[0].args.includes("--no-config"), false, name);
+    assert.equal(calls[0].args.some((arg) => arg.startsWith("--rules=")), false, name);
+    assert.ok(calls[0].config, name);
+  }
+});
+
+test("empty settings and options on disabled rules remain fast-path eligible", (t) => {
+  const project = createProject(t);
+  writeConfig(project, {
+    rules: {
+      "no-console": ["off", { allow: ["warn"] }],
+      "no-debugger": "error"
+    },
+    settings: {}
+  });
+  const sourcePath = write(join(project, "index.js"), "debugger;\n");
+  const { calls } = captureNativeRuns(() =>
+    lintFiles([sourcePath], { binary: "mock-utoo-lint", cwd: project })
+  );
+
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].args.includes("--no-config"));
+  assert.ok(calls[0].args.includes("--rules=no-debugger"));
+  assert.equal(calls[0].args.some((arg) => arg.startsWith("--config=")), false);
+});


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- route severity-only config groups through the native `--no-config --rules=...` fast path
- preserve configured warning/error/off severities while falling back for enabled rule options and shared settings
- add focused fast-path/fallback tests and a 1,000-file Umi-style CodSpeed benchmark

## Verification

- `node --test --test-concurrency=1 --test-reporter=dot test/*.test.mjs` (121 tests)
- `pnpm test:types`
- `pnpm --dir benchmarks codspeed:severity-config -- --files=1000 --runs=1 --warmups=0`
- `node --check` and `git diff --check`

Fixes #1185