### PR TITLE
fix: apply ESLint directives before autofix

### DIFF
--- a/npm/@utoo/lint-wasm/index.d.ts
+++ b/npm/@utoo/lint-wasm/index.d.ts
@@ -40,6 +40,7 @@ export interface LintDiagnostic {
   fixes: LintFix[];
   suggestions: LintSuggestion[];
   suppression?: LintSuppression;
+  suppressions?: LintSuppression[];
 }
 
 export interface LintOptions {

--- a/npm/@utoo/lint-wasm/test/types/usage.ts
+++ b/npm/@utoo/lint-wasm/test/types/usage.ts
@@ -15,6 +15,8 @@ const direct: LintResult = linter.lint("debugger;", {
 });
 const diagnostic: LintDiagnostic | undefined = direct.diagnostics[0];
 void diagnostic?.range;
+const suppressedDiagnostic: LintDiagnostic | undefined = direct.suppressedDiagnostics[0];
+void suppressedDiagnostic?.suppressions?.[0]?.justification;
 
 const lintOnly: LintOnlyResult = await lint("console.log('x');", {
   rules: { "no-console": "warn" },

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -2426,6 +2426,7 @@ function applyDisableDirectives(messages, sourceCode) {
   }
   const directives = sourceCode.getDisableDirectives()
     .filter((directive) => directive.node?.loc?.start?.line)
+    .filter((directive) => directive.type !== "eslint-disable-line" || directive.node.loc.start.line === directive.node.loc.end.line)
     .sort((left, right) => left.node.loc.start.line - right.node.loc.start.line);
   const utlintDirectives = sourceCode.getAllComments()
     .map((comment) => utlintDirectiveFromComment(comment, sourceCode))

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -4804,10 +4804,12 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 function suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities) {
   return {
     ...diagnosticToESLintMessage(diagnostic, ruleSeverities),
-    suppressions: [{
-      kind: diagnostic.suppression?.kind ?? "directive",
-      justification: diagnostic.suppression?.justification ?? ""
-    }]
+    suppressions: diagnostic.suppressions?.length > 0
+      ? diagnostic.suppressions
+      : [{
+          kind: diagnostic.suppression?.kind ?? "directive",
+          justification: diagnostic.suppression?.justification ?? ""
+        }]
   };
 }
 

--- a/npm/utoo-lint/index.d.ts
+++ b/npm/utoo-lint/index.d.ts
@@ -17,7 +17,7 @@ export interface LintSuppression {
   justification: string;
 }
 
-export interface LintDiagnostic extends Omit<LintMessage, "severity" | "suppressions"> {
+export interface LintDiagnostic extends Omit<LintMessage, "severity"> {
   severity: "warning" | "error";
   suppression?: LintSuppression;
 }

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -4807,10 +4807,12 @@ function diagnosticToESLintMessage(diagnostic, ruleSeverities) {
 function suppressedDiagnosticToESLintMessage(diagnostic, ruleSeverities) {
   return {
     ...diagnosticToESLintMessage(diagnostic, ruleSeverities),
-    suppressions: [{
-      kind: diagnostic.suppression?.kind ?? "directive",
-      justification: diagnostic.suppression?.justification ?? ""
-    }]
+    suppressions: diagnostic.suppressions?.length > 0
+      ? diagnostic.suppressions
+      : [{
+          kind: diagnostic.suppression?.kind ?? "directive",
+          justification: diagnostic.suppression?.justification ?? ""
+        }]
   };
 }
 

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -984,6 +984,7 @@ function applyDisableDirectives(messages, sourceCode) {
   }
   const directives = sourceCode.getDisableDirectives()
     .filter((directive) => directive.node?.loc?.start?.line)
+    .filter((directive) => directive.type !== "eslint-disable-line" || directive.node.loc.start.line === directive.node.loc.end.line)
     .sort((left, right) => left.node.loc.start.line - right.node.loc.start.line);
   const utlintDirectives = sourceCode.getAllComments()
     .map((comment) => utlintDirectiveFromComment(comment, sourceCode))

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -650,6 +650,51 @@ test("ESM and CommonJS ESLint report every overlapping disable directive", async
   ]);
 });
 
+test("ESLint disable directives accept empty justifications", async () => {
+  const source = [
+    "/* eslint-disable no-extra-semi -- */",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: { rules: { "no-extra-semi": "error" } }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "empty-justification.js" });
+  assert.equal(result.output, undefined);
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "" }
+  ]);
+});
+
+test("native reports preserve overlapping utlint and ESLint metadata", () => {
+  const source = [
+    "/* eslint-disable no-extra-semi -- generated */",
+    "// utlint-ignore no-extra-semi: intentional",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const report = lintText(source, {
+    binary: testBinary(),
+    noConfig: true,
+    filePath: "mixed-directives.js",
+    overrideConfig: { rules: { "no-extra-semi": "error" } }
+  });
+
+  assert.deepEqual(report.diagnostics, []);
+  assert.equal(report.suppressedDiagnostics[0].suppression.justification, "intentional");
+  assert.deepEqual(report.suppressedDiagnostics[0].suppressions, [
+    { kind: "directive", justification: "generated" },
+    { kind: "directive", justification: "intentional" }
+  ]);
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -564,6 +564,21 @@ test("multiline eslint-disable-line does not suppress diagnostics", async () => 
   assert.equal(result.output, source.replace("const value = 1;;", "const value = 1;"));
   assert.deepEqual(result.messages, []);
   assert.deepEqual(result.suppressedMessages, []);
+
+  const lintOnly = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+  const [lintResult] = await lintOnly.lintText(source, { filePath: "invalid-directive.js" });
+  assert.equal(lintResult.messages.length, 1);
+  assert.equal(lintResult.messages[0].ruleId, "no-extra-semi");
+  assert.deepEqual(lintResult.suppressedMessages, []);
 });
 
 test("ESLint directives accept ECMAScript whitespace", async () => {

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -609,6 +609,47 @@ test("ESLint directives accept ECMAScript whitespace", async () => {
   ]);
 });
 
+test("ESM and CommonJS ESLint report every overlapping disable directive", async () => {
+  const source = [
+    "/* eslint-disable no-extra-semi -- generated */",
+    "const value = 1;; // eslint-disable-line no-extra-semi -- intentional",
+    "void value;",
+    ""
+  ].join("\n");
+  for (const ESLintImplementation of [ESLint, CommonJSESLint]) {
+    const eslint = new ESLintImplementation({
+      binary: testBinary(),
+      noConfig: true,
+      overrideConfig: {
+        rules: {
+          "no-extra-semi": "error",
+          "no-unused-vars": "off"
+        }
+      }
+    });
+
+    const [result] = await eslint.lintText(source, { filePath: "overlapping-directives.js" });
+    assert.deepEqual(result.messages, []);
+    assert.equal(result.suppressedMessages.length, 1);
+    assert.deepEqual(result.suppressedMessages[0].suppressions, [
+      { kind: "directive", justification: "generated" },
+      { kind: "directive", justification: "intentional" }
+    ]);
+  }
+
+  const report = lintText(source, {
+    binary: testBinary(),
+    noConfig: true,
+    filePath: "overlapping-directives.js",
+    overrideConfig: { rules: { "no-extra-semi": "error" } }
+  });
+  assert.equal(report.suppressedDiagnostics[0].suppression.justification, "intentional");
+  assert.deepEqual(report.suppressedDiagnostics[0].suppressions, [
+    { kind: "directive", justification: "generated" },
+    { kind: "directive", justification: "intentional" }
+  ]);
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -535,6 +535,34 @@ test("multiline eslint-disable-line does not suppress diagnostics", async () => 
   assert.deepEqual(result.suppressedMessages, []);
 });
 
+test("ESLint directives accept ECMAScript whitespace", async () => {
+  const source = [
+    "/*\feslint-disable-next-line\fno-extra-semi\f--\fintentional\f*/",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "whitespace.js" });
+  assert.equal(result.output, undefined);
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "intentional" }
+  ]);
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -666,6 +666,22 @@ test("ESLint range suppressions precede earlier same-line suppressions", async (
   ]);
 });
 
+test("utlint metadata survives an earlier ESLint line suppression", () => {
+  const source = "/* eslint-disable-line no-undef -- eslint */ /* utlint-ignore no-undef: utoo */ foo();\n";
+  const report = lintText(source, {
+    binary: testBinary(),
+    noConfig: true,
+    filePath: "mixed-line-directives.js",
+    overrideConfig: { rules: { "no-undef": "error" } }
+  });
+
+  assert.deepEqual(report.diagnostics, []);
+  assert.deepEqual(report.suppressedDiagnostics[0].suppressions, [
+    { kind: "directive", justification: "eslint" },
+    { kind: "directive", justification: "utoo" }
+  ]);
+});
+
 test("ESLint disable directives accept empty justifications", async () => {
   const source = [
     "/* eslint-disable no-extra-semi -- */",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -510,6 +510,31 @@ test("eslint-disable-next-line recognizes every JavaScript line terminator", asy
   }
 });
 
+test("multiline eslint-disable-line does not suppress diagnostics", async () => {
+  const source = [
+    "const value = 1;; /* eslint-disable-line",
+    "   no-extra-semi */",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "invalid-directive.js" });
+  assert.equal(result.output, source.replace("const value = 1;;", "const value = 1;"));
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.suppressedMessages, []);
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -449,6 +449,67 @@ test("ESLint directives inside template interpolations suppress native diagnosti
   assert.equal(result.suppressedMessages[0].ruleId, "no-undef");
 });
 
