### PR TITLE
fix: preserve rule defaults in --rules fast path

### DIFF
--- a/npm/utoo-lint/test/native-config-fast-path.test.mjs
+++ b/npm/utoo-lint/test/native-config-fast-path.test.mjs
@@ -87,6 +87,39 @@ test("severity-only config groups use the native --rules fast path", (t) => {
   }
 });
 
+test("severity-only config groups preserve native rule defaults", (t) => {
+  const project = createProject(t);
+  writeConfig(project, [
+    {
+      files: ["**/*.tsx"],
+      rules: { "react/button-has-type": "error" }
+    },
+    {
+      files: ["**/*.ts"],
+      rules: {
+        "@typescript-eslint/no-namespace": "error",
+        "@typescript-eslint/no-use-before-define": "error"
+      }
+    }
+  ]);
+  const paths = [
+    write(join(project, "src", "button.tsx"), 'const button = <button type="button" />;\n'),
+    write(
+      join(project, "src", "types.ts"),
+      "interface Before { value: After }\ninterface After { value: string }\n"
+    ),
+    write(
+      join(project, "src", "global.d.ts"),
+      "declare namespace API { interface Value { value: string } }\n"
+    )
+  ];
+
+  const report = lintFiles(paths, { cwd: project });
+
+  assert.deepEqual(report.diagnostics, []);
+  assert.equal(report.exitCode, 0);
+});
+
 test("fast-path diagnostics keep configured severities and exit status", (t) => {
   const project = createProject(t);
   writeConfig(project, [

--- a/src/main.zig
+++ b/src/main.zig
@@ -1706,10 +1706,14 @@ fn parseEnabledRules(
             std.debug.print("utoo-lint: --rules contains an empty rule name\n", .{});
             std.process.exit(2);
         }
-        if (!options.setByCliName(rule, true)) {
-            std.debug.print("utoo-lint: unknown rule in --rules: {s}\n", .{rule});
+        options.setByRuleConfigValue(rule, .{ .string = "warn" }) catch |err| {
+            if (err == error.UnknownRule) {
+                std.debug.print("utoo-lint: unknown rule in --rules: {s}\n", .{rule});
+            } else {
+                std.debug.print("utoo-lint: invalid rule in --rules {s}: {s}\n", .{ rule, @errorName(err) });
+            }
             std.process.exit(2);
-        }
+        };
         const owned_rule = try allocator.dupe(u8, rule);
         errdefer allocator.free(owned_rule);
         const entry = try rule_severities.getOrPut(owned_rule);


### PR DESCRIPTION
## Summary

- preserve native rule option defaults when rules are selected through --rules
- retain the severity-only Node config fast path introduced in #1190
- add regression coverage for react/button-has-type, @typescript-eslint/no-use-before-define, and @typescript-eslint/no-namespace

## Root cause

The --rules path starts from Options.allDisabled(), which clears boolean rule-option defaults as well as rule enablement flags. setByCliName() then re-enabled only the main rule flag. Enabling each selected rule through the normal scalar rule-config path restores its ESLint-compatible option defaults.

## Validation

- zig build test --summary all (2153 tests passed)
- pnpm --dir npm/utoo-lint test (157 tests plus type checks passed)
- rago-web: tnpm run lint with the fixed local binary exits 0; the previous run reported 135 errors