### PR TITLE
feat(native): resolve flat config per file

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,7 +59,6 @@ npm run bench -- --skip-eslint
   `no-unsafe-negation`.
 - The runner measures wall-clock time for fresh CLI processes. Editor daemon
   behavior, caches, and type-aware ESLint rules are intentionally out of scope.
-
 ## Node API severity-config benchmark
 
 CodSpeed also runs a `CLIEngine` workload modeled after Umi: 1,000 TypeScript
@@ -68,4 +67,16 @@ rule severities. Run a smaller local sample with:
 
 ```bash
 pnpm codspeed:severity-config -- --files=100 --runs=3 --warmups=1
+```
+
+## Native flat-config benchmark
+
+CodSpeed also exercises the npm wrapper with 1,000 TypeScript files split
+across source and test flat-config groups. The wrapper serializes the config
+once and delegates per-file selector resolution to one native process.
+
+Run a smaller local sample with:
+
+```bash
+pnpm codspeed:native-flat-config -- --files=100 --time=100 --warmup-time=0
 ```

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,6 +9,7 @@
     "bench:config-discovery": "node scripts/run-codspeed.mjs --config-only",
     "chart": "node scripts/render-chart.mjs",
     "codspeed": "node scripts/run-all-codspeed.mjs",
+    "codspeed:native-flat-config": "node scripts/run-native-flat-config-codspeed.mjs",
     "codspeed:severity-config": "node scripts/run-severity-config-codspeed.mjs"
   },
   "devDependencies": {

--- a/benchmarks/scripts/run-all-codspeed.mjs
+++ b/benchmarks/scripts/run-all-codspeed.mjs
@@ -1,2 +1,3 @@
 await import("./run-codspeed.mjs");
 await import("./run-severity-config-codspeed.mjs");
+await import("./run-native-flat-config-codspeed.mjs");

--- a/benchmarks/scripts/run-codspeed.mjs
+++ b/benchmarks/scripts/run-codspeed.mjs
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { Bench } from "tinybench";
 import { withCodSpeed } from "@codspeed/tinybench-plugin";
 import { findConfigPath } from "../../npm/utoo-lint/lib/config-loader.js";
@@ -12,7 +12,7 @@ const configOnly = Boolean(args["config-only"]);
 const target = args.target ?? "fixtures/codspeed";
 const time = nonNegativeNumber(args.time, 1000, "time");
 const warmupTime = nonNegativeNumber(args["warmup-time"], 500, "warmup-time");
-const utooBin = process.env.UTOO_LINT_BIN ?? join("..", "zig-out", "bin", process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint");
+const utooBin = resolve(process.env.UTOO_LINT_BIN ?? join("..", "zig-out", "bin", process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint"));
 
 if (!configOnly && !existsSync(utooBin)) {
   throw new Error(`utoo-lint binary was not found at ${utooBin}. Build utoo-lint first.`);
@@ -24,12 +24,12 @@ if (!configOnly && !existsSync(target)) {
 
 const bench = withCodSpeed(
   new Bench({
+    throws: true,
     time,
     warmup: warmupTime > 0,
     warmupTime
   })
 );
-
 if (!configOnly) {
   bench.add(`utoo-lint/${target}`, () => {
     runUtooLint(target);

--- a/benchmarks/scripts/run-native-flat-config-codspeed.mjs
+++ b/benchmarks/scripts/run-native-flat-config-codspeed.mjs
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Bench } from "tinybench";
+import { withCodSpeed } from "@codspeed/tinybench-plugin";
+import { CLIEngine } from "../../npm/utoo-lint/index.js";
+
+const args = parseArgs(process.argv.slice(2));
+const fileCount = positiveInt(args.files, 1000, "files");
+const time = nonNegativeNumber(args.time, 1000, "time");
+const warmupTime = nonNegativeNumber(args["warmup-time"], 500, "warmup-time");
+const utooBin = resolve(
+  process.env.UTOO_LINT_BIN ?? join("..", "zig-out", "bin", process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint")
+);
+
+if (!existsSync(utooBin)) {
+  throw new Error(`utoo-lint binary was not found at ${utooBin}. Build utoo-lint first.`);
+}
+
+const fixture = createFixture(fileCount);
+const engine = new CLIEngine({
+  binary: utooBin,
+  cwd: fixture.root,
+  overrideConfigFile: true,
+  overrideConfig: [
+    { files: ["packages/*/src/**/*.ts"], rules: { "no-console": "off", "no-debugger": "warn" } },
+    { files: ["packages/*/test/**/*.ts"], rules: { "no-console": ["warn", { allow: ["warn"] }], "no-debugger": "off" } },
+    { files: ["packages/package-0/test/**/*.ts"], rules: { "no-console": "error" } }
+  ]
+});
+const bench = withCodSpeed(
+  new Bench({
+    throws: true,
+    time,
+    warmup: warmupTime > 0,
+    warmupTime
+  })
+);
+
+bench.add(`npm-wrapper/native-flat-config/${fixture.files.length}-files`, () => {
+  const report = engine.executeOnFiles(fixture.files);
+  if (report.errorCount !== 0 || report.warningCount !== 0 || report.results.length !== fixture.files.length) {
+    throw new Error("native flat-config benchmark produced an unexpected lint report");
+  }
+});
+
+try {
+  await bench.run();
+  console.table(bench.table());
+} finally {
+  rmSync(fixture.root, { recursive: true, force: true });
+}
+
+function createFixture(count) {
+  const root = mkdtempSync(join(tmpdir(), "utoo-lint-flat-config-benchmark-"));
+  const files = [];
+  for (let index = 0; index < count; index += 1) {
+    const scope = index % 2 === 0 ? "src" : "test";
+    const directory = join(root, "packages", `package-${Math.floor(index / 2) % 100}`, scope);
+    mkdirSync(directory, { recursive: true });
+    const file = join(directory, `fixture-${index}.ts`);
+    writeFileSync(file, `export const value${index} = ${index};\n`);
+    files.push(file);
+  }
+  return { files, root };
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (const arg of argv) {
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unknown positional argument: ${arg}`);
+    }
+    const [rawKey, rawValue] = arg.slice(2).split("=", 2);
+    result[rawKey] = rawValue ?? "true";
+  }
+  return result;
+}
+
+function positiveInt(value, fallback, name) {
+  const parsed = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeNumber(value, fallback, name) {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`--${name} must be a non-negative number`);
+  }
+  return parsed;
+}

--- a/build.zig
+++ b/build.zig
@@ -119,6 +119,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     test_module.addImport("utoo_lint", lint_module);
+    const flat_config_test_module = b.createModule(.{
+        .root_source_file = b.path("src/flat_config.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    flat_config_test_module.addImport("utoo_lint", lint_module);
+    test_module.addImport("flat_config", flat_config_test_module);
 
     const unit_tests = b.addTest(.{
         .root_module = test_module,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,16 +138,16 @@ CLI, JavaScript API, and fishlint compatibility command apply this rule
 resolution separately for each linted file.
 
 The npm wrapper executes the TypeScript file, materializes its result as JSON,
-and passes that JSON to the native binary. The raw native binary intentionally
-does not execute or discover TypeScript. It searches for `utlint.config.json`
-and then the legacy JSON names. Use the npm CLI for `utlint.config.ts`; when
+and passes that flat config to one native process. The raw native binary does
+not execute or discover TypeScript; it searches for `utlint.config.json` and
+then the legacy JSON names. Use the npm CLI for `utlint.config.ts`; when
 invoking the raw binary directly, use `utlint.config.json`.
 
-The raw binary applies the JSON config's `rules` and supported shared
-`settings`. Config-driven
-`files` and `ignores` filtering, including choosing default lint targets, is an
-npm/Node wrapper feature. Pass lint targets explicitly when invoking the raw
-binary.
+The raw binary resolves static flat-config `files`, global and entry-scoped
+`ignores`, ordered rule overrides, and supported shared `settings` for each
+file. With no explicit lint target, config selectors and global ignores also
+control native file discovery. Patterns are relative to the selected config's
+directory.
 
 ## JSON Config
 

--- a/docs/eslint-migration.md
+++ b/docs/eslint-migration.md
@@ -228,13 +228,12 @@ export default defineConfig({
 ```
 
 Loading `utlint.config.ts` executes project code. The npm wrapper materializes
-the exported value as JSON for the native binary; the raw binary itself does
+the exported value as JSON for one native process; the raw binary itself does
 not execute or discover TypeScript. It searches for `utlint.config.json` and
 then the legacy JSON names, so use JSON when invoking it directly. The raw
-binary applies only `rules` from that JSON; omitted rules are disabled, matching
-ESLint's configuration model. Config-driven `files` and
-`ignores` filtering and default target selection are npm/Node wrapper features.
-Pass lint targets explicitly when invoking the raw binary.
+binary resolves flat-config `files`, global and entry-scoped `ignores`, rule
+overrides, and supported settings per file. Omitted rules are disabled,
+matching ESLint's configuration model.
 
 ## Step 4: Translate Rules Manually When Needed
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -1211,6 +1211,12 @@ function lintFiles(paths, options = {}) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
+  const nativeFlatOptions = nativeFlatConfigOptions(options);
+  if (nativeFlatOptions) {
+    const report = runNativeLintReport(lintPaths, nativeFlatOptions);
+    return finalizeLintReport(report, ignoredDiagnostics, options);
+  }
+
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
   if (configRuns) {
     const report = mergeNativeReports(
@@ -1221,6 +1227,76 @@ function lintFiles(paths, options = {}) {
 
   const report = runNativeLintReport(lintPaths, options);
   return finalizeLintReport(report, ignoredDiagnostics, options);
+}
+
+function nativeFlatConfigOptions(options) {
+  if (options.rules || options.extraArgs?.some((arg) => arg.startsWith("--") && arg !== "--fix" && arg !== "--fix-dry-run")) {
+    return undefined;
+  }
+
+  const fileConfigPath = options.noConfig ? undefined : configPathForOptions(options);
+  const inlineConfigs = [options.baseConfig, options.overrideConfig].filter(Boolean);
+  if (fileConfigPath && inlineConfigs.length > 0) {
+    return undefined;
+  }
+
+  let config;
+  let configRoot;
+  if (fileConfigPath) {
+    config = readConfig(fileConfigPath, options.cwd, options.configCache);
+    configRoot = dirname(fileConfigPath);
+  } else if (inlineConfigs.length > 0) {
+    config = inlineConfigs.length === 1 ? inlineConfigs[0] : inlineConfigs;
+    configRoot = resolvePath(options.cwd ?? process.cwd());
+  } else {
+    return undefined;
+  }
+
+  if (configCanUseNativeRulesFastPath(config)) {
+    return undefined;
+  }
+
+  const serializedConfig = nativeSerializableConfig(config);
+  return {
+    ...options,
+    nativeFlatConfigData: Array.isArray(serializedConfig) ? serializedConfig : [serializedConfig],
+    nativeConfigRoot: configRoot,
+    nativeConfigCwd: resolvePath(options.cwd ?? process.cwd())
+  };
+}
+
+function configCanUseNativeRulesFastPath(config) {
+  const entries = Array.isArray(config) ? config : [config];
+  let hasEnabledRule = false;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Object.keys(entry.settings ?? {}).length > 0) {
+      return false;
+    }
+    for (const ruleConfig of Object.values(entry.rules ?? {})) {
+      if (ruleConfigSeverity(ruleConfig) === 0) {
+        continue;
+      }
+      if (!isPureRuleSeverity(ruleConfig)) {
+        return false;
+      }
+      hasEnabledRule = true;
+    }
+  }
+  return hasEnabledRule;
+}
+
+function nativeSerializableConfig(config) {
+  if (Array.isArray(config)) {
+    return config.map(nativeSerializableConfig);
+  }
+  if (!config || typeof config !== "object") {
+    return config;
+  }
+  return Object.fromEntries(
+    ["$schema", "name", "files", "ignores", "rules", "settings"]
+      .filter((key) => config[key] !== undefined)
+      .map((key) => [key, config[key]])
+  );
 }
 
 function expandNativeConfigRunPaths(paths, options) {
@@ -1510,7 +1586,7 @@ function buildNativeLintArgs(paths, options) {
   if (options.noConfig) {
     cliArgs.push("--no-config");
   }
-  if (!options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
+  if (!options.nativeFlatConfigData && !options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
     const configForRuleSelection = options.noConfig
       ? undefined
       : options.config ? readConfig(options.config, options.cwd, options.configCache) : undefined;
@@ -1525,6 +1601,12 @@ function buildNativeLintArgs(paths, options) {
   }
   if (options.config) {
     cliArgs.push(`--config=${options.config}`);
+  }
+  if (options.nativeConfigRoot) {
+    cliArgs.push(`--config-root=${options.nativeConfigRoot}`);
+  }
+  if (options.nativeConfigCwd) {
+    cliArgs.push(`--config-cwd=${options.nativeConfigCwd}`);
   }
   if (options.rules) {
     const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
@@ -1941,6 +2023,24 @@ function configPathFromDirectory(directory, options) {
 }
 
 function withTemporaryConfig(options, callback) {
+  if (options.nativeFlatConfigData !== undefined) {
+    const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-flat-config-"));
+    const configPath = join(tmp, "utlint.config.json");
+    try {
+      writeFileSync(configPath, JSON.stringify(options.nativeFlatConfigData));
+      return callback({
+        ...options,
+        config: configPath,
+        noConfig: false,
+        baseConfig: undefined,
+        overrideConfig: undefined,
+        forceMaterializedConfig: true
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
   const fileConfigPath = !options.noConfig ? configPathForOptions(options) : undefined;
   const shouldMaterializeFileConfig = Boolean(fileConfigPath);
   const fileConfig = shouldMaterializeFileConfig

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -3109,6 +3109,12 @@ export function lintFiles(paths, options = {}) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
 
+  const nativeFlatOptions = nativeFlatConfigOptions(options);
+  if (nativeFlatOptions) {
+    const report = runNativeLintReport(lintPaths, nativeFlatOptions);
+    return finalizeLintReport(report, ignoredDiagnostics, options);
+  }
+
   const configRuns = nativeConfigRunsForFiles(expandNativeConfigRunPaths(lintPaths, options), options);
   if (configRuns) {
     const report = mergeNativeReports(
@@ -3119,6 +3125,76 @@ export function lintFiles(paths, options = {}) {
 
   const report = runNativeLintReport(lintPaths, options);
   return finalizeLintReport(report, ignoredDiagnostics, options);
+}
+
+function nativeFlatConfigOptions(options) {
+  if (options.rules || options.extraArgs?.some((arg) => arg.startsWith("--") && arg !== "--fix" && arg !== "--fix-dry-run")) {
+    return undefined;
+  }
+
+  const fileConfigPath = options.noConfig ? undefined : configPathForOptions(options);
+  const inlineConfigs = [options.baseConfig, options.overrideConfig].filter(Boolean);
+  if (fileConfigPath && inlineConfigs.length > 0) {
+    return undefined;
+  }
+
+  let config;
+  let configRoot;
+  if (fileConfigPath) {
+    config = readConfig(fileConfigPath, options.cwd, options.configCache);
+    configRoot = dirname(fileConfigPath);
+  } else if (inlineConfigs.length > 0) {
+    config = inlineConfigs.length === 1 ? inlineConfigs[0] : inlineConfigs;
+    configRoot = resolvePath(options.cwd ?? process.cwd());
+  } else {
+    return undefined;
+  }
+
+  if (configCanUseNativeRulesFastPath(config)) {
+    return undefined;
+  }
+
+  const serializedConfig = nativeSerializableConfig(config);
+  return {
+    ...options,
+    nativeFlatConfigData: Array.isArray(serializedConfig) ? serializedConfig : [serializedConfig],
+    nativeConfigRoot: configRoot,
+    nativeConfigCwd: resolvePath(options.cwd ?? process.cwd())
+  };
+}
+
+function configCanUseNativeRulesFastPath(config) {
+  const entries = Array.isArray(config) ? config : [config];
+  let hasEnabledRule = false;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Object.keys(entry.settings ?? {}).length > 0) {
+      return false;
+    }
+    for (const ruleConfig of Object.values(entry.rules ?? {})) {
+      if (ruleConfigSeverity(ruleConfig) === 0) {
+        continue;
+      }
+      if (!isPureRuleSeverity(ruleConfig)) {
+        return false;
+      }
+      hasEnabledRule = true;
+    }
+  }
+  return hasEnabledRule;
+}
+
+function nativeSerializableConfig(config) {
+  if (Array.isArray(config)) {
+    return config.map(nativeSerializableConfig);
+  }
+  if (!config || typeof config !== "object") {
+    return config;
+  }
+  return Object.fromEntries(
+    ["$schema", "name", "files", "ignores", "rules", "settings"]
+      .filter((key) => config[key] !== undefined)
+      .map((key) => [key, config[key]])
+  );
 }
 
 function expandNativeConfigRunPaths(paths, options) {
@@ -3408,7 +3484,7 @@ function buildNativeLintArgs(paths, options) {
   if (options.noConfig) {
     cliArgs.push("--no-config");
   }
-  if (!options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
+  if (!options.nativeFlatConfigData && !options.rules && !options.forceMaterializedConfig && (options.config || options.baseConfig || options.overrideConfig)) {
     const configForRuleSelection = options.noConfig
       ? undefined
       : options.config ? readConfig(options.config, options.cwd, options.configCache) : undefined;
@@ -3423,6 +3499,12 @@ function buildNativeLintArgs(paths, options) {
   }
   if (options.config) {
     cliArgs.push(`--config=${options.config}`);
+  }
+  if (options.nativeConfigRoot) {
+    cliArgs.push(`--config-root=${options.nativeConfigRoot}`);
+  }
+  if (options.nativeConfigCwd) {
+    cliArgs.push(`--config-cwd=${options.nativeConfigCwd}`);
   }
   if (options.rules) {
     const rules = Array.isArray(options.rules) ? options.rules.join(",") : options.rules;
@@ -3839,6 +3921,24 @@ function configPathFromDirectory(directory, options) {
 }
 
 function withTemporaryConfig(options, callback) {
+  if (options.nativeFlatConfigData !== undefined) {
+    const tmp = mkdtempSync(join(tmpdir(), "utoo-lint-flat-config-"));
+    const configPath = join(tmp, "utlint.config.json");
+    try {
+      writeFileSync(configPath, JSON.stringify(options.nativeFlatConfigData));
+      return callback({
+        ...options,
+        config: configPath,
+        noConfig: false,
+        baseConfig: undefined,
+        overrideConfig: undefined,
+        forceMaterializedConfig: true
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
   const fileConfigPath = !options.noConfig ? configPathForOptions(options) : undefined;
   const shouldMaterializeFileConfig = Boolean(fileConfigPath);
   const fileConfig = shouldMaterializeFileConfig

--- a/npm/utoo-lint/test/config-discovery.test.mjs
+++ b/npm/utoo-lint/test/config-discovery.test.mjs
@@ -133,8 +133,8 @@ test("one lint invocation discovers a shared config only once", (t) => {
 
   assert.equal(first.value.files, 2);
   assert.equal(second.value.files, 2);
-  assert.equal(first.count, CONFIG_FILENAMES.length + 1);
-  assert.equal(second.count, CONFIG_FILENAMES.length + 1);
+  assert.equal(first.count, 1);
+  assert.equal(second.count, 1);
 });
 
 test("separate public config lookups observe config changes", async (t) => {

--- a/npm/utoo-lint/test/native-flat-config.test.mjs
+++ b/npm/utoo-lint/test/native-flat-config.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import childProcess, { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { lintFiles } from "../index.js";
+
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const builtBinary = resolve(
+  packageDirectory,
+  "..",
+  "..",
+  "zig-out",
+  "bin",
+  process.platform === "win32" ? "utoo-lint.exe" : "utoo-lint"
+);
+
+function createProject(t) {
+  const project = mkdtempSync(join(tmpdir(), "utoo-lint-native-flat-config-"));
+  t.after(() => rmSync(project, { recursive: true, force: true }));
+  return project;
+}
+
+function write(path, source) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, source);
+  return path;
+}
+
+function writeConfig(project, config) {
+  return write(join(project, "utlint.config.json"), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function runNative(project, args = []) {
+  assert.equal(existsSync(builtBinary), true, `missing test binary at ${builtBinary}`);
+  return spawnSync(builtBinary, ["--format=json", ...args], { cwd: project, encoding: "utf8" });
+}
+
+function diagnosticSummary(result) {
+  return JSON.parse(result.stdout).diagnostics
+    .filter(({ ruleId }) => ruleId !== "parse" && ruleId !== "io")
+    .map(({ filePath, ruleId, severity }) => ({ filePath, ruleId, severity }))
+    .sort((left, right) => `${left.filePath}:${left.ruleId}`.localeCompare(`${right.filePath}:${right.ruleId}`));
+}
+
+test("raw native binary resolves flat files, ignores, and later overrides per file", (t) => {
+  const project = createProject(t);
+  const configPath = writeConfig(project, [
+    { name: "global ignores", ignores: ["dist/**"] },
+    {
+      files: ["src/**/*.js"],
+      ignores: ["src/generated/**"],
+      rules: { "no-console": "error", "no-debugger": "warn" }
+    },
+    { files: ["test/**/*.js"], rules: { "no-console": "off", "no-debugger": "error" } },
+    { files: ["src/special/**/*.js"], rules: { "no-console": "off" } }
+  ]);
+  const sourcePath = write(join(project, "src", "index.js"), "console.log('source');\ndebugger;\n");
+  const testPath = write(join(project, "test", "index.js"), "console.log('test');\ndebugger;\n");
+  const specialPath = write(join(project, "src", "special", "index.js"), "console.log('special');\ndebugger;\n");
+  const generatedPath = write(join(project, "src", "generated", "index.js"), "console.log('generated');\ndebugger;\n");
+  const distPath = write(join(project, "dist", "index.js"), "console.log('dist');\ndebugger;\n");
+
+  const result = runNative(project, [
+    `--config=${configPath}`,
+    sourcePath,
+    testPath,
+    specialPath,
+    generatedPath,
+    distPath
+  ]);
+
+  assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.files, 4);
+  assert.equal(report.filePaths.includes(distPath), false);
+  assert.deepEqual(diagnosticSummary(result), [
+    { filePath: sourcePath, ruleId: "no-console", severity: "error" },
+    { filePath: sourcePath, ruleId: "no-debugger", severity: "warning" },
+    { filePath: specialPath, ruleId: "no-debugger", severity: "warning" },
+    { filePath: testPath, ruleId: "no-debugger", severity: "error" }
+  ].sort((left, right) => `${left.filePath}:${left.ruleId}`.localeCompare(`${right.filePath}:${right.ruleId}`)));
+});
+
+test("raw native default discovery honors selectors, braces, and global ignores", (t) => {
+  const project = createProject(t);
+  writeConfig(project, [
+    { ignores: ["src/generated/**"] },
+    { files: ["src/**/*.{js,ts}"], rules: { "no-debugger": "error" } }
+  ]);
+  const selectedPath = write(join(project, "src", "index.ts"), "debugger;\n");
+  write(join(project, "src", "generated", "index.ts"), "debugger;\n");
+  write(join(project, "test", "index.ts"), "debugger;\n");
+
+  const result = runNative(project);
+
+  assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+  const report = JSON.parse(result.stdout);
+  assert.deepEqual(report.filePaths.map((path) => resolve(project, path)), [selectedPath]);
+  assert.deepEqual(
+    diagnosticSummary(result).map((diagnostic) => ({
+      ...diagnostic,
+      filePath: resolve(project, diagnostic.filePath)
+    })),
+    [{ filePath: selectedPath, ruleId: "no-debugger", severity: "error" }]
+  );
+  assert.equal(report.files, 1);
+});
+
+test("raw native resolves explicit ancestor configs relative to the config directory", (t) => {
+  const project = createProject(t);
+  const configPath = writeConfig(project, [
+    { files: [["packages/**/*.js", "**/*.test.js"]], rules: { "no-debugger": "error" } }
+  ]);
+  const selectedPath = write(join(project, "packages", "app", "src", "index.test.js"), "debugger;\n");
+  const unmatchedPath = write(join(project, "packages", "app", "src", "index.js"), "debugger;\n");
+
+  const result = runNative(join(project, "packages", "app"), [
+    `--config=${configPath}`,
+    selectedPath,
+    unmatchedPath
+  ]);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.deepEqual(diagnosticSummary(result), [
+    { filePath: selectedPath, ruleId: "no-debugger", severity: "error" }
+  ]);
+});
+
+test("later severity-only entries retain earlier rule options", (t) => {
+  const project = createProject(t);
+  writeConfig(project, [
+    { files: ["src/**/*.js"], rules: { "no-console": ["error", { allow: ["warn"] }] } },
+    { files: ["src/**/*.js"], rules: { "no-console": "warn" } }
+  ]);
+  const sourcePath = write(join(project, "src", "index.js"), "console.warn('allowed');\n");
+
+  const result = runNative(project, [sourcePath]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(diagnosticSummary(result), []);
+});
+
+test("raw native rule flags keep CLI precedence over flat config", (t) => {
+  const project = createProject(t);
+  writeConfig(project, [
+    { files: ["src/**/*.js"], rules: { "no-debugger": "off" } },
+    { files: ["test/**/*.js"], rules: { "no-debugger": "error" } }
+  ]);
+  const sourcePath = write(join(project, "src", "index.js"), "debugger;\n");
+  const testPath = write(join(project, "test", "index.js"), "debugger;\n");
+
+  const result = runNative(project, ["--no-debugger=off", sourcePath, testPath]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(diagnosticSummary(result), []);
+});
+
+test("Node wrapper serializes TypeScript flat config into one native process", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.ts"),
+    [
+      "export default [",
+      '  { files: ["src/**/*.ts"], rules: { "no-debugger": "warn" }, settings: { jest: { version: 29 } } },',
+      '  { files: ["test/**/*.ts"], rules: { "no-debugger": "error" } }',
+      "];",
+      ""
+    ].join("\n")
+  );
+  const sourcePath = write(join(project, "src", "index.ts"), "debugger;\n");
+  const testPath = write(join(project, "test", "index.ts"), "debugger;\n");
+  const originalSpawnSync = childProcess.spawnSync;
+  const calls = [];
+  childProcess.spawnSync = (command, args, spawnOptions) => {
+    if (command !== "mock-utoo-lint") {
+      return originalSpawnSync(command, args, spawnOptions);
+    }
+    const configArg = args.find((arg) => arg.startsWith("--config="));
+    calls.push({
+      args,
+      command,
+      config: JSON.parse(readFileSync(configArg.slice("--config=".length), "utf8"))
+    });
+    const stdout = JSON.stringify({
+      files: 2,
+      filePaths: [sourcePath, testPath],
+      diagnostics: [],
+      suppressedDiagnostics: [],
+      outputs: []
+    });
+    return { error: undefined, status: 0, stdout, stderr: "", output: [null, stdout, ""] };
+  };
+  syncBuiltinESMExports();
+  t.after(() => {
+    childProcess.spawnSync = originalSpawnSync;
+    syncBuiltinESMExports();
+  });
+
+  const report = lintFiles([sourcePath, testPath], { binary: "mock-utoo-lint", cwd: project });
+
+  assert.equal(report.files, 2);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "mock-utoo-lint");
+  assert.deepEqual(calls[0].config.map(({ files, rules }) => ({ files, rules })), [
+    { files: ["src/**/*.ts"], rules: { "no-debugger": "warn" } },
+    { files: ["test/**/*.ts"], rules: { "no-debugger": "error" } }
+  ]);
+  assert.ok(calls[0].args.includes(`--config-root=${project}`));
+});
+
+test("Node wrapper preserves selectors from a single config object", (t) => {
+  const project = createProject(t);
+  write(
+    join(project, "utlint.config.ts"),
+    'export default { files: ["test/**/*.ts"], rules: { "no-debugger": "error" } };\n'
+  );
+  const sourcePath = write(join(project, "src", "index.ts"), "debugger;\n");
+  const testPath = write(join(project, "test", "index.ts"), "debugger;\n");
+
+  const report = lintFiles([sourcePath, testPath], { binary: builtBinary, cwd: project });
+
+  assert.deepEqual(report.diagnostics.map(({ filePath, ruleId }) => ({ filePath, ruleId })), [
+    { filePath: testPath, ruleId: "no-debugger" }
+  ]);
+});

--- a/src/flat_config.zig
+++ b/src/flat_config.zig
@@ -1,0 +1,500 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+
+pub const RuleSeverityMap = std.StringHashMap(lint.Severity);
+
+pub const ResolvedConfig = struct {
+    options: lint.Options,
+    rule_severities: RuleSeverityMap,
+
+    pub fn deinit(self: *ResolvedConfig, allocator: std.mem.Allocator) void {
+        clearRuleSeverities(allocator, &self.rule_severities);
+        self.rule_severities.deinit();
+    }
+};
+
+pub const FlatConfig = struct {
+    parsed: std.json.Parsed(std.json.Value),
+    io: std.Io,
+    directory: []u8,
+    cwd: []u8,
+
+    pub fn deinit(self: *FlatConfig, allocator: std.mem.Allocator) void {
+        self.parsed.deinit();
+        allocator.free(self.directory);
+        allocator.free(self.cwd);
+    }
+
+    pub fn validateAndApplyAggregate(
+        self: *FlatConfig,
+        allocator: std.mem.Allocator,
+        options: *lint.Options,
+        rule_severities: *RuleSeverityMap,
+    ) !void {
+        const entries = self.parsed.value.array.items;
+        options.* = lint.Options.allDisabled();
+        for (entries) |entry_value| {
+            const entry = switch (entry_value) {
+                .object => |object| object,
+                else => return error.InvalidFlatConfigEntry,
+            };
+            if (isGlobalIgnoreEntry(entry)) continue;
+            try applyConfigObject(allocator, entry, options, rule_severities);
+        }
+    }
+
+    pub fn resolveForFile(
+        self: *const FlatConfig,
+        allocator: std.mem.Allocator,
+        file_path: []const u8,
+    ) !ResolvedConfig {
+        var resolved = ResolvedConfig{
+            .options = lint.Options.allDisabled(),
+            .rule_severities = RuleSeverityMap.init(allocator),
+        };
+        errdefer resolved.deinit(allocator);
+
+        const paths = try ConfigPaths.init(allocator, self.io, self.cwd, self.directory, file_path);
+        defer paths.deinit(allocator);
+
+        for (self.parsed.value.array.items) |entry_value| {
+            const entry = entry_value.object;
+            if (isGlobalIgnoreEntry(entry) or !entryApplies(entry, paths)) continue;
+            try applyConfigObject(allocator, entry, &resolved.options, &resolved.rule_severities);
+        }
+        return resolved;
+    }
+
+    pub fn isGloballyIgnored(self: *const FlatConfig, allocator: std.mem.Allocator, path: []const u8) !bool {
+        const paths = try ConfigPaths.init(allocator, self.io, self.cwd, self.directory, path);
+        defer paths.deinit(allocator);
+
+        var ignored = false;
+        for (self.parsed.value.array.items) |entry_value| {
+            const entry = entry_value.object;
+            if (!isGlobalIgnoreEntry(entry)) continue;
+            ignored = ignoredByValue(paths, entry.get("ignores").?, ignored);
+        }
+        return ignored;
+    }
+
+    pub fn shouldTraverseDirectory(self: *const FlatConfig, allocator: std.mem.Allocator, path: []const u8) !bool {
+        if (!try self.isGloballyIgnored(allocator, path)) return true;
+
+        // Negated global patterns may re-include a descendant. Traversing in
+        // that uncommon case is conservative and preserves ignore ordering.
+        for (self.parsed.value.array.items) |entry_value| {
+            const entry = entry_value.object;
+            if (!isGlobalIgnoreEntry(entry)) continue;
+            if (hasNegatedPattern(entry.get("ignores").?)) return true;
+        }
+        return false;
+    }
+
+    pub fn selectsFile(self: *const FlatConfig, allocator: std.mem.Allocator, path: []const u8) !bool {
+        if (!self.hasFileSelectors()) return true;
+
+        const paths = try ConfigPaths.init(allocator, self.io, self.cwd, self.directory, path);
+        defer paths.deinit(allocator);
+        for (self.parsed.value.array.items) |entry_value| {
+            const entry = entry_value.object;
+            if (isGlobalIgnoreEntry(entry)) continue;
+            if (entry.get("files") != null) {
+                if (entryApplies(entry, paths)) return true;
+                continue;
+            }
+            if (hasRules(entry) and entryApplies(entry, paths)) return true;
+        }
+        return false;
+    }
+
+    fn hasFileSelectors(self: *const FlatConfig) bool {
+        for (self.parsed.value.array.items) |entry_value| {
+            if (entry_value.object.get("files") != null) return true;
+        }
+        return false;
+    }
+};
+
+pub fn applyConfigObject(
+    allocator: std.mem.Allocator,
+    root: std.json.ObjectMap,
+    options: *lint.Options,
+    rule_severities: *RuleSeverityMap,
+) !void {
+    if (root.get("settings")) |settings_value| {
+        const settings = switch (settings_value) {
+            .object => |object| object,
+            else => return error.InvalidSettings,
+        };
+        if (settings.get("jest")) |jest_value| {
+            const jest = switch (jest_value) {
+                .object => |object| object,
+                else => return error.InvalidJestSettings,
+            };
+            const defaults = lint.Options{};
+            options.jest_version = defaults.jest_version;
+            options.jest_global_aliases = defaults.jest_global_aliases;
+            if (jest.get("version")) |version| try options.setJestVersionFromConfig(version);
+            if (jest.get("globalAliases")) |aliases| try options.setJestGlobalAliasesFromConfig(aliases);
+        }
+    }
+
+    const rules_value = root.get("rules") orelse return;
+    const rules = switch (rules_value) {
+        .object => |object| object,
+        else => return error.InvalidRules,
+    };
+
+    var iter = rules.iterator();
+    while (iter.next()) |entry| {
+        const severity = try lint.Options.severityFromRuleConfigValue(entry.value_ptr.*);
+        if (isSeverityOnlyRuleConfig(entry.value_ptr.*)) {
+            if (!options.setByCliName(entry.key_ptr.*, severity != null)) return error.UnknownRule;
+        } else {
+            try options.setByRuleConfigValue(entry.key_ptr.*, entry.value_ptr.*);
+        }
+        try setRuleSeverity(allocator, rule_severities, entry.key_ptr.*, severity);
+    }
+}
+
+fn setRuleSeverity(
+    allocator: std.mem.Allocator,
+    rule_severities: *RuleSeverityMap,
+    rule: []const u8,
+    severity: ?lint.Severity,
+) !void {
+    if (severity) |configured| {
+        const existing = try rule_severities.getOrPut(rule);
+        if (!existing.found_existing) {
+            existing.key_ptr.* = try allocator.dupe(u8, rule);
+        }
+        existing.value_ptr.* = configured;
+        return;
+    }
+    if (rule_severities.fetchRemove(rule)) |removed| allocator.free(removed.key);
+}
+
+fn clearRuleSeverities(allocator: std.mem.Allocator, rule_severities: *RuleSeverityMap) void {
+    var iter = rule_severities.keyIterator();
+    while (iter.next()) |rule| allocator.free(rule.*);
+    rule_severities.clearRetainingCapacity();
+}
+
+fn isSeverityOnlyRuleConfig(value: std.json.Value) bool {
+    return switch (value) {
+        .array => |items| items.items.len == 1,
+        else => true,
+    };
+}
+
+const ConfigPaths = struct {
+    absolute: []u8,
+    relative: []u8,
+
+    fn init(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8, directory: []const u8, path: []const u8) !ConfigPaths {
+        const absolute = try canonicalPathAlloc(allocator, io, cwd, path);
+        errdefer allocator.free(absolute);
+        const relative = try std.fs.path.relative(allocator, ".", null, directory, absolute);
+        return .{ .absolute = absolute, .relative = relative };
+    }
+
+    fn deinit(self: ConfigPaths, allocator: std.mem.Allocator) void {
+        allocator.free(self.absolute);
+        allocator.free(self.relative);
+    }
+};
+
+pub fn canonicalPathAlloc(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    cwd: []const u8,
+    path: []const u8,
+) ![]u8 {
+    const absolute = try std.fs.path.resolve(allocator, &.{ cwd, path });
+    const canonical = std.Io.Dir.realPathFileAbsoluteAlloc(io, absolute, allocator) catch return absolute;
+    defer allocator.free(canonical);
+    allocator.free(absolute);
+    return allocator.dupe(u8, canonical);
+}
+
+fn entryApplies(entry: std.json.ObjectMap, paths: ConfigPaths) bool {
+    if (entry.get("files")) |files| {
+        if (!fileSelectorsMatch(paths, files)) return false;
+    }
+    if (entry.get("ignores")) |ignores| {
+        if (ignoredByValue(paths, ignores, false)) return false;
+    }
+    return true;
+}
+
+fn hasRules(entry: std.json.ObjectMap) bool {
+    const rules = entry.get("rules") orelse return false;
+    return switch (rules) {
+        .object => |object| object.count() > 0,
+        else => false,
+    };
+}
+
+fn isGlobalIgnoreEntry(entry: std.json.ObjectMap) bool {
+    if (entry.get("ignores") == null) return false;
+    var iter = entry.iterator();
+    while (iter.next()) |field| {
+        if (!std.mem.eql(u8, field.key_ptr.*, "name") and !std.mem.eql(u8, field.key_ptr.*, "ignores")) return false;
+    }
+    return true;
+}
+
+fn fileSelectorsMatch(paths: ConfigPaths, value: std.json.Value) bool {
+    return switch (value) {
+        .string => |pattern| matchesConfigPattern(paths, pattern),
+        .array => |items| blk: {
+            for (items.items) |selector| {
+                switch (selector) {
+                    .string => |pattern| if (matchesConfigPattern(paths, pattern)) break :blk true,
+                    .array => |patterns| {
+                        if (patterns.items.len == 0) continue;
+                        for (patterns.items) |pattern_value| {
+                            const pattern = switch (pattern_value) {
+                                .string => |text| text,
+                                else => break,
+                            };
+                            if (!matchesConfigPattern(paths, pattern)) break;
+                        } else break :blk true;
+                    },
+                    else => {},
+                }
+            }
+            break :blk false;
+        },
+        else => false,
+    };
+}
+
+fn ignoredByValue(paths: ConfigPaths, value: std.json.Value, initial: bool) bool {
+    var ignored = initial;
+    switch (value) {
+        .string => |pattern| applyIgnorePattern(paths, pattern, &ignored),
+        .array => |items| for (items.items) |item| {
+            if (item == .string) applyIgnorePattern(paths, item.string, &ignored);
+        },
+        else => {},
+    }
+    return ignored;
+}
+
+fn hasNegatedPattern(value: std.json.Value) bool {
+    return switch (value) {
+        .string => |pattern| pattern.len > 1 and pattern[0] == '!',
+        .array => |items| blk: {
+            for (items.items) |item| {
+                if (item == .string and item.string.len > 1 and item.string[0] == '!') break :blk true;
+            }
+            break :blk false;
+        },
+        else => false,
+    };
+}
+
+fn applyIgnorePattern(paths: ConfigPaths, raw_pattern: []const u8, ignored: *bool) void {
+    const negated = raw_pattern.len > 1 and raw_pattern[0] == '!';
+    const pattern = if (negated) raw_pattern[1..] else raw_pattern;
+    if (matchesIgnorePattern(paths, pattern)) ignored.* = !negated;
+}
+
+fn matchesConfigPattern(paths: ConfigPaths, raw_pattern: []const u8) bool {
+    const pattern = normalizePattern(raw_pattern);
+    const target = if (std.fs.path.isAbsolute(pattern)) paths.absolute else paths.relative;
+    if (!hasGlobSyntax(pattern)) {
+        return pathEql(target, pattern) or pathStartsWith(target, pattern) or pathEndsWith(target, pattern);
+    }
+    return globMatches(pattern, target);
+}
+
+fn matchesIgnorePattern(paths: ConfigPaths, raw_pattern: []const u8) bool {
+    var pattern = normalizePattern(raw_pattern);
+    const absolute = std.fs.path.isAbsolute(pattern);
+    var target = if (absolute) paths.absolute else paths.relative;
+    const anchored = !absolute and pattern.len > 0 and isSeparator(pattern[0]);
+    if (anchored) pattern = pattern[1..];
+    if (anchored and target.len > 0 and isSeparator(target[0])) target = target[1..];
+
+    if (endsWithNormalized(pattern, "/**")) {
+        const directory_pattern = pattern[0 .. pattern.len - 3];
+        if (!hasGlobSyntax(directory_pattern)) {
+            return pathEql(target, directory_pattern) or pathStartsWith(target, directory_pattern);
+        }
+        if (globMatches(directory_pattern, target)) return true;
+        var index: usize = 0;
+        while (index < target.len) : (index += 1) {
+            if (isSeparator(target[index]) and globMatches(directory_pattern, target[0..index])) return true;
+        }
+        return false;
+    }
+    if (startsWithNormalized(pattern, "**/")) {
+        const suffix = pattern[3..];
+        if (!hasGlobSyntax(suffix) and (pathEndsWith(target, suffix) or pathContainsSegmentSuffix(target, suffix))) return true;
+    }
+    if (!hasGlobSyntax(pattern)) {
+        if (absolute or anchored or containsSeparator(pattern)) {
+            return pathEql(target, pattern) or pathStartsWith(target, pattern);
+        }
+        return pathEql(target, pattern) or pathEndsWith(target, pattern) or pathStartsWith(target, pattern);
+    }
+    if (absolute or anchored or containsSeparator(pattern)) return globMatches(pattern, target);
+    if (globMatches(pattern, target)) return true;
+    var index: usize = 0;
+    while (index < target.len) : (index += 1) {
+        if (isSeparator(target[index]) and globMatches(pattern, target[index + 1 ..])) return true;
+    }
+    return false;
+}
+
+fn normalizePattern(pattern: []const u8) []const u8 {
+    var result = pattern;
+    while (startsWithNormalized(result, "./")) result = result[2..];
+    while (result.len > 1 and isSeparator(result[result.len - 1])) result = result[0 .. result.len - 1];
+    return result;
+}
+
+fn hasGlobSyntax(pattern: []const u8) bool {
+    return std.mem.indexOfAny(u8, pattern, "*?[{") != null;
+}
+
+fn globMatches(pattern: []const u8, path: []const u8) bool {
+    return globMatchesAt(pattern, 0, path, 0);
+}
+
+fn globMatchesAt(pattern: []const u8, pattern_index: usize, path: []const u8, path_index: usize) bool {
+    var pi = pattern_index;
+    var si = path_index;
+    while (pi < pattern.len) {
+        const char = normalizedChar(pattern[pi]);
+        if (char == '*') {
+            if (pi + 1 < pattern.len and pattern[pi + 1] == '*') {
+                var next = pi + 2;
+                while (next < pattern.len and pattern[next] == '*') next += 1;
+                if (next < pattern.len and isSeparator(pattern[next])) {
+                    next += 1;
+                    if (globMatchesAt(pattern, next, path, si)) return true;
+                    var cursor = si;
+                    while (cursor < path.len) : (cursor += 1) {
+                        if (isSeparator(path[cursor]) and globMatchesAt(pattern, next, path, cursor + 1)) return true;
+                    }
+                    return false;
+                }
+                var cursor = si;
+                while (true) : (cursor += 1) {
+                    if (globMatchesAt(pattern, next, path, cursor)) return true;
+                    if (cursor == path.len) return false;
+                }
+            }
+            var cursor = si;
+            while (true) : (cursor += 1) {
+                if (globMatchesAt(pattern, pi + 1, path, cursor)) return true;
+                if (cursor == path.len or isSeparator(path[cursor])) return false;
+            }
+        }
+        if (char == '?') {
+            if (si == path.len or isSeparator(path[si])) return false;
+            pi += 1;
+            si += 1;
+            continue;
+        }
+        if (char == '{') {
+            const end = std.mem.indexOfScalarPos(u8, pattern, pi + 1, '}') orelse return false;
+            var choices = std.mem.splitScalar(u8, pattern[pi + 1 .. end], ',');
+            while (choices.next()) |choice| {
+                if (pathHasLiteral(path, si, choice) and globMatchesAt(pattern, end + 1, path, si + choice.len)) return true;
+            }
+            return false;
+        }
+        if (char == '[') {
+            const end = std.mem.indexOfScalarPos(u8, pattern, pi + 1, ']') orelse return false;
+            if (si == path.len or isSeparator(path[si]) or !classMatches(pattern[pi + 1 .. end], path[si])) return false;
+            pi = end + 1;
+            si += 1;
+            continue;
+        }
+        if (si == path.len or normalizedChar(path[si]) != char) return false;
+        pi += 1;
+        si += 1;
+    }
+    return si == path.len;
+}
+
+fn classMatches(class: []const u8, value: u8) bool {
+    if (class.len == 0) return false;
+    const negated = class[0] == '!' or class[0] == '^';
+    var matched = false;
+    var index: usize = if (negated) 1 else 0;
+    while (index < class.len) : (index += 1) {
+        if (index + 2 < class.len and class[index + 1] == '-') {
+            matched = matched or (value >= class[index] and value <= class[index + 2]);
+            index += 2;
+        } else {
+            matched = matched or value == class[index];
+        }
+    }
+    return if (negated) !matched else matched;
+}
+
+fn pathHasLiteral(path: []const u8, start: usize, literal: []const u8) bool {
+    if (start + literal.len > path.len) return false;
+    for (literal, 0..) |char, index| {
+        if (normalizedChar(path[start + index]) != normalizedChar(char)) return false;
+    }
+    return true;
+}
+
+fn pathEql(path: []const u8, pattern: []const u8) bool {
+    return path.len == pattern.len and pathHasLiteral(path, 0, pattern);
+}
+
+fn pathStartsWith(path: []const u8, pattern: []const u8) bool {
+    return pathHasLiteral(path, 0, pattern) and path.len > pattern.len and isSeparator(path[pattern.len]);
+}
+
+fn pathEndsWith(path: []const u8, pattern: []const u8) bool {
+    if (pattern.len > path.len) return false;
+    const start = path.len - pattern.len;
+    return pathHasLiteral(path, start, pattern) and start > 0 and isSeparator(path[start - 1]);
+}
+
+fn pathContainsSegmentSuffix(path: []const u8, suffix: []const u8) bool {
+    if (suffix.len > path.len) return false;
+    var index: usize = 0;
+    while (index + suffix.len <= path.len) : (index += 1) {
+        if ((index == 0 or isSeparator(path[index - 1])) and pathHasLiteral(path, index, suffix)) return true;
+    }
+    return false;
+}
+
+fn containsSeparator(value: []const u8) bool {
+    for (value) |char| if (isSeparator(char)) return true;
+    return false;
+}
+
+fn startsWithNormalized(value: []const u8, prefix: []const u8) bool {
+    return value.len >= prefix.len and pathHasLiteral(value, 0, prefix);
+}
+
+fn endsWithNormalized(value: []const u8, suffix: []const u8) bool {
+    return value.len >= suffix.len and pathHasLiteral(value, value.len - suffix.len, suffix);
+}
+
+fn normalizedChar(char: u8) u8 {
+    return if (char == '\\') '/' else char;
+}
+
+fn isSeparator(char: u8) bool {
+    return char == '/' or char == '\\';
+}
+
+test "glob matching covers flat config selectors" {
+    try std.testing.expect(globMatches("src/**/*.ts", "src/index.ts"));
+    try std.testing.expect(globMatches("src/**/*.ts", "src/nested/index.ts"));
+    try std.testing.expect(globMatches("**/*.{js,ts}", "packages/app/src/index.ts"));
+    try std.testing.expect(globMatches("test/?oo.[jt]s", "test/foo.js"));
+    try std.testing.expect(!globMatches("src/**/*.ts", "test/index.ts"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const lint = @import("utoo_lint");
+const flat_config = @import("flat_config.zig");
 
 const max_file_size = 64 * 1024 * 1024;
 const max_config_file_size = 1024 * 1024;
@@ -66,7 +67,7 @@ const JsonOutput = struct {
 };
 
 const JsonOutputList = std.ArrayList(JsonOutput);
-const RuleSeverityMap = std.StringHashMap(lint.Severity);
+const RuleSeverityMap = flat_config.RuleSeverityMap;
 
 const JsonReport = struct {
     files: usize,
@@ -81,6 +82,7 @@ const WorkQueue = struct {
     files: []const []const u8,
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
+    config: ?*const flat_config.FlatConfig,
     fix_mode: FixMode,
     use_color: bool,
     next_index: std.atomic.Value(usize) = .init(0),
@@ -109,12 +111,14 @@ pub fn main(init: std.process.Init) !void {
         rule_severities.deinit();
     }
     const config = parseConfigArgs(args[1..]);
+    var loaded_flat_config: ?flat_config.FlatConfig = null;
+    defer if (loaded_flat_config) |*loaded| loaded.deinit(allocator);
     if (config.enabled) {
         if (config.path) |path| {
-            try loadConfigFile(allocator, io, path, true, &options, &rule_severities);
+            loaded_flat_config = try loadConfigFile(allocator, io, path, config.root, config.cwd, true, &options, &rule_severities);
         } else if (try findDefaultConfig(allocator, io)) |path| {
             defer allocator.free(path);
-            try loadConfigFile(allocator, io, path, false, &options, &rule_severities);
+            loaded_flat_config = try loadConfigFile(allocator, io, path, config.root, config.cwd, false, &options, &rule_severities);
         }
     }
 
@@ -132,6 +136,10 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, arg, "--no-config")) {
             continue;
         } else if (std.mem.startsWith(u8, arg, "--config=")) {
+            continue;
+        } else if (std.mem.startsWith(u8, arg, "--config-root=")) {
+            continue;
+        } else if (std.mem.startsWith(u8, arg, "--config-cwd=")) {
             continue;
         } else if (std.mem.startsWith(u8, arg, "--threads=")) {
             const value = arg["--threads=".len..];
@@ -1334,7 +1342,8 @@ pub fn main(init: std.process.Init) !void {
         }
     }
 
-    if (targets.items.len == 0) {
+    const uses_default_targets = targets.items.len == 0;
+    if (uses_default_targets) {
         try targets.append(allocator, ".");
     }
 
@@ -1356,21 +1365,45 @@ pub fn main(init: std.process.Init) !void {
 
     var stats = Stats{};
     for (targets.items) |target| {
-        try collectLintablePaths(allocator, io, target, &files, &stats, json_diagnostics_ptr);
+        try collectLintablePaths(allocator, io, target, &files, &stats, json_diagnostics_ptr, if (loaded_flat_config) |*loaded| loaded else null, uses_default_targets);
     }
 
+    const resolve_flat_rules = !hasRuleOverrideArg(args[1..]);
+    const flat_config_for_lint: ?*const flat_config.FlatConfig = if (resolve_flat_rules)
+        if (loaded_flat_config) |*loaded| loaded else null
+    else
+        null;
     if (output_format == .json) {
-        try lintFilesJson(allocator, io, files.items, options, &rule_severities, fix_mode, &stats, &json_diagnostics, &json_suppressed_diagnostics, &json_outputs);
+        try lintFilesJson(allocator, io, files.items, options, &rule_severities, flat_config_for_lint, fix_mode, &stats, &json_diagnostics, &json_suppressed_diagnostics, &json_outputs);
         try writeJsonReport(io, stats, files.items, json_diagnostics.items, json_suppressed_diagnostics.items, json_outputs.items);
     } else {
         const use_color = color_override orelse detectColorSupport(io, init.environ_map.*);
-        try lintFiles(allocator, io, files.items, options, &rule_severities, fix_mode, thread_count_override, use_color, &stats);
+        try lintFiles(allocator, io, files.items, options, &rule_severities, flat_config_for_lint, fix_mode, thread_count_override, use_color, &stats);
         printTextSummary(stats, fix_mode, use_color);
     }
 
     if (stats.errors > 0) {
         std.process.exit(1);
     }
+}
+
+fn hasRuleOverrideArg(args: []const []const u8) bool {
+    for (args) |arg| {
+        if (!std.mem.startsWith(u8, arg, "--")) continue;
+        if (std.mem.eql(u8, arg, "--no-config") or
+            std.mem.eql(u8, arg, "--json") or
+            std.mem.eql(u8, arg, "--color") or
+            std.mem.eql(u8, arg, "--no-color") or
+            std.mem.eql(u8, arg, "--fix") or
+            std.mem.eql(u8, arg, "--fix-dry-run") or
+            std.mem.startsWith(u8, arg, "--config=") or
+            std.mem.startsWith(u8, arg, "--config-root=") or
+            std.mem.startsWith(u8, arg, "--config-cwd=") or
+            std.mem.startsWith(u8, arg, "--threads=") or
+            std.mem.startsWith(u8, arg, "--format=")) continue;
+        return true;
+    }
+    return false;
 }
 
 fn hasHelpArg(args: []const []const u8) bool {
@@ -1383,6 +1416,8 @@ fn hasHelpArg(args: []const []const u8) bool {
 const ConfigArgs = struct {
     enabled: bool = true,
     path: ?[]const u8 = null,
+    root: ?[]const u8 = null,
+    cwd: ?[]const u8 = null,
 };
 
 fn parseConfigArgs(args: []const []const u8) ConfigArgs {
@@ -1398,13 +1433,27 @@ fn parseConfigArgs(args: []const []const u8) ConfigArgs {
                 std.debug.print("utoo-lint: --config requires a path\n", .{});
                 std.process.exit(2);
             }
+        } else if (std.mem.startsWith(u8, arg, "--config-root=")) {
+            config.root = arg["--config-root=".len..];
+            if (config.root.?.len == 0) {
+                std.debug.print("utoo-lint: --config-root requires a path\n", .{});
+                std.process.exit(2);
+            }
+        } else if (std.mem.startsWith(u8, arg, "--config-cwd=")) {
+            config.cwd = arg["--config-cwd=".len..];
+            if (config.cwd.?.len == 0) {
+                std.debug.print("utoo-lint: --config-cwd requires a path\n", .{});
+                std.process.exit(2);
+            }
         }
     }
     return config;
 }
 
 fn findDefaultConfig(allocator: std.mem.Allocator, io: std.Io) !?[]u8 {
-    const start = try std.process.currentPathAlloc(io, allocator);
+    const current = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(current);
+    const start = try allocator.dupe(u8, current);
     return findDefaultConfigFrom(allocator, io, start);
 }
 
@@ -1454,16 +1503,18 @@ fn loadConfigFile(
     allocator: std.mem.Allocator,
     io: std.Io,
     path: []const u8,
+    config_root: ?[]const u8,
+    config_cwd: ?[]const u8,
     explicit: bool,
     options: *lint.Options,
     rule_severities: *RuleSeverityMap,
-) !void {
+) !?flat_config.FlatConfig {
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_config_file_size)) catch |err| {
         if (explicit) {
             std.debug.print("utoo-lint: unable to read config {s}: {s}\n", .{ path, @errorName(err) });
             std.process.exit(2);
         }
-        return;
+        return null;
     };
     defer allocator.free(source);
 
@@ -1471,16 +1522,55 @@ fn loadConfigFile(
         std.debug.print("utoo-lint: invalid config {s}: {s}\n", .{ path, @errorName(err) });
         std.process.exit(2);
     };
-    defer parsed.deinit();
 
-    const root = switch (parsed.value) {
-        .object => |object| object,
+    switch (parsed.value) {
+        .object => |root| {
+            defer parsed.deinit();
+            try loadConfigObject(allocator, path, root, options, rule_severities);
+            return null;
+        },
+        .array => {
+            errdefer parsed.deinit();
+            const current = try std.process.currentPathAlloc(io, allocator);
+            defer allocator.free(current);
+            const cwd = try flat_config.canonicalPathAlloc(allocator, io, current, config_cwd orelse current);
+            errdefer allocator.free(cwd);
+            const absolute_path = try flat_config.canonicalPathAlloc(allocator, io, cwd, path);
+            defer allocator.free(absolute_path);
+            const directory = try flat_config.canonicalPathAlloc(
+                allocator,
+                io,
+                cwd,
+                config_root orelse std.fs.path.dirname(absolute_path) orelse ".",
+            );
+            var loaded = flat_config.FlatConfig{
+                .parsed = parsed,
+                .io = io,
+                .directory = directory,
+                .cwd = cwd,
+            };
+            loaded.validateAndApplyAggregate(allocator, options, rule_severities) catch |err| {
+                loaded.deinit(allocator);
+                std.debug.print("utoo-lint: invalid flat config {s}: {s}\n", .{ path, @errorName(err) });
+                std.process.exit(2);
+            };
+            return loaded;
+        },
         else => {
-            std.debug.print("utoo-lint: config {s} must be a JSON object\n", .{path});
+            parsed.deinit();
+            std.debug.print("utoo-lint: config {s} must be a JSON object or flat-config array\n", .{path});
             std.process.exit(2);
         },
-    };
+    }
+}
 
+fn loadConfigObject(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    root: std.json.ObjectMap,
+    options: *lint.Options,
+    rule_severities: *RuleSeverityMap,
+) !void {
     options.* = lint.Options.allDisabled();
     if (root.get("settings")) |settings_value| {
         const settings = switch (settings_value) {
@@ -1558,6 +1648,8 @@ fn collectLintablePaths(
     files: *std.ArrayList([]const u8),
     stats: *Stats,
     json_diagnostics: ?*JsonDiagnosticList,
+    config: ?*const flat_config.FlatConfig,
+    default_targets: bool,
 ) !void {
     const cwd = std.Io.Dir.cwd();
     const stat = cwd.statFile(io, path, .{}) catch |err| {
@@ -1575,13 +1667,24 @@ fn collectLintablePaths(
 
     switch (stat.kind) {
         .file => {
-            if (lint.isLintablePath(path)) {
+            if (lint.isLintablePath(path) and try shouldLintCollectedPath(allocator, path, config, default_targets)) {
                 try files.append(allocator, try allocator.dupe(u8, path));
             }
         },
-        .directory => try collectLintableDirectory(allocator, io, path, files, stats, json_diagnostics),
+        .directory => try collectLintableDirectory(allocator, io, path, files, stats, json_diagnostics, config, default_targets),
         else => {},
     }
+}
+
+fn shouldLintCollectedPath(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    config: ?*const flat_config.FlatConfig,
+    default_targets: bool,
+) !bool {
+    const loaded = config orelse return true;
+    if (try loaded.isGloballyIgnored(allocator, path)) return false;
+    return !default_targets or try loaded.selectsFile(allocator, path);
 }
 
 fn parseEnabledRules(
@@ -1967,6 +2070,8 @@ fn collectLintableDirectory(
     files: *std.ArrayList([]const u8),
     stats: *Stats,
     json_diagnostics: ?*JsonDiagnosticList,
+    config: ?*const flat_config.FlatConfig,
+    default_targets: bool,
 ) !void {
     var dir = try std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true });
     defer dir.close(io);
@@ -1980,11 +2085,15 @@ fn collectLintableDirectory(
 
         switch (entry.kind) {
             .file => {
-                if (lint.isLintablePath(child_path)) {
+                if (lint.isLintablePath(child_path) and try shouldLintCollectedPath(allocator, child_path, config, default_targets)) {
                     try files.append(allocator, try allocator.dupe(u8, child_path));
                 }
             },
-            .directory => try collectLintableDirectory(allocator, io, child_path, files, stats, json_diagnostics),
+            .directory => {
+                if (config == null or try config.?.shouldTraverseDirectory(allocator, child_path)) {
+                    try collectLintableDirectory(allocator, io, child_path, files, stats, json_diagnostics, config, default_targets);
+                }
+            },
             else => {},
         }
     }
@@ -1996,6 +2105,7 @@ fn lintFiles(
     files: []const []const u8,
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
+    config: ?*const flat_config.FlatConfig,
     fix_mode: FixMode,
     thread_count_override: ?usize,
     use_color: bool,
@@ -2006,7 +2116,7 @@ fn lintFiles(
     const worker_count = @min(files.len, thread_count_override orelse (std.Thread.getCpuCount() catch 1));
     if (worker_count <= 1) {
         for (files) |file| {
-            try lintFile(std.heap.smp_allocator, io, file, options, rule_severities, fix_mode, use_color, stats, null);
+            try lintFile(std.heap.smp_allocator, io, file, options, rule_severities, config, fix_mode, use_color, stats, null);
         }
         return;
     }
@@ -2016,6 +2126,7 @@ fn lintFiles(
         .files = files,
         .options = options,
         .rule_severities = rule_severities,
+        .config = config,
         .fix_mode = fix_mode,
         .use_color = use_color,
     };
@@ -2064,6 +2175,7 @@ fn lintFilesJson(
     files: []const []const u8,
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
+    config: ?*const flat_config.FlatConfig,
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
@@ -2071,7 +2183,7 @@ fn lintFilesJson(
     json_outputs: *JsonOutputList,
 ) !void {
     for (files) |file| {
-        try lintFileJson(allocator, io, file, options, rule_severities, fix_mode, stats, json_diagnostics, json_suppressed_diagnostics, json_outputs);
+        try lintFileJson(allocator, io, file, options, rule_severities, config, fix_mode, stats, json_diagnostics, json_suppressed_diagnostics, json_outputs);
     }
 }
 
@@ -2086,6 +2198,7 @@ fn lintWorker(queue: *WorkQueue, result: *WorkerResult) void {
             queue.files[index],
             queue.options,
             queue.rule_severities,
+            queue.config,
             queue.fix_mode,
             queue.use_color,
             &result.stats,
@@ -2103,12 +2216,18 @@ fn lintFileJson(
     path: []const u8,
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
+    config: ?*const flat_config.FlatConfig,
     fix_mode: FixMode,
     stats: *Stats,
     json_diagnostics: *JsonDiagnosticList,
     json_suppressed_diagnostics: *JsonDiagnosticList,
     json_outputs: *JsonOutputList,
 ) !void {
+    var resolved_config = if (config) |loaded| try loaded.resolveForFile(allocator, path) else null;
+    defer if (resolved_config) |*resolved| resolved.deinit(allocator);
+    const effective_options = if (resolved_config) |*resolved| resolved.options else options;
+    const effective_rule_severities = if (resolved_config) |*resolved| &resolved.rule_severities else rule_severities;
+
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
         defer allocator.free(message);
@@ -2122,13 +2241,13 @@ fn lintFileJson(
     stats.files += 1;
 
     if (fix_mode == .none) {
-        var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
+        var result = try lint.lintSourceWithIo(allocator, io, source, path, effective_options);
         defer result.deinit(allocator);
-        try appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, rule_severities, stats);
-        return appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, source, result, rule_severities);
+        try appendJsonResultDiagnostics(allocator, json_diagnostics, path, source, result, effective_rule_severities, stats);
+        return appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, source, result, effective_rule_severities);
     }
 
-    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
+    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, effective_options);
     defer fixed.deinit(allocator);
 
     if (fixed.fixed) {
@@ -2139,8 +2258,8 @@ fn lintFileJson(
         try appendJsonOutput(allocator, json_outputs, path, fixed.output);
     }
 
-    try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, rule_severities, stats);
-    try appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, fixed.output, fixed.result, rule_severities);
+    try appendJsonResultDiagnostics(allocator, json_diagnostics, path, fixed.output, fixed.result, effective_rule_severities, stats);
+    try appendJsonResultSuppressedDiagnostics(allocator, json_suppressed_diagnostics, path, fixed.output, fixed.result, effective_rule_severities);
 }
 
 fn lintFile(
@@ -2149,11 +2268,17 @@ fn lintFile(
     path: []const u8,
     options: lint.Options,
     rule_severities: *const RuleSeverityMap,
+    config: ?*const flat_config.FlatConfig,
     fix_mode: FixMode,
     use_color: bool,
     stats: *Stats,
     print_mutex: ?*std.Io.Mutex,
 ) !void {
+    var resolved_config = if (config) |loaded| try loaded.resolveForFile(allocator, path) else null;
+    defer if (resolved_config) |*resolved| resolved.deinit(allocator);
+    const effective_options = if (resolved_config) |*resolved| resolved.options else options;
+    const effective_rule_severities = if (resolved_config) |*resolved| &resolved.rule_severities else rule_severities;
+
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         printLocked(io, print_mutex, "{s}: unable to read file: {s}\n", .{ path, @errorName(err) });
         stats.errors += 1;
@@ -2165,12 +2290,12 @@ fn lintFile(
     stats.files += 1;
 
     if (fix_mode == .none) {
-        var result = try lint.lintSourceWithIo(allocator, io, source, path, options);
+        var result = try lint.lintSourceWithIo(allocator, io, source, path, effective_options);
         defer result.deinit(allocator);
-        return printResultDiagnostics(allocator, io, print_mutex, path, source, result, rule_severities, use_color, stats);
+        return printResultDiagnostics(allocator, io, print_mutex, path, source, result, effective_rule_severities, use_color, stats);
     }
 
-    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, options);
+    var fixed = try lint.lintSourceAndFixWithIo(allocator, io, source, path, effective_options);
     defer fixed.deinit(allocator);
 
     if (fixed.fixed) {
@@ -2180,7 +2305,7 @@ fn lintFile(
         }
     }
 
-    try printResultDiagnostics(allocator, io, print_mutex, path, fixed.output, fixed.result, rule_severities, use_color, stats);
+    try printResultDiagnostics(allocator, io, print_mutex, path, fixed.output, fixed.result, effective_rule_severities, use_color, stats);
 }
 
 fn printResultDiagnostics(

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -3,6 +3,10 @@ comptime {
 }
 
 comptime {
+    _ = @import("flat_config");
+}
+
+comptime {
     _ = @import("suppressions.zig");
 }
 


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- resolve JSON flat-config arrays inside the native binary, including per-file `files`, global and scoped `ignores`, ordered rule/settings overrides, config-relative patterns, and default target filtering
- serialize TypeScript and inline JavaScript configs once in the npm wrapper and delegate supported workloads to a single native process, with the existing grouped path retained for explicit rule overrides and mixed config sources
- add raw-native and wrapper regression coverage, matcher unit tests, updated docs, and a 1,000-file source/test CodSpeed workload

## Verification

- `node --test --test-concurrency=1 --test-reporter=dot test/*.test.mjs` (124 tests)
- `pnpm test:types`
- `zig build test`
- `pnpm --dir benchmarks codspeed -- --target=/private/tmp/utoo-lint-codspeed-smoke-1187 --time=0 --warmup-time=0`
- `node --check` and `git diff --check`

Fixes #1187