### PR TITLE
fix: treat TypeScript parameter properties as used

### DIFF
--- a/src/rules/no_unused_vars.zig
+++ b/src/rules/no_unused_vars.zig
@@ -157,7 +157,7 @@ pub fn runWithOptions(
         const decls = symbol_table.symbolDecls(entry.id);
         if (decls.len == 0) continue;
 
-        if (symbol_table.isReferenced(entry.id)) {
+        if (symbol_table.isReferenced(entry.id) or isParameterProperty(tree, symbol_table, decls[0])) {
             if (options.report_used_ignore_pattern and isReportedUsedIgnoredName(name, flags, decls, &destructured_array_ignored_decls, options)) {
                 try core.addDiagnosticFmt(
                     allocator,
@@ -307,6 +307,14 @@ fn isLintableSymbol(flags: traverser.semantic.Symbol.Flags, options: Options) bo
         (options.check_type_parameters and flags.type_parameter);
 }
 
+fn isParameterProperty(tree: *const ast.Tree, symbol_table: traverser.semantic.SymbolTable, declaration: ast.NodeIndex) bool {
+    var parent = symbol_table.parentOf(declaration) orelse return false;
+    if (tree.data(parent) == .assignment_pattern) {
+        parent = symbol_table.parentOf(parent) orelse return false;
+    }
+    return tree.data(parent) == .ts_parameter_property;
+}
+
 fn collectParameters(
     allocator: Allocator,
     tree: *const ast.Tree,
@@ -325,7 +333,7 @@ fn collectParameters(
             .symbol_id = entry.id,
             .scope = symbol.scope,
             .start = tree.span(decls[0]).start,
-            .used = symbol_table.isReferenced(entry.id),
+            .used = symbol_table.isReferenced(entry.id) or isParameterProperty(tree, symbol_table, decls[0]),
         });
     }
 }

--- a/tests/rules/typescript_eslint_no_unused_vars.zig
+++ b/tests/rules/typescript_eslint_no_unused_vars.zig
@@ -2,6 +2,41 @@ const std = @import("std");
 const lint = @import("utoo_lint");
 const helpers = @import("../helpers.zig");
 
+test "treats TypeScript constructor parameter properties as implicitly used" {
+    const source =
+        \\export class Message {
+        \\  constructor(
+        \\    public readonly id: string,
+        \\    readonly body: string,
+        \\    protected handler: () => void,
+        \\    private label: string = "message",
+        \\  ) {}
+        \\  read() { return this.body; }
+        \\}
+    ;
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", .{ .string = "error" });
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}
+
+test "counts parameter properties as used when checking trailing unused arguments" {
+    const source =
+        \\export class Message {
+        \\  constructor(before: string, public id: string, after: string) {}
+        \\}
+    ;
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-unused-vars", .{ .string = "error" });
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics.len);
+    try std.testing.expectEqualStrings("'after' is declared but never used.", result.diagnostics[0].message);
+}
+
 test "reports @typescript-eslint/no-unused-vars while ignoring catch parameters by default" {
     const source =
         \\const unused = 1;


### PR DESCRIPTION
## Summary

- Treat TypeScript constructor parameter properties as implicitly used in `@typescript-eslint/no-unused-vars`.
- Include that implicit use when applying the default `args: after-used` behavior, while continuing to report truly unused trailing arguments.
- Cover public, protected, private, readonly, and default-valued parameter properties in regression tests.

## Root cause

The parser already produces `TSParameterProperty` nodes. The rule only checked ordinary symbol references, so constructor parameters that also declare and initialize instance properties were incorrectly reported as unused. The rule now recognizes this implicit use without changing the parser or Umi integration.

## Local validation

- Combined local verification of #1199, #1200, and #1201: the unchanged Bigfish project's `tnpm run lint` reports 2 errors instead of 8. Only the two genuine missing-JSX-key diagnostics remain (exit code 1).
- With the real project config, `export const debugValue: any = 1;` produces one error at a regular source filename and zero at its configured DebugView exemption. The combined targeted API suite passes all 9 tests.

- Both regression tests were observed failing before their corresponding fixes.
- `zig fmt --check src/rules/no_unused_vars.zig tests/rules/typescript_eslint_no_unused_vars.zig`
- `zig build test --summary all`: 2155/2155 tests passed; 16 rule snapshots passed.
- `zig build`
- A real Bigfish library project's unchanged `tnpm run lint`, with only `UTOO_LINT_BIN` pointing at the local build: 8 errors → 2. All six parameter-property false positives disappear; the two remaining missing-JSX-key diagnostics are unrelated.

No business-project source changes or CI runs are needed for this verification.
