### PR TITLE
refactor(site): simplify the homepage hero and use ut installation

### DIFF
--- a/.dumi/overrides.css
+++ b/.dumi/overrides.css
@@ -816,6 +816,14 @@ body:where(html[data-prefers-color='dark'] *)
 .product-hero .product-actions {
   justify-content: center;
 }
+.product-hero-logo {
+  display: block;
+  width: 105px;
+  height: 150px;
+  margin: 0 auto 28px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 28px #38a9ec26);
+}
 .product-hero h1 {
   margin: 0 0 28px;
   font-size: clamp(52px, 6vw, 84px);
@@ -1744,6 +1752,11 @@ body:where(html[data-prefers-color='dark'] *)
   }
   .product-hero h1 {
     font-size: clamp(40px, 11vw, 58px);
+  }
+  .product-hero-logo {
+    width: 73px;
+    height: 104px;
+    margin-bottom: 24px;
   }
   .product-hero-copy > p {
     font-size: 16px;

--- a/.dumi/overrides.css
+++ b/.dumi/overrides.css
@@ -800,35 +800,25 @@ body:where(html[data-prefers-color='dark'] *)
 .product-hero::after {
   display: none;
 }
-.product-hero-grid {
+.product-hero-content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  min-height: calc(100svh - 72px);
   align-items: center;
-  gap: 56px;
-  padding-block: 96px 88px;
+  padding-block: 88px;
+  text-align: center;
 }
 .product-hero-copy {
+  width: 100%;
+  max-width: 780px;
   min-width: 0;
+  margin-inline: auto;
 }
-.product-eyebrow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--product-muted);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.6;
-}
-.product-eyebrow > span {
-  flex: none;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--product-green);
+.product-hero .product-actions {
+  justify-content: center;
 }
 .product-hero h1 {
-  margin: 26px 0;
-  font-size: clamp(46px, 4.9vw, 68px);
+  margin: 0 0 28px;
+  font-size: clamp(52px, 6vw, 84px);
   font-weight: 650;
   line-height: 1.08;
   letter-spacing: -0.045em;
@@ -838,8 +828,9 @@ body:where(html[data-prefers-color='dark'] *)
   color: var(--product-blue);
 }
 .product-hero-copy > p {
-  max-width: 520px;
-  margin: 0 0 30px;
+  max-width: 620px;
+  margin: 0 auto 32px;
+  text-wrap: balance;
   color: var(--product-muted);
   font-size: 18px;
   line-height: 1.8;
@@ -892,11 +883,13 @@ body:where(html[data-prefers-color='dark'] *)
   outline-offset: 4px;
 }
 .product-install {
-  margin-top: 28px;
-  max-width: 430px;
+  width: 100%;
+  max-width: 340px;
+  margin: 24px auto 0;
+  text-align: left;
 }
 .product-install .dumi-default-source-code {
-  margin: 0 0 10px;
+  margin: 0;
   border-color: var(--product-line);
   border-radius: 7px;
   background: #0b1017;
@@ -911,11 +904,6 @@ body:where(html[data-prefers-color='dark'] *)
 .product-install .dumi-default-source-code-copy {
   top: 10px;
   right: 8px;
-}
-.product-install > span {
-  color: var(--product-muted);
-  font-size: 12px;
-  line-height: 1.6;
 }
 .product-demo {
   min-width: 0;
@@ -1005,8 +993,8 @@ body:where(html[data-prefers-color='dark'] *)
 }
 .product-demo-result {
   display: flex;
-  min-height: 93px;
-  align-items: flex-start;
+  min-height: 62px;
+  align-items: center;
   gap: 12px;
   padding: 18px 20px;
   border-top: 1px solid var(--product-line);
@@ -1030,65 +1018,9 @@ body:where(html[data-prefers-color='dark'] *)
   font-weight: 500;
   line-height: 1.7;
 }
-.product-demo-result div > span {
-  display: block;
-  max-width: 420px;
-  margin-top: 5px;
-  color: var(--product-muted);
-  font-size: 12px;
-  line-height: 1.7;
-  overflow-wrap: anywhere;
-}
 .product-demo-result[data-fixed='true'] .product-demo-status {
   border-color: var(--product-green);
   color: var(--product-green);
-}
-.product-demo-footer {
-  display: flex;
-  min-height: 42px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  padding: 10px 20px;
-  border-top: 1px solid var(--product-line);
-  color: var(--product-muted);
-  font-size: 12px;
-}
-.product-demo-footer code {
-  color: var(--product-green);
-  font-family: var(--utlint-mono);
-}
-.product-compatibility {
-  display: flex;
-  align-items: center;
-  gap: 30px;
-  padding-block: 24px;
-  border-top: 1px solid var(--product-line);
-  border-bottom: 1px solid var(--product-line);
-  font-size: 13px;
-  color: var(--product-muted);
-}
-.product-compatibility ul {
-  display: flex;
-  flex: 1;
-  flex-wrap: wrap;
-  gap: 22px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.product-compatibility li {
-  color: #d8e2f1;
-  font-size: 14px;
-  font-weight: 500;
-}
-.product-compatibility > a {
-  color: var(--product-muted);
-  text-decoration: none;
-}
-.product-compatibility > a:hover {
-  color: var(--product-blue);
 }
 .product-home {
   color: var(--product-text);
@@ -1152,17 +1084,31 @@ body:where(html[data-prefers-color='dark'] *)
 }
 .product-features {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 44px;
-  padding-block: 58px 64px;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  align-items: center;
+  gap: 72px;
+  padding-block: 72px 88px;
+  border-top: 1px solid var(--product-line);
   border-bottom: 1px solid var(--product-line);
+}
+.product-feature-list {
+  display: grid;
+  gap: 32px;
+}
+.product-feature-list article {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 0 18px;
+  align-items: center;
+}
+.product-feature-list p {
+  grid-column: 2;
 }
 .product-feature-icon {
   display: grid;
   width: 38px;
   height: 38px;
   place-items: center;
-  margin-bottom: 20px;
   border: 1px solid #33485f;
   border-radius: 7px;
   color: var(--product-blue);
@@ -1726,30 +1672,17 @@ body:where(html[data-prefers-color='dark'] *)
   min-width: 180px;
 }
 @media (max-width: 1100px) {
-  .product-hero-grid {
-    gap: 32px;
-    padding-block: 70px;
-  }
   .product-config {
     gap: 40px;
-  }
-  .product-compatibility {
-    gap: 22px;
-  }
-  .product-compatibility ul {
-    gap: 16px;
   }
   .product-demo .dumi-default-source-code pre.prism-code {
     font-size: 12px;
   }
 }
 @media (max-width: 900px) {
-  .product-hero-grid,
+  .product-features,
   .product-config {
     grid-template-columns: 1fr;
-  }
-  .product-hero-grid {
-    gap: 46px;
   }
   .product-hero-copy > p {
     max-width: 650px;
@@ -1761,15 +1694,8 @@ body:where(html[data-prefers-color='dark'] *)
   .product-demo .dumi-default-source-code pre.prism-code {
     font-size: 14px;
   }
-  .product-compatibility {
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-  .product-compatibility ul {
-    flex-basis: 70%;
-  }
   .product-features {
-    gap: 28px;
+    gap: 40px;
   }
   .product-benchmark-layout {
     gap: 28px;
@@ -1812,16 +1738,12 @@ body:where(html[data-prefers-color='dark'] *)
   .product-container {
     width: calc(100% - 40px);
   }
-  .product-hero-grid {
-    padding-block: 52px 40px;
-    gap: 36px;
+  .product-hero-content {
+    min-height: calc(100svh - 64px);
+    padding-block: 56px;
   }
   .product-hero h1 {
     font-size: clamp(40px, 11vw, 58px);
-  }
-  .product-eyebrow {
-    align-items: baseline;
-    font-size: 12px;
   }
   .product-hero-copy > p {
     font-size: 16px;
@@ -1836,8 +1758,7 @@ body:where(html[data-prefers-color='dark'] *)
   }
   .product-demo-title,
   .product-demo-tools,
-  .product-demo-result,
-  .product-demo-footer {
+  .product-demo-result {
     padding-inline: 14px;
   }
   .product-demo .dumi-default-source-code pre.prism-code {
@@ -1847,21 +1768,6 @@ body:where(html[data-prefers-color='dark'] *)
   .product-demo-tools button {
     padding-inline: 8px;
   }
-  .product-demo-footer {
-    font-size: 12px;
-  }
-  .product-compatibility {
-    gap: 16px;
-    padding-block: 22px;
-  }
-  .product-compatibility ul {
-    flex-basis: 100%;
-    order: 3;
-    gap: 12px 20px;
-  }
-  .product-compatibility > a {
-    margin-left: auto;
-  }
   .product-features,
   .product-steps,
   .product-runtimes {
@@ -1869,7 +1775,10 @@ body:where(html[data-prefers-color='dark'] *)
     gap: 30px;
   }
   .product-features {
-    padding-block: 40px;
+    padding-block: 48px;
+  }
+  .product-feature-list article {
+    gap: 0 14px;
   }
   .product-section {
     padding-block: 56px;

--- a/.dumi/theme/builtins/ProductHome/index.tsx
+++ b/.dumi/theme/builtins/ProductHome/index.tsx
@@ -2,6 +2,7 @@ import { Link, useLocale } from 'dumi';
 import React from 'react';
 import SourceCode from '../SourceCode';
 import BenchmarkChart from '../../components/BenchmarkChart';
+import AutofixExample from '../../components/AutofixExample';
 import NativeLink from '../../components/NativeLink';
 import benchmark from '../../../../public/benchmarks/2026-08-30.json';
 
@@ -207,15 +208,18 @@ export default function ProductHome() {
         className="product-container product-features"
         aria-label={chinese ? '核心能力' : 'Core capabilities'}
       >
-        {t.features.map(([title, description], index) => (
-          <article key={title}>
-            <span className="product-feature-icon" aria-hidden="true">
-              {['↯', '{ }', '>_'][index]}
-            </span>
-            <h2>{title}</h2>
-            <p>{description}</p>
-          </article>
-        ))}
+        <div className="product-feature-list">
+          {t.features.map(([title, description], index) => (
+            <article key={title}>
+              <span className="product-feature-icon" aria-hidden="true">
+                {['↯', '{ }', '>_'][index]}
+              </span>
+              <h2>{title}</h2>
+              <p>{description}</p>
+            </article>
+          ))}
+        </div>
+        <AutofixExample />
       </section>
       <section
         id="performance"

--- a/.dumi/theme/components/AutofixExample/index.tsx
+++ b/.dumi/theme/components/AutofixExample/index.tsx
@@ -1,0 +1,71 @@
+import { useLocale } from 'dumi';
+import React, { useState } from 'react';
+import SourceCode from '../../builtins/SourceCode';
+
+const before = `function greet(name: string) {
+  let message = \`Hello, \${name}\`;;
+  const messages = new Array(message, 'Welcome');
+  return { messages: messages };
+}`;
+const after = `function greet(name: string) {
+  const message = \`Hello, \${name}\`;
+  const messages = [message, 'Welcome'];
+  return { messages };
+}`;
+
+export default function AutofixExample() {
+  const isChinese = useLocale().id === 'zh-CN';
+  const [fixed, setFixed] = useState(false);
+  return (
+    <div className="product-demo">
+      <div className="product-demo-title">
+        <span>
+          <span className="product-code-symbol" aria-hidden="true">
+            {'</>'}
+          </span>{' '}
+          index.ts
+        </span>
+        <span>TypeScript</span>
+      </div>
+      <div className="product-demo-tools">
+        <span>{isChinese ? '自动修复示例' : 'Autofix example'}</span>
+        <div
+          role="group"
+          aria-label={isChinese ? '查看修复示例' : 'View autofix example'}
+        >
+          <button
+            type="button"
+            aria-pressed={!fixed}
+            onClick={() => setFixed(false)}
+          >
+            {isChinese ? '修复前' : 'Before'}
+          </button>
+          <button
+            type="button"
+            aria-pressed={fixed}
+            onClick={() => setFixed(true)}
+          >
+            {isChinese ? '修复后' : 'After fix'}
+          </button>
+        </div>
+      </div>
+      <SourceCode lang="typescript">{fixed ? after : before}</SourceCode>
+      <div className="product-demo-result" data-fixed={fixed} role="status">
+        <span className="product-demo-status" aria-hidden="true">
+          {fixed ? '✓' : '!'}
+        </span>
+        <div>
+          <strong>
+            {fixed
+              ? isChinese
+                ? '4 处问题，已全部修复。'
+                : 'Four fixes. Cleaner code.'
+              : isChinese
+                ? '4 处可自动修复的问题'
+                : '4 diagnostics with safe autofixes'}
+          </strong>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/.dumi/theme/slots/Hero/index.tsx
+++ b/.dumi/theme/slots/Hero/index.tsx
@@ -23,6 +23,13 @@ export default function Hero() {
     >
       <div className="product-container product-hero-content">
         <div className="product-hero-copy">
+          <img
+            className="product-hero-logo"
+            src="/utoo-lint-mark.svg"
+            alt={isChinese ? 'UTOO 蓝白兔子标志' : 'UTOO rabbit logo'}
+            width="105"
+            height="150"
+          />
           <h1 id="product-title">
             {hero.title} <span>{hero.accent}</span>
           </h1>

--- a/.dumi/theme/slots/Hero/index.tsx
+++ b/.dumi/theme/slots/Hero/index.tsx
@@ -1,22 +1,7 @@
 import { Link, useLocale, useRouteMeta } from 'dumi';
-import React, { useState } from 'react';
+import React from 'react';
 import SourceCode from '../../builtins/SourceCode';
 import NativeLink from '../../components/NativeLink';
-
-const before = `function greet(name: string) {
-  let message = \`Hello, \${name}\`;;
-  const messages = new Array(message, 'Welcome');
-  return { messages: messages };
-}
-
-greet('utoo');`;
-const after = `function greet(name: string) {
-  const message = \`Hello, \${name}\`;
-  const messages = [message, 'Welcome'];
-  return { messages };
-}
-
-greet('utoo');`;
 
 interface HeroData {
   title: string;
@@ -27,7 +12,6 @@ interface HeroData {
 export default function Hero() {
   const { frontmatter } = useRouteMeta();
   const isChinese = useLocale().id === 'zh-CN';
-  const [fixed, setFixed] = useState(false);
   if (!frontmatter.hero) return null;
   const hero = frontmatter.hero as HeroData;
   const docs = isChinese ? '/zh-CN' : '';
@@ -37,14 +21,8 @@ export default function Hero() {
       className="dumi-default-hero product-hero"
       aria-labelledby="product-title"
     >
-      <div className="product-container product-hero-grid">
+      <div className="product-container product-hero-content">
         <div className="product-hero-copy">
-          <div className="product-eyebrow">
-            <span />
-            {isChinese
-              ? '用 Zig 构建的 JavaScript / TypeScript Linter'
-              : 'A JavaScript / TypeScript linter, built in Zig'}
-          </div>
           <h1 id="product-title">
             {hero.title} <span>{hero.accent}</span>
           </h1>
@@ -63,100 +41,9 @@ export default function Hero() {
             </NativeLink>
           </div>
           <div className="product-install">
-            <SourceCode lang="bash">pnpm add -D @utoo/lint</SourceCode>
-            <span>
-              {isChinese
-                ? 'Node.js 20+ · 自带原生二进制，无需安装 Zig'
-                : 'Node.js 20+ · Prebuilt binaries. No Zig setup.'}
-            </span>
+            <SourceCode lang="bash">ut install -D @utoo/lint</SourceCode>
           </div>
         </div>
-        <div className="product-demo">
-          <div className="product-demo-title">
-            <span>
-              <span className="product-code-symbol" aria-hidden="true">
-                {'</>'}
-              </span>{' '}
-              index.ts
-            </span>
-            <span>TypeScript</span>
-          </div>
-          <div className="product-demo-tools">
-            <span>{isChinese ? '自动修复示例' : 'Autofix example'}</span>
-            <div
-              role="group"
-              aria-label={isChinese ? '查看修复示例' : 'View autofix example'}
-            >
-              <button
-                type="button"
-                aria-pressed={!fixed}
-                onClick={() => setFixed(false)}
-              >
-                {isChinese ? '修复前' : 'Before'}
-              </button>
-              <button
-                type="button"
-                aria-pressed={fixed}
-                onClick={() => setFixed(true)}
-              >
-                {isChinese ? '修复后' : 'After fix'}
-              </button>
-            </div>
-          </div>
-          <SourceCode lang="typescript">{fixed ? after : before}</SourceCode>
-          <div className="product-demo-result" data-fixed={fixed} role="status">
-            <span className="product-demo-status" aria-hidden="true">
-              {fixed ? '✓' : '!'}
-            </span>
-            <div>
-              <strong>
-                {fixed
-                  ? isChinese
-                    ? '4 处问题，已全部修复。'
-                    : 'Four fixes. Cleaner code.'
-                  : isChinese
-                    ? '4 处可自动修复的问题'
-                    : '4 diagnostics with safe autofixes'}
-              </strong>
-              <span>
-                {fixed
-                  ? isChinese
-                    ? '常量、数组字面量与属性简写。'
-                    : 'Constants, array literals, and property shorthand.'
-                  : 'no-extra-semi · prefer-const · object-shorthand · no-array-constructor'}
-              </span>
-            </div>
-          </div>
-          <div className="product-demo-footer">
-            <code>utoo-lint --fix src</code>
-            <span>
-              {isChinese ? '只应用受支持的修复' : 'Apply supported fixes'}
-            </span>
-          </div>
-        </div>
-      </div>
-      <div className="product-container product-compatibility">
-        <span>{isChinese ? '融入你的技术栈' : 'Fits your stack'}</span>
-        <ul
-          aria-label={
-            isChinese
-              ? '支持的语言与生态'
-              : 'Supported languages and ecosystems'
-          }
-        >
-          <li>JavaScript</li>
-          <li>TypeScript</li>
-          <li>React & JSX</li>
-          <li>Node.js</li>
-          <li>WebAssembly</li>
-        </ul>
-        <a
-          href="https://github.com/utooland/utoo-lint"
-          target="_blank"
-          rel="noreferrer"
-        >
-          GitHub <span aria-hidden="true">↗</span>
-        </a>
       </div>
     </section>
   );

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ toc: false
 hero:
   title: Fast linting.
   accent: Familiar rules.
-  description: Find problems in JavaScript and TypeScript with a native Zig engine. Keep the rule names you know, configure in TypeScript, and apply safe fixes from your terminal to CI.
+  description: A fast JavaScript and TypeScript linter, built in Zig.
 ---
 
 <ProductHome />

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -5,7 +5,7 @@ toc: false
 hero:
   title: 原生速度。
   accent: 熟悉的规则。
-  description: 用 Zig 原生引擎检查 JavaScript 和 TypeScript。沿用熟悉的规则名称，使用 TypeScript 编写配置，从本地终端到 CI，高效发现并修复代码问题。
+  description: 用 Zig 加速 JavaScript 与 TypeScript 代码检查。
 ---
 
 <ProductHome />

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -321,16 +321,14 @@ function verifyHomepageActions(html, quickStartText, quickStartHref) {
     }
 
     quickStartFound ||= text === quickStartText && href === quickStartHref;
-    githubFound ||=
-      text.startsWith('GitHub') &&
-      href === 'https://github.com/utooland/utoo-lint';
+    githubFound ||= href === 'https://github.com/utooland/utoo-lint';
   }
 
   if (!quickStartFound) {
     throw new Error('docs index is missing the localized Quick Start hero CTA');
   }
   if (!githubFound) {
-    throw new Error('docs index is missing the GitHub hero CTA');
+    throw new Error('docs index is missing its GitHub repository link');
   }
   if (linkCount < 1) {
     throw new Error('docs index is missing its native Playground link');


### PR DESCRIPTION
The homepage now opens with a focused, centered introduction: the original UTOO rabbit logo, the product headline, one sentence, two primary actions, and a copyable `ut install -D @utoo/lint` command. Remove the technology-stack strip and installation footnote, and move the shorter before/after autofix example below the first screen alongside the product capabilities.

Apply the same layout and concise copy to English and Chinese. Reuse the original SVG mark with localized alt text and a subtle blue glow; size it for desktop and mobile without pushing the primary actions out of the first screen. Remove obsolete styles and keep the repository-link audit aligned with the GitHub link in the header.

Validation: production docs and Playground builds, `pnpm site:verify`, and `pnpm site:smoke` passed. Chromium checks cover both languages at eight widths from 320 to 1920px, first-screen composition, installation clipboard content, relocated autofix controls, and Quick Start navigation. `git diff --check` passed.

Logo follow-up: `pnpm docs:build` and `pnpm site:verify` passed; checked image loading, centered placement, and first-screen fit at 320, 390, 768, and 1440px in both languages.