+test("multiline eslint-disable-next-line starts after the block comment", async () => {
+  const source = [
+    "/* eslint-disable-next-line",
+    "   no-extra-semi */",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "multiline.js" });
+  assert.equal(result.output, undefined);
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-extra-semi");
+});
+
+test("eslint-disable-next-line recognizes every JavaScript line terminator", async (t) => {
+  for (const [name, lineTerminator] of [
+    ["carriage return", "\r"],
+    ["line separator", "\u2028"],
+    ["paragraph separator", "\u2029"]
+  ]) {
+    await t.test(name, async () => {
+      const source = [
+        "// eslint-disable-next-line no-extra-semi",
+        "const value = 1;;",
+        "void value;",
+        ""
+      ].join(lineTerminator);
+      const eslint = new ESLint({
+        binary: testBinary(),
+        fix: true,
+        noConfig: true,
+        overrideConfig: {
+          rules: {
+            "no-extra-semi": "error",
+            "no-unused-vars": "off"
+          }
+        }
+      });
+
+      const [result] = await eslint.lintText(source, { filePath: `${name}.js` });
+      assert.equal(result.output, undefined);
+      assert.deepEqual(result.messages, []);
+      assert.equal(result.suppressedMessages.length, 1);
+      assert.equal(result.suppressedMessages[0].ruleId, "no-extra-semi");
+    });
+  }
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -650,6 +650,22 @@ test("ESM and CommonJS ESLint report every overlapping disable directive", async
   ]);
 });
 
+test("ESLint range suppressions precede earlier same-line suppressions", async () => {
+  const source = "/* eslint-disable-line no-undef -- line */ /* eslint-disable no-undef -- range */ foo();\n";
+  const eslint = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: { rules: { "no-undef": "error" } }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "suppression-order.js" });
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "range" },
+    { kind: "directive", justification: "line" }
+  ]);
+});
+
 test("ESLint disable directives accept empty justifications", async () => {
   const source = [
     "/* eslint-disable no-extra-semi -- */",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -369,6 +369,86 @@ test("CLIEngine.executeOnFiles applies eslint-disable directives to native diagn
   assert.equal(report.results[0].suppressedMessages[0].ruleId, "no-param-reassign");
 });
 
+test("ESLint fix mode does not apply fixes disabled by eslint directives", async () => {
+  const source = "const value = 1;; // eslint-disable-line no-extra-semi\nconsole.log(value);\n";
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-console": "off",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "suppressed.js" });
+  assert.equal(result.output, undefined);
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-extra-semi");
+});
+
+test("ESLint fix mode honors disable ranges with selective enables", async () => {
+  const source = [
+    "/* eslint-disable -- generated code */",
+    "const first = 1;;",
+    "/* eslint-enable no-extra-semi */",
+    "const second = 2;;",
+    "void first;",
+    "void second;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "suppressed.js" });
+  assert.equal(result.output, source.replace("const second = 2;;", "const second = 2;"));
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-extra-semi");
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated code" }
+  ]);
+});
+
+test("ESLint directives inside template interpolations suppress native diagnostics", async () => {
+  const source = [
+    "const text = `${",
+    "  // eslint-disable-next-line no-console, no-undef",
+    "  missingValue",
+    "}`;",
+    "void text;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-undef": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "template.js" });
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.equal(result.suppressedMessages[0].ruleId, "no-undef");
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -423,6 +423,37 @@ test("ESLint fix mode honors disable ranges with selective enables", async () =>
   ]);
 });
 
