### PR TITLE
feat(playground): improve readability and workspace layout

### DIFF
--- a/apps/playground/scripts/lint-client.test.mjs
+++ b/apps/playground/scripts/lint-client.test.mjs
@@ -233,7 +233,7 @@ test('loads versioned WebAssembly URLs and defaults to the latest release', () =
   );
   assert.equal(
     lintVersionManifestUrl('https://example.test/playground'),
-    'https://example.test/versions/manifest.json',
+    'https://example.test/playground/versions/manifest.json',
   );
   assert.equal(
     catalog.versions[0].wasmUrl,
@@ -259,6 +259,21 @@ test('loads versioned WebAssembly URLs and defaults to the latest release', () =
   );
   assert.equal(resolveLintVersion(catalog, LATEST_LINT_VERSION)?.id, '0.3.4');
   assert.equal(resolveLintVersion(catalog, '0.3.3')?.id, '0.3.3');
+});
+
+test('resolves version assets within the Playground after shared URL normalization', () => {
+  for (const route of ['/playground', '/playground/']) {
+    assert.equal(
+      lintVersionManifestUrl(
+        `https://example.test${route}?version=0.3.3#playground=state`,
+      ),
+      'https://example.test/playground/versions/manifest.json',
+    );
+  }
+  assert.equal(
+    lintVersionManifestUrl('http://localhost:3000/playground?version=0.3.3'),
+    'http://localhost:3000/playground/versions/manifest.json',
+  );
 });
 
 test('pins concrete version selections but leaves the latest channel implicit', () => {

--- a/apps/playground/src/features/playground/icon.tsx
+++ b/apps/playground/src/features/playground/icon.tsx
@@ -1,0 +1,28 @@
+const paths = {
+  code: 'm8 5-6 7 6 7m8-14 6 7-6 7m-3-16-2 18',
+  config:
+    'M8 3H5a2 2 0 0 0-2 2v3m13-5h3a2 2 0 0 1 2 2v3M3 16v3a2 2 0 0 0 2 2h3m8 0h3a2 2 0 0 0 2-2v-3M9 8l-3 4 3 4m6-8 3 4-3 4',
+  tree: 'M12 8v5M5 17v-4h14v4M9 3h6v5H9zM2 17h6v4H2zm14 0h6v4h-6z',
+  fix: 'm15 4 5 5M4 20l-1-1 12-12 2 2L5 21zm2-17v4M4 5h4m11 9v6m-3-3h6',
+  link: 'm10 13 4-4m-6 6-1 1a4 4 0 0 1-6-6l4-4a4 4 0 0 1 6 0m2 2 1-1a4 4 0 0 1 6 6l-4 4a4 4 0 0 1-6 0',
+  check: 'm5 12 4 4L19 6',
+  error: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zm-3 6 6 6m0-6-6 6',
+  warning: 'm12 3 10 18H2L12 3zm0 6v5m0 3v.1',
+} as const;
+
+export function Icon({ name }: { name: keyof typeof paths }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className="ui-icon"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.7}
+      viewBox="0 0 24 24"
+    >
+      <path d={paths[name]} />
+    </svg>
+  );
+}

--- a/apps/playground/src/features/playground/versions.ts
+++ b/apps/playground/src/features/playground/versions.ts
@@ -40,7 +40,10 @@ function isManifestVersion(value: unknown): value is ManifestVersion {
 }
 
 export function lintVersionManifestUrl(pageUrl: string): string {
-  return new URL('versions/manifest.json', pageUrl).href;
+  const baseUrl = new URL(pageUrl);
+  // The router can remove the trailing slash when restoring a shared URL.
+  baseUrl.pathname = baseUrl.pathname.replace(/\/playground$/, '/playground/');
+  return new URL('versions/manifest.json', baseUrl).href;
 }
 
 export function parseLintVersionCatalog(

--- a/apps/playground/src/pages/page.config.ts
+++ b/apps/playground/src/pages/page.config.ts
@@ -5,7 +5,7 @@ export default definePageConfig({
   meta: {
     description: 'Run utoo-lint in the browser and inspect diagnostics or AST output.',
     viewport: 'width=device-width, initial-scale=1',
-    'theme-color': '#111315',
+    'theme-color': '#0f131a',
   },
   render: 'csr',
 });

--- a/apps/playground/src/pages/page.tsx
+++ b/apps/playground/src/pages/page.tsx
@@ -31,6 +31,7 @@ import {
   type PlaygroundLanguage,
   type PlaygroundRulesMode,
 } from '../features/playground/model';
+import { Icon } from '../features/playground/icon';
 import '../features/playground/monaco';
 import { Splitter } from '../features/playground/splitter';
 import {
@@ -52,7 +53,7 @@ type RunPhase = 'idle' | 'running' | 'ready' | 'error';
 type ShareState = 'idle' | 'copied' | 'error';
 
 const EDITOR_THEME = 'utoo-dark';
-const DEFAULT_EDITOR_RATIO = 68;
+const DEFAULT_EDITOR_RATIO = 58;
 const DEFAULT_RULES_RATIO = 42;
 const INSPECTOR_MODES = ['rules', 'ast'] as const;
 
@@ -77,22 +78,22 @@ function defineEditorTheme(monaco: MonacoInstance): void {
     base: 'vs-dark',
     inherit: true,
     rules: [
-      { token: 'comment', foreground: '727A85' },
+      { token: 'comment', foreground: '9AA7B8' },
       { token: 'keyword', foreground: 'E58A82' },
       { token: 'number', foreground: '79B8EA' },
       { token: 'string', foreground: 'A9C98F' },
       { token: 'type.identifier', foreground: 'C49ADD' },
     ],
     colors: {
-      'editor.background': '#141618',
-      'editor.foreground': '#D9DDE3',
+      'editor.background': '#151A22',
+      'editor.foreground': '#E5EAF1',
       'editorCursor.foreground': '#2BA7EE',
-      'editorGutter.background': '#141618',
-      'editorIndentGuide.background1': '#25292E',
-      'editorIndentGuide.activeBackground1': '#3A4047',
+      'editorGutter.background': '#151A22',
+      'editorIndentGuide.background1': '#293342',
+      'editorIndentGuide.activeBackground1': '#46556A',
       'editorLineNumber.activeForeground': '#C4C9D0',
-      'editorLineNumber.foreground': '#59616B',
-      'editor.lineHighlightBackground': '#191C1F',
+      'editorLineNumber.foreground': '#8793A4',
+      'editor.lineHighlightBackground': '#1D2531',
       'editor.selectionBackground': '#164A67',
       'editor.inactiveSelectionBackground': '#183B4F',
       'editorWhitespace.foreground': '#2B3035',
@@ -531,6 +532,7 @@ export default function PlaygroundPage() {
         ? `Fix all ${fixableCount} diagnostics`
         : `Fix ${fixableCount} of ${diagnostics.length} diagnostics with safe autofixes`
       : 'No safe autofixes available';
+  const isChecking = runState.phase === 'idle' || runState.phase === 'running';
   const rulesDescriptionId = hasCustomRulesError
     ? 'rules-config-error'
     : undefined;
@@ -606,10 +608,12 @@ export default function PlaygroundPage() {
 
         <div className="run-summary" aria-hidden="true">
           <span className="summary-count error-count">
+            <Icon name="error" />
             <strong>{errorCount}</strong>{' '}
             {errorCount === 1 ? 'error' : 'errors'}
           </span>
           <span className="summary-count warning-count">
+            <Icon name="warning" />
             <strong>{warningCount}</strong>{' '}
             {warningCount === 1 ? 'warning' : 'warnings'}
           </span>
@@ -629,19 +633,6 @@ export default function PlaygroundPage() {
         </span>
 
         <div className="control-actions">
-          <button
-            aria-label={fixButtonLabel}
-            className="fix-button"
-            disabled={
-              !selectedLintVersion || (isRetry ? !hasValidRules : !canFix)
-            }
-            onClick={() => void execute(isRetry ? 'lint' : 'fix')}
-            title={fixButtonLabel}
-            type="button"
-          >
-            {fixButtonText}
-          </button>
-
           <label className="version-control">
             <span className="version-control-label">Version</span>
             <span className="select-wrap">
@@ -677,11 +668,26 @@ export default function PlaygroundPage() {
             onClick={() => void sharePlayground()}
             type="button"
           >
+            <Icon name={shareState === 'copied' ? 'check' : 'link'} />
             <span aria-live="polite">
               {shareState === 'idle' && 'Share'}
               {shareState === 'copied' && 'Copied'}
               {shareState === 'error' && 'Copy failed'}
             </span>
+          </button>
+
+          <button
+            aria-label={fixButtonLabel}
+            className="fix-button"
+            disabled={
+              !selectedLintVersion || (isRetry ? !hasValidRules : !canFix)
+            }
+            onClick={() => void execute(isRetry ? 'lint' : 'fix')}
+            title={fixButtonLabel}
+            type="button"
+          >
+            <Icon name="fix" />
+            {fixButtonText}
           </button>
         </div>
       </section>
@@ -698,13 +704,29 @@ export default function PlaygroundPage() {
         >
           <div className="panel-heading">
             <div className="panel-heading-copy">
+              <Icon name="code" />
               <span className="panel-title file-name">{fileName}</span>
             </div>
+            <span
+              aria-hidden="true"
+              className={`editor-status status-${runState.phase}`}
+            >
+              <span className="status-dot" />
+              {isChecking
+                ? 'Checking…'
+                : runState.phase === 'error' ? 'Check failed' : 'Live lint'}
+            </span>
           </div>
           <div className="editor-frame">
             <Editor
               beforeMount={handleEditorBeforeMount}
               height="100%"
+              loading={
+                <div className="empty-state">
+                  <span className="loading-spinner" />
+                  <strong>Loading editor…</strong>
+                </div>
+              }
               language={monacoLanguage}
               onChange={(value) => {
                 invalidateShareUrl();
@@ -723,15 +745,19 @@ export default function PlaygroundPage() {
                 automaticLayout: true,
                 bracketPairColorization: { enabled: true },
                 fontFamily:
-                  "'SFMono-Regular', Consolas, 'Liberation Mono', monospace",
-                fontLigatures: true,
+                  "'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace",
+                fontLigatures: false,
+                fontWeight: '400',
                 fontSize: 16,
-                lineHeight: 25,
+                lineHeight: 27,
+                lineNumbersMinChars: 3,
                 minimap: { enabled: false },
-                padding: { top: 16 },
+                padding: { top: 20, bottom: 20 },
                 renderLineHighlight: 'gutter',
                 scrollBeyondLastLine: false,
-                smoothScrolling: true,
+                smoothScrolling:
+                  typeof window !== 'undefined' &&
+                  !window.matchMedia('(prefers-reduced-motion: reduce)').matches,
                 tabSize: 2,
               }}
             />
@@ -742,8 +768,8 @@ export default function PlaygroundPage() {
           ariaControls="source-editor-panel lint-side-panel"
           ariaLabel="Resize source editor and lint sidebar"
           containerRef={workspaceRef}
-          minPrimaryPx={480}
-          minSecondaryPx={340}
+          minPrimaryPx={440}
+          minSecondaryPx={360}
           onChange={setEditorRatio}
           onReset={() => setEditorRatio(DEFAULT_EDITOR_RATIO)}
           orientation="vertical"
@@ -779,6 +805,7 @@ export default function PlaygroundPage() {
                   tabIndex={inspectorMode === 'rules' ? 0 : -1}
                   type="button"
                 >
+                  <Icon name="config" />
                   utlint.json
                 </button>
                 <button
@@ -792,41 +819,10 @@ export default function PlaygroundPage() {
                   tabIndex={inspectorMode === 'ast' ? 0 : -1}
                   type="button"
                 >
+                  <Icon name="tree" />
                   AST
                 </button>
               </div>
-
-              {inspectorMode === 'rules' ? (
-                <div className="segmented-control">
-                  <span className="segmented-label">Ruleset</span>
-                  <button
-                    aria-pressed={rulesMode === 'recommended'}
-                    className={
-                      rulesMode === 'recommended' ? 'is-active' : undefined
-                    }
-                    onClick={() => {
-                      invalidateShareUrl();
-                      setRunState(EMPTY_RUN_STATE);
-                      setRulesMode('recommended');
-                    }}
-                    type="button"
-                  >
-                    Recommended
-                  </button>
-                  <button
-                    aria-pressed={rulesMode === 'custom'}
-                    className={rulesMode === 'custom' ? 'is-active' : undefined}
-                    onClick={() => {
-                      invalidateShareUrl();
-                      setRunState(EMPTY_RUN_STATE);
-                      setRulesMode('custom');
-                    }}
-                    type="button"
-                  >
-                    Custom
-                  </button>
-                </div>
-              ) : null}
             </div>
 
             {inspectorMode === 'rules' ? (
@@ -836,6 +832,41 @@ export default function PlaygroundPage() {
                 id="rules-config-panel"
                 role="tabpanel"
               >
+                <div className="rules-toolbar">
+                  <span className="rules-toolbar-label">Ruleset</span>
+                  <div
+                    aria-label="Ruleset"
+                    className="segmented-control"
+                    role="group"
+                  >
+                    <button
+                      aria-pressed={rulesMode === 'recommended'}
+                      className={
+                        rulesMode === 'recommended' ? 'is-active' : undefined
+                      }
+                      onClick={() => {
+                        invalidateShareUrl();
+                        setRunState(EMPTY_RUN_STATE);
+                        setRulesMode('recommended');
+                      }}
+                      type="button"
+                    >
+                      Recommended
+                    </button>
+                    <button
+                      aria-pressed={rulesMode === 'custom'}
+                      className={rulesMode === 'custom' ? 'is-active' : undefined}
+                      onClick={() => {
+                        invalidateShareUrl();
+                        setRunState(EMPTY_RUN_STATE);
+                        setRulesMode('custom');
+                      }}
+                      type="button"
+                    >
+                      Custom
+                    </button>
+                  </div>
+                </div>
                 <textarea
                   aria-describedby={rulesDescriptionId}
                   aria-invalid={hasCustomRulesError || undefined}
@@ -881,6 +912,7 @@ export default function PlaygroundPage() {
                 {(astState.phase === 'idle' ||
                   astState.phase === 'running') && (
                   <div className="empty-state ast-loading-state">
+                    <span className="loading-spinner" />
                     <strong>Parsing syntax tree…</strong>
                   </div>
                 )}
@@ -927,7 +959,9 @@ export default function PlaygroundPage() {
                   Diagnostics
                 </h2>
               </div>
-              <span className="diagnostic-total">{diagnostics.length}</span>
+              <span className="diagnostic-total">
+                {isChecking ? '…' : diagnostics.length}
+              </span>
             </div>
 
             <div className="diagnostic-list">
@@ -940,13 +974,18 @@ export default function PlaygroundPage() {
 
               {(runState.phase === 'idle' || runState.phase === 'running') && (
                 <div className="empty-state">
-                  <strong>Checking…</strong>
+                  <span className="loading-spinner" />
+                  <strong>Checking your code…</strong>
                 </div>
               )}
 
               {runState.phase === 'ready' && diagnostics.length === 0 && (
-                <div className="empty-state">
+                <div className="empty-state success-state">
+                  <span className="success-icon">
+                    <Icon name="check" />
+                  </span>
                   <strong>No problems found</strong>
+                  <span>Your code is clear of diagnostics for this ruleset.</span>
                 </div>
               )}
 
@@ -959,7 +998,9 @@ export default function PlaygroundPage() {
                   type="button"
                 >
                   <span className="severity-symbol" aria-hidden="true">
-                    {diagnostic.severity === 'error' ? '×' : '!'}
+                    <Icon
+                      name={diagnostic.severity === 'error' ? 'error' : 'warning'}
+                    />
                   </span>
                   <span className="diagnostic-content">
                     <span className="diagnostic-message">
@@ -967,7 +1008,9 @@ export default function PlaygroundPage() {
                     </span>
                     <span className="diagnostic-meta">
                       <code>{diagnostic.ruleId}</code>
-                      <span>{diagnosticLabel(diagnostic)}</span>
+                      <span className="diagnostic-location">
+                        {diagnosticLabel(diagnostic)}
+                      </span>
                       {diagnostic.fixes.length > 0 && (
                         <span className="fixable-badge">fixable</span>
                       )}

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -1,28 +1,29 @@
 :root {
-  color: #d9dde3;
-  background: #111315;
+  color: #e5eaf1;
+  background: #0f131a;
   color-scheme: dark;
-  font-family:
-    Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --app: #111315;
-  --canvas: #141618;
-  --surface: #191b1e;
-  --surface-raised: #202328;
-  --surface-hover: #1d2024;
-  --line: #2a2e33;
-  --line-muted: #23272b;
-  --text: #d9dde3;
-  --text-strong: #f3f5f7;
-  --muted: #9299a3;
-  --muted-subtle: #69717c;
-  --accent: #2ba7ee;
-  --accent-hover: #4ab6f4;
-  --success: #69c38d;
-  --error: #ff716c;
-  --warning: #d6a956;
+  font-size: 14px;
+  line-height: 1.5;
+  --mono: 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
+  --app: #0f131a;
+  --canvas: #151a22;
+  --surface: #1a212c;
+  --surface-raised: #242e3d;
+  --surface-hover: #1e2836;
+  --line: #303b4c;
+  --line-muted: #252f3e;
+  --text: #e5eaf1;
+  --text-strong: #f4f7fb;
+  --muted: #a7b3c4;
+  --muted-subtle: #95a2b5;
+  --accent: #51b5f5;
+  --accent-hover: #7bc8fa;
+  --success: #85d6ab;
+  --error: #ff8e88;
+  --warning: #ebbf70;
   --splitter-size: 7px;
 }
 
@@ -80,7 +81,7 @@ select:focus-visible {
 
 .playground-shell {
   display: grid;
-  grid-template-rows: 76px 44px minmax(0, 1fr);
+  grid-template-rows: 64px 76px minmax(0, 1fr);
   width: 100%;
   height: 100vh;
   height: 100dvh;
@@ -91,7 +92,7 @@ select:focus-visible {
 .site-header {
   min-width: 0;
   border-bottom: 1px solid var(--line);
-  background: rgba(21, 22, 22, 0.96);
+  background: var(--app);
 }
 
 .brand,
@@ -111,7 +112,7 @@ select:focus-visible {
 }
 
 .site-header-content {
-  width: min(100%, 1280px);
+  width: 100%;
   height: 100%;
   min-width: 0;
   margin: 0 auto;
@@ -119,7 +120,7 @@ select:focus-visible {
 }
 
 .brand {
-  width: 184px;
+  width: 180px;
   height: 100%;
   flex: none;
   gap: 10px;
@@ -150,7 +151,7 @@ select:focus-visible {
 .brand h1 {
   margin: 0;
   color: currentColor;
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.025em;
 }
@@ -165,7 +166,7 @@ select:focus-visible {
   display: inline-flex;
   height: 100%;
   align-items: center;
-  color: #c3c6c4;
+  color: var(--muted);
   font-size: 14px;
   font-weight: 500;
   text-decoration: none;
@@ -176,7 +177,7 @@ select:focus-visible {
 .site-nav a::after {
   position: absolute;
   right: 0;
-  bottom: 17px;
+  bottom: 0;
   left: 0;
   height: 2px;
   border-radius: 999px;
@@ -209,7 +210,7 @@ select:focus-visible {
 .site-language-link,
 .site-github-link {
   display: inline-flex;
-  min-height: 34px;
+  min-height: 36px;
   align-items: center;
   justify-content: center;
   color: var(--muted);
@@ -235,7 +236,7 @@ select:focus-visible {
 }
 
 .site-github-link {
-  width: 34px;
+  width: 36px;
   border-radius: 7px;
 }
 
@@ -252,15 +253,14 @@ select:focus-visible {
 
 .controlbar {
   min-width: 0;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface);
-  padding: 0 10px 0 12px;
+  gap: 16px;
+  padding: 16px 20px;
 }
 
 .language-select-control {
   position: relative;
   display: flex;
-  height: 28px;
+  height: 36px;
   flex: none;
   align-items: center;
 }
@@ -273,27 +273,28 @@ select:focus-visible {
 .select-wrap::after {
   position: absolute;
   top: 50%;
-  right: 2px;
-  width: 4px;
-  height: 4px;
+  right: 10px;
+  width: 6px;
+  height: 6px;
   border-right: 1px solid var(--muted);
   border-bottom: 1px solid var(--muted);
-  content: "";
+  content: '';
   pointer-events: none;
   transform: translateY(-70%) rotate(45deg);
 }
 
 .language-select-control select {
-  width: 102px;
-  height: 28px;
-  padding: 0 18px 0 0;
+  width: 138px;
+  height: 38px;
+  padding: 0 30px 0 12px;
   appearance: none;
-  border: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
   color: var(--text);
-  background: transparent;
+  background: var(--surface);
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 550;
+  font-size: 14px;
+  font-weight: 600;
   transition: color 120ms ease;
 }
 
@@ -313,17 +314,14 @@ select:focus-visible {
 
 .run-summary {
   min-width: 0;
-  gap: 12px;
-  margin-left: 12px;
-  padding-left: 14px;
-  border-left: 1px solid var(--line);
+  gap: 16px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: 13px;
   white-space: nowrap;
 }
 
 .summary-count {
-  gap: 4px;
+  gap: 6px;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
@@ -332,30 +330,32 @@ select:focus-visible {
   font-weight: 600;
 }
 
-.error-count strong {
+.error-count strong,
+.error-count .ui-icon {
   color: var(--error);
 }
 
-.warning-count strong {
+.warning-count strong,
+.warning-count .ui-icon {
   color: var(--warning);
 }
 
 .control-actions {
   min-width: 0;
   flex: none;
-  gap: 7px;
+  gap: 8px;
   margin-left: auto;
 }
 
 .version-control {
   display: inline-flex;
-  min-height: 30px;
+  min-height: 38px;
   flex: none;
   align-items: center;
-  gap: 7px;
-  padding: 0 7px 0 9px;
+  gap: 8px;
+  padding: 0 10px 0 12px;
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: 8px;
   background: transparent;
   transition:
     border-color 120ms ease,
@@ -370,10 +370,8 @@ select:focus-visible {
 
 .version-control-label {
   color: var(--muted-subtle);
-  font-size: 9px;
-  font-weight: 650;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .version-control .select-wrap::after {
@@ -381,17 +379,17 @@ select:focus-visible {
 }
 
 .version-control select {
-  width: 102px;
-  height: 28px;
-  padding: 0 15px 0 0;
+  width: 120px;
+  height: 36px;
+  padding: 0 20px 0 0;
   appearance: none;
   border: 0;
   color: var(--text);
   background: transparent;
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
-  font-weight: 550;
+  font-weight: 600;
 }
 
 .version-control select:focus-visible {
@@ -412,13 +410,13 @@ select:focus-visible {
 .fix-button,
 .share-button {
   display: inline-flex;
-  min-height: 30px;
+  min-height: 38px;
   flex: none;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 550;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
   text-decoration: none;
   transition:
     color 120ms ease,
@@ -427,9 +425,9 @@ select:focus-visible {
 }
 
 .fix-button {
-  min-width: 60px;
+  min-width: 100px;
   padding: 0 12px;
-  border: 1px solid #238dca;
+  border: 1px solid var(--accent);
   color: #081117;
   background: var(--accent);
   cursor: pointer;
@@ -452,11 +450,11 @@ select:focus-visible {
 }
 
 .share-button {
-  min-width: 58px;
+  min-width: 106px;
   padding: 0 10px;
   border: 1px solid var(--line);
-  color: var(--muted);
-  background: transparent;
+  color: var(--text);
+  background: var(--surface);
   cursor: pointer;
 }
 
@@ -468,12 +466,13 @@ select:focus-visible {
 
 .workspace {
   display: grid;
+  margin: 0 20px 20px;
   grid-template-columns:
-    minmax(480px, var(--editor-ratio, 68%)) var(--splitter-size)
-    minmax(340px, 1fr);
+    minmax(440px, var(--editor-ratio, 58%)) var(--splitter-size)
+    minmax(360px, 1fr);
   min-height: 0;
   overflow: hidden;
-  background: var(--canvas);
+  background: var(--app);
 }
 
 .editor-panel,
@@ -486,18 +485,18 @@ select:focus-visible {
 
 .editor-panel {
   display: grid;
-  grid-template-rows: 40px minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr);
 }
 
 .panel-heading {
   justify-content: space-between;
-  min-height: 40px;
-  padding: 0 13px;
+  min-height: 48px;
+  padding: 0 18px;
   border-bottom: 1px solid var(--line);
   color: var(--text);
   background: var(--surface);
-  font-size: 12px;
-  font-weight: 550;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .panel-heading-copy {
@@ -510,14 +509,13 @@ select:focus-visible {
   color: var(--text);
   font-size: inherit;
   font-weight: inherit;
-  line-height: 1.2;
+  line-height: 1.5;
 }
 
 .file-name {
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 11px;
-  font-weight: 550;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .editor-frame {
@@ -539,7 +537,7 @@ select:focus-visible {
 }
 
 .rules-section {
-  grid-template-rows: 40px minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr);
 }
 
 .pane-splitter {
@@ -547,7 +545,7 @@ select:focus-visible {
   z-index: 2;
   min-width: 0;
   min-height: 0;
-  background: var(--surface);
+  background: var(--app);
   cursor: default;
   touch-action: none;
   user-select: none;
@@ -555,9 +553,31 @@ select:focus-visible {
 
 .pane-splitter::before {
   position: absolute;
-  background: var(--line);
-  content: "";
+  border-radius: 4px;
+  background: transparent;
+  content: '';
   transition: background-color 120ms ease;
+}
+
+.pane-splitter::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 4px;
+  background: var(--line);
+  content: '';
+  transform: translate(-50%, -50%);
+  transition: background-color 120ms ease;
+}
+
+.pane-splitter-vertical::after {
+  width: 3px;
+  height: 32px;
+}
+
+.pane-splitter-horizontal::after {
+  width: 32px;
+  height: 3px;
 }
 
 .pane-splitter-vertical {
@@ -583,7 +603,9 @@ select:focus-visible {
 }
 
 .pane-splitter:hover::before,
-.pane-splitter:focus-visible::before {
+.pane-splitter:focus-visible::before,
+.pane-splitter:hover::after,
+.pane-splitter:focus-visible::after {
   background: var(--accent);
 }
 
@@ -592,9 +614,7 @@ select:focus-visible {
 }
 
 .rules-heading {
-  gap: 12px;
-  padding-right: 12px;
-  padding-left: 0;
+  padding: 0 6px;
 }
 
 .inspector-tabs {
@@ -613,13 +633,13 @@ select:focus-visible {
 .inspector-tabs button {
   position: relative;
   display: inline-flex;
-  min-width: 74px;
+  min-width: 90px;
   align-items: center;
   justify-content: center;
   padding: 0 14px;
-  border-right: 1px solid var(--line-muted);
-  font-size: 11px;
-  font-weight: 550;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
   transition:
     color 120ms ease,
     background-color 120ms ease;
@@ -627,12 +647,13 @@ select:focus-visible {
 
 .inspector-tabs button:hover,
 .segmented-control button:hover {
-  color: var(--text);
+  color: var(--text-strong);
+  background: var(--surface-hover);
 }
 
 .inspector-tabs button.is-active {
   color: var(--text-strong);
-  background: var(--canvas);
+  background: transparent;
 }
 
 .inspector-tabs button.is-active::after {
@@ -642,24 +663,22 @@ select:focus-visible {
   left: 12px;
   height: 2px;
   background: var(--accent);
-  content: "";
+  content: '';
 }
 
 .segmented-control {
-  align-self: stretch;
-  gap: 3px;
-}
-
-.segmented-label {
-  margin-right: 4px;
-  color: var(--muted-subtle);
-  font-size: 10px;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--app);
 }
 
 .segmented-control button {
-  padding: 4px 7px;
-  border-radius: 3px;
-  font-size: 10px;
+  min-height: 30px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  font-size: 12px;
   font-weight: 500;
 }
 
@@ -672,27 +691,26 @@ select:focus-visible {
   display: grid;
   min-width: 0;
   min-height: 0;
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 .rules-editor {
   width: 100%;
   min-height: 0;
-  padding: 15px 16px;
+  padding: 16px 20px;
   resize: none;
   border: 0;
   color: var(--text);
   background: var(--canvas);
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
-  line-height: 1.65;
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.85;
   scrollbar-color: #363c43 transparent;
   tab-size: 2;
 }
 
 .rules-editor:read-only {
-  color: #a8afb8;
+  color: var(--muted);
   cursor: default;
 }
 
@@ -706,7 +724,7 @@ select:focus-visible {
   border-top: 1px solid #553033;
   color: #ff918d;
   background: #25191b;
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1.45;
 }
 
@@ -732,16 +750,15 @@ select:focus-visible {
   border-bottom: 1px solid #544529;
   color: var(--warning);
   background: #211d16;
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .ast-tree {
   min-width: max-content;
   padding: 12px 16px 20px;
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
-  line-height: 1.75;
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.85;
 }
 
 .ast-tree details {
@@ -765,7 +782,7 @@ select:focus-visible {
   display: inline-block;
   width: 1.1em;
   color: var(--muted-subtle);
-  content: "\25B8";
+  content: '\25B8';
   transition: transform 120ms ease;
 }
 
@@ -820,17 +837,20 @@ select:focus-visible {
 }
 
 .diagnostics-section {
-  grid-template-rows: 40px minmax(0, 1fr) auto;
+  grid-template-rows: 48px minmax(0, 1fr) auto;
 }
 
 .diagnostic-total {
-  min-width: 18px;
-  color: var(--muted-subtle);
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 10px;
+  min-width: 26px;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-align: center;
 }
 
 .diagnostic-list {
@@ -843,11 +863,11 @@ select:focus-visible {
 
 .diagnostic-card {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  gap: 8px;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 12px;
   width: 100%;
   margin: 0;
-  padding: 11px 14px 12px;
+  padding: 16px 18px;
   border: 0;
   border-bottom: 1px solid var(--line-muted);
   color: inherit;
@@ -863,10 +883,9 @@ select:focus-visible {
 
 .severity-symbol {
   display: block;
-  width: 16px;
-  margin-top: 1px;
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  width: 20px;
+  margin-top: 2px;
+  font-family: var(--mono);
   font-size: 12px;
   font-weight: 700;
   line-height: 1.45;
@@ -888,53 +907,56 @@ select:focus-visible {
 .diagnostic-message {
   display: block;
   color: var(--text);
-  font-size: 12px;
-  font-weight: 450;
-  line-height: 1.5;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.6;
 }
 
 .diagnostic-meta {
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 5px;
+  margin-top: 8px;
   color: var(--muted-subtle);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .diagnostic-meta code {
   max-width: 100%;
   overflow: hidden;
-  color: #67b8e8;
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: #84caff;
+  font-family: var(--mono);
   text-overflow: ellipsis;
 }
 
-.fixable-badge::before {
-  margin-right: 8px;
-  color: var(--line);
-  content: "/";
+.fixable-badge {
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--success);
+  background: #20372e;
+  font-size: 12px;
 }
 
 .empty-state {
   display: flex;
   min-height: 120px;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 18px 16px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 28px 20px;
   color: var(--muted-subtle);
 }
 
 .empty-state strong {
   margin: 0;
   color: var(--muted);
-  font-size: 11px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .error-state {
   flex-direction: column;
-  gap: 5px;
+  gap: 8px;
+  align-items: flex-start;
   color: #ff918d;
 }
 
@@ -944,7 +966,7 @@ select:focus-visible {
 }
 
 .error-state span {
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1.5;
 }
 
@@ -955,7 +977,7 @@ select:focus-visible {
   border-top: 1px solid var(--line);
   color: var(--muted);
   background: var(--surface);
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.45;
 }
 
@@ -969,27 +991,147 @@ select:focus-visible {
   color: var(--warning);
 }
 
+.ui-icon {
+  display: block;
+  width: 16px;
+  height: 16px;
+  flex: none;
+}
+
+.fix-button,
+.share-button {
+  gap: 8px;
+}
+
+.editor-panel,
+.rules-section,
+.diagnostics-section {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--canvas);
+}
+
+.panel-heading-copy > .ui-icon {
+  color: var(--accent);
+}
+
+.editor-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--success);
+}
+
+.status-idle .status-dot,
+.status-running .status-dot {
+  background: var(--warning);
+}
+
+.status-error .status-dot {
+  background: var(--error);
+}
+
+.rules-toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line-muted);
+}
+
+.rules-toolbar-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.diagnostic-location {
+  font-variant-numeric: tabular-nums;
+}
+
+.diagnostic-message {
+  overflow-wrap: anywhere;
+}
+
+.severity-symbol .ui-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.success-state {
+  flex-direction: column;
+  min-height: 220px;
+  text-align: center;
+}
+
+.success-state strong {
+  color: var(--text-strong);
+}
+
+.success-state > span:last-child {
+  max-width: 260px;
+  font-size: 13px;
+}
+
+.success-icon {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 4px;
+  place-items: center;
+  border: 1px solid #365649;
+  border-radius: 50%;
+  color: var(--success);
+  background: #20372e;
+}
+
+.success-icon .ui-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.loading-spinner {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  border: 2px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (min-width: 901px) and (max-height: 599px) {
   body {
     overflow: auto;
   }
-
   .playground-shell {
     height: 600px;
   }
 }
 
-@media (min-width: 901px) and (max-width: 1120px) {
+@media (max-width: 1100px) {
   .brand {
-    width: 160px;
+    width: 150px;
   }
-
   .site-nav {
-    gap: 22px;
-  }
-
-  .segmented-label {
-    display: none;
+    gap: 20px;
   }
 }
 
@@ -1007,39 +1149,31 @@ select:focus-visible {
   .site-header-content {
     min-height: 64px;
   }
-
-  .brand {
-    width: 150px;
-  }
-
-  .controlbar {
-    min-height: 44px;
-  }
-
   .site-nav {
     gap: 18px;
   }
-
-  .workspace {
-    grid-template-columns: 1fr;
+  .controlbar {
+    min-height: 72px;
   }
-
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
   .pane-splitter {
     display: none;
   }
 
   .editor-panel {
-    height: 58vh;
-    min-height: 420px;
-    border-bottom: 1px solid var(--line);
+    height: 52vh;
+    min-height: 360px;
   }
 
   .side-panel {
-    grid-template-rows: 260px minmax(400px, auto);
+    grid-template-rows: 340px minmax(340px, auto);
+    gap: 16px;
   }
-
   .diagnostics-section {
-    min-height: 400px;
+    min-height: 340px;
   }
 }
 
@@ -1048,20 +1182,18 @@ select:focus-visible {
     min-height: 0;
     flex-wrap: wrap;
   }
-
   .brand {
     width: auto;
-    height: 54px;
+    height: 58px;
     flex: 1;
   }
-
   .site-header-actions {
-    height: 54px;
+    height: 58px;
   }
 
   .site-nav {
     width: calc(100% + 48px);
-    height: 42px;
+    height: 44px;
     min-width: 0;
     flex: none;
     order: 3;
@@ -1076,34 +1208,18 @@ select:focus-visible {
   .site-nav::-webkit-scrollbar {
     display: none;
   }
-
-  .site-nav a::after {
-    bottom: 5px;
-  }
-}
-
-@media (max-width: 640px) {
   .controlbar {
     flex-wrap: wrap;
-    gap: 0;
-    padding: 8px 10px;
+    gap: 14px 12px;
   }
-
   .run-summary {
-    gap: 9px;
-    margin-left: 12px;
+    margin-left: auto;
   }
-
   .control-actions {
-    gap: 5px;
+    width: 100%;
   }
-
-  .side-panel {
-    grid-template-rows: 240px minmax(360px, auto);
-  }
-
-  .diagnostics-section {
-    min-height: 360px;
+  .version-control {
+    margin-right: auto;
   }
 }
 
@@ -1111,35 +1227,59 @@ select:focus-visible {
   .site-header-content {
     padding: 0 16px;
   }
-
   .site-nav {
     width: calc(100% + 32px);
     margin-inline: -16px;
     padding-inline: 16px;
   }
-
   .controlbar {
-    row-gap: 8px;
+    padding: 14px 12px;
   }
-
+  .workspace {
+    margin: 0 12px 12px;
+    gap: 12px;
+  }
   .run-summary {
-    margin-left: auto;
+    gap: 10px;
+    font-size: 12px;
   }
-
-  .control-actions {
-    width: 100%;
-  }
-
-  .segmented-label {
+  .run-summary .ui-icon {
     display: none;
   }
-
-  .rules-heading {
-    gap: 6px;
+  .control-actions {
+    gap: 8px;
+    flex-wrap: wrap;
   }
-
-  .segmented-control button {
-    padding-inline: 5px;
+  .version-control {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .version-control select {
+    width: 146px;
+  }
+  .share-button,
+  .fix-button {
+    flex: 1;
+    min-height: 40px;
+  }
+  .panel-heading {
+    padding-inline: 14px;
+  }
+  .rules-heading {
+    padding-inline: 4px;
+  }
+  .rules-toolbar {
+    padding-inline: 12px;
+  }
+  .rules-editor {
+    padding-inline: 14px;
+  }
+  .side-panel {
+    gap: 12px;
+  }
+  .diagnostic-card {
+    padding: 14px;
+    gap: 10px;
   }
 }
 

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -253,6 +253,13 @@ async function runSmoke(page, origin) {
       await page.waitForURL(
         (url) => url.searchParams.get('version') === previousVersion,
       );
+      stage = 'Playground pinned version reload';
+      await page.reload({ waitUntil: 'networkidle' });
+      await waitForSettledPage(page);
+      assert.equal(await versionSelect.inputValue(), previousVersion);
+      await page.waitForFunction(() =>
+        document.querySelector('[role="status"]')?.textContent?.includes('Lint complete.'),
+      );
       await versionSelect.selectOption(versionManifest.latest);
       await page.waitForURL(
         (url) => url.searchParams.get('version') === versionManifest.latest,


### PR DESCRIPTION
## Summary

The Playground's small, low-contrast labels and crowded panel headers made configuration and diagnostics difficult to scan. This refresh keeps the dark editor while making text and actions easier to read.

- Increase UI and configuration typography, brighten secondary text and code line numbers, and use a consistent system/monospace font stack with unambiguous code characters.
- Rebalance the resizable workspace, separate the ruleset controls from inspector tabs, and add clearer diagnostic badges, loading/empty states, resize handles, and responsive toolbar layouts.
- Fix versioned share links failing after reload when the router removes the trailing slash from `/playground/`; keep the manifest and WASM requests under `/playground/versions/`.

## Test Plan

- `pnpm playground:typecheck`
- `pnpm --filter @utoo/lint-playground test` — 14 tests, including shared URL resource resolution.
- Production Playground and docs builds, static deployment audit, unified site assembly and verification.
- `pnpm site:smoke` — includes reloading a pinned version.
- Chromium checks at 320, 390, 640, 760, 900, 901, 1024, 1440, and 1920px; keyboard/pointer resizing; diagnostic navigation; invalid configuration; ruleset and AST keyboard navigation; autofix in all four languages; version selection and clipboard share/reload.
- Checked primary, secondary, metadata, code line number, comment, and action text color pairs; all exceed 4.5:1 contrast.