+test("ESLint disable ranges treat comma-only rule lists as all rules", async () => {
+  const source = [
+    "/* eslint-disable , -- generated code */",
+    "const first = 1;;",
+    "/* eslint-enable , */",
+    "const second = 2;;",
+    "void first;",
+    "void second;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: {
+      rules: {
+        "no-extra-semi": "error",
+        "no-unused-vars": "off"
+      }
+    }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "comma-only.js" });
+  assert.equal(result.output, source.replace("const second = 2;;", "const second = 2;"));
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.suppressedMessages.length, 1);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated code" }
+  ]);
+});
+
 test("ESLint directives inside template interpolations suppress native diagnostics", async () => {
   const source = [
     "const text = `${",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -695,6 +695,26 @@ test("native reports preserve overlapping utlint and ESLint metadata", () => {
   ]);
 });
 
+test("repeated rule targets produce one suppression per ESLint directive", async () => {
+  const source = [
+    "/* eslint-disable no-extra-semi, no-extra-semi -- generated */",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    noConfig: true,
+    overrideConfig: { rules: { "no-extra-semi": "error" } }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "repeated-rule-target.js" });
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.suppressedMessages[0].suppressions, [
+    { kind: "directive", justification: "generated" }
+  ]);
+});
+
 test("lintText returns suppressed native diagnostics with the requested file path", () => {
   const report = lintText(
     "// utlint-ignore no-debugger: generated breakpoint\ndebugger;\n",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -672,6 +672,25 @@ test("ESLint disable directives accept empty justifications", async () => {
   ]);
 });
 
+test("ESLint justification separators require trailing whitespace", async () => {
+  const source = [
+    "/* eslint-disable-next-line no-extra-semi --*/",
+    "const value = 1;;",
+    "void value;",
+    ""
+  ].join("\n");
+  const eslint = new ESLint({
+    binary: testBinary(),
+    fix: true,
+    noConfig: true,
+    overrideConfig: { rules: { "no-extra-semi": "error" } }
+  });
+
+  const [result] = await eslint.lintText(source, { filePath: "invalid-separator.js" });
+  assert.notEqual(result.output, undefined);
+  assert.deepEqual(result.suppressedMessages, []);
+});
+
 test("native reports preserve overlapping utlint and ESLint metadata", () => {
   const source = [
     "/* eslint-disable no-extra-semi -- generated */",

--- a/src/core.zig
+++ b/src/core.zig
@@ -10362,6 +10362,7 @@ pub const Diagnostic = struct {
     fixes: []Fix,
     suggestions: []Suggestion = &.{},
     suppression: ?Suppression = null,
+    suppressions: []Suppression = &.{},
 };
 
 pub const Suppression = struct {
@@ -10601,7 +10602,12 @@ pub fn freeDiagnostic(allocator: Allocator, diagnostic: Diagnostic) void {
     allocator.free(diagnostic.message);
     freeFixes(allocator, diagnostic.fixes);
     freeSuggestions(allocator, diagnostic.suggestions);
-    if (diagnostic.suppression) |suppression| allocator.free(suppression.justification);
+    if (diagnostic.suppressions.len > 0) {
+        for (diagnostic.suppressions) |suppression| allocator.free(suppression.justification);
+        allocator.free(diagnostic.suppressions);
+    } else if (diagnostic.suppression) |suppression| {
+        allocator.free(suppression.justification);
+    }
 }
 
 pub fn freeDiagnosticSlice(allocator: Allocator, diagnostics: []Diagnostic) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,6 +56,7 @@ const JsonDiagnostic = struct {
     fixes: []const JsonFix,
     suggestions: []const JsonSuggestion,
     suppression: ?JsonSuppression = null,
+    suppressions: []const JsonSuppression = &.{},
 };
 
 const JsonDiagnosticList = std.ArrayList(JsonDiagnostic);
@@ -1564,7 +1565,7 @@ fn collectLintablePaths(
         if (json_diagnostics) |diagnostics| {
             const message = try std.fmt.allocPrint(allocator, "unable to stat path: {s}", .{@errorName(err)});
             defer allocator.free(message);
-            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null);
+            try appendJsonDiagnostic(allocator, diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null, &.{});
         } else {
             std.debug.print("{s}: unable to stat path: {s}\n", .{ path, @errorName(err) });
         }
@@ -2112,7 +2113,7 @@ fn lintFileJson(
     const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_file_size)) catch |err| {
         const message = try std.fmt.allocPrint(allocator, "unable to read file: {s}", .{@errorName(err)});
         defer allocator.free(message);
-        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null);
+        try appendJsonDiagnostic(allocator, json_diagnostics, path, 0, 0, "error", message, "io", "", &.{}, &.{}, null, &.{});
         stats.errors += 1;
         stats.diagnostics += 1;
         return;
@@ -2250,7 +2251,8 @@ fn appendJsonDiagnostic(
     source: []const u8,
     fixes: []const lint.Fix,
     suggestions: []const lint.Suggestion,
-    suppression: ?JsonSuppression,
+    suppression: ?lint.Suppression,
+    suppressions: []const lint.Suppression,
 ) !void {
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
@@ -2267,16 +2269,42 @@ fn appendJsonDiagnostic(
     const owned_suggestions = try dupeJsonSuggestions(allocator, source, suggestions);
     errdefer freeOwnedJsonSuggestions(allocator, owned_suggestions);
 
-    const owned_suppression: ?JsonSuppression = if (suppression) |item| suppression: {
-        const kind = try allocator.dupe(u8, item.kind);
-        errdefer allocator.free(kind);
-        const justification = try allocator.dupe(u8, item.justification);
-        break :suppression .{ .kind = kind, .justification = justification };
-    } else null;
-    errdefer if (owned_suppression) |item| {
-        allocator.free(item.kind);
-        allocator.free(item.justification);
+    const owned_suppressions = if (suppressions.len == 0)
+        &.{}
+    else suppressions: {
+        const owned = try allocator.alloc(JsonSuppression, suppressions.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (owned[0..initialized]) |item| {
+                allocator.free(item.kind);
+                allocator.free(item.justification);
+            }
+            allocator.free(owned);
+        }
+        for (suppressions, 0..) |item, index| {
+            const kind = try allocator.dupe(u8, "directive");
+            errdefer allocator.free(kind);
+            owned[index] = .{
+                .kind = kind,
+                .justification = try allocator.dupe(u8, item.justification),
+            };
+            initialized += 1;
+        }
+        break :suppressions owned;
     };
+    errdefer {
+        for (owned_suppressions) |item| {
+            allocator.free(item.kind);
+            allocator.free(item.justification);
+        }
+        if (owned_suppressions.len > 0) allocator.free(owned_suppressions);
+    }
+    const primary_suppression_index: ?usize = if (suppression) |primary| suppression_index: {
+        for (suppressions, 0..) |item, index| {
+            if (std.mem.eql(u8, item.justification, primary.justification)) break :suppression_index index;
+        }
+        break :suppression_index null;
+    } else null;
 
     try diagnostics.append(allocator, .{
         .filePath = owned_path,
@@ -2287,7 +2315,13 @@ fn appendJsonDiagnostic(
         .ruleId = owned_rule_id,
         .fixes = owned_fixes,
         .suggestions = owned_suggestions,
-        .suppression = owned_suppression,
+        .suppression = if (primary_suppression_index) |index|
+            owned_suppressions[index]
+        else if (owned_suppressions.len > 0)
+            owned_suppressions[0]
+        else
+            null,
+        .suppressions = owned_suppressions,
     });
 }
 
@@ -2316,6 +2350,7 @@ fn appendJsonResultDiagnostics(
             diagnostic.fixes,
             diagnostic.suggestions,
             null,
+            &.{},
         );
 
         stats.diagnostics += 1;
@@ -2346,10 +2381,13 @@ fn appendJsonResultSuppressedDiagnostics(
             source,
             diagnostic.fixes,
             diagnostic.suggestions,
-            if (diagnostic.suppression) |suppression| .{
-                .kind = "directive",
-                .justification = suppression.justification,
-            } else null,
+            diagnostic.suppression,
+            if (diagnostic.suppressions.len > 0)
+                diagnostic.suppressions
+            else if (diagnostic.suppression) |suppression|
+                &.{suppression}
+            else
+                &.{},
         );
     }
 }
@@ -2444,10 +2482,11 @@ fn freeJsonDiagnostics(allocator: std.mem.Allocator, diagnostics: *JsonDiagnosti
         allocator.free(diagnostic.ruleId);
         freeOwnedJsonFixes(allocator, diagnostic.fixes);
         freeOwnedJsonSuggestions(allocator, diagnostic.suggestions);
-        if (diagnostic.suppression) |suppression| {
+        for (diagnostic.suppressions) |suppression| {
             allocator.free(suppression.kind);
             allocator.free(suppression.justification);
         }
+        if (diagnostic.suppressions.len > 0) allocator.free(diagnostic.suppressions);
     }
     diagnostics.deinit(allocator);
 }

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -34,6 +34,7 @@ const Directive = struct {
     kind: DirectiveKind,
     target: DirectiveTarget,
     span_start: u32,
+    span_end: u32,
     next_code_offset: ?u32 = null,
     top_level: bool = false,
 };
@@ -110,13 +111,14 @@ fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Erro
                 .kind = parsed.kind,
                 .target = parsed.target,
                 .span_start = comment.span.start,
+                .span_end = comment.span.end,
                 .next_code_offset = if (parsed.kind == .ignore) nextCodeOffset(tree, comment.span.end) else null,
                 .top_level = parsed.kind == .ignore_all and isTopLevelComment(tree, comment),
             });
             continue;
         }
         if (parseEslintDirective(value, comment.type)) |parsed| {
-            try appendEslintDirectiveTargets(allocator, &directives, parsed, comment.span.start);
+            try appendEslintDirectiveTargets(allocator, &directives, parsed, comment.span.start, comment.span.end);
         }
     }
 
@@ -191,12 +193,14 @@ fn appendEslintDirectiveTargets(
     directives: *std.ArrayList(Directive),
     parsed: ParsedEslintDirective,
     span_start: u32,
+    span_end: u32,
 ) Allocator.Error!void {
     if (parsed.rules.len == 0) {
         try directives.append(allocator, .{
             .kind = parsed.kind,
             .target = .{ .rule_id = null, .justification = parsed.justification },
             .span_start = span_start,
+            .span_end = span_end,
         });
         return;
     }
@@ -209,6 +213,7 @@ fn appendEslintDirectiveTargets(
             .kind = parsed.kind,
             .target = .{ .rule_id = rule_id, .justification = parsed.justification },
             .span_start = span_start,
+            .span_end = span_end,
         });
     }
 }
@@ -250,7 +255,11 @@ fn suppressionFor(
 
     for (directives) |directive| {
         if (directive.kind == .eslint_disable_line or directive.kind == .eslint_disable_next_line) {
-            const directive_line = lineAtOffset(line_starts, directive.span_start);
+            const directive_offset = if (directive.kind == .eslint_disable_next_line and directive.span_end > directive.span_start)
+                directive.span_end - 1
+            else
+                directive.span_start;
+            const directive_line = lineAtOffset(line_starts, directive_offset);
             const target_line = directive_line + @intFromBool(directive.kind == .eslint_disable_next_line);
             if (target_line == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
                 return .{ .justification = directive.target.justification };
@@ -375,8 +384,25 @@ fn collectLineStarts(allocator: Allocator, source: []const u8) Allocator.Error!s
     var starts: std.ArrayList(u32) = .empty;
     errdefer starts.deinit(allocator);
     try starts.append(allocator, 0);
-    for (source, 0..) |byte, index| {
-        if (byte == '\n' and index + 1 < source.len) try starts.append(allocator, @intCast(index + 1));
+
+    var index: usize = 0;
+    while (index < source.len) {
+        const terminator_len: usize = if (source[index] == '\r')
+            if (index + 1 < source.len and source[index + 1] == '\n') 2 else 1
+        else if (source[index] == '\n')
+            1
+        else if (index + 2 < source.len and source[index] == 0xe2 and source[index + 1] == 0x80 and
+            (source[index + 2] == 0xa8 or source[index + 2] == 0xa9))
+            3
+        else
+            0;
+        if (terminator_len == 0) {
+            index += 1;
+            continue;
+        }
+
+        index += terminator_len;
+        if (index < source.len) try starts.append(allocator, @intCast(index));
     }
     return starts;
 }

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -251,7 +251,7 @@ const ParsedEslintDirective = struct {
 };
 
 fn parseEslintDirective(value: []const u8, comment_type: ast.Comment.Type) ?ParsedEslintDirective {
-    const trimmed = trimEslintWhitespace(value);
+    const trimmed = trimEslintWhitespaceStart(value);
     const kinds = [_]struct { prefix: []const u8, kind: DirectiveKind }{
         .{ .prefix = "eslint-disable-next-line", .kind = .eslint_disable_next_line },
         .{ .prefix = "eslint-disable-line", .kind = .eslint_disable_line },
@@ -287,8 +287,7 @@ fn eslintDescriptionSeparator(value: []const u8) ?DescriptionSeparator {
 
         var end = index + leading_whitespace_len;
         while (end < value.len and value[end] == '-') : (end += 1) {}
-        if (end < index + leading_whitespace_len + 2) continue;
-        if (end == value.len) return .{ .start = index, .end = end };
+        if (end < index + leading_whitespace_len + 2 or end == value.len) continue;
         const trailing_whitespace_len = eslintWhitespaceLengthAt(value, end);
         if (trailing_whitespace_len == 0) continue;
         return .{ .start = index, .end = end + trailing_whitespace_len };
@@ -550,12 +549,8 @@ fn lineTerminatorLengthAt(source: []const u8, index: usize) usize {
 }
 
 fn trimEslintWhitespace(value: []const u8) []const u8 {
-    var start: usize = 0;
-    while (start < value.len) {
-        const whitespace_len = eslintWhitespaceLengthAt(value, start);
-        if (whitespace_len == 0) break;
-        start += whitespace_len;
-    }
+    const without_leading = trimEslintWhitespaceStart(value);
+    const start = value.len - without_leading.len;
 
     var cursor = start;
     var end = start;
@@ -569,6 +564,16 @@ fn trimEslintWhitespace(value: []const u8) []const u8 {
         }
     }
     return value[start..end];
+}
+
+fn trimEslintWhitespaceStart(value: []const u8) []const u8 {
+    var start: usize = 0;
+    while (start < value.len) {
+        const whitespace_len = eslintWhitespaceLengthAt(value, start);
+        if (whitespace_len == 0) break;
+        start += whitespace_len;
+    }
+    return value[start..];
 }
 
 fn eslintWhitespaceLengthAt(value: []const u8, index: usize) usize {

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -54,12 +54,34 @@ pub fn apply(
     var line_starts = try collectLineStarts(allocator, tree.source);
     defer line_starts.deinit(allocator);
 
-    const decisions = try allocator.alloc(?core.Suppression, diagnostics.items.len);
-    defer allocator.free(decisions);
+    const decisions = try allocator.alloc(std.ArrayList([]const u8), diagnostics.items.len);
+    var initialized_decisions: usize = 0;
+    defer {
+        for (decisions[0..initialized_decisions]) |*decision| decision.deinit(allocator);
+        allocator.free(decisions);
+    }
+    const primary_decision_indices = try allocator.alloc(usize, diagnostics.items.len);
+    defer allocator.free(primary_decision_indices);
     var suppressed_count: usize = 0;
     for (diagnostics.items, 0..) |diagnostic, index| {
-        decisions[index] = suppressionFor(directives.items, line_starts.items, diagnostic);
-        if (decisions[index] != null) suppressed_count += 1;
+        decisions[index] = .empty;
+        initialized_decisions += 1;
+        if (suppressionFor(directives.items, line_starts.items, diagnostic)) |suppression| {
+            try appendEslintSuppressionsFor(
+                allocator,
+                &decisions[index],
+                directives.items,
+                line_starts.items,
+                diagnostic,
+            );
+            if (decisions[index].items.len == 0) {
+                try decisions[index].append(allocator, suppression.justification);
+            }
+            primary_decision_indices[index] = for (decisions[index].items, 0..) |justification, suppression_index| {
+                if (std.mem.eql(u8, justification, suppression.justification)) break suppression_index;
+            } else 0;
+            suppressed_count += 1;
+        }
     }
     if (suppressed_count == 0) return;
 
@@ -68,27 +90,41 @@ pub fn apply(
     try kept.ensureTotalCapacity(allocator, diagnostics.items.len);
     try suppressed_diagnostics.ensureUnusedCapacity(allocator, suppressed_count);
 
-    const owned_justifications = try allocator.alloc(?[]u8, diagnostics.items.len);
-    @memset(owned_justifications, null);
+    const owned_suppressions = try allocator.alloc(?[]core.Suppression, diagnostics.items.len);
+    @memset(owned_suppressions, null);
     var ownership_transferred = false;
     defer {
         if (!ownership_transferred) {
-            for (owned_justifications) |justification| {
-                if (justification) |owned| allocator.free(owned);
+            for (owned_suppressions) |maybe_suppressions| {
+                if (maybe_suppressions) |owned| {
+                    for (owned) |suppression| allocator.free(suppression.justification);
+                    allocator.free(owned);
+                }
             }
         }
-        allocator.free(owned_justifications);
+        allocator.free(owned_suppressions);
     }
     for (decisions, 0..) |decision, index| {
-        if (decision) |suppression| {
-            owned_justifications[index] = try allocator.dupe(u8, suppression.justification);
+        if (decision.items.len == 0) continue;
+
+        const owned = try allocator.alloc(core.Suppression, decision.items.len);
+        var initialized_suppressions: usize = 0;
+        errdefer {
+            for (owned[0..initialized_suppressions]) |suppression| allocator.free(suppression.justification);
+            allocator.free(owned);
         }
+        for (decision.items, 0..) |justification, suppression_index| {
+            owned[suppression_index] = .{ .justification = try allocator.dupe(u8, justification) };
+            initialized_suppressions += 1;
+        }
+        owned_suppressions[index] = owned;
     }
 
     for (diagnostics.items, 0..) |item, index| {
         var diagnostic = item;
-        if (owned_justifications[index]) |justification| {
-            diagnostic.suppression = .{ .justification = justification };
+        if (owned_suppressions[index]) |items| {
+            diagnostic.suppression = items[primary_decision_indices[index]];
+            diagnostic.suppressions = items;
             suppressed_diagnostics.appendAssumeCapacity(diagnostic);
         } else {
             kept.appendAssumeCapacity(diagnostic);
@@ -98,6 +134,64 @@ pub fn apply(
 
     diagnostics.deinit(allocator);
     diagnostics.* = kept;
+}
+
+fn appendEslintSuppressionsFor(
+    allocator: Allocator,
+    suppressions: *std.ArrayList([]const u8),
+    directives: []const Directive,
+    line_starts: []const u32,
+    diagnostic: core.Diagnostic,
+) Allocator.Error!void {
+    if (std.mem.eql(u8, diagnostic.rule_id, "parse")) return;
+
+    const diagnostic_line = lineAtOffset(line_starts, diagnostic.span.start);
+    var range_matches: std.ArrayList(usize) = .empty;
+    defer range_matches.deinit(allocator);
+    var line_matches: std.ArrayList(usize) = .empty;
+    defer line_matches.deinit(allocator);
+
+    for (directives, 0..) |directive, index| {
+        if (directive.kind == .eslint_disable_line or directive.kind == .eslint_disable_next_line) {
+            const directive_offset = if (directive.kind == .eslint_disable_next_line and directive.span_end > directive.span_start)
+                directive.span_end - 1
+            else
+                directive.span_start;
+            const directive_line = lineAtOffset(line_starts, directive_offset);
+            const target_line = directive_line + @intFromBool(directive.kind == .eslint_disable_next_line);
+            if (target_line == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
+                try line_matches.append(allocator, index);
+            }
+            continue;
+        }
+        if (directive.span_start > diagnostic.span.start) continue;
+
+        switch (directive.kind) {
+            .eslint_disable => {
+                if (directive.target.matches(diagnostic.rule_id)) try range_matches.append(allocator, index);
+            },
+            .eslint_enable => {
+                if (directive.target.matches(diagnostic.rule_id)) range_matches.clearRetainingCapacity();
+            },
+            else => {},
+        }
+    }
+
+    var range_index: usize = 0;
+    var line_index: usize = 0;
+    while (range_index < range_matches.items.len or line_index < line_matches.items.len) {
+        const selected = if (line_index >= line_matches.items.len or
+            (range_index < range_matches.items.len and range_matches.items[range_index] < line_matches.items[line_index]))
+            range_matches.items[range_index]
+        else
+            line_matches.items[line_index];
+        if (range_index < range_matches.items.len and selected == range_matches.items[range_index]) {
+            range_index += 1;
+        } else {
+            line_index += 1;
+        }
+        try suppressions.append(allocator, directives[selected].target.justification);
+    }
 }
 
 fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Error!std.ArrayList(Directive) {

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -54,7 +54,7 @@ pub fn apply(
     var line_starts = try collectLineStarts(allocator, tree.source);
     defer line_starts.deinit(allocator);
 
-    const decisions = try allocator.alloc(std.ArrayList([]const u8), diagnostics.items.len);
+    const decisions = try allocator.alloc(std.ArrayList(usize), diagnostics.items.len);
     var initialized_decisions: usize = 0;
     defer {
         for (decisions[0..initialized_decisions]) |*decision| decision.deinit(allocator);
@@ -66,20 +66,23 @@ pub fn apply(
     for (diagnostics.items, 0..) |diagnostic, index| {
         decisions[index] = .empty;
         initialized_decisions += 1;
-        if (suppressionFor(directives.items, line_starts.items, diagnostic)) |suppression| {
-            try appendEslintSuppressionsFor(
+        if (suppressionDirectiveIndexFor(directives.items, line_starts.items, diagnostic)) |primary_directive_index| {
+            try appendEslintSuppressionIndicesFor(
                 allocator,
                 &decisions[index],
                 directives.items,
                 line_starts.items,
                 diagnostic,
             );
-            if (decisions[index].items.len == 0) {
-                try decisions[index].append(allocator, suppression.justification);
+            if (std.mem.indexOfScalar(usize, decisions[index].items, primary_directive_index) == null) {
+                try decisions[index].append(allocator, primary_directive_index);
             }
-            primary_decision_indices[index] = for (decisions[index].items, 0..) |justification, suppression_index| {
-                if (std.mem.eql(u8, justification, suppression.justification)) break suppression_index;
-            } else 0;
+            std.mem.sort(usize, decisions[index].items, {}, std.sort.asc(usize));
+            primary_decision_indices[index] = std.mem.indexOfScalar(
+                usize,
+                decisions[index].items,
+                primary_directive_index,
+            ).?;
             suppressed_count += 1;
         }
     }
@@ -113,8 +116,10 @@ pub fn apply(
             for (owned[0..initialized_suppressions]) |suppression| allocator.free(suppression.justification);
             allocator.free(owned);
         }
-        for (decision.items, 0..) |justification, suppression_index| {
-            owned[suppression_index] = .{ .justification = try allocator.dupe(u8, justification) };
+        for (decision.items, 0..) |directive_index, suppression_index| {
+            owned[suppression_index] = .{
+                .justification = try allocator.dupe(u8, directives.items[directive_index].target.justification),
+            };
             initialized_suppressions += 1;
         }
         owned_suppressions[index] = owned;
@@ -136,9 +141,9 @@ pub fn apply(
     diagnostics.* = kept;
 }
 
-fn appendEslintSuppressionsFor(
+fn appendEslintSuppressionIndicesFor(
     allocator: Allocator,
-    suppressions: *std.ArrayList([]const u8),
+    suppression_indices: *std.ArrayList(usize),
     directives: []const Directive,
     line_starts: []const u32,
     diagnostic: core.Diagnostic,
@@ -190,7 +195,7 @@ fn appendEslintSuppressionsFor(
         } else {
             line_index += 1;
         }
-        try suppressions.append(allocator, directives[selected].target.justification);
+        try suppression_indices.append(allocator, selected);
     }
 }
 
@@ -282,7 +287,8 @@ fn eslintDescriptionSeparator(value: []const u8) ?DescriptionSeparator {
 
         var end = index + leading_whitespace_len;
         while (end < value.len and value[end] == '-') : (end += 1) {}
-        if (end < index + leading_whitespace_len + 2 or end >= value.len) continue;
+        if (end < index + leading_whitespace_len + 2) continue;
+        if (end == value.len) return .{ .start = index, .end = end };
         const trailing_whitespace_len = eslintWhitespaceLengthAt(value, end);
         if (trailing_whitespace_len == 0) continue;
         return .{ .start = index, .end = end + trailing_whitespace_len };
@@ -349,23 +355,23 @@ fn parseDirectiveTarget(value: []const u8, prefix: []const u8) ?DirectiveTarget 
     };
 }
 
-fn suppressionFor(
+fn suppressionDirectiveIndexFor(
     directives: []const Directive,
     line_starts: []const u32,
     diagnostic: core.Diagnostic,
-) ?core.Suppression {
+) ?usize {
     if (std.mem.eql(u8, diagnostic.rule_id, "parse")) return null;
 
     const diagnostic_line = lineAtOffset(line_starts, diagnostic.span.start);
     var all_rules_range_depth: usize = 0;
     var named_rule_range_depth: usize = 0;
-    var all_rules_range_justification: []const u8 = "";
-    var named_rule_range_justification: []const u8 = "";
-    var eslint_all_rules_justification: ?[]const u8 = null;
-    var eslint_named_rule_justification: ?[]const u8 = null;
+    var all_rules_range_directive_index: ?usize = null;
+    var named_rule_range_directive_index: ?usize = null;
+    var eslint_all_rules_directive_index: ?usize = null;
+    var eslint_named_rule_directive_index: ?usize = null;
     var eslint_rule_enabled_under_all = false;
 
-    for (directives) |directive| {
+    for (directives, 0..) |directive, index| {
         if (directive.kind == .eslint_disable_line or directive.kind == .eslint_disable_next_line) {
             const directive_offset = if (directive.kind == .eslint_disable_next_line and directive.span_end > directive.span_start)
                 directive.span_end - 1
@@ -374,7 +380,7 @@ fn suppressionFor(
             const directive_line = lineAtOffset(line_starts, directive_offset);
             const target_line = directive_line + @intFromBool(directive.kind == .eslint_disable_next_line);
             if (target_line == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
-                return .{ .justification = directive.target.justification };
+                return index;
             }
             continue;
         }
@@ -384,11 +390,11 @@ fn suppressionFor(
             .ignore_start => {
                 if (directive.target.rule_id) |rule_id| {
                     if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
-                        if (named_rule_range_depth == 0) named_rule_range_justification = directive.target.justification;
+                        if (named_rule_range_depth == 0) named_rule_range_directive_index = index;
                         named_rule_range_depth += 1;
                     }
                 } else {
-                    if (all_rules_range_depth == 0) all_rules_range_justification = directive.target.justification;
+                    if (all_rules_range_depth == 0) all_rules_range_directive_index = index;
                     all_rules_range_depth += 1;
                 }
             },
@@ -401,35 +407,35 @@ fn suppressionFor(
             },
             .ignore_all => {
                 if (directive.top_level and directive.target.matches(diagnostic.rule_id)) {
-                    return .{ .justification = directive.target.justification };
+                    return index;
                 }
             },
             .ignore => {
                 const next_offset = directive.next_code_offset orelse continue;
                 if (lineAtOffset(line_starts, next_offset) == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
-                    return .{ .justification = directive.target.justification };
+                    return index;
                 }
             },
             .eslint_disable => {
                 if (directive.target.rule_id) |rule_id| {
                     if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
-                        eslint_named_rule_justification = directive.target.justification;
+                        eslint_named_rule_directive_index = index;
                         eslint_rule_enabled_under_all = false;
                     }
                 } else {
-                    eslint_all_rules_justification = directive.target.justification;
+                    eslint_all_rules_directive_index = index;
                     eslint_rule_enabled_under_all = false;
                 }
             },
             .eslint_enable => {
                 if (directive.target.rule_id) |rule_id| {
                     if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
-                        eslint_named_rule_justification = null;
-                        if (eslint_all_rules_justification != null) eslint_rule_enabled_under_all = true;
+                        eslint_named_rule_directive_index = null;
+                        if (eslint_all_rules_directive_index != null) eslint_rule_enabled_under_all = true;
                     }
                 } else {
-                    eslint_all_rules_justification = null;
-                    eslint_named_rule_justification = null;
+                    eslint_all_rules_directive_index = null;
+                    eslint_named_rule_directive_index = null;
                     eslint_rule_enabled_under_all = false;
                 }
             },
@@ -437,11 +443,11 @@ fn suppressionFor(
         }
     }
 
-    if (named_rule_range_depth > 0) return .{ .justification = named_rule_range_justification };
-    if (all_rules_range_depth > 0) return .{ .justification = all_rules_range_justification };
-    if (eslint_named_rule_justification) |justification| return .{ .justification = justification };
-    if (eslint_all_rules_justification) |justification| {
-        if (!eslint_rule_enabled_under_all) return .{ .justification = justification };
+    if (named_rule_range_depth > 0) return named_rule_range_directive_index.?;
+    if (all_rules_range_depth > 0) return all_rules_range_directive_index.?;
+    if (eslint_named_rule_directive_index) |index| return index;
+    if (eslint_all_rules_directive_index) |index| {
+        if (!eslint_rule_enabled_under_all) return index;
     }
     return null;
 }

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -10,6 +10,10 @@ const DirectiveKind = enum {
     ignore_all,
     ignore_start,
     ignore_end,
+    eslint_disable,
+    eslint_enable,
+    eslint_disable_line,
+    eslint_disable_next_line,
 };
 
 const DirectiveTarget = struct {
@@ -100,14 +104,20 @@ fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Erro
     errdefer directives.deinit(allocator);
 
     for (tree.comments) |comment| {
-        const parsed = parseCommentDirective(tree.string(comment.value)) orelse continue;
-        try directives.append(allocator, .{
-            .kind = parsed.kind,
-            .target = parsed.target,
-            .span_start = comment.span.start,
-            .next_code_offset = if (parsed.kind == .ignore) nextCodeOffset(tree, comment.span.end) else null,
-            .top_level = parsed.kind == .ignore_all and isTopLevelComment(tree, comment),
-        });
+        const value = tree.string(comment.value);
+        if (parseCommentDirective(value)) |parsed| {
+            try directives.append(allocator, .{
+                .kind = parsed.kind,
+                .target = parsed.target,
+                .span_start = comment.span.start,
+                .next_code_offset = if (parsed.kind == .ignore) nextCodeOffset(tree, comment.span.end) else null,
+                .top_level = parsed.kind == .ignore_all and isTopLevelComment(tree, comment),
+            });
+            continue;
+        }
+        if (parseEslintDirective(value, comment.type)) |parsed| {
+            try appendEslintDirectiveTargets(allocator, &directives, parsed, comment.span.start);
+        }
     }
 
     return directives;
@@ -126,6 +136,81 @@ fn parseCommentDirective(value: []const u8) ?ParsedDirective {
         }
     }
     return null;
+}
+
+const ParsedEslintDirective = struct {
+    kind: DirectiveKind,
+    rules: []const u8,
+    justification: []const u8,
+};
+
+fn parseEslintDirective(value: []const u8, comment_type: ast.Comment.Type) ?ParsedEslintDirective {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    const kinds = [_]struct { prefix: []const u8, kind: DirectiveKind }{
+        .{ .prefix = "eslint-disable-next-line", .kind = .eslint_disable_next_line },
+        .{ .prefix = "eslint-disable-line", .kind = .eslint_disable_line },
+        .{ .prefix = "eslint-disable", .kind = .eslint_disable },
+        .{ .prefix = "eslint-enable", .kind = .eslint_enable },
+    };
+    for (kinds) |entry| {
+        if (!std.mem.startsWith(u8, trimmed, entry.prefix)) continue;
+        if (trimmed.len > entry.prefix.len and !std.ascii.isWhitespace(trimmed[entry.prefix.len])) continue;
+        if (comment_type == .line and (entry.kind == .eslint_disable or entry.kind == .eslint_enable)) continue;
+
+        const tail = trimmed[entry.prefix.len..];
+        const separator = eslintDescriptionSeparator(tail);
+        return .{
+            .kind = entry.kind,
+            .rules = std.mem.trim(u8, if (separator) |item| tail[0..item.start] else tail, " \t\r\n"),
+            .justification = if (separator) |item| std.mem.trim(u8, tail[item.end..], " \t\r\n") else "",
+        };
+    }
+    return null;
+}
+
+const DescriptionSeparator = struct {
+    start: usize,
+    end: usize,
+};
+
+fn eslintDescriptionSeparator(value: []const u8) ?DescriptionSeparator {
+    var index: usize = 0;
+    while (index < value.len) : (index += 1) {
+        if (!std.ascii.isWhitespace(value[index])) continue;
+
+        var end = index + 1;
+        while (end < value.len and value[end] == '-') : (end += 1) {}
+        if (end < index + 3 or end >= value.len or !std.ascii.isWhitespace(value[end])) continue;
+        return .{ .start = index, .end = end + 1 };
+    }
+    return null;
+}
+
+fn appendEslintDirectiveTargets(
+    allocator: Allocator,
+    directives: *std.ArrayList(Directive),
+    parsed: ParsedEslintDirective,
+    span_start: u32,
+) Allocator.Error!void {
+    if (parsed.rules.len == 0) {
+        try directives.append(allocator, .{
+            .kind = parsed.kind,
+            .target = .{ .rule_id = null, .justification = parsed.justification },
+            .span_start = span_start,
+        });
+        return;
+    }
+
+    var rules = std.mem.splitScalar(u8, parsed.rules, ',');
+    while (rules.next()) |raw_rule_id| {
+        const rule_id = std.mem.trim(u8, raw_rule_id, " \t\r\n");
+        if (rule_id.len == 0) continue;
+        try directives.append(allocator, .{
+            .kind = parsed.kind,
+            .target = .{ .rule_id = rule_id, .justification = parsed.justification },
+            .span_start = span_start,
+        });
+    }
 }
 
 fn parseDirectiveTarget(value: []const u8, prefix: []const u8) ?DirectiveTarget {
@@ -159,9 +244,20 @@ fn suppressionFor(
     var named_rule_range_depth: usize = 0;
     var all_rules_range_justification: []const u8 = "";
     var named_rule_range_justification: []const u8 = "";
+    var eslint_all_rules_justification: ?[]const u8 = null;
+    var eslint_named_rule_justification: ?[]const u8 = null;
+    var eslint_rule_enabled_under_all = false;
 
     for (directives) |directive| {
-        if (directive.span_start > diagnostic.span.start) break;
+        if (directive.kind == .eslint_disable_line or directive.kind == .eslint_disable_next_line) {
+            const directive_line = lineAtOffset(line_starts, directive.span_start);
+            const target_line = directive_line + @intFromBool(directive.kind == .eslint_disable_next_line);
+            if (target_line == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
+                return .{ .justification = directive.target.justification };
+            }
+            continue;
+        }
+        if (directive.span_start > diagnostic.span.start) continue;
 
         switch (directive.kind) {
             .ignore_start => {
@@ -193,11 +289,39 @@ fn suppressionFor(
                     return .{ .justification = directive.target.justification };
                 }
             },
+            .eslint_disable => {
+                if (directive.target.rule_id) |rule_id| {
+                    if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
+                        eslint_named_rule_justification = directive.target.justification;
+                        eslint_rule_enabled_under_all = false;
+                    }
+                } else {
+                    eslint_all_rules_justification = directive.target.justification;
+                    eslint_rule_enabled_under_all = false;
+                }
+            },
+            .eslint_enable => {
+                if (directive.target.rule_id) |rule_id| {
+                    if (std.mem.eql(u8, rule_id, diagnostic.rule_id)) {
+                        eslint_named_rule_justification = null;
+                        if (eslint_all_rules_justification != null) eslint_rule_enabled_under_all = true;
+                    }
+                } else {
+                    eslint_all_rules_justification = null;
+                    eslint_named_rule_justification = null;
+                    eslint_rule_enabled_under_all = false;
+                }
+            },
+            .eslint_disable_line, .eslint_disable_next_line => unreachable,
         }
     }
 
     if (named_rule_range_depth > 0) return .{ .justification = named_rule_range_justification };
     if (all_rules_range_depth > 0) return .{ .justification = all_rules_range_justification };
+    if (eslint_named_rule_justification) |justification| return .{ .justification = justification };
+    if (eslint_all_rules_justification) |justification| {
+        if (!eslint_rule_enabled_under_all) return .{ .justification = justification };
+    }
     return null;
 }
 

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -77,7 +77,6 @@ pub fn apply(
             if (std.mem.indexOfScalar(usize, decisions[index].items, primary_directive_index) == null) {
                 try decisions[index].append(allocator, primary_directive_index);
             }
-            std.mem.sort(usize, decisions[index].items, {}, std.sort.asc(usize));
             primary_decision_indices[index] = std.mem.indexOfScalar(
                 usize,
                 decisions[index].items,
@@ -182,21 +181,8 @@ fn appendEslintSuppressionIndicesFor(
         }
     }
 
-    var range_index: usize = 0;
-    var line_index: usize = 0;
-    while (range_index < range_matches.items.len or line_index < line_matches.items.len) {
-        const selected = if (line_index >= line_matches.items.len or
-            (range_index < range_matches.items.len and range_matches.items[range_index] < line_matches.items[line_index]))
-            range_matches.items[range_index]
-        else
-            line_matches.items[line_index];
-        if (range_index < range_matches.items.len and selected == range_matches.items[range_index]) {
-            range_index += 1;
-        } else {
-            line_index += 1;
-        }
-        try suppression_indices.append(allocator, selected);
-    }
+    try suppression_indices.appendSlice(allocator, range_matches.items);
+    try suppression_indices.appendSlice(allocator, line_matches.items);
 }
 
 fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Error!std.ArrayList(Directive) {

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -118,6 +118,11 @@ fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Erro
             continue;
         }
         if (parseEslintDirective(value, comment.type)) |parsed| {
+            if (parsed.kind == .eslint_disable_line and comment.type == .block and
+                containsLineTerminator(tree.source[@intCast(comment.span.start)..@intCast(comment.span.end)]))
+            {
+                continue;
+            }
             try appendEslintDirectiveTargets(allocator, &directives, parsed, comment.span.start, comment.span.end);
         }
     }
@@ -387,15 +392,7 @@ fn collectLineStarts(allocator: Allocator, source: []const u8) Allocator.Error!s
 
     var index: usize = 0;
     while (index < source.len) {
-        const terminator_len: usize = if (source[index] == '\r')
-            if (index + 1 < source.len and source[index + 1] == '\n') 2 else 1
-        else if (source[index] == '\n')
-            1
-        else if (index + 2 < source.len and source[index] == 0xe2 and source[index + 1] == 0x80 and
-            (source[index + 2] == 0xa8 or source[index + 2] == 0xa9))
-            3
-        else
-            0;
+        const terminator_len = lineTerminatorLengthAt(source, index);
         if (terminator_len == 0) {
             index += 1;
             continue;
@@ -405,6 +402,29 @@ fn collectLineStarts(allocator: Allocator, source: []const u8) Allocator.Error!s
         if (index < source.len) try starts.append(allocator, @intCast(index));
     }
     return starts;
+}
+
+fn containsLineTerminator(source: []const u8) bool {
+    var index: usize = 0;
+    while (index < source.len) {
+        const terminator_len = lineTerminatorLengthAt(source, index);
+        if (terminator_len > 0) return true;
+        index += 1;
+    }
+    return false;
+}
+
+fn lineTerminatorLengthAt(source: []const u8, index: usize) usize {
+    if (source[index] == '\r') {
+        return if (index + 1 < source.len and source[index + 1] == '\n') 2 else 1;
+    }
+    if (source[index] == '\n') return 1;
+    if (index + 2 < source.len and source[index] == 0xe2 and source[index + 1] == 0x80 and
+        (source[index + 2] == 0xa8 or source[index + 2] == 0xa9))
+    {
+        return 3;
+    }
+    return 0;
 }
 
 fn lineAtOffset(line_starts: []const u32, offset: u32) usize {

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -152,7 +152,7 @@ const ParsedEslintDirective = struct {
 };
 
 fn parseEslintDirective(value: []const u8, comment_type: ast.Comment.Type) ?ParsedEslintDirective {
-    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    const trimmed = trimEslintWhitespace(value);
     const kinds = [_]struct { prefix: []const u8, kind: DirectiveKind }{
         .{ .prefix = "eslint-disable-next-line", .kind = .eslint_disable_next_line },
         .{ .prefix = "eslint-disable-line", .kind = .eslint_disable_line },
@@ -161,15 +161,15 @@ fn parseEslintDirective(value: []const u8, comment_type: ast.Comment.Type) ?Pars
     };
     for (kinds) |entry| {
         if (!std.mem.startsWith(u8, trimmed, entry.prefix)) continue;
-        if (trimmed.len > entry.prefix.len and !std.ascii.isWhitespace(trimmed[entry.prefix.len])) continue;
+        if (trimmed.len > entry.prefix.len and eslintWhitespaceLengthAt(trimmed, entry.prefix.len) == 0) continue;
         if (comment_type == .line and (entry.kind == .eslint_disable or entry.kind == .eslint_enable)) continue;
 
         const tail = trimmed[entry.prefix.len..];
         const separator = eslintDescriptionSeparator(tail);
         return .{
             .kind = entry.kind,
-            .rules = std.mem.trim(u8, if (separator) |item| tail[0..item.start] else tail, " \t\r\n"),
-            .justification = if (separator) |item| std.mem.trim(u8, tail[item.end..], " \t\r\n") else "",
+            .rules = trimEslintWhitespace(if (separator) |item| tail[0..item.start] else tail),
+            .justification = if (separator) |item| trimEslintWhitespace(tail[item.end..]) else "",
         };
     }
     return null;
@@ -183,12 +183,15 @@ const DescriptionSeparator = struct {
 fn eslintDescriptionSeparator(value: []const u8) ?DescriptionSeparator {
     var index: usize = 0;
     while (index < value.len) : (index += 1) {
-        if (!std.ascii.isWhitespace(value[index])) continue;
+        const leading_whitespace_len = eslintWhitespaceLengthAt(value, index);
+        if (leading_whitespace_len == 0) continue;
 
-        var end = index + 1;
+        var end = index + leading_whitespace_len;
         while (end < value.len and value[end] == '-') : (end += 1) {}
-        if (end < index + 3 or end >= value.len or !std.ascii.isWhitespace(value[end])) continue;
-        return .{ .start = index, .end = end + 1 };
+        if (end < index + leading_whitespace_len + 2 or end >= value.len) continue;
+        const trailing_whitespace_len = eslintWhitespaceLengthAt(value, end);
+        if (trailing_whitespace_len == 0) continue;
+        return .{ .start = index, .end = end + trailing_whitespace_len };
     }
     return null;
 }
@@ -212,7 +215,7 @@ fn appendEslintDirectiveTargets(
 
     var rules = std.mem.splitScalar(u8, parsed.rules, ',');
     while (rules.next()) |raw_rule_id| {
-        const rule_id = std.mem.trim(u8, raw_rule_id, " \t\r\n");
+        const rule_id = trimEslintWhitespace(raw_rule_id);
         if (rule_id.len == 0) continue;
         try directives.append(allocator, .{
             .kind = parsed.kind,
@@ -425,6 +428,43 @@ fn lineTerminatorLengthAt(source: []const u8, index: usize) usize {
         return 3;
     }
     return 0;
+}
+
+fn trimEslintWhitespace(value: []const u8) []const u8 {
+    var start: usize = 0;
+    while (start < value.len) {
+        const whitespace_len = eslintWhitespaceLengthAt(value, start);
+        if (whitespace_len == 0) break;
+        start += whitespace_len;
+    }
+
+    var cursor = start;
+    var end = start;
+    while (cursor < value.len) {
+        const whitespace_len = eslintWhitespaceLengthAt(value, cursor);
+        if (whitespace_len > 0) {
+            cursor += whitespace_len;
+        } else {
+            cursor += 1;
+            end = cursor;
+        }
+    }
+    return value[start..end];
+}
+
+fn eslintWhitespaceLengthAt(value: []const u8, index: usize) usize {
+    return switch (value[index]) {
+        '\t', '\n', '\x0b', '\x0c', '\r', ' ' => 1,
+        0xc2 => if (index + 1 < value.len and value[index + 1] == 0xa0) 2 else 0,
+        0xe1 => if (index + 2 < value.len and value[index + 1] == 0x9a and value[index + 2] == 0x80) 3 else 0,
+        0xe2 => if (index + 2 < value.len and ((value[index + 1] == 0x80 and
+            (value[index + 2] >= 0x80 and value[index + 2] <= 0x8a or value[index + 2] == 0xa8 or
+                value[index + 2] == 0xa9 or value[index + 2] == 0xaf)) or
+            (value[index + 1] == 0x81 and value[index + 2] == 0x9f))) 3 else 0,
+        0xe3 => if (index + 2 < value.len and value[index + 1] == 0x80 and value[index + 2] == 0x80) 3 else 0,
+        0xef => if (index + 2 < value.len and value[index + 1] == 0xbb and value[index + 2] == 0xbf) 3 else 0,
+        else => 0,
+    };
 }
 
 fn lineAtOffset(line_starts: []const u32, offset: u32) usize {

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -213,13 +213,23 @@ fn appendEslintDirectiveTargets(
         return;
     }
 
+    var appended_rule = false;
     var rules = std.mem.splitScalar(u8, parsed.rules, ',');
     while (rules.next()) |raw_rule_id| {
         const rule_id = trimEslintWhitespace(raw_rule_id);
         if (rule_id.len == 0) continue;
+        appended_rule = true;
         try directives.append(allocator, .{
             .kind = parsed.kind,
             .target = .{ .rule_id = rule_id, .justification = parsed.justification },
+            .span_start = span_start,
+            .span_end = span_end,
+        });
+    }
+    if (!appended_rule) {
+        try directives.append(allocator, .{
+            .kind = parsed.kind,
+            .target = .{ .rule_id = null, .justification = parsed.justification },
             .span_start = span_start,
             .span_end = span_end,
         });

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -313,11 +313,20 @@ fn appendEslintDirectiveTargets(
         return;
     }
 
+    const first_target_index = directives.items.len;
     var appended_rule = false;
     var rules = std.mem.splitScalar(u8, parsed.rules, ',');
     while (rules.next()) |raw_rule_id| {
         const rule_id = trimEslintWhitespace(raw_rule_id);
         if (rule_id.len == 0) continue;
+        var duplicate = false;
+        for (directives.items[first_target_index..]) |existing| {
+            if (std.mem.eql(u8, existing.target.rule_id.?, rule_id)) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) continue;
         appended_rule = true;
         try directives.append(allocator, .{
             .kind = parsed.kind,

--- a/src/suppressions.zig
+++ b/src/suppressions.zig
@@ -74,6 +74,13 @@ pub fn apply(
                 line_starts.items,
                 diagnostic,
             );
+            try appendUtlintSuppressionIndicesFor(
+                allocator,
+                &decisions[index],
+                directives.items,
+                line_starts.items,
+                diagnostic,
+            );
             if (std.mem.indexOfScalar(usize, decisions[index].items, primary_directive_index) == null) {
                 try decisions[index].append(allocator, primary_directive_index);
             }
@@ -183,6 +190,65 @@ fn appendEslintSuppressionIndicesFor(
 
     try suppression_indices.appendSlice(allocator, range_matches.items);
     try suppression_indices.appendSlice(allocator, line_matches.items);
+}
+
+fn appendUtlintSuppressionIndicesFor(
+    allocator: Allocator,
+    suppression_indices: *std.ArrayList(usize),
+    directives: []const Directive,
+    line_starts: []const u32,
+    diagnostic: core.Diagnostic,
+) Allocator.Error!void {
+    if (std.mem.eql(u8, diagnostic.rule_id, "parse")) return;
+
+    const diagnostic_line = lineAtOffset(line_starts, diagnostic.span.start);
+    var all_rule_ranges: std.ArrayList(usize) = .empty;
+    defer all_rule_ranges.deinit(allocator);
+    var named_rule_ranges: std.ArrayList(usize) = .empty;
+    defer named_rule_ranges.deinit(allocator);
+    var matches: std.ArrayList(usize) = .empty;
+    defer matches.deinit(allocator);
+
+    for (directives, 0..) |directive, index| {
+        if (directive.span_start > diagnostic.span.start) continue;
+
+        switch (directive.kind) {
+            .ignore_start => {
+                if (!directive.target.matches(diagnostic.rule_id)) continue;
+                if (directive.target.rule_id == null) {
+                    try all_rule_ranges.append(allocator, index);
+                } else {
+                    try named_rule_ranges.append(allocator, index);
+                }
+            },
+            .ignore_end => {
+                if (directive.target.rule_id) |rule_id| {
+                    if (std.mem.eql(u8, rule_id, diagnostic.rule_id) and named_rule_ranges.items.len > 0) {
+                        _ = named_rule_ranges.pop();
+                    }
+                } else if (all_rule_ranges.items.len > 0) {
+                    _ = all_rule_ranges.pop();
+                }
+            },
+            .ignore_all => {
+                if (directive.top_level and directive.target.matches(diagnostic.rule_id)) {
+                    try matches.append(allocator, index);
+                }
+            },
+            .ignore => {
+                const next_offset = directive.next_code_offset orelse continue;
+                if (lineAtOffset(line_starts, next_offset) == diagnostic_line and directive.target.matches(diagnostic.rule_id)) {
+                    try matches.append(allocator, index);
+                }
+            },
+            else => {},
+        }
+    }
+
+    try matches.appendSlice(allocator, all_rule_ranges.items);
+    try matches.appendSlice(allocator, named_rule_ranges.items);
+    std.mem.sort(usize, matches.items, {}, std.sort.asc(usize));
+    try suppression_indices.appendSlice(allocator, matches.items);
 }
 
 fn collectDirectives(allocator: Allocator, tree: *const ast.Tree) Allocator.Error!std.ArrayList(Directive) {

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -471,6 +471,16 @@ fn writeDiagnostic(
         try writeJsonValue(writer, suppression.justification);
         try writer.writeByte('}');
     }
+    if (diagnostic.suppressions.len > 0) {
+        try writer.writeAll(",\"suppressions\":[");
+        for (diagnostic.suppressions, 0..) |suppression, index| {
+            if (index != 0) try writer.writeByte(',');
+            try writer.writeAll("{\"kind\":\"directive\",\"justification\":");
+            try writeJsonValue(writer, suppression.justification);
+            try writer.writeByte('}');
+        }
+        try writer.writeByte(']');
+    }
     try writer.writeByte('}');
 }
 

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -211,6 +211,24 @@ test "overlapping utlint and ESLint directives preserve both suppressions" {
     try std.testing.expectEqualStrings("intentional", result.suppressed_diagnostics[0].suppression.?.justification);
 }
 
+test "repeated rule targets produce one suppression per ESLint directive" {
+    const source =
+        \\/* eslint-disable no-extra-semi, no-extra-semi -- generated */
+        \\const value = 1;;
+        \\void value;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics[0].suppressions.len);
+    try std.testing.expectEqualStrings("generated", result.suppressed_diagnostics[0].suppressions[0].justification);
+}
+
 test "utlint-ignore-all suppresses a named rule throughout the file" {
     const source =
         \\// utlint-ignore-all no-debugger: generated file

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -148,6 +148,28 @@ test "autofix does not apply fixes from suppressed diagnostics" {
     try std.testing.expectEqual(@as(usize, 1), fixed.result.suppressed_diagnostics.len);
 }
 
+test "overlapping ESLint directives preserve every suppression" {
+    const source =
+        \\/* eslint-disable no-extra-semi -- generated */
+        \\const value = 1;; // eslint-disable-line no-extra-semi -- intentional
+        \\void value;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    const suppressions = result.suppressed_diagnostics[0].suppressions;
+    try std.testing.expectEqual(@as(usize, 2), suppressions.len);
+    try std.testing.expectEqualStrings("generated", suppressions[0].justification);
+    try std.testing.expectEqualStrings("intentional", suppressions[1].justification);
+    try std.testing.expectEqualStrings("intentional", result.suppressed_diagnostics[0].suppression.?.justification);
+}
+
 test "utlint-ignore-all suppresses a named rule throughout the file" {
     const source =
         \\// utlint-ignore-all no-debugger: generated file

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -188,6 +188,24 @@ test "overlapping ESLint range suppressions precede line suppressions" {
     try std.testing.expectEqualStrings("line", suppressions[1].justification);
 }
 
+test "utlint metadata survives an earlier ESLint line suppression" {
+    const source =
+        \\/* eslint-disable-line no-undef -- eslint */ /* utlint-ignore no-undef: utoo */ foo();
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_undef = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    const suppressions = result.suppressed_diagnostics[0].suppressions;
+    try std.testing.expectEqual(@as(usize, 2), suppressions.len);
+    try std.testing.expectEqualStrings("eslint", suppressions[0].justification);
+    try std.testing.expectEqualStrings("utoo", suppressions[1].justification);
+}
+
 test "ESLint directive accepts an empty justification after a separator" {
     const source =
         \\/* eslint-disable no-extra-semi -- */

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -170,6 +170,24 @@ test "overlapping ESLint directives preserve every suppression" {
     try std.testing.expectEqualStrings("intentional", result.suppressed_diagnostics[0].suppression.?.justification);
 }
 
+test "overlapping ESLint range suppressions precede line suppressions" {
+    const source =
+        \\/* eslint-disable-line no-undef -- line */ /* eslint-disable no-undef -- range */ foo();
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_undef = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    const suppressions = result.suppressed_diagnostics[0].suppressions;
+    try std.testing.expectEqual(@as(usize, 2), suppressions.len);
+    try std.testing.expectEqualStrings("range", suppressions[0].justification);
+    try std.testing.expectEqualStrings("line", suppressions[1].justification);
+}
+
 test "ESLint directive accepts an empty justification after a separator" {
     const source =
         \\/* eslint-disable no-extra-semi -- */

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -170,6 +170,47 @@ test "overlapping ESLint directives preserve every suppression" {
     try std.testing.expectEqualStrings("intentional", result.suppressed_diagnostics[0].suppression.?.justification);
 }
 
+test "ESLint directive accepts an empty justification after a separator" {
+    const source =
+        \\/* eslint-disable no-extra-semi -- */
+        \\const value = 1;;
+        \\void value;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var fixed = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer fixed.deinit(std.testing.allocator);
+
+    try std.testing.expect(!fixed.fixed);
+    try std.testing.expectEqualStrings(source, fixed.output);
+    try std.testing.expectEqual(@as(usize, 1), fixed.result.suppressed_diagnostics.len);
+    try std.testing.expectEqualStrings("", fixed.result.suppressed_diagnostics[0].suppression.?.justification);
+}
+
+test "overlapping utlint and ESLint directives preserve both suppressions" {
+    const source =
+        \\/* eslint-disable no-extra-semi -- generated */
+        \\// utlint-ignore no-extra-semi: intentional
+        \\const value = 1;;
+        \\void value;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.js", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.suppressed_diagnostics.len);
+    const suppressions = result.suppressed_diagnostics[0].suppressions;
+    try std.testing.expectEqual(@as(usize, 2), suppressions.len);
+    try std.testing.expectEqualStrings("generated", suppressions[0].justification);
+    try std.testing.expectEqualStrings("intentional", suppressions[1].justification);
+    try std.testing.expectEqualStrings("intentional", result.suppressed_diagnostics[0].suppression.?.justification);
+}
+
 test "utlint-ignore-all suppresses a named rule throughout the file" {
     const source =
         \\// utlint-ignore-all no-debugger: generated file

--- a/tests/suppressions.zig
+++ b/tests/suppressions.zig
@@ -189,6 +189,23 @@ test "ESLint directive accepts an empty justification after a separator" {
     try std.testing.expectEqualStrings("", fixed.result.suppressed_diagnostics[0].suppression.?.justification);
 }
 
+test "ESLint justification separator requires trailing whitespace" {
+    const source =
+        \\/* eslint-disable-next-line no-extra-semi --*/
+        \\const value = 1;;
+        \\void value;
+    ;
+
+    var options = lint.Options.allDisabled();
+    options.no_extra_semi = true;
+
+    var fixed = try lint.lintSourceAndFix(std.testing.allocator, source, "fixture.js", options);
+    defer fixed.deinit(std.testing.allocator);
+
+    try std.testing.expect(fixed.fixed);
+    try std.testing.expectEqual(@as(usize, 0), fixed.result.suppressed_diagnostics.len);
+}
+
 test "overlapping utlint and ESLint directives preserve both suppressions" {
     const source =
         \\/* eslint-disable no-extra-semi -- generated */

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -62,6 +62,27 @@ test("uses defaults only when rules is absent", () => {
   assert.ok(!empty.diagnostics.some((item) => item.ruleId === "no-debugger"));
 });
 
+test("returns every overlapping ESLint suppression", () => {
+  const source = [
+    "/* eslint-disable no-extra-semi -- generated */",
+    "const value = 1;; // eslint-disable-line no-extra-semi -- intentional",
+    "void value;",
+    "",
+  ].join("\n");
+  const result = linter.lint(source, {
+    filePath: "overlapping-directives.js",
+    rules: { "no-extra-semi": "error" },
+  });
+
+  assert.deepEqual(result.diagnostics, []);
+  assert.equal(result.suppressedDiagnostics.length, 1);
+  assert.deepEqual(result.suppressedDiagnostics[0].suppressions, [
+    { kind: "directive", justification: "generated" },
+    { kind: "directive", justification: "intentional" },
+  ]);
+  assert.equal(result.suppressedDiagnostics[0].suppression.justification, "intentional");
+});
+
 test("parses JS, TS, JSX, and TSX by file name", () => {
   const fixtures = [
     ["input.js", "export const value = 1;"],


### PR DESCRIPTION
## Summary

- parse ESLint disable directives from native parser comments before fix selection
- support line, next-line, range, multiple-rule, selective-enable, and justification semantics
- preserve directives inside template interpolations without relying on the JavaScript fallback scanner

## Follow-up

Addresses both review findings on #1192: disabled fixes are no longer applied, and native diagnostics inside template interpolations are suppressed through the parser comment stream.

## Tests

- `zig build test`
- `corepack pnpm --dir npm/utoo-lint test`
- `zig build test-wasm`